### PR TITLE
fix(core): retry on LLM 400 bad tool call generation

### DIFF
--- a/agent-core/src/client/llm.py
+++ b/agent-core/src/client/llm.py
@@ -63,6 +63,12 @@ def _classify_error(e: Exception) -> tuple[str, float | None]:
     if status in (500, 502, 503, 529):
         return LLMErrorKind.SERVER_ERROR, 3.0
 
+    # 模型生成了非法 tool call（arguments 非 JSON）：可重试，下次可能正确
+    if status == 400 and any(kw in body_msg for kw in (
+        'json format', 'invalid_parameter', 'must be in json',
+    )):
+        return LLMErrorKind.SERVER_ERROR, 1.0
+
     # 上下文溢出：从错误消息推断
     if any(kw in body_msg for kw in (
         'context length', 'context_length', 'too many tokens',

--- a/agent-core/src/event/llm.py
+++ b/agent-core/src/event/llm.py
@@ -412,7 +412,7 @@ class Event:
             msg_count = len(messages)
             tool_count = len(all_tool_list)
             # Estimate prompt size (rough: 1 token ≈ 3 chars for CJK)
-            prompt_chars = sum(len(m.get('content', '')) for m in messages)
+            prompt_chars = sum(len(m.get('content') or '') for m in messages)
             last_user = next((m.get('content', '')[:80] for m in reversed(messages) if m.get('role') == 'user'), '')
             print(f'[decision] llm request: round={round_idx} messages={msg_count} tools={tool_count} ~chars={prompt_chars} last_user={last_user}')
 


### PR DESCRIPTION
## Summary
- Classify 400 errors with "json format" / "invalid_parameter" keywords as retryable
- These occur when LLM generates malformed tool call arguments (not valid JSON)
- Retry after 1s — model typically produces valid output on next attempt

## Test plan
- [x] Verified error message pattern matches Qwen's 400 response
- [ ] Confirm retry happens on next occurrence

🤖 Generated with [Claude Code](https://claude.com/claude-code)