### PR TITLE
fix(collector): avoid stale sensor snapshots under slow LLM inference

### DIFF
--- a/agent-core/src/collector.py
+++ b/agent-core/src/collector.py
@@ -2,10 +2,12 @@
 collector.py — 信息整理器。
 
 职责：
-  - 从 event_bus 持续消费事件，在触发间隔内积累
-  - 超过 max_window 的事件 FIFO 丢弃
-  - 间隔到达时，将积累的事件批量格式化为 XML 并输出
-  - agent loop 通过 next_trigger() 获取下一批格式化事件
+  - 从 event_bus 持续消费事件，在 buffer 中积累
+  - 同一 source 限流（1 条/秒，保留最新），超过 max_window 的事件 FIFO 丢弃
+  - agent loop 空闲时通过 next_trigger() 按需快照当前 buffer：
+    取出此刻累积的全部事件、清空 buffer、格式化为 XML 返回。
+    这样大模型每次拿到的都是「当下」的状态快照，不会因推理耗时
+    而读到很久以前积压的旧批次。
 """
 
 import asyncio
@@ -18,11 +20,11 @@ import event_bus
 
 
 _buffer: deque = deque()
-_output: asyncio.Queue = asyncio.Queue(maxsize=64)
-_task: asyncio.Task | None = None
 # Per-source throttle: source → timestamp of last accepted event
 _last_accepted: dict[str, float] = {}
 _THROTTLE_INTERVAL = 1.0  # 每个 source 最多 1 条/秒
+_last_trigger_ts: float = 0.0  # 上次 next_trigger 触发时间（用于最小间隔防抖）
+_data_event: asyncio.Event = asyncio.Event()  # buffer 有数据时置位，唤醒等待的 next_trigger
 
 
 def _get_interval_ms() -> int:
@@ -70,40 +72,48 @@ async def _drain_loop():
         while len(_buffer) > max_window:
             _buffer.popleft()
 
-
-async def _trigger_loop():
-    """后台任务：每隔 trigger_interval 检查 buffer，有内容则格式化并放入 output。"""
-    while True:
-        interval = _get_interval_ms() / 1000.0
-        await asyncio.sleep(interval)
-
-        if not _buffer:
-            continue
-
-        # 取出当前所有积累的事件
-        batch = list(_buffer)
-        _buffer.clear()
-
-        formatted = _format_batch(batch)
-        # 构造一个合成的 trigger 对象供 agent loop 使用
-        trigger = {
-            'source': 'collector',
-            'text': formatted,
-            'payload': {'event_count': len(batch), 'sources': [e['source'] for e in batch]},
-            'ts': batch[-1]['ts'],  # 使用最后一个事件的时间戳
-        }
-        await _output.put(trigger)
+        # 通知等待中的 next_trigger：buffer 有数据可消费
+        if _buffer:
+            _data_event.set()
 
 
 def start():
     """启动 collector 后台任务（在 lifespan 中调用）。"""
-    global _task
-    loop = asyncio.get_event_loop()
     asyncio.ensure_future(_drain_loop())
-    asyncio.ensure_future(_trigger_loop())
     print(f'[collector] started: interval={_get_interval_ms()}ms, max_window={_get_max_window()}')
 
 
 async def next_trigger() -> dict:
-    """阻塞等待下一批格式化事件。返回合成的 trigger event dict。"""
-    return await _output.get()
+    """阻塞等待并按需快照。
+
+    当 buffer 有内容、且距上次触发已达最小间隔时，取出此刻累积的
+    全部事件、清空 buffer，格式化为合成 trigger event 返回。
+
+    与旧的固定频率定时生产不同：这里在 agent 空闲时才快照，因此
+    大模型每次看到的都是最新状态，不会积压、回放陈旧批次。
+    """
+    global _last_trigger_ts
+    while True:
+        if not _buffer:
+            _data_event.clear()
+            await _data_event.wait()
+            continue
+
+        # 防抖：保证两次触发的最小间隔；agent 推理慢于 interval 时此值为负，立即触发
+        interval = _get_interval_ms() / 1000.0
+        wait = _last_trigger_ts + interval - time.time()
+        if wait > 0:
+            await asyncio.sleep(wait)
+            continue  # 醒来后重新读取最新 buffer
+
+        # 快照 + 清空（中间无 await，单线程 asyncio 下天然原子，无需加锁）
+        batch = list(_buffer)
+        _buffer.clear()
+        _last_trigger_ts = time.time()
+
+        return {
+            'source': 'collector',
+            'text': _format_batch(batch),
+            'payload': {'event_count': len(batch), 'sources': [e['source'] for e in batch]},
+            'ts': max(e['ts'] for e in batch),  # 取最新事件时间，反映「当下」
+        }


### PR DESCRIPTION
## Problem

`collector` feeds the agent loop via a two-stage timed pipeline:

- `_trigger_loop` formats the current buffer into a batch and `put`s it onto a FIFO `asyncio.Queue` (`_output`, `maxsize=64`) at a **fixed cadence** (`trigger_interval_ms`, default 1s), independent of whether the agent loop is ready.
- `next_trigger()` returns the **oldest** queued batch (`_output.get()`).

When LLM inference is slower than the trigger interval (the normal case once several sensors are streaming), batches accumulate in `_output` faster than they are consumed. The agent always pulls an old batch, so **the model reasons over a sensor snapshot from the past**. Under sustained overload the lag can reach ~64s (the queue depth) before backpressure kicks in.

The existing per-source throttle and `collector_max_window` only bound the size of a *single* batch — they do nothing about the FIFO backlog between the producer and the consumer, which is where the staleness actually builds up.

## Fix

Collapse the timed producer + FIFO queue into an **on-demand snapshot**:

- Remove `_trigger_loop` and the `_output` queue.
- `next_trigger()` now blocks until the buffer has data, then snapshots and clears the **current** buffer in place — so the model always sees the latest accumulated state. Snapshot+clear has no `await` in between, so it stays atomic on the single asyncio event loop.
- `trigger_interval_ms` becomes a **minimum-gap debounce** instead of a hard producer cadence: it still caps trigger frequency when idle, but fires immediately when inference already took longer than the interval (so the agent never falls behind real time).
- Use `max(ts)` for the synthetic trigger timestamp instead of the last deque element's `ts`: the per-source throttle replaces events in place, so the last element isn't necessarily the freshest.

Discrete events (user commands, scheduler ticks) accumulated during an inference are now merged into the **next** turn rather than replayed from a backlog — they are delivered fresh and are not dropped.

Net change is a single file and removes more code than it adds; the public `next_trigger()` contract (signature + returned dict shape) is unchanged, so the agent loop (`event/llm.py`) needs no changes.

## Verification

Verified locally without ROS (collector only depends on stdlib + `config` + `event_bus`). Driving a slow consumer:

- the snapshot `ts` always tracks the **newest** enqueued event, not a backlog value;
- the buffer is cleared after each trigger;
- `next_trigger()` correctly **blocks** when there is no data (proving no pre-baked stale backlog exists);
- an early discrete event (e.g. a user command) arriving before a long inference is still present in the next snapshot (not dropped).

## Out of scope

Under extreme overload, `collector_max_window`'s FIFO drop can still discard the oldest *discrete* events. That behavior is pre-existing and unchanged here; protecting discrete events from window eviction would be a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
