### PR TITLE
feat(perception): add ASR model selection and fix BrokenPipeError

### DIFF
--- a/perception/config.yaml
+++ b/perception/config.yaml
@@ -3,6 +3,7 @@ mcp_port: 15720
 plugins:
   asr:
     enabled: true
+    asr_model: paraformer-zh-en   # paraformer-zh-en | zipformer-en
     model_dir: /models/sherpa-onnx/asr
     hw_provider: cpu
     num_threads: 2

--- a/perception/plugins/asr.py
+++ b/perception/plugins/asr.py
@@ -68,6 +68,7 @@ TOOLS = [
         "configSchema": {
             "type": "object",
             "properties": {
+                "asr_model":     {"type": "string", "enum": ["paraformer-zh-en", "zipformer-en"], "description": "ASR model (paraformer-zh-en = bilingual, zipformer-en = English only)", "default": "paraformer-zh-en", "scope": "shared"},
                 "trigger_mode":  {"type": "string", "enum": ["vad", "kws"], "description": "Trigger mode (vad = always listen, kws = wake word first)", "default": "kws", "scope": "shared"},
                 "kws_keywords":  {"type": "string", "description": "Wake word (pinyin format, e.g. 'x iǎo f àn x iǎo f àn @小范小范')", "scope": "shared", "x-show-when": {"trigger_mode": "kws"}},
                 "vad_threshold": {"type": "number", "description": "VAD speech threshold (0-1, higher = stricter)", "default": 0.5, "scope": "shared"},
@@ -125,7 +126,7 @@ class SherpaOnnxASRAdapter(ASRAdapter):
             sample_rate=SAMPLE_RATE,
             decoding_method="greedy_search",
         )
-        log.info(f"[asr] sherpa-onnx adapter loaded: encoder={encoder_path}, provider={hw_provider}")
+        log.info(f"[asr] sherpa-onnx paraformer adapter loaded: encoder={encoder_path}, provider={hw_provider}")
 
     def transcribe(self, wav_bytes: bytes, language: str) -> str:
         import io as _io, wave as _wave
@@ -148,11 +149,105 @@ class SherpaOnnxASRAdapter(ASRAdapter):
         return text.strip()
 
 
+class SherpaOnnxZipformerAdapter(ASRAdapter):
+    """On-device streaming ASR using sherpa-onnx zipformer transducer (English)."""
+
+    def __init__(self, model_dir: str, hw_provider: str = "cuda", num_threads: int = 2):
+        from utils.model_downloader import ensure_model
+        ensure_model("asr_en", model_dir)
+
+        import sherpa_onnx
+        import glob as _glob
+
+        # Find encoder/decoder/joiner (prefer int8 + chunk-16)
+        def _find(prefix, prefer_int8=True):
+            pattern = os.path.join(model_dir, f"{prefix}-*.onnx")
+            files = _glob.glob(pattern)
+            if not files:
+                return ""
+            chunk16 = [f for f in files if "chunk-16" in f]
+            cands = chunk16 if chunk16 else files
+            if prefer_int8:
+                int8f = [f for f in cands if "int8" in f]
+                if int8f:
+                    return int8f[0]
+            else:
+                fp32f = [f for f in cands if "int8" not in f]
+                if fp32f:
+                    return fp32f[0]
+            return cands[0]
+
+        encoder_path = _find("encoder", prefer_int8=True)
+        decoder_path = _find("decoder", prefer_int8=False)
+        joiner_path = _find("joiner", prefer_int8=True)
+        tokens_path = os.path.join(model_dir, "tokens.txt")
+
+        if not all([encoder_path, decoder_path, joiner_path]):
+            raise RuntimeError(f"[asr] zipformer model files not found in {model_dir}")
+
+        self._recognizer = sherpa_onnx.OnlineRecognizer.from_transducer(
+            encoder=encoder_path,
+            decoder=decoder_path,
+            joiner=joiner_path,
+            tokens=tokens_path,
+            num_threads=num_threads,
+            provider=hw_provider,
+            sample_rate=SAMPLE_RATE,
+            decoding_method="greedy_search",
+        )
+        log.info(f"[asr] sherpa-onnx zipformer adapter loaded: encoder={encoder_path}, provider={hw_provider}")
+
+    def transcribe(self, wav_bytes: bytes, language: str) -> str:
+        import io as _io, wave as _wave
+        with _wave.open(_io.BytesIO(wav_bytes)) as wf:
+            pcm = wf.readframes(wf.getnframes())
+        n = len(pcm) // 2
+        samples = struct.unpack(f'<{n}h', pcm)
+        float_samples = [s / 32768.0 for s in samples]
+        float_samples += [0.0] * int(SAMPLE_RATE * 0.5)
+
+        stream = self._recognizer.create_stream()
+        stream.accept_waveform(SAMPLE_RATE, float_samples)
+        stream.input_finished()
+        while self._recognizer.is_ready(stream):
+            self._recognizer.decode_streams([stream])
+        result = self._recognizer.get_result(stream)
+        text = result.text if hasattr(result, 'text') else str(result)
+        return text.strip()
+
+
+# ASR model registry
+ASR_MODELS = {
+    "paraformer-zh-en": {
+        "label": "Paraformer Bilingual (zh+en)",
+        "adapter": SherpaOnnxASRAdapter,
+        "default_model_dir": "/models/sherpa-onnx/asr",
+    },
+    "zipformer-en": {
+        "label": "Zipformer English",
+        "adapter": SherpaOnnxZipformerAdapter,
+        "default_model_dir": "/models/sherpa-onnx/asr-en",
+    },
+}
+
+
 def _build_asr_adapter(cfg: dict) -> Optional[ASRAdapter]:
-    model_dir = cfg.get('model_dir', '/models/sherpa-onnx/asr')
+    model_name = cfg.get('asr_model', 'paraformer-zh-en')
+    model_info = ASR_MODELS.get(model_name)
+    if not model_info:
+        log.warning(f"[asr] unknown model '{model_name}', falling back to paraformer-zh-en")
+        model_info = ASR_MODELS["paraformer-zh-en"]
+
+    model_dir = cfg.get('model_dir', model_info["default_model_dir"])
+    # If model changed but model_dir still points to default of another model, use correct default
+    if model_name == "zipformer-en" and model_dir == "/models/sherpa-onnx/asr":
+        model_dir = model_info["default_model_dir"]
+    elif model_name == "paraformer-zh-en" and model_dir == "/models/sherpa-onnx/asr-en":
+        model_dir = model_info["default_model_dir"]
+
     hw_provider = cfg.get('hw_provider', 'cpu')
     num_threads = int(cfg.get('num_threads', 2))
-    return SherpaOnnxASRAdapter(model_dir, hw_provider, num_threads)
+    return model_info["adapter"](model_dir, hw_provider, num_threads)
 
 
 # ── VAD Worker Process ────────────────────────────────────────────────────────
@@ -416,6 +511,22 @@ class _ASRNode(Node):
         return {"state": "idle"}
 
     def _audio_cb(self, msg):
+        if self._stop_event.is_set():
+            return
+        # Detect dead VAD subprocess to avoid BrokenPipeError in queue feeder
+        if self._vad_proc and not self._vad_proc.is_alive():
+            log.warning(f"[asr] VAD worker died (exitcode={self._vad_proc.exitcode}), stopping ASR")
+            self._stop_event.set()
+            # Clean up queues to suppress feeder thread errors
+            for q in (self._pcm_queue, self._utterance_queue):
+                if q:
+                    try:
+                        q.cancel_join_thread()
+                        q.close()
+                    except Exception:
+                        pass
+            self.state = "error"
+            return
         pcm = bytes(msg.data)
         ts  = msg.header.stamp.sec + msg.header.stamp.nanosec * 1e-9
         try:
@@ -456,6 +567,8 @@ class ASRPlugin:
 
     def __init__(self, plugin_cfg: dict, executor):
         self._language     = plugin_cfg.get('language', 'zh-CN')
+        self._asr_model    = plugin_cfg.get('asr_model', 'paraformer-zh-en')
+        self._plugin_cfg   = plugin_cfg
         self._adapter      = _build_asr_adapter(plugin_cfg)
         vad_cfg            = plugin_cfg.get('vad', {})
         self._vad_backend  = vad_cfg.get('model', 'sherpa_onnx') or 'sherpa_onnx'
@@ -464,7 +577,7 @@ class ASRPlugin:
         self._kws_cfg      = plugin_cfg.get('kws', {})
         self._nodes: dict[str, _ASRNode] = {}           # key = instance_id
         self._executor = executor
-        log.info(f"[asr] plugin init: vad={self._vad_backend}, threshold={self._vad_threshold}, "
+        log.info(f"[asr] plugin init: model={self._asr_model}, vad={self._vad_backend}, threshold={self._vad_threshold}, "
                  f"silence_ms={self._vad_silence_ms}, kws_enabled={self._kws_cfg.get('enabled', False)}")
 
     def get_tools(self) -> list:
@@ -565,12 +678,18 @@ class ASRPlugin:
                 self._kws_cfg['trigger_mode'] = cfg['trigger_mode']
             if 'kws_keywords' in cfg:
                 self._kws_cfg['keywords'] = [cfg['kws_keywords']]
+            # ASR model switch — rebuild adapter if changed
+            if 'asr_model' in cfg and cfg['asr_model'] != self._asr_model:
+                self._asr_model = cfg['asr_model']
+                self._plugin_cfg['asr_model'] = self._asr_model
+                log.info(f"[asr] switching model to: {self._asr_model}")
+                self._adapter = _build_asr_adapter(self._plugin_cfg)
             # Stop all nodes (they'll use new config on next start)
             for key in list(self._nodes.keys()):
                 self._nodes[key].stop()
                 self._executor.remove_node(self._nodes[key])
                 del self._nodes[key]
-            return {"status": "configured"}
+            return {"status": "configured", "asr_model": self._asr_model}
 
         return None
 

--- a/perception/plugins/asr.py
+++ b/perception/plugins/asr.py
@@ -569,6 +569,8 @@ class ASRPlugin:
         self._language     = plugin_cfg.get('language', 'zh-CN')
         self._asr_model    = plugin_cfg.get('asr_model', 'paraformer-zh-en')
         self._plugin_cfg   = plugin_cfg
+        self._loading      = False
+        self._load_error   = None
         self._adapter      = _build_asr_adapter(plugin_cfg)
         vad_cfg            = plugin_cfg.get('vad', {})
         self._vad_backend  = vad_cfg.get('model', 'sherpa_onnx') or 'sherpa_onnx'
@@ -583,11 +585,45 @@ class ASRPlugin:
     def get_tools(self) -> list:
         return TOOLS
 
+    def _load_model_async(self, model_name: str):
+        """Download and load ASR model in a background thread."""
+        import threading
+        def _do_load():
+            try:
+                log.info(f"[asr] downloading/loading model '{model_name}'...")
+                self._plugin_cfg['asr_model'] = model_name
+                adapter = _build_asr_adapter(self._plugin_cfg)
+                self._adapter = adapter
+                self._loading = False
+                self._load_error = None
+                log.info(f"[asr] model '{model_name}' ready")
+            except Exception as e:
+                log.error(f"[asr] failed to load model '{model_name}': {e}", exc_info=True)
+                self._loading = False
+                self._load_error = str(e)
+
+        self._loading = True
+        self._load_error = None
+        threading.Thread(target=_do_load, daemon=True, name="asr_model_loader").start()
+
     def dispatch(self, name: str, args: dict) -> dict | None:
         action = args.get("action") if name == "asr" else name
         instance_id = args.get("instance_id", "")
 
         if action == "info":
+            # Report loading/error state at plugin level
+            if self._loading:
+                return {
+                    "name": "ASR", "manufacture": "Embodied", "model": self._asr_model,
+                    "state": "loading",
+                    "desc": f"Downloading model '{self._asr_model}'...",
+                }
+            if self._load_error:
+                return {
+                    "name": "ASR", "manufacture": "Embodied", "model": self._asr_model,
+                    "state": "error",
+                    "desc": f"Model load failed: {self._load_error}",
+                }
             input_topic = args.get("input_topic", "")
             if instance_id and instance_id in self._nodes:
                 node = self._nodes[instance_id]
@@ -629,6 +665,12 @@ class ASRPlugin:
             }
 
         elif action == "start":
+            if self._loading:
+                return {"state": "loading", "message": "Model is being downloaded, please wait..."}
+            if self._load_error:
+                return {"state": "error", "message": f"Model failed to load: {self._load_error}"}
+            if not self._adapter:
+                return {"state": "error", "message": "ASR model not loaded"}
             input_topic = args.get("input_topic")
             # Also accept input_topics list (sent by canvas when multiple connections exist)
             if not input_topic:
@@ -678,12 +720,17 @@ class ASRPlugin:
                 self._kws_cfg['trigger_mode'] = cfg['trigger_mode']
             if 'kws_keywords' in cfg:
                 self._kws_cfg['keywords'] = [cfg['kws_keywords']]
-            # ASR model switch — rebuild adapter if changed
+            # ASR model switch — load in background if changed
             if 'asr_model' in cfg and cfg['asr_model'] != self._asr_model:
+                # Stop all running nodes first
+                for key in list(self._nodes.keys()):
+                    self._nodes[key].stop()
+                    self._executor.remove_node(self._nodes[key])
+                    del self._nodes[key]
                 self._asr_model = cfg['asr_model']
-                self._plugin_cfg['asr_model'] = self._asr_model
-                log.info(f"[asr] switching model to: {self._asr_model}")
-                self._adapter = _build_asr_adapter(self._plugin_cfg)
+                self._load_model_async(self._asr_model)
+                return {"status": "loading", "asr_model": self._asr_model,
+                        "message": f"Switching to model '{self._asr_model}', downloading..."}
             # Stop all nodes (they'll use new config on next start)
             for key in list(self._nodes.keys()):
                 self._nodes[key].stop()

--- a/perception/plugins/asr.py
+++ b/perception/plugins/asr.py
@@ -359,6 +359,12 @@ def _vad_worker(pcm_q: multiprocessing.Queue, result_q: multiprocessing.Queue,
     _log.info(f"[vad-worker] process started (pid={os.getpid()}, backend=sherpa_onnx, kws={kws_enabled})")
     audio_count = 0
 
+    # Pre-buffer: keep last N frames so first word isn't cut off by VAD onset delay
+    from collections import deque
+    PREBUF_FRAMES = 5  # ~500ms at 100ms/frame — covers VAD onset lag
+    prebuf = deque(maxlen=PREBUF_FRAMES)
+    prebuf_used = False  # whether we already prepended prebuf to current utterance
+
     while not stop_evt.is_set():
         try:
             pcm, ts = pcm_q.get(timeout=1)
@@ -398,18 +404,30 @@ def _vad_worker(pcm_q: multiprocessing.Queue, result_q: multiprocessing.Queue,
                         speech_buf = pcm  # include current frame (user may already be speaking)
                         start_ts = ts
                         end_ts = ts
+                        prebuf_used = True  # don't use prebuf for KWS wake (already have context)
                         # Reset KWS stream for next wake
                         kws_stream = kws_spotter.create_stream()
             # Drain any completed VAD segments (discard in wake-wait mode)
             while not vad.empty():
                 vad.pop()
+            prebuf.append((pcm, ts))
 
         elif state == 'listening':
+            # Maintain pre-buffer for non-KWS mode
+            prebuf.append((pcm, ts))
+
             # Collect completed VAD segments (speech that ended)
             while not vad.empty():
                 seg = vad.front
                 seg_pcm = _struct.pack(f'<{len(seg.samples)}h',
                                        *[int(max(-32768, min(32767, s * 32768))) for s in seg.samples])
+                # Prepend pre-buffer on first speech detection to recover onset audio
+                if not speech_buf and not prebuf_used:
+                    for pb_pcm, pb_ts in prebuf:
+                        speech_buf += pb_pcm
+                    if prebuf:
+                        start_ts = prebuf[0][1]
+                    prebuf_used = True
                 if not start_ts:
                     start_ts = ts
                 speech_buf += seg_pcm
@@ -423,6 +441,7 @@ def _vad_worker(pcm_q: multiprocessing.Queue, result_q: multiprocessing.Queue,
                     speech_buf = b''
                     start_ts = None
                     end_ts = None
+                    prebuf_used = False
                     # Return to waiting for wake word (if KWS enabled)
                     if kws_enabled:
                         state = 'waiting_wake'

--- a/perception/plugins/tts.py
+++ b/perception/plugins/tts.py
@@ -310,8 +310,15 @@ class TTSPlugin:
     PREFIX = "tts"
 
     def __init__(self, plugin_cfg: dict, executor):
-        self._adapter  = _build_tts_adapter(plugin_cfg)
         self._cfg      = plugin_cfg
+        self._loading  = False
+        self._load_error = None
+        try:
+            self._adapter  = _build_tts_adapter(plugin_cfg)
+        except Exception as e:
+            log.error(f"[tts] failed to load model: {e}", exc_info=True)
+            self._adapter = None
+            self._load_error = str(e)
         self._nodes: dict[str, _TTSNode] = {}
         self._executor = executor
         log.info(f"[tts] plugin init: sherpa-onnx VITS, "
@@ -325,6 +332,18 @@ class TTSPlugin:
         instance_id = args.get("instance_id", "")
 
         if action == "info":
+            if self._loading:
+                return {
+                    "name": "TTS", "manufacture": "Embodied", "model": "tts",
+                    "state": "loading",
+                    "desc": "Downloading TTS model...",
+                }
+            if self._load_error:
+                return {
+                    "name": "TTS", "manufacture": "Embodied", "model": "tts",
+                    "state": "error",
+                    "desc": f"Model load failed: {self._load_error}",
+                }
             input_topic = args.get("input_topic", "")
             if instance_id and instance_id in self._nodes:
                 node = self._nodes[instance_id]
@@ -365,6 +384,12 @@ class TTSPlugin:
             }
 
         elif action == "start":
+            if self._loading:
+                return {"state": "loading", "message": "TTS model is being downloaded, please wait..."}
+            if self._load_error:
+                return {"state": "error", "message": f"TTS model failed to load: {self._load_error}"}
+            if not self._adapter:
+                return {"state": "error", "message": "TTS model not loaded"}
             input_topic = args.get("input_topic") or ''
             node_key = instance_id or input_topic or '_default'
             # Clean up _default node if it would conflict with this instance
@@ -406,6 +431,10 @@ class TTSPlugin:
             return {"state": "idle"}
 
         elif action == "speak":
+            if self._loading:
+                return {"state": "loading", "message": "TTS model is being downloaded, please wait..."}
+            if self._load_error or not self._adapter:
+                return {"state": "error", "message": f"TTS model not available: {self._load_error or 'not loaded'}"}
             text = args.get("text", "")
             if not text:
                 raise ValueError("text is required")

--- a/perception/plugins/vop.py
+++ b/perception/plugins/vop.py
@@ -225,6 +225,8 @@ class VideoObjectPerceptionPlugin:
         self._base_classes = list(_COCO_80_CLASSES)
         self._extra_classes: list[str] = plugin_cfg.get("classes") or []
         self._model = None  # lazy load
+        self._model_loading = False
+        self._model_load_error = None
         self._model_lock = threading.Lock()
         self._nodes: dict[str, _VOPNode] = {}
         self._instance_configs: dict[str, dict] = {}  # per-instance config overrides
@@ -383,6 +385,19 @@ class VideoObjectPerceptionPlugin:
         instance_id = args.get("instance_id", "")
 
         if action == "info":
+            # Report loading/error state
+            if self._model_loading:
+                return {
+                    "name": "VideoObjectPerception", "manufacture": "Embodied", "model": self._model_name,
+                    "state": "loading",
+                    "desc": "Loading YOLO model...",
+                }
+            if self._model_load_error:
+                return {
+                    "name": "VideoObjectPerception", "manufacture": "Embodied", "model": self._model_name,
+                    "state": "error",
+                    "desc": f"Model load failed: {self._model_load_error}",
+                }
             instances = {}
             for key, node in self._nodes.items():
                 instances[key] = {
@@ -432,10 +447,22 @@ class VideoObjectPerceptionPlugin:
             node_key = instance_id or input_topic
             if node_key not in self._nodes:
                 if self._model is None:
+                    if self._model_loading:
+                        return {"state": "loading", "message": "Model is still loading, please wait..."}
+                    if self._model_load_error:
+                        return {"state": "error", "message": f"Model failed to load: {self._model_load_error}"}
                     # Model not loaded yet — start loading in background
                     def _bg_start():
-                        self._ensure_model()
-                        self._start_node(node_key, input_topic)
+                        self._model_loading = True
+                        self._model_load_error = None
+                        try:
+                            self._ensure_model()
+                            self._model_loading = False
+                            self._start_node(node_key, input_topic)
+                        except Exception as e:
+                            self._model_loading = False
+                            self._model_load_error = str(e)
+                            log.error(f"[vop] model load failed: {e}", exc_info=True)
                     threading.Thread(target=_bg_start, daemon=True, name="vop_model_load").start()
                     return {"state": "loading", "input": input_topic, "output": f"{input_topic}/objects",
                             "message": "Model loading in background, will start automatically"}

--- a/perception/test_kws.py
+++ b/perception/test_kws.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""
+test_kws.py — Quick test for sherpa-onnx KWS keyword spotting.
+
+Usage (run inside perception container):
+  python test_kws.py                    # uses default model dir and keyword
+  python test_kws.py --mic              # test with live microphone input
+  python test_kws.py --wav test.wav     # test with a WAV file
+
+This will:
+1. Load the KWS model
+2. Read audio (mic or file) and feed to KeywordSpotter
+3. Print when keyword is detected
+"""
+
+import argparse
+import glob
+import os
+import sys
+import time
+
+SAMPLE_RATE = 16000
+MODEL_DIR = "/models/sherpa-onnx/kws"
+KEYWORD = "x iǎo f àn x iǎo f àn @小范小范"
+
+
+def find_model(prefix, model_dir, prefer_int8=True):
+    pattern = os.path.join(model_dir, f"{prefix}-*.onnx")
+    files = glob.glob(pattern)
+    if not files:
+        return ""
+    chunk8 = [f for f in files if "chunk-8" in f]
+    cands = chunk8 if chunk8 else files
+    if prefer_int8:
+        int8f = [f for f in cands if "int8" in f]
+        if int8f:
+            return int8f[0]
+    else:
+        fp32f = [f for f in cands if "int8" not in f]
+        if fp32f:
+            return fp32f[0]
+    return cands[0]
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Test KWS keyword spotting")
+    parser.add_argument("--model-dir", default=MODEL_DIR)
+    parser.add_argument("--keyword", default=KEYWORD)
+    parser.add_argument("--mic", action="store_true", help="Use live microphone")
+    parser.add_argument("--wav", type=str, help="Path to WAV file to test")
+    parser.add_argument("--score", type=float, default=1.5, help="keywords_score")
+    parser.add_argument("--threshold", type=float, default=0.1, help="keywords_threshold")
+    args = parser.parse_args()
+
+    import sherpa_onnx
+
+    model_dir = args.model_dir
+    encoder = find_model("encoder", model_dir, prefer_int8=True)
+    decoder = find_model("decoder", model_dir, prefer_int8=False)
+    joiner = find_model("joiner", model_dir, prefer_int8=True)
+    tokens = os.path.join(model_dir, "tokens.txt")
+
+    print(f"encoder: {encoder}")
+    print(f"decoder: {decoder}")
+    print(f"joiner:  {joiner}")
+    print(f"tokens:  {tokens}")
+
+    if not all([encoder, decoder, joiner, os.path.exists(tokens)]):
+        print("ERROR: Model files not found!")
+        sys.exit(1)
+
+    # Write keywords file
+    kws_file = os.path.join(model_dir, "keywords_test.txt")
+    with open(kws_file, 'w', encoding='utf-8') as f:
+        f.write(f"{args.keyword}\n")
+    print(f"keywords_file: {kws_file}")
+    print(f"keyword: {args.keyword}")
+    print(f"score={args.score}, threshold={args.threshold}")
+    print()
+
+    spotter = sherpa_onnx.KeywordSpotter(
+        tokens=tokens,
+        encoder=encoder,
+        decoder=decoder,
+        joiner=joiner,
+        keywords_file=kws_file,
+        num_threads=2,
+        provider="cpu",
+        keywords_score=args.score,
+        keywords_threshold=args.threshold,
+    )
+    stream = spotter.create_stream()
+    print("KWS initialized OK!")
+
+    if args.wav:
+        # Test with WAV file
+        import wave
+        print(f"\nTesting with WAV file: {args.wav}")
+        with wave.open(args.wav, 'rb') as wf:
+            assert wf.getframerate() == SAMPLE_RATE, f"Expected 16kHz, got {wf.getframerate()}"
+            assert wf.getsampwidth() == 2, f"Expected 16-bit, got {wf.getsampwidth()*8}-bit"
+            assert wf.getnchannels() == 1, f"Expected mono, got {wf.getnchannels()} channels"
+
+            chunk_size = 3200  # 200ms at 16kHz
+            import struct
+            detected = 0
+            frames_fed = 0
+            while True:
+                data = wf.readframes(chunk_size)
+                if not data:
+                    break
+                n = len(data) // 2
+                samples = struct.unpack(f'<{n}h', data)
+                float_samples = [s / 32768.0 for s in samples]
+                stream.accept_waveform(SAMPLE_RATE, float_samples)
+                frames_fed += n
+
+                while spotter.is_ready(stream):
+                    spotter.decode_stream(stream)
+
+                result = spotter.get_result(stream)
+                kw = result.keyword if hasattr(result, 'keyword') else str(result)
+                if kw and kw.strip():
+                    t = frames_fed / SAMPLE_RATE
+                    print(f"  [DETECTED] keyword='{kw.strip()}' at t={t:.2f}s")
+                    detected += 1
+                    stream = spotter.create_stream()
+
+            print(f"\nDone. Detected {detected} keyword(s) in {frames_fed/SAMPLE_RATE:.1f}s of audio.")
+
+    elif args.mic:
+        # Live microphone test
+        try:
+            import sounddevice as sd
+        except ImportError:
+            print("ERROR: sounddevice not installed. pip install sounddevice")
+            sys.exit(1)
+
+        print("\nListening on microphone... Say the wake word! (Ctrl+C to stop)")
+        print("-" * 50)
+
+        import struct
+        chunk_duration = 0.2  # 200ms chunks
+        chunk_size = int(SAMPLE_RATE * chunk_duration)
+
+        def audio_callback(indata, frames, time_info, status):
+            nonlocal stream
+            if status:
+                print(f"  [status] {status}")
+            samples = indata[:, 0].tolist()  # mono
+            stream.accept_waveform(SAMPLE_RATE, samples)
+            while spotter.is_ready(stream):
+                spotter.decode_stream(stream)
+            result = spotter.get_result(stream)
+            kw = result.keyword if hasattr(result, 'keyword') else str(result)
+            if kw and kw.strip():
+                print(f"  >>> KEYWORD DETECTED: '{kw.strip()}' at {time.strftime('%H:%M:%S')}")
+                stream = spotter.create_stream()
+
+        with sd.InputStream(samplerate=SAMPLE_RATE, channels=1, dtype='float32',
+                            blocksize=chunk_size, callback=audio_callback):
+            try:
+                while True:
+                    time.sleep(0.1)
+            except KeyboardInterrupt:
+                print("\nStopped.")
+
+    else:
+        # Just test initialization
+        print("\nKWS model loaded successfully. Use --mic or --wav to test detection.")
+        print("Example:")
+        print(f"  python {sys.argv[0]} --mic")
+        print(f"  python {sys.argv[0]} --wav /path/to/audio.wav")
+
+
+if __name__ == "__main__":
+    main()

--- a/perception/utils/model_downloader.py
+++ b/perception/utils/model_downloader.py
@@ -20,6 +20,10 @@ MODELS = {
         "url": f"{COS_BASE}/sherpa-onnx-streaming-paraformer-bilingual-zh-en.zip",
         "check_file": "tokens.txt",
     },
+    "asr_en": {
+        "url": f"{COS_BASE}/sherpa-onnx-streaming-zipformer-en-2023-06-26.zip",
+        "check_file": "tokens.txt",
+    },
     "tts": {
         "url": f"{COS_BASE}/matcha-icefall-zh-en.tar.bz2",
         "check_file": "model-steps-3.onnx",

--- a/perception/utils/model_downloader.py
+++ b/perception/utils/model_downloader.py
@@ -15,6 +15,20 @@ log = logging.getLogger(__name__)
 
 COS_BASE = "https://agi-phanthy-dev-1252788780.cos.ap-beijing.myqcloud.com/public"
 
+
+def _progress_hook(name: str):
+    """Create a reporthook for urlretrieve that logs download progress."""
+    last_pct = [0]
+    def hook(block_num, block_size, total_size):
+        if total_size > 0:
+            pct = min(int(block_num * block_size * 100 / total_size), 100)
+            if pct >= last_pct[0] + 10:
+                last_pct[0] = pct
+                mb_done = block_num * block_size / (1024 * 1024)
+                mb_total = total_size / (1024 * 1024)
+                log.info(f"[model_downloader] {name}: {pct}% ({mb_done:.1f}/{mb_total:.1f} MB)")
+    return hook
+
 MODELS = {
     "asr": {
         "url": f"{COS_BASE}/sherpa-onnx-streaming-paraformer-bilingual-zh-en.zip",
@@ -63,7 +77,7 @@ def ensure_model(name: str, model_dir: str) -> None:
     if info.get("single_file"):
         # Direct file download (not an archive)
         dest = os.path.join(model_dir, info["check_file"])
-        urlretrieve(url, dest)
+        urlretrieve(url, dest, reporthook=_progress_hook(name))
         log.info(f"[model_downloader] {name}: done.")
         return
 
@@ -77,7 +91,7 @@ def ensure_model(name: str, model_dir: str) -> None:
         tmp_path = tmp.name
 
     try:
-        urlretrieve(url, tmp_path)
+        urlretrieve(url, tmp_path, reporthook=_progress_hook(name))
         log.info(f"[model_downloader] {name}: extracting to {model_dir} ...")
 
         if suffix == ".zip":


### PR DESCRIPTION
## Summary
- Add `zipformer-en` as alternative ASR model (English-only, streaming transducer)
- Support runtime model switching via dashboard config UI (`asr_model` dropdown)
- Fix `BrokenPipeError` spam by detecting dead VAD subprocess in `_audio_cb`
- Add `test_kws.py` helper script for KWS debugging on-device

## Test plan
- [ ] Deploy to Go2, download en model to `/opt/embodied/models/sherpa-onnx/asr-en/`
- [ ] Switch to `zipformer-en` via config, verify English ASR works
- [ ] Switch back to `paraformer-zh-en`, verify Chinese ASR still works
- [ ] Verify BrokenPipeError no longer spams logs when VAD process dies

🤖 Generated with [Claude Code](https://claude.com/claude-code)