### PR TITLE
fix(perception): resolve BrokenPipeError spam and config save hang

### DIFF
--- a/agent-core/src/api/canvas.py
+++ b/agent-core/src/api/canvas.py
@@ -5,6 +5,7 @@ Stores the orchestration canvas layout (card positions) and per-tool
 configuration in the SQLite config table.
 """
 
+import asyncio
 import json
 import fastapi
 from pydantic import BaseModel
@@ -70,13 +71,15 @@ async def save_tool_config(mcp_id: str, tool_name: str, body: Any = fastapi.Body
     """Save config for a tool and apply it to the MCP plugin."""
     config.main[f'{_TOOL_CONFIG_PREFIX}{mcp_id}:{tool_name}'] = body
 
-    # Apply config to the MCP plugin
+    # Apply config to the MCP plugin (fire-and-forget, don't block response)
     from api.mcp_manage import mcp_call_tool, MCPCallRequest
-    try:
-        req = MCPCallRequest(tool=tool_name, arguments={'action': 'config', **body})
-        await mcp_call_tool(mcp_id, req)
-    except Exception:
-        pass  # Config saved even if apply fails (MCP may be offline)
+    async def _apply():
+        try:
+            req = MCPCallRequest(tool=tool_name, arguments={'action': 'config', **body})
+            await mcp_call_tool(mcp_id, req)
+        except Exception:
+            pass
+    asyncio.create_task(_apply())
 
     return {'code': 200}
 
@@ -108,13 +111,15 @@ async def save_instance_config(mcp_id: str, tool_name: str, instance_id: str, bo
     """Save config for a specific tool instance and apply it."""
     config.main[f'{_TOOL_CONFIG_PREFIX}{mcp_id}:{tool_name}:{instance_id}'] = body
 
-    # Apply instance config to the MCP plugin
+    # Apply instance config to the MCP plugin (fire-and-forget)
     from api.mcp_manage import mcp_call_tool, MCPCallRequest
-    try:
-        req = MCPCallRequest(tool=tool_name, arguments={'action': 'config', 'instance_id': instance_id, **body})
-        await mcp_call_tool(mcp_id, req)
-    except Exception:
-        pass
+    async def _apply():
+        try:
+            req = MCPCallRequest(tool=tool_name, arguments={'action': 'config', 'instance_id': instance_id, **body})
+            await mcp_call_tool(mcp_id, req)
+        except Exception:
+            pass
+    asyncio.create_task(_apply())
     return {'code': 200}
 
 

--- a/perception/main.py
+++ b/perception/main.py
@@ -21,6 +21,11 @@ import os
 import signal
 import threading
 from http.server import BaseHTTPRequestHandler, HTTPServer
+from socketserver import ThreadingMixIn
+
+
+class ThreadingHTTPServer(ThreadingMixIn, HTTPServer):
+    daemon_threads = True
 from pathlib import Path
 
 import yaml
@@ -253,9 +258,14 @@ def make_handler():
                         ok({"content": [{"type": "text", "text": json.dumps(result)}]})
                 else:
                     err(-32601, f"Method not found: {method}")
+            except BrokenPipeError:
+                log.debug(f"Client disconnected before response")
             except Exception as e:
                 log.error(f"RPC error: {e}", exc_info=True)
-                err(-32603, str(e))
+                try:
+                    err(-32603, str(e))
+                except BrokenPipeError:
+                    pass
 
     return Handler
 
@@ -411,7 +421,7 @@ def main():
 
     _start_registration(mcp_port, "Perception Stack", "perception")
 
-    server = HTTPServer(("", mcp_port), make_handler())
+    server = ThreadingHTTPServer(("", mcp_port), make_handler())
     log.info(f"MCP server → http://0.0.0.0:{mcp_port}")
 
     def _shutdown(signum, frame):


### PR DESCRIPTION
## Summary
- Switch perception HTTP server to `ThreadingHTTPServer` for concurrent request handling
- Catch `BrokenPipeError` gracefully instead of cascading error logs
- Make tool config save non-blocking (fire-and-forget MCP apply) so the modal closes immediately

## Root Cause
The config save modal was hanging because the backend `await`-ed `mcp_call_tool()` (10s timeout) which blocked when perception's single-threaded server was busy. Now config is saved to DB immediately and MCP apply happens in the background.

## Test plan
- [ ] Restart perception container, verify no more BrokenPipeError spam in logs
- [ ] Open TTS config modal, click save — modal should close instantly
- [ ] Verify config is applied (TTS works after save)

🤖 Generated with [Claude Code](https://claude.com/claude-code)