### PR TITLE
fix(perception): ASR truncation, KWS tuning, config race fix

### DIFF
--- a/perception/config.yaml
+++ b/perception/config.yaml
@@ -3,7 +3,7 @@ mcp_port: 15720
 plugins:
   asr:
     enabled: true
-    asr_model: paraformer-zh-en   # paraformer-zh-en | zipformer-en
+    asr_model: paraformer-zh-en   # paraformer-zh-en | zipformer-en | sensevoice-small
     model_dir: /models/sherpa-onnx/asr
     hw_provider: cpu
     num_threads: 2

--- a/perception/plugins/asr.py
+++ b/perception/plugins/asr.py
@@ -385,8 +385,8 @@ def _vad_worker(pcm_q: multiprocessing.Queue, result_q: multiprocessing.Queue,
                     keywords_file=kws_keywords_file,
                     num_threads=1,
                     provider="cpu",
-                    keywords_score=1.5,
-                    keywords_threshold=0.1,
+                    keywords_score=1.0,
+                    keywords_threshold=0.25,
                 )
                 kws_stream = kws_spotter.create_stream()
                 _log.info(f"[vad-worker] KWS initialized, keywords={keywords}")

--- a/perception/plugins/asr.py
+++ b/perception/plugins/asr.py
@@ -250,6 +250,8 @@ class SherpaOnnxSenseVoiceAdapter(ASRAdapter):
         n = len(pcm) // 2
         samples = struct.unpack(f'<{n}h', pcm)
         float_samples = [s / 32768.0 for s in samples]
+        # Pad 500ms silence at the end to avoid last-token truncation
+        float_samples += [0.0] * int(SAMPLE_RATE * 0.5)
 
         stream = self._recognizer.create_stream()
         stream.accept_waveform(SAMPLE_RATE, float_samples)
@@ -460,8 +462,10 @@ def _vad_worker(pcm_q: multiprocessing.Queue, result_q: multiprocessing.Queue,
             prebuf.append((pcm, ts))
 
         elif state == 'listening':
-            # Maintain pre-buffer for non-KWS mode
-            prebuf.append((pcm, ts))
+            # Only update pre-buffer when VAD has NOT detected speech onset yet,
+            # so prebuf retains the frames *before* speech started.
+            if not vad.is_speech_detected():
+                prebuf.append((pcm, ts))
 
             # Collect completed VAD segments (speech that ended)
             while not vad.empty():

--- a/perception/plugins/asr.py
+++ b/perception/plugins/asr.py
@@ -794,18 +794,20 @@ class ASRPlugin:
             if 'asr_model' in cfg and cfg['asr_model'] != self._asr_model:
                 # Stop all running nodes first
                 for key in list(self._nodes.keys()):
-                    self._nodes[key].stop()
-                    self._executor.remove_node(self._nodes[key])
-                    del self._nodes[key]
+                    node = self._nodes.pop(key, None)
+                    if node:
+                        node.stop()
+                        self._executor.remove_node(node)
                 self._asr_model = cfg['asr_model']
                 self._load_model_async(self._asr_model)
                 return {"status": "loading", "asr_model": self._asr_model,
                         "message": f"Switching to model '{self._asr_model}', downloading..."}
             # Stop all nodes (they'll use new config on next start)
             for key in list(self._nodes.keys()):
-                self._nodes[key].stop()
-                self._executor.remove_node(self._nodes[key])
-                del self._nodes[key]
+                node = self._nodes.pop(key, None)
+                if node:
+                    node.stop()
+                    self._executor.remove_node(node)
             return {"status": "configured", "asr_model": self._asr_model}
 
         return None


### PR DESCRIPTION
## Summary

- **Fix ASR dropping first/last 1-3 characters**: prebuffer was being overwritten during speech (now freezes via `vad.is_speech_detected()`); added 500ms silence padding to SenseVoice transcribe
- **Tune KWS params to official values**: `keywords_score` 1.5→1.0, `keywords_threshold` 0.1→0.25
- **Fix KeyError on concurrent config/stop**: use `dict.pop()` in config action's node cleanup to handle race condition

## Test plan

- [ ] Deploy to Jetson, verify ASR no longer drops first/last characters
- [ ] Test KWS wake word detection (fewer false triggers)
- [ ] Rapid config/restart in dashboard — no KeyError

🤖 Generated with [Claude Code](https://claude.com/claude-code)