### PR TITLE
feat(perception): ASR model selection & fix restart helper

### DIFF
--- a/deploy/restart/entrypoint.sh
+++ b/deploy/restart/entrypoint.sh
@@ -1,60 +1,90 @@
 #!/bin/sh
-# entrypoint.sh — merge service compose from new image and restart
-# Env: COMPOSE_DIR, SERVICE, NEW_IMAGE
+# entrypoint.sh — extract compose from new image, replace image ref, restart service
+# Aligned with install.sh behavior: full compose extraction + sed replacement + clean restart
+# Env: COMPOSE_DIR, SERVICE, NEW_IMAGE, CONTAINER_NAME (optional)
 set -e
 
 : "${COMPOSE_DIR:?COMPOSE_DIR required}"
 : "${SERVICE:?SERVICE required}"
 : "${NEW_IMAGE:?NEW_IMAGE required}"
 
+CONTAINER_NAME="${CONTAINER_NAME:-phanthy-motus-${SERVICE}-1}"
+
 echo "[restart] service=${SERVICE} image=${NEW_IMAGE}"
 echo "[restart] compose_dir=${COMPOSE_DIR}"
+echo "[restart] container=${CONTAINER_NAME}"
 
 COMPOSE_FILE="${COMPOSE_DIR}/docker-compose.yml"
 
-# Extract service compose from image into a temp file
-echo "[restart] extracting compose from image..."
+# ── Step 1: Extract compose from new image (single source of truth) ──────────
+echo "[restart] extracting compose from new image..."
 CID=$(docker create "${NEW_IMAGE}")
 docker cp "${CID}:/deploy/docker-compose.yml" /tmp/new-compose.yml 2>/dev/null || true
 docker rm "${CID}" >/dev/null
 
-# Merge: update the service definition in existing compose (preserving other services)
-# If compose file doesn't exist, just use the extracted one directly.
-if [ -f "${COMPOSE_FILE}" ] && [ -f /tmp/new-compose.yml ]; then
-    # Use the agent-core container (which has python3+yaml) to merge
-    # If python3 is available locally (alpine), use it; otherwise fall back to sed
-    if command -v python3 >/dev/null 2>&1; then
-        python3 - "${COMPOSE_FILE}" /tmp/new-compose.yml "${NEW_IMAGE}" "${SERVICE}" <<'PY'
-import sys, yaml, os
+if [ ! -f /tmp/new-compose.yml ]; then
+    echo "[restart] ERROR: /deploy/docker-compose.yml not found in image"
+    exit 1
+fi
+
+# ── Step 2: Update compose file ──────────────────────────────────────────────
+# Strategy: if other services exist in current compose, preserve them and only
+# replace the target service definition. Otherwise use extracted file directly.
+
+if [ -f "${COMPOSE_FILE}" ] && command -v python3 >/dev/null 2>&1; then
+    python3 - "${COMPOSE_FILE}" /tmp/new-compose.yml "${NEW_IMAGE}" "${SERVICE}" <<'PY'
+import sys, yaml
 
 compose_path, new_path, new_image, service = sys.argv[1:5]
 
 with open(compose_path) as f:
-    compose = yaml.safe_load(f) or {'services': {}}
+    existing = yaml.safe_load(f) or {}
 
 with open(new_path) as f:
     new = yaml.safe_load(f) or {}
 
+existing_services = existing.get('services', {})
 new_services = new.get('services', {})
-if service in new_services:
-    new_services[service]['image'] = new_image
-    compose.setdefault('services', {})[service] = new_services[service]
 
-with open(compose_path, 'w') as f:
-    yaml.dump(compose, f, default_flow_style=False, allow_unicode=True, sort_keys=False)
+# Check if there are other services beyond the target one
+other_services = {k: v for k, v in existing_services.items() if k != service}
+
+if other_services and service in new_services:
+    # Preserve other services, replace target service with new definition
+    new_services[service]['image'] = new_image
+    existing_services[service] = new_services[service]
+    existing['services'] = existing_services
+    with open(compose_path, 'w') as f:
+        yaml.dump(existing, f, default_flow_style=False, allow_unicode=True, sort_keys=False)
+else:
+    # No other services — use extracted compose directly (same as install.sh)
+    import shutil
+    shutil.copy2(new_path, compose_path)
+    # Replace __IMAGE__ placeholder and any existing image line for the service
+    with open(compose_path) as f:
+        content = f.read()
+    content = content.replace('__IMAGE__', new_image)
+    with open(compose_path, 'w') as f:
+        f.write(content)
 PY
-    else
-        # Fallback: no python3, just update image line via sed
-        sed -i "/^  ${SERVICE}:/,/^  [^ ]/{s|image:.*|image: ${NEW_IMAGE}|}" "${COMPOSE_FILE}"
-    fi
-elif [ -f /tmp/new-compose.yml ]; then
-    # No existing compose, use extracted one directly
+else
+    # No existing compose or no python3 — use extracted file with sed (same as install.sh)
     cp /tmp/new-compose.yml "${COMPOSE_FILE}"
-    sed -i "s|__IMAGE__|${NEW_IMAGE}|" "${COMPOSE_FILE}"
+    sed -i "s|image:.*__IMAGE__.*|image: ${NEW_IMAGE}|" "${COMPOSE_FILE}"
+    # Also replace any existing image line under the service block
+    sed -i "/^  ${SERVICE}:/,/^  [^ ]/{s|image:.*|image: ${NEW_IMAGE}|}" "${COMPOSE_FILE}"
 fi
 
-echo "[restart] starting service via docker compose..."
+echo "[restart] compose file updated"
+
+# ── Step 3: Stop and remove old container (clean slate, same as install.sh) ──
+echo "[restart] stopping old container..."
 cd "${COMPOSE_DIR}"
-docker compose up -d --no-deps --force-recreate "${SERVICE}"
+docker compose stop "${SERVICE}" 2>/dev/null || true
+docker rm -f "${CONTAINER_NAME}" 2>/dev/null || true
+
+# ── Step 4: Start service ────────────────────────────────────────────────────
+echo "[restart] starting service..."
+docker compose up -d "${SERVICE}"
 
 echo "[restart] done. ${SERVICE} is up."


### PR DESCRIPTION
## Summary
- Add ASR model selection support with async model loading and proper state feedback
- Fix BrokenPipeError in perception plugins (ASR/TTS/VOP)
- Pre-buffer audio to prevent first words being cut off by VAD
- Align restart helper `entrypoint.sh` with `install.sh` behavior to fix OTA update inconsistencies

## Changes
- **perception/plugins/asr.py**: Model selection, async loading, state feedback
- **perception/plugins/tts.py, vop.py**: Fix BrokenPipeError handling
- **deploy/restart/entrypoint.sh**: Full compose extraction + clean container removal (same as install.sh), fixing web update failures

## Test plan
- [ ] Verify ASR model switching via MCP tool call
- [ ] Confirm no audio cut-off on first utterance after VAD trigger
- [ ] Test OTA update via web dashboard — should now match install.sh behavior
- [ ] Verify restart helper properly cleans old container before starting new one

🤖 Generated with [Claude Code](https://claude.com/claude-code)