### PR TITLE
fix(web): keep Chrome connector SVG paintable

### DIFF
--- a/agent-core/web/css/style.css
+++ b/agent-core/web/css/style.css
@@ -1081,6 +1081,9 @@ html, body {
   inset: 0;
   width: 100%;
   height: 100%;
+  /* Chrome skips overflow painting when the SVG viewport collapses to 0x0. */
+  min-width: 1px;
+  min-height: 1px;
   pointer-events: none;
   overflow: visible;
   z-index: 5;


### PR DESCRIPTION
## Summary

- Give the canvas connector SVG a minimum non-zero viewport.
- Fix missing connector lines in Chrome without changing canvas coordinates or JavaScript behavior.

## Root cause

The absolutely positioned canvas viewport has no intrinsic dimensions because its children are also absolutely positioned. As a result, the connector SVG collapses to a 0×0 viewport.

Safari still paints overflowing SVG paths in this state, while Chrome skips painting them. Setting a 1px minimum width and height keeps the SVG paintable while `overflow: visible` continues to render the full connector paths.
- Built `phanthymotus/core:local-bc72b13-g1-test` locally on the Shanghai G1.
- Replaced the running Agent Core container with the test image.
- Confirmed the deployed CSS SHA matches the source commit.
- Verified through Chrome CDP that all three connector paths have visible, non-zero render boxes.
- Confirmed no temporary inline CSS injection was present.
- Perception remained running without restart.