### PR TITLE
fix(perception): ASR/TTS fixes + startup modal + KWS models

### DIFF
--- a/agent-core/src/api/mcp_manage.py
+++ b/agent-core/src/api/mcp_manage.py
@@ -754,7 +754,7 @@ async def mcp_call_tool(mcp_id: str, req: MCPCallRequest):
         raise fastapi.HTTPException(status_code=400, detail='MCP not reachable via HTTP')
 
     headers = {'Content-Type': 'application/json'}
-    timeout = aiohttp.ClientTimeout(total=10)
+    timeout = aiohttp.ClientTimeout(total=45)
     try:
         async with aiohttp.ClientSession(timeout=timeout) as session:
             # Initialize first (required by MCP protocol)

--- a/agent-core/src/api/mcp_manage.py
+++ b/agent-core/src/api/mcp_manage.py
@@ -754,7 +754,7 @@ async def mcp_call_tool(mcp_id: str, req: MCPCallRequest):
         raise fastapi.HTTPException(status_code=400, detail='MCP not reachable via HTTP')
 
     headers = {'Content-Type': 'application/json'}
-    timeout = aiohttp.ClientTimeout(total=45)
+    timeout = aiohttp.ClientTimeout(total=None)
     try:
         async with aiohttp.ClientSession(timeout=timeout) as session:
             # Initialize first (required by MCP protocol)

--- a/agent-core/web/css/style.css
+++ b/agent-core/web/css/style.css
@@ -4381,3 +4381,66 @@ html, body {
   color: var(--text-dim);
 }
 
+/* ── Startup Modal ──────────────────────────────────────────────────────────── */
+.startup-modal-list {
+  list-style: none;
+  padding: 14px 22px;
+  margin: 0;
+}
+.startup-modal-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 9px 0;
+  font-size: 13px;
+  color: var(--text);
+  border-bottom: 1px solid var(--border);
+}
+.startup-modal-item:last-child { border-bottom: none; }
+.startup-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: var(--text-muted);
+  opacity: 0.4;
+  transition: background 0.3s, opacity 0.3s;
+  flex-shrink: 0;
+}
+.startup-dot.starting {
+  background: var(--accent);
+  opacity: 1;
+  animation: pulse-dot 1s infinite;
+}
+.startup-dot.ready { background: #22c55e; opacity: 1; }
+.startup-dot.error { background: #ef4444; opacity: 1; }
+@keyframes pulse-dot {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.35; }
+}
+.startup-name { font-weight: 600; min-width: 80px; }
+.startup-status {
+  color: var(--text-muted);
+  font-size: 12px;
+  margin-left: auto;
+}
+.startup-modal-footer {
+  display: flex;
+  justify-content: center;
+  padding: 14px 22px;
+  border-top: 1px solid var(--border);
+}
+.startup-cancel-btn {
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 7px 20px;
+  font-size: 13px;
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: border-color 0.15s, color 0.15s;
+}
+.startup-cancel-btn:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+

--- a/agent-core/web/js/canvas.js
+++ b/agent-core/web/js/canvas.js
@@ -1333,12 +1333,10 @@ async function _startProject() {
   // Enable execute buttons
   document.querySelectorAll('.canvas-exec-btn').forEach(btn => btn.classList.remove('locked'));
 
-  // Start all cards on canvas, resolving input_topic(s) from connections
-  for (const card of _cards) {
-    // Collect ALL inbound connections to support multiple input topics (deduplicate)
+  // Collect start args for all cards
+  const startItems = _cards.map(card => {
     const inConns = _connections.filter(c => c.toCardId === card.id);
     const topics = [...new Set(inConns.map(conn => conn.fromTopic || '').filter(Boolean))];
-
     let args;
     if (topics.length > 1) {
       args = { input_topics: topics };
@@ -1348,41 +1346,72 @@ async function _startProject() {
       args = {};
     }
     args.instance_id = card.id;
-    const startResult = await _triggerAction(card.mcpId, card.toolName, 'start', args);
-    if (startResult && startResult.code !== 200) {
-      const msg = `${card.toolName} 启动失败: ${startResult.message || '未知错误'}`;
-      _logActivity('error', msg);
-      _flashStartError(msg);
-    }
-    // Auto-start mic stream when remote_mic card starts
-    if (card.toolName === 'remote_mic' && !isMicActive()) {
-      const wsProto = location.protocol === 'https:' ? 'wss' : 'ws';
-      const wsUrl = `${wsProto}://${location.host}/ws/mic`;
-      try {
-        await toggleMicStream(wsUrl, (active) => {
-          const micBtn = card.el?.querySelector('.canvas-mic-btn');
-          if (micBtn) {
-            micBtn.textContent = active ? '\u23F9 停止录音' : '\uD83C\uDF99 开始录音';
-            micBtn.classList.toggle('recording', active);
-          }
-        });
-      } catch (err) {
-        _logActivity('error', '麦克风启动失败: ' + err.message);
+    return { card, args };
+  });
+
+  // Show startup modal
+  const { modal, updateItem, close } = _showStartupModal(startItems);
+  let aborted = false;
+
+  modal.onCancel = () => {
+    aborted = true;
+    close();
+    _stopProject();
+  };
+
+  // Start all cards in parallel
+  const promises = startItems.map(async ({ card, args }, i) => {
+    updateItem(i, 'starting');
+    try {
+      const startResult = await _triggerAction(card.mcpId, card.toolName, 'start', args);
+      if (aborted) return;
+      if (startResult && startResult.code !== 200) {
+        updateItem(i, 'error', startResult.message || '启动失败');
+        _logActivity('error', `${card.toolName} 启动失败: ${startResult.message || '未知错误'}`);
+        return;
       }
+      // Auto-start mic stream for remote_mic card
+      if (card.toolName === 'remote_mic' && !isMicActive()) {
+        const wsProto = location.protocol === 'https:' ? 'wss' : 'ws';
+        const wsUrl = `${wsProto}://${location.host}/ws/mic`;
+        try {
+          await toggleMicStream(wsUrl, (active) => {
+            const micBtn = card.el?.querySelector('.canvas-mic-btn');
+            if (micBtn) {
+              micBtn.textContent = active ? '\u23F9 停止录音' : '\uD83C\uDF99 开始录音';
+              micBtn.classList.toggle('recording', active);
+            }
+          });
+        } catch (err) {
+          _logActivity('error', '麦克风启动失败: ' + err.message);
+        }
+      }
+      // Update card.topicOut from start response
+      const parsed = _parseMcpCallResult(startResult);
+      if (parsed?.topic_out?.some(t => t.topic)) {
+        card.topicOut = parsed.topic_out;
+        const outPorts = [...card.el.querySelectorAll('.canvas-port.out')];
+        parsed.topic_out.forEach((t, idx) => { if (outPorts[idx] && t.topic) outPorts[idx].dataset.topic = t.topic; });
+      }
+      updateItem(i, 'ready');
+    } catch (e) {
+      if (!aborted) updateItem(i, 'error', e.message || '异常');
     }
-    // Update card.topicOut from start response (multiInstance tools return real topic paths on start)
-    const parsed = _parseMcpCallResult(startResult);
-    if (parsed?.topic_out?.some(t => t.topic)) {
-      card.topicOut = parsed.topic_out;
-      const outPorts = [...card.el.querySelectorAll('.canvas-port.out')];
-      parsed.topic_out.forEach((t, i) => { if (outPorts[i] && t.topic) outPorts[i].dataset.topic = t.topic; });
-      _resolveAllTopics();  // re-propagate updated topic paths into conn.fromTopic before next card starts
-      _redrawConnections();
-    }
+  });
+
+  await Promise.allSettled(promises);
+  if (!aborted) {
+    // Re-resolve topics after all starts complete
+    _resolveAllTopics();
+    _redrawConnections();
+    // Update cancel button to close button
+    const cancelBtn = modal.querySelector('.startup-cancel-btn');
+    cancelBtn.textContent = '关闭';
+    cancelBtn.onclick = close;
+    modal.onCancel = null;
   }
-  // Immediately persist layout so monitor-dashboard can read inferred topic paths
+  // Persist layout and running state
   await _saveLayout();
-  // 持久化运行状态
   fetch('/api/config/project-running', {
     method: 'PUT', headers: {'Content-Type': 'application/json'},
     body: JSON.stringify({running: true}),
@@ -1448,6 +1477,48 @@ async function _triggerAction(mcpId, toolName, action, extraArgs = {}) {
     console.error(`[canvas] ${action} call failed:`, err);
     return null;
   }
+}
+
+// ── Startup Modal ──────────────────────────────────────────────────────────────
+function _showStartupModal(items) {
+  const overlay = document.createElement('div');
+  overlay.className = 'modal-overlay';
+  const modal = document.createElement('div');
+  modal.className = 'modal';
+  modal.style.width = '420px';
+  modal.innerHTML = `
+    <div class="modal-header">
+      <span class="modal-title">启动智能控制</span>
+    </div>
+    <ul class="startup-modal-list"></ul>
+    <div class="startup-modal-footer">
+      <button class="startup-cancel-btn">取消启动</button>
+    </div>`;
+  overlay.appendChild(modal);
+  const list = modal.querySelector('.startup-modal-list');
+  const dots = [];
+  const statuses = [];
+  items.forEach(({ card }) => {
+    const li = document.createElement('li');
+    li.className = 'startup-modal-item';
+    li.innerHTML = `<span class="startup-dot"></span><span class="startup-name">${card.toolName}</span><span class="startup-status">等待启动</span>`;
+    list.appendChild(li);
+    dots.push(li.querySelector('.startup-dot'));
+    statuses.push(li.querySelector('.startup-status'));
+  });
+  document.body.appendChild(overlay);
+
+  const STATUS_TEXT = { starting: '启动中...', ready: '已就绪', error: '启动失败' };
+  function updateItem(i, state, msg) {
+    dots[i].className = 'startup-dot ' + state;
+    statuses[i].textContent = msg || STATUS_TEXT[state] || '';
+  }
+  function close() {
+    overlay.remove();
+  }
+  const cancelBtn = modal.querySelector('.startup-cancel-btn');
+  cancelBtn.addEventListener('click', () => { if (modal.onCancel) modal.onCancel(); });
+  return { modal, updateItem, close };
 }
 
 /**

--- a/agent-core/web/js/canvas.js
+++ b/agent-core/web/js/canvas.js
@@ -1368,6 +1368,7 @@ async function _startProject() {
       if (startResult && startResult.code !== 200) {
         updateItem(i, 'error', startResult.message || '启动失败');
         _logActivity('error', `${card.toolName} 启动失败: ${startResult.message || '未知错误'}`);
+        if (!aborted) { aborted = true; modal.onCancel?.(); }
         return;
       }
       // Auto-start mic stream for remote_mic card
@@ -1395,7 +1396,11 @@ async function _startProject() {
       }
       updateItem(i, 'ready');
     } catch (e) {
-      if (!aborted) updateItem(i, 'error', e.message || '异常');
+      if (!aborted) {
+        updateItem(i, 'error', e.message || '异常');
+        aborted = true;
+        modal.onCancel?.();
+      }
     }
   });
 
@@ -1409,14 +1414,14 @@ async function _startProject() {
     cancelBtn.textContent = '关闭';
     cancelBtn.onclick = close;
     modal.onCancel = null;
+    // Persist layout and running state
+    await _saveLayout();
+    fetch('/api/config/project-running', {
+      method: 'PUT', headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({running: true}),
+    });
+    _logActivity('project', '智能控制已开启');
   }
-  // Persist layout and running state
-  await _saveLayout();
-  fetch('/api/config/project-running', {
-    method: 'PUT', headers: {'Content-Type': 'application/json'},
-    body: JSON.stringify({running: true}),
-  });
-  _logActivity('project', '智能控制已开启');
 }
 
 function _stopProject() {

--- a/agent-core/web/js/canvas.js
+++ b/agent-core/web/js/canvas.js
@@ -1359,52 +1359,72 @@ async function _startProject() {
     _stopProject();
   };
 
-  // Start all cards in parallel
-  const promises = startItems.map(async ({ card, args }, i) => {
-    updateItem(i, 'starting');
-    try {
-      const startResult = await _triggerAction(card.mcpId, card.toolName, 'start', args);
-      if (aborted) return;
-      if (startResult && startResult.code !== 200) {
-        updateItem(i, 'error', startResult.message || '启动失败');
-        _logActivity('error', `${card.toolName} 启动失败: ${startResult.message || '未知错误'}`);
-        if (!aborted) { aborted = true; modal.onCancel?.(); }
-        return;
-      }
-      // Auto-start mic stream for remote_mic card
-      if (card.toolName === 'remote_mic' && !isMicActive()) {
-        const wsProto = location.protocol === 'https:' ? 'wss' : 'ws';
-        const wsUrl = `${wsProto}://${location.host}/ws/mic`;
-        try {
-          await toggleMicStream(wsUrl, (active) => {
-            const micBtn = card.el?.querySelector('.canvas-mic-btn');
-            if (micBtn) {
-              micBtn.textContent = active ? '\u23F9 停止录音' : '\uD83C\uDF99 开始录音';
-              micBtn.classList.toggle('recording', active);
-            }
-          });
-        } catch (err) {
-          _logActivity('error', '麦克风启动失败: ' + err.message);
-        }
-      }
-      // Update card.topicOut from start response
-      const parsed = _parseMcpCallResult(startResult);
-      if (parsed?.topic_out?.some(t => t.topic)) {
-        card.topicOut = parsed.topic_out;
-        const outPorts = [...card.el.querySelectorAll('.canvas-port.out')];
-        parsed.topic_out.forEach((t, idx) => { if (outPorts[idx] && t.topic) outPorts[idx].dataset.topic = t.topic; });
-      }
-      updateItem(i, 'ready');
-    } catch (e) {
-      if (!aborted) {
-        updateItem(i, 'error', e.message || '异常');
-        aborted = true;
-        modal.onCancel?.();
-      }
-    }
+  // Split into sources (no inbound connections) and processors (have inbound connections)
+  const sourceIndices = [];
+  const processorIndices = [];
+  startItems.forEach(({ card }, i) => {
+    const hasInbound = _connections.some(c => c.toCardId === card.id);
+    (hasInbound ? processorIndices : sourceIndices).push(i);
   });
 
-  await Promise.allSettled(promises);
+  // Helper to start a batch of items by index
+  async function _startBatch(indices) {
+    const batch = indices.map(i => (async () => {
+      const { card, args } = startItems[i];
+      updateItem(i, 'starting');
+      try {
+        const startResult = await _triggerAction(card.mcpId, card.toolName, 'start', args);
+        if (aborted) return;
+        if (startResult && startResult.code !== 200) {
+          updateItem(i, 'error', startResult.message || '启动失败');
+          _logActivity('error', `${card.toolName} 启动失败: ${startResult.message || '未知错误'}`);
+          if (!aborted) { aborted = true; modal.onCancel?.(); }
+          return;
+        }
+        // Auto-start mic stream for remote_mic card
+        if (card.toolName === 'remote_mic' && !isMicActive()) {
+          const wsProto = location.protocol === 'https:' ? 'wss' : 'ws';
+          const wsUrl = `${wsProto}://${location.host}/ws/mic`;
+          try {
+            await toggleMicStream(wsUrl, (active) => {
+              const micBtn = card.el?.querySelector('.canvas-mic-btn');
+              if (micBtn) {
+                micBtn.textContent = active ? '\u23F9 停止录音' : '\uD83C\uDF99 开始录音';
+                micBtn.classList.toggle('recording', active);
+              }
+            });
+          } catch (err) {
+            _logActivity('error', '麦克风启动失败: ' + err.message);
+          }
+        }
+        // Update card.topicOut from start response
+        const parsed = _parseMcpCallResult(startResult);
+        if (parsed?.topic_out?.some(t => t.topic)) {
+          card.topicOut = parsed.topic_out;
+          const outPorts = [...card.el.querySelectorAll('.canvas-port.out')];
+          parsed.topic_out.forEach((t, idx) => { if (outPorts[idx] && t.topic) outPorts[idx].dataset.topic = t.topic; });
+        }
+        updateItem(i, 'ready');
+      } catch (e) {
+        if (!aborted) {
+          updateItem(i, 'error', e.message || '异常');
+          aborted = true;
+          modal.onCancel?.();
+        }
+      }
+    })());
+    await Promise.allSettled(batch);
+  }
+
+  // Phase 1: start sources (data producers) first
+  await _startBatch(sourceIndices);
+  if (aborted) return;
+
+  // Re-resolve topics so processors can find source output topics
+  _resolveAllTopics();
+
+  // Phase 2: start processors (data consumers)
+  await _startBatch(processorIndices);
   if (!aborted) {
     // Re-resolve topics after all starts complete
     _resolveAllTopics();

--- a/agent-core/web/js/canvas.js
+++ b/agent-core/web/js/canvas.js
@@ -1409,6 +1409,9 @@ async function _startProject() {
     // Re-resolve topics after all starts complete
     _resolveAllTopics();
     _redrawConnections();
+    // Ensure button shows running state
+    _syncProjectBtn();
+    document.querySelectorAll('.canvas-exec-btn').forEach(btn => btn.classList.remove('locked'));
     // Update cancel button to close button
     const cancelBtn = modal.querySelector('.startup-cancel-btn');
     cancelBtn.textContent = '关闭';

--- a/agent-core/web/js/sidebar.js
+++ b/agent-core/web/js/sidebar.js
@@ -605,12 +605,20 @@ function _openToolConfigModal(mcpId, toolName, configSchema) {
 
     // Save to per-tool API
     try {
-      await fetch(`/api/canvas/tool-config/${encodeURIComponent(mcpId)}/${encodeURIComponent(toolName)}`, {
+      const resp = await fetch(`/api/canvas/tool-config/${encodeURIComponent(mcpId)}/${encodeURIComponent(toolName)}`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(values),
       });
-    } catch (err) { console.error('[config] save failed:', err); }
+      if (!resp.ok) {
+        alert(`配置保存失败 (HTTP ${resp.status})`);
+        return;
+      }
+    } catch (err) {
+      alert('配置保存失败: ' + err.message);
+      console.error('[config] save failed:', err);
+      return;
+    }
 
     // Update local cache
     _toolConfigs[configKey] = values;
@@ -847,12 +855,20 @@ export function openInstanceConfigModal(mcpId, toolName, instanceId, configSchem
     });
 
     try {
-      await fetch(`/api/canvas/tool-config/${encodeURIComponent(mcpId)}/${encodeURIComponent(toolName)}/${encodeURIComponent(instanceId)}`, {
+      const resp = await fetch(`/api/canvas/tool-config/${encodeURIComponent(mcpId)}/${encodeURIComponent(toolName)}/${encodeURIComponent(instanceId)}`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(values),
       });
-    } catch (err) { console.error('[config] instance save failed:', err); }
+      if (!resp.ok) {
+        alert(`配置保存失败 (HTTP ${resp.status})`);
+        return;
+      }
+    } catch (err) {
+      alert('配置保存失败: ' + err.message);
+      console.error('[config] instance save failed:', err);
+      return;
+    }
 
     _toolConfigs[configKey] = values;
     close();

--- a/perception/Dockerfile
+++ b/perception/Dockerfile
@@ -23,6 +23,10 @@ RUN pip3 install --no-cache-dir -i ${PYPI_MIRROR} \
 RUN pip3 install --no-cache-dir -i ${PYPI_MIRROR} \
     sherpa-onnx
 
+# Override base image RMW (some ros-base tags ship cyclonedds by default)
+ENV RMW_IMPLEMENTATION=rmw_fastrtps_cpp
+ENV ROS_DOMAIN_ID=42
+
 WORKDIR /work
 COPY main.py    /work/main.py
 COPY plugins/   /work/plugins/

--- a/perception/plugins/asr.py
+++ b/perception/plugins/asr.py
@@ -408,12 +408,6 @@ def _vad_worker(pcm_q: multiprocessing.Queue, result_q: multiprocessing.Queue,
     _log.info(f"[vad-worker] process started (pid={os.getpid()}, backend=sherpa_onnx, kws={kws_enabled})")
     audio_count = 0
 
-    # Pre-buffer: keep last N frames so first word isn't cut off by VAD onset delay
-    from collections import deque
-    PREBUF_FRAMES = 15  # ~480ms at 32ms/frame — covers VAD onset lag without overlap
-    prebuf = deque(maxlen=PREBUF_FRAMES)
-    prebuf_used = False  # whether we already prepended prebuf to current utterance
-
     while not stop_evt.is_set():
         try:
             pcm, ts = pcm_q.get(timeout=1)
@@ -453,32 +447,20 @@ def _vad_worker(pcm_q: multiprocessing.Queue, result_q: multiprocessing.Queue,
                         speech_buf = pcm  # include current frame (user may already be speaking)
                         start_ts = ts
                         end_ts = ts
-                        prebuf_used = True  # don't use prebuf for KWS wake (already have context)
                         # Reset KWS stream for next wake
                         kws_stream = kws_spotter.create_stream()
             # Drain any completed VAD segments (discard in wake-wait mode)
             while not vad.empty():
                 vad.pop()
-            prebuf.append((pcm, ts))
 
         elif state == 'listening':
-            # Only update pre-buffer when VAD has NOT detected speech onset yet,
-            # so prebuf retains the frames *before* speech started.
-            if not vad.is_speech_detected():
-                prebuf.append((pcm, ts))
-
             # Collect completed VAD segments (speech that ended)
+            # Note: sherpa-onnx VAD internally buffers pre-speech audio,
+            # so seg.samples already contains the full speech onset.
             while not vad.empty():
                 seg = vad.front
                 seg_pcm = _struct.pack(f'<{len(seg.samples)}h',
                                        *[int(max(-32768, min(32767, s * 32768))) for s in seg.samples])
-                # Prepend pre-buffer on first speech detection to recover onset audio
-                if not speech_buf and not prebuf_used:
-                    for pb_pcm, pb_ts in prebuf:
-                        speech_buf += pb_pcm
-                    if prebuf:
-                        start_ts = prebuf[0][1]
-                    prebuf_used = True
                 if not start_ts:
                     start_ts = ts
                 speech_buf += seg_pcm
@@ -492,7 +474,6 @@ def _vad_worker(pcm_q: multiprocessing.Queue, result_q: multiprocessing.Queue,
                     speech_buf = b''
                     start_ts = None
                     end_ts = None
-                    prebuf_used = False
                     # Return to waiting for wake word (if KWS enabled)
                     if kws_enabled:
                         state = 'waiting_wake'

--- a/perception/plugins/asr.py
+++ b/perception/plugins/asr.py
@@ -385,8 +385,8 @@ def _vad_worker(pcm_q: multiprocessing.Queue, result_q: multiprocessing.Queue,
                     keywords_file=kws_keywords_file,
                     num_threads=1,
                     provider="cpu",
-                    keywords_score=1.0,
-                    keywords_threshold=0.25,
+                    keywords_score=1.5,
+                    keywords_threshold=0.1,
                 )
                 kws_stream = kws_spotter.create_stream()
                 _log.info(f"[vad-worker] KWS initialized, keywords={keywords}")

--- a/perception/plugins/asr.py
+++ b/perception/plugins/asr.py
@@ -71,7 +71,7 @@ TOOLS = [
                 "asr_model":     {"type": "string", "enum": ["paraformer-zh-en", "zipformer-en", "sensevoice-small"], "description": "ASR model (paraformer-zh-en = bilingual streaming, zipformer-en = English only, sensevoice-small = multilingual non-autoregressive)", "default": "paraformer-zh-en", "scope": "shared"},
                 "trigger_mode":  {"type": "string", "enum": ["vad", "kws"], "description": "Trigger mode (vad = always listen, kws = wake word first)", "default": "kws", "scope": "shared"},
                 "kws_model":     {"type": "string", "enum": ["zh", "en", "zh-en"], "description": "KWS 模型 (zh=纯中文, en=纯英文, zh-en=双语)", "default": "zh", "scope": "shared", "x-show-when": {"trigger_mode": "kws"}},
-                "kws_keywords":  {"type": "string", "description": "Wake word (zh: pinyin e.g. 'f àn sh ì x iǎo g ǒu @范式小狗', zh-en: phone+ppinyin, en: BPE)", "scope": "shared", "x-show-when": {"trigger_mode": "kws"}},
+                "kws_keywords":  {"type": "string", "description": "Wake word (zh: 'f àn sh ì x iǎo g ǒu @范式小狗', en: '▁FA N C Y ▁RO B O T @FANCY_ROBOT')", "scope": "shared", "x-show-when": {"trigger_mode": "kws"}},
                 "vad_threshold": {"type": "number", "description": "VAD speech threshold (0-1, higher = stricter)", "default": 0.5, "scope": "shared"},
                 "vad_silence_ms":{"type": "integer", "description": "Silence duration (ms) before sentence end", "default": 400, "scope": "shared"},
             },

--- a/perception/plugins/asr.py
+++ b/perception/plugins/asr.py
@@ -555,10 +555,12 @@ class _ASRNode(Node):
         self._worker_thread = threading.Thread(target=self._worker, daemon=True)
         self._worker_thread.start()
         self.state = "starting"
-        log.info("[asr] waiting for first audio chunk (up to 30s)...")
-        # Block until first audio chunk arrives or timeout
-        if not self._first_chunk_event.wait(timeout=30):
-            log.warning("[asr] timeout waiting for first audio chunk — proceeding anyway")
+        log.info("[asr] waiting for first audio chunk...")
+        # Block until first audio chunk arrives (or stop() is called via cancel)
+        self._first_chunk_event.wait()
+        if self._stop_event.is_set():
+            log.info("[asr] start cancelled by stop()")
+            return {"state": "idle"}
         self.state = "running"
         log.info("[asr] started, receiving audio data")
         return self._status_dict()

--- a/perception/plugins/asr.py
+++ b/perception/plugins/asr.py
@@ -31,10 +31,10 @@ SILENCE_THRESH = 0.35
 SILENCE_FRAMES = 16
 
 _LOW_LAT_QOS = QoSProfile(
-    reliability=ReliabilityPolicy.RELIABLE,
+    reliability=ReliabilityPolicy.BEST_EFFORT,
     history=HistoryPolicy.KEEP_LAST,
     depth=50,
-    durability=DurabilityPolicy.TRANSIENT_LOCAL,
+    durability=DurabilityPolicy.VOLATILE,
 )
 
 _ASR_PUB_QOS = QoSProfile(

--- a/perception/plugins/asr.py
+++ b/perception/plugins/asr.py
@@ -31,10 +31,10 @@ SILENCE_THRESH = 0.35
 SILENCE_FRAMES = 16
 
 _LOW_LAT_QOS = QoSProfile(
-    reliability=ReliabilityPolicy.BEST_EFFORT,
+    reliability=ReliabilityPolicy.RELIABLE,
     history=HistoryPolicy.KEEP_LAST,
     depth=50,
-    durability=DurabilityPolicy.VOLATILE,
+    durability=DurabilityPolicy.TRANSIENT_LOCAL,
 )
 
 _ASR_PUB_QOS = QoSProfile(

--- a/perception/plugins/asr.py
+++ b/perception/plugins/asr.py
@@ -460,21 +460,21 @@ def _vad_worker(pcm_q: multiprocessing.Queue, result_q: multiprocessing.Queue,
         denoised = denoiser.run(float_samples, SAMPLE_RATE)
         float_samples = list(denoised.samples)
 
-        # AGC: normalize RMS to consistent level regardless of distance
+        # Feed VAD with denoised signal (no AGC — AGC would distort VAD energy detection)
+        vad.accept_waveform(float_samples)
+
+        # AGC: normalize RMS for KWS/ASR (applied after VAD, before KWS)
         rms = (sum(s * s for s in float_samples) / max(len(float_samples), 1)) ** 0.5
         if rms > 1e-6:
             desired_gain = _agc_target / rms
             desired_gain = min(desired_gain, _AGC_MAX_GAIN)
             _agc_gain[0] += _AGC_SMOOTHING * (desired_gain - _agc_gain[0])
-        float_samples = [max(-1.0, min(1.0, s * _agc_gain[0])) for s in float_samples]
-
-        # Feed VAD
-        vad.accept_waveform(float_samples)
+        agc_samples = [max(-1.0, min(1.0, s * _agc_gain[0])) for s in float_samples]
 
         if state == 'waiting_wake':
-            # Feed KWS continuously (not gated by VAD) to avoid missing wake word onset
+            # Feed KWS with AGC-normalized audio for better detection at distance
             if kws_spotter:
-                kws_stream.accept_waveform(SAMPLE_RATE, float_samples)
+                kws_stream.accept_waveform(SAMPLE_RATE, agc_samples)
                 while kws_spotter.is_ready(kws_stream):
                     kws_spotter.decode_stream(kws_stream)
                 result = kws_spotter.get_result(kws_stream)
@@ -515,8 +515,10 @@ def _vad_worker(pcm_q: multiprocessing.Queue, result_q: multiprocessing.Queue,
             # Collect completed VAD segments
             while not vad.empty():
                 seg = vad.front
-                seg_pcm = _struct.pack(f'<{len(seg.samples)}h',
-                                       *[int(max(-32768, min(32767, s * 32768))) for s in seg.samples])
+                # Apply AGC gain to segment for ASR
+                seg_agc = [max(-1.0, min(1.0, s * _agc_gain[0])) for s in seg.samples]
+                seg_pcm = _struct.pack(f'<{len(seg_agc)}h',
+                                       *[int(max(-32768, min(32767, s * 32768))) for s in seg_agc])
                 if not start_ts:
                     start_ts = ts
                 speech_buf += seg_pcm

--- a/perception/plugins/asr.py
+++ b/perception/plugins/asr.py
@@ -432,6 +432,12 @@ def _vad_worker(pcm_q: multiprocessing.Queue, result_q: multiprocessing.Queue,
     _log.info(f"[vad-worker] process started (pid={os.getpid()}, backend=sherpa_onnx, kws={kws_enabled})")
     audio_count = 0
 
+    # AGC (Automatic Gain Control) parameters
+    _agc_target = 2000.0 / 32768.0   # target RMS (~6% full scale, typical speech level)
+    _AGC_MAX_GAIN = 20.0             # max amplification to prevent noise blowup
+    _AGC_SMOOTHING = 0.3             # gain smoothing (0-1, lower = smoother transitions)
+    _agc_gain = [1.0]                # mutable container for current gain
+
     while not stop_evt.is_set():
         try:
             pcm, ts = pcm_q.get(timeout=1)
@@ -453,6 +459,14 @@ def _vad_worker(pcm_q: multiprocessing.Queue, result_q: multiprocessing.Queue,
         # Denoise before VAD/KWS
         denoised = denoiser.run(float_samples, SAMPLE_RATE)
         float_samples = list(denoised.samples)
+
+        # AGC: normalize RMS to consistent level regardless of distance
+        rms = (sum(s * s for s in float_samples) / max(len(float_samples), 1)) ** 0.5
+        if rms > 1e-6:
+            desired_gain = _agc_target / rms
+            desired_gain = min(desired_gain, _AGC_MAX_GAIN)
+            _agc_gain[0] += _AGC_SMOOTHING * (desired_gain - _agc_gain[0])
+        float_samples = [max(-1.0, min(1.0, s * _agc_gain[0])) for s in float_samples]
 
         # Feed VAD
         vad.accept_waveform(float_samples)
@@ -477,8 +491,24 @@ def _vad_worker(pcm_q: multiprocessing.Queue, result_q: multiprocessing.Queue,
                         end_ts = ts
                         # Reset KWS stream for next wake
                         kws_stream = kws_spotter.create_stream()
-            # Drain any completed VAD segments (discard in wake-wait mode)
+            # Drain any completed VAD segments (discard in wake-wait mode, but save debug)
             while not vad.empty():
+                seg = vad.front
+                # Debug: save VAD segment even in waiting_wake mode
+                try:
+                    import wave as _wave, time as _time2
+                    seg_pcm = _struct.pack(f'<{len(seg.samples)}h',
+                                           *[int(max(-32768, min(32767, s * 32768))) for s in seg.samples])
+                    debug_dir = '/tmp/vad_debug'
+                    os.makedirs(debug_dir, exist_ok=True)
+                    fname = os.path.join(debug_dir, f"vad_seg_{int(_time2.time()*1000)}.wav")
+                    with _wave.open(fname, 'wb') as wf:
+                        wf.setnchannels(1)
+                        wf.setsampwidth(2)
+                        wf.setframerate(SAMPLE_RATE)
+                        wf.writeframes(seg_pcm)
+                except Exception:
+                    pass
                 vad.pop()
 
         elif state == 'listening':
@@ -496,6 +526,20 @@ def _vad_worker(pcm_q: multiprocessing.Queue, result_q: multiprocessing.Queue,
                 # Output the segment as an utterance
                 if len(speech_buf) > SAMPLE_RATE:  # >500ms
                     _log.info(f"[vad-worker] utterance complete, len={len(speech_buf)} bytes")
+                    # Debug: save utterance as WAV file
+                    try:
+                        import wave as _wave, io as _io, time as _time2
+                        debug_dir = '/tmp/vad_debug'
+                        os.makedirs(debug_dir, exist_ok=True)
+                        fname = os.path.join(debug_dir, f"utt_{int(_time2.time()*1000)}.wav")
+                        with _wave.open(fname, 'wb') as wf:
+                            wf.setnchannels(1)
+                            wf.setsampwidth(2)
+                            wf.setframerate(SAMPLE_RATE)
+                            wf.writeframes(speech_buf)
+                        _log.info(f"[vad-worker] saved debug wav: {fname}")
+                    except Exception as e:
+                        _log.warning(f"[vad-worker] failed to save debug wav: {e}")
                     result_q.put((speech_buf, start_ts or ts, end_ts or ts))
                     speech_buf = b''
                     start_ts = None

--- a/perception/plugins/asr.py
+++ b/perception/plugins/asr.py
@@ -68,7 +68,7 @@ TOOLS = [
         "configSchema": {
             "type": "object",
             "properties": {
-                "asr_model":     {"type": "string", "enum": ["paraformer-zh-en", "zipformer-en", "sensevoice-small"], "description": "ASR model (paraformer-zh-en = bilingual streaming, zipformer-en = English only, sensevoice-small = multilingual non-autoregressive)", "default": "paraformer-zh-en", "scope": "shared"},
+                "asr_model":     {"type": "string", "enum": ["paraformer-zh-en", "paraformer-offline", "zipformer-en", "sensevoice-small"], "description": "ASR model (paraformer-zh-en = bilingual streaming, paraformer-offline = bilingual offline, zipformer-en = English streaming, sensevoice-small = multilingual offline)", "default": "sensevoice-small", "scope": "shared"},
                 "trigger_mode":  {"type": "string", "enum": ["vad", "kws"], "description": "Trigger mode (vad = always listen, kws = wake word first)", "default": "kws", "scope": "shared"},
                 "kws_model":     {"type": "string", "enum": ["zh", "en", "zh-en"], "description": "KWS 模型 (zh=纯中文, en=纯英文, zh-en=双语)", "default": "zh", "scope": "shared", "x-show-when": {"trigger_mode": "kws"}},
                 "kws_keywords":  {"type": "string", "description": "Wake word (zh: 'f àn sh ì x iǎo g ǒu @范式小狗', en: '▁FA N C Y ▁RO B O T @FANCY_ROBOT')", "scope": "shared", "x-show-when": {"trigger_mode": "kws"}},
@@ -261,15 +261,62 @@ class SherpaOnnxSenseVoiceAdapter(ASRAdapter):
         return text.strip()
 
 
+class SherpaOnnxOfflineParaformerAdapter(ASRAdapter):
+    """Offline non-streaming Paraformer (zh+en, small).
+
+    Better accuracy than streaming version — no tail truncation.
+    Uses sherpa_onnx.OfflineRecognizer.from_paraformer.
+    """
+
+    def __init__(self, model_dir: str, hw_provider: str = "cuda", num_threads: int = 2):
+        from utils.model_downloader import ensure_model
+        ensure_model("asr_paraformer_offline", model_dir)
+
+        import sherpa_onnx
+        model_path = os.path.join(model_dir, "model.int8.onnx")
+        if not os.path.exists(model_path):
+            model_path = os.path.join(model_dir, "model.onnx")
+        tokens_path = os.path.join(model_dir, "tokens.txt")
+
+        self._recognizer = sherpa_onnx.OfflineRecognizer.from_paraformer(
+            paraformer=model_path,
+            tokens=tokens_path,
+            num_threads=num_threads,
+            provider=hw_provider,
+            sample_rate=SAMPLE_RATE,
+            decoding_method="greedy_search",
+        )
+        log.info(f"[asr] sherpa-onnx offline paraformer adapter loaded: model={model_path}, provider={hw_provider}")
+
+    def transcribe(self, wav_bytes: bytes, language: str) -> str:
+        import io as _io, wave as _wave
+        with _wave.open(_io.BytesIO(wav_bytes)) as wf:
+            pcm = wf.readframes(wf.getnframes())
+        n = len(pcm) // 2
+        samples = struct.unpack(f'<{n}h', pcm)
+        float_samples = [s / 32768.0 for s in samples]
+
+        stream = self._recognizer.create_stream()
+        stream.accept_waveform(SAMPLE_RATE, float_samples)
+        self._recognizer.decode_streams([stream])
+        text = stream.result.text
+        return text.strip()
+
+
 # ASR model registry
 ASR_MODELS = {
     "paraformer-zh-en": {
-        "label": "Paraformer Bilingual (zh+en)",
+        "label": "Paraformer Bilingual (zh+en, streaming)",
         "adapter": SherpaOnnxASRAdapter,
         "default_model_dir": "/models/sherpa-onnx/asr",
     },
+    "paraformer-offline": {
+        "label": "Paraformer Offline (zh+en, small)",
+        "adapter": SherpaOnnxOfflineParaformerAdapter,
+        "default_model_dir": "/models/sherpa-onnx/asr-paraformer-offline",
+    },
     "zipformer-en": {
-        "label": "Zipformer English",
+        "label": "Zipformer English (streaming)",
         "adapter": SherpaOnnxZipformerAdapter,
         "default_model_dir": "/models/sherpa-onnx/asr-en",
     },

--- a/perception/plugins/asr.py
+++ b/perception/plugins/asr.py
@@ -757,6 +757,15 @@ class ASRPlugin:
                                 node_suffix=node_key.replace('/', '_').replace('-', '_'))
                 self._executor.add_node(node)
                 self._nodes[node_key] = node
+            else:
+                # Sync latest config into existing node before restart
+                node = self._nodes[node_key]
+                node._adapter = self._adapter
+                node._language = self._language
+                node._vad_backend = self._vad_backend
+                node._vad_threshold = self._vad_threshold
+                node._vad_silence_ms = self._vad_silence_ms
+                node._kws_cfg = self._kws_cfg
             return self._nodes[node_key].start()
 
         elif action == "stop":
@@ -803,11 +812,10 @@ class ASRPlugin:
                 return {"status": "loading", "asr_model": self._asr_model,
                         "message": f"Switching to model '{self._asr_model}', downloading..."}
             # Stop all nodes (they'll use new config on next start)
+            # Only stop VAD internals — keep node in executor to avoid DDS re-discovery delay
             for key in list(self._nodes.keys()):
-                node = self._nodes.pop(key, None)
-                if node:
-                    node.stop()
-                    self._executor.remove_node(node)
+                node = self._nodes[key]
+                node.stop()
             return {"status": "configured", "asr_model": self._asr_model}
 
         return None

--- a/perception/plugins/asr.py
+++ b/perception/plugins/asr.py
@@ -135,8 +135,8 @@ class SherpaOnnxASRAdapter(ASRAdapter):
         n = len(pcm) // 2
         samples = struct.unpack(f'<{n}h', pcm)
         float_samples = [s / 32768.0 for s in samples]
-        # Pad 500ms silence at the end to avoid last-token truncation
-        float_samples += [0.0] * int(SAMPLE_RATE * 0.5)
+        # Pad 1000ms silence at the end to avoid last-token truncation
+        float_samples += [0.0] * int(SAMPLE_RATE * 1.0)
 
         stream = self._recognizer.create_stream()
         stream.accept_waveform(SAMPLE_RATE, float_samples)

--- a/perception/plugins/asr.py
+++ b/perception/plugins/asr.py
@@ -410,7 +410,7 @@ def _vad_worker(pcm_q: multiprocessing.Queue, result_q: multiprocessing.Queue,
 
     # Pre-buffer: keep last N frames so first word isn't cut off by VAD onset delay
     from collections import deque
-    PREBUF_FRAMES = 25  # ~800ms at 32ms/frame (1024B chunks) — covers VAD onset lag
+    PREBUF_FRAMES = 15  # ~480ms at 32ms/frame — covers VAD onset lag without overlap
     prebuf = deque(maxlen=PREBUF_FRAMES)
     prebuf_used = False  # whether we already prepended prebuf to current utterance
 

--- a/perception/plugins/asr.py
+++ b/perception/plugins/asr.py
@@ -408,13 +408,6 @@ def _vad_worker(pcm_q: multiprocessing.Queue, result_q: multiprocessing.Queue,
     _log.info(f"[vad-worker] process started (pid={os.getpid()}, backend=sherpa_onnx, kws={kws_enabled})")
     audio_count = 0
 
-    # Pre-buffer: keep raw PCM frames before VAD detects speech.
-    # seg.samples does NOT include pre-speech audio, so we need this.
-    from collections import deque
-    PREBUF_FRAMES = 15  # ~480ms at 32ms/frame
-    prebuf = deque(maxlen=PREBUF_FRAMES)
-    prebuf_prepended = False
-
     while not stop_evt.is_set():
         try:
             pcm, ts = pcm_q.get(timeout=1)
@@ -461,20 +454,11 @@ def _vad_worker(pcm_q: multiprocessing.Queue, result_q: multiprocessing.Queue,
                 vad.pop()
 
         elif state == 'listening':
-            # Maintain prebuf only while VAD has not yet detected speech
-            if not vad.is_speech_detected():
-                prebuf.append(pcm)
-
-            # Collect completed VAD segments (speech that ended)
+            # Collect completed VAD segments
             while not vad.empty():
                 seg = vad.front
                 seg_pcm = _struct.pack(f'<{len(seg.samples)}h',
                                        *[int(max(-32768, min(32767, s * 32768))) for s in seg.samples])
-                # Prepend prebuf before first segment (covers VAD onset delay)
-                if not prebuf_prepended:
-                    for pb_pcm in prebuf:
-                        speech_buf += pb_pcm
-                    prebuf_prepended = True
                 if not start_ts:
                     start_ts = ts
                 speech_buf += seg_pcm
@@ -488,7 +472,6 @@ def _vad_worker(pcm_q: multiprocessing.Queue, result_q: multiprocessing.Queue,
                     speech_buf = b''
                     start_ts = None
                     end_ts = None
-                    prebuf_prepended = False
                     # Return to waiting for wake word (if KWS enabled)
                     if kws_enabled:
                         state = 'waiting_wake'

--- a/perception/plugins/asr.py
+++ b/perception/plugins/asr.py
@@ -554,15 +554,8 @@ class _ASRNode(Node):
         # Transcription worker thread (reads from utterance_queue)
         self._worker_thread = threading.Thread(target=self._worker, daemon=True)
         self._worker_thread.start()
-        self.state = "starting"
-        log.info("[asr] waiting for first audio chunk...")
-        # Block until first audio chunk arrives (or stop() is called via cancel)
-        self._first_chunk_event.wait()
-        if self._stop_event.is_set():
-            log.info("[asr] start cancelled by stop()")
-            return {"state": "idle"}
         self.state = "running"
-        log.info("[asr] started, receiving audio data")
+        log.info("[asr] started, waiting for audio data...")
         return self._status_dict()
 
     def stop(self) -> dict:

--- a/perception/plugins/asr.py
+++ b/perception/plugins/asr.py
@@ -340,6 +340,20 @@ def _vad_worker(pcm_q: multiprocessing.Queue, result_q: multiprocessing.Queue,
     vad = sherpa_onnx.VoiceActivityDetector(vad_config, buffer_size_in_seconds=30)
     _log.info(f"[vad-worker] sherpa-onnx VAD initialized (threshold={threshold}, silence_ms={silence_ms})")
 
+    # ── Initialize GTCRN denoiser ──
+    denoise_model_dir = '/models/sherpa-onnx/denoise'
+    ensure_model("denoise", denoise_model_dir)
+    denoise_model_path = os.path.join(denoise_model_dir, "gtcrn_simple.onnx")
+    denoiser = sherpa_onnx.OnlineSpeechDenoiser(
+        sherpa_onnx.OnlineSpeechDenoiserConfig(
+            model=sherpa_onnx.OfflineSpeechDenoiserModelConfig(
+                gtcrn=sherpa_onnx.OfflineSpeechDenoiserGtcrnModelConfig(model=denoise_model_path),
+                num_threads=1, provider="cpu",
+            )
+        )
+    )
+    _log.info("[vad-worker] GTCRN denoiser initialized")
+
     # ── Initialize KWS (optional) ──
     kws_spotter = None
     kws_stream = None
@@ -435,6 +449,10 @@ def _vad_worker(pcm_q: multiprocessing.Queue, result_q: multiprocessing.Queue,
         import struct as _struct
         samples = _struct.unpack(f'<{n}h', pcm)
         float_samples = [s / 32768.0 for s in samples]
+
+        # Denoise before VAD/KWS
+        denoised = denoiser.run(float_samples, SAMPLE_RATE)
+        float_samples = list(denoised.samples)
 
         # Feed VAD
         vad.accept_waveform(float_samples)

--- a/perception/plugins/asr.py
+++ b/perception/plugins/asr.py
@@ -74,7 +74,7 @@ TOOLS = [
                 "kws_keywords":  {"type": "string", "description": "Wake word (zh: 'f àn sh ì x iǎo g ǒu @范式小狗', en: '▁FA N C Y ▁RO B O T @FANCY_ROBOT')", "scope": "shared", "x-show-when": {"trigger_mode": "kws"}},
                 "vad_threshold": {"type": "number", "description": "VAD speech threshold (0-1, higher = stricter)", "default": 0.5, "scope": "shared"},
                 "vad_silence_ms":{"type": "integer", "description": "Silence duration (ms) before sentence end", "default": 400, "scope": "shared"},
-                "save_vad_segments": {"type": "boolean", "description": "Save VAD segments as WAV files to /tmp/vad_debug/", "default": False, "scope": "shared"},
+                "save_vad_segments": {"type": "boolean", "description": "Save VAD segments as WAV to /opt/embodied/models/vad_segments/", "default": False, "scope": "shared"},
                 "max_saved_segments": {"type": "integer", "description": "Max saved VAD segments (oldest deleted when exceeded)", "default": 1000, "scope": "shared"},
             },
             "required": []
@@ -469,7 +469,7 @@ def _vad_worker(pcm_q: multiprocessing.Queue, result_q: multiprocessing.Queue,
     audio_count = 0
 
     # VAD segment saving
-    _VAD_SEG_DIR = '/data/vad_segments'
+    _VAD_SEG_DIR = '/models/vad_segments'
     _seg_count = [0]
 
     def _save_segment(float_samples_list, count_ref):

--- a/perception/plugins/asr.py
+++ b/perception/plugins/asr.py
@@ -135,8 +135,8 @@ class SherpaOnnxASRAdapter(ASRAdapter):
         n = len(pcm) // 2
         samples = struct.unpack(f'<{n}h', pcm)
         float_samples = [s / 32768.0 for s in samples]
-        # Pad 1000ms silence at the end to avoid last-token truncation
-        float_samples += [0.0] * int(SAMPLE_RATE * 1.0)
+        # Pad 500ms silence at the end to avoid last-token truncation
+        float_samples += [0.0] * int(SAMPLE_RATE * 0.5)
 
         stream = self._recognizer.create_stream()
         stream.accept_waveform(SAMPLE_RATE, float_samples)

--- a/perception/plugins/asr.py
+++ b/perception/plugins/asr.py
@@ -340,20 +340,6 @@ def _vad_worker(pcm_q: multiprocessing.Queue, result_q: multiprocessing.Queue,
     vad = sherpa_onnx.VoiceActivityDetector(vad_config, buffer_size_in_seconds=30)
     _log.info(f"[vad-worker] sherpa-onnx VAD initialized (threshold={threshold}, silence_ms={silence_ms})")
 
-    # ── Initialize GTCRN denoiser ──
-    denoise_model_dir = '/models/sherpa-onnx/denoise'
-    ensure_model("denoise", denoise_model_dir)
-    denoise_model_path = os.path.join(denoise_model_dir, "gtcrn_simple.onnx")
-    denoiser = sherpa_onnx.OnlineSpeechDenoiser(
-        sherpa_onnx.OnlineSpeechDenoiserConfig(
-            model=sherpa_onnx.OfflineSpeechDenoiserModelConfig(
-                gtcrn=sherpa_onnx.OfflineSpeechDenoiserGtcrnModelConfig(model=denoise_model_path),
-                num_threads=1, provider="cpu",
-            )
-        )
-    )
-    _log.info("[vad-worker] GTCRN denoiser initialized")
-
     # ── Initialize KWS (optional) ──
     kws_spotter = None
     kws_stream = None
@@ -432,12 +418,6 @@ def _vad_worker(pcm_q: multiprocessing.Queue, result_q: multiprocessing.Queue,
     _log.info(f"[vad-worker] process started (pid={os.getpid()}, backend=sherpa_onnx, kws={kws_enabled})")
     audio_count = 0
 
-    # AGC (Automatic Gain Control) parameters
-    _agc_target = 2000.0 / 32768.0   # target RMS (~6% full scale, typical speech level)
-    _AGC_MAX_GAIN = 20.0             # max amplification to prevent noise blowup
-    _AGC_SMOOTHING = 0.3             # gain smoothing (0-1, lower = smoother transitions)
-    _agc_gain = [1.0]                # mutable container for current gain
-
     while not stop_evt.is_set():
         try:
             pcm, ts = pcm_q.get(timeout=1)
@@ -456,25 +436,13 @@ def _vad_worker(pcm_q: multiprocessing.Queue, result_q: multiprocessing.Queue,
         samples = _struct.unpack(f'<{n}h', pcm)
         float_samples = [s / 32768.0 for s in samples]
 
-        # Denoise before VAD/KWS
-        denoised = denoiser.run(float_samples, SAMPLE_RATE)
-        float_samples = list(denoised.samples)
-
-        # Feed VAD with denoised signal (no AGC — AGC would distort VAD energy detection)
+        # Feed VAD
         vad.accept_waveform(float_samples)
-
-        # AGC: normalize RMS for KWS/ASR (applied after VAD, before KWS)
-        rms = (sum(s * s for s in float_samples) / max(len(float_samples), 1)) ** 0.5
-        if rms > 1e-6:
-            desired_gain = _agc_target / rms
-            desired_gain = min(desired_gain, _AGC_MAX_GAIN)
-            _agc_gain[0] += _AGC_SMOOTHING * (desired_gain - _agc_gain[0])
-        agc_samples = [max(-1.0, min(1.0, s * _agc_gain[0])) for s in float_samples]
 
         if state == 'waiting_wake':
             # Feed KWS with AGC-normalized audio for better detection at distance
             if kws_spotter:
-                kws_stream.accept_waveform(SAMPLE_RATE, agc_samples)
+                kws_stream.accept_waveform(SAMPLE_RATE, float_samples)
                 while kws_spotter.is_ready(kws_stream):
                     kws_spotter.decode_stream(kws_stream)
                 result = kws_spotter.get_result(kws_stream)

--- a/perception/plugins/asr.py
+++ b/perception/plugins/asr.py
@@ -74,6 +74,8 @@ TOOLS = [
                 "kws_keywords":  {"type": "string", "description": "Wake word (zh: 'f àn sh ì x iǎo g ǒu @范式小狗', en: '▁FA N C Y ▁RO B O T @FANCY_ROBOT')", "scope": "shared", "x-show-when": {"trigger_mode": "kws"}},
                 "vad_threshold": {"type": "number", "description": "VAD speech threshold (0-1, higher = stricter)", "default": 0.5, "scope": "shared"},
                 "vad_silence_ms":{"type": "integer", "description": "Silence duration (ms) before sentence end", "default": 400, "scope": "shared"},
+                "save_vad_segments": {"type": "boolean", "description": "Save VAD segments as WAV files to /tmp/vad_debug/", "default": False, "scope": "shared"},
+                "max_saved_segments": {"type": "integer", "description": "Max saved VAD segments (oldest deleted when exceeded)", "default": 1000, "scope": "shared"},
             },
             "required": []
         },
@@ -352,7 +354,8 @@ def _build_asr_adapter(cfg: dict) -> Optional[ASRAdapter]:
 def _vad_worker(pcm_q: multiprocessing.Queue, result_q: multiprocessing.Queue,
                 stop_evt: multiprocessing.Event,
                 backend: str, threshold: float, silence_ms: int,
-                kws_cfg: dict = None):
+                kws_cfg: dict = None,
+                save_vad_segments: bool = False, max_saved_segments: int = 1000):
     """Runs in a child process — sherpa-onnx ONNX VAD + optional KWS gate.
 
     Pipeline: Audio → VAD → (KWS gate) → utterance output
@@ -465,6 +468,49 @@ def _vad_worker(pcm_q: multiprocessing.Queue, result_q: multiprocessing.Queue,
     _log.info(f"[vad-worker] process started (pid={os.getpid()}, backend=sherpa_onnx, kws={kws_enabled})")
     audio_count = 0
 
+    # VAD segment saving
+    _VAD_SEG_DIR = '/data/vad_segments'
+    _seg_count = [0]
+
+    def _save_segment(float_samples_list, count_ref):
+        """Save float samples as WAV."""
+        try:
+            import wave as _wave, time as _time2
+            os.makedirs(_VAD_SEG_DIR, exist_ok=True)
+            seg_pcm = _struct.pack(f'<{len(float_samples_list)}h',
+                                   *[int(max(-32768, min(32767, s * 32768))) for s in float_samples_list])
+            fname = os.path.join(_VAD_SEG_DIR, f"seg_{int(_time2.time()*1000)}.wav")
+            with _wave.open(fname, 'wb') as wf:
+                wf.setnchannels(1)
+                wf.setsampwidth(2)
+                wf.setframerate(SAMPLE_RATE)
+                wf.writeframes(seg_pcm)
+            # Enforce max segments limit
+            if count_ref[0] >= max_saved_segments:
+                files = sorted(os.listdir(_VAD_SEG_DIR))
+                for old in files[:len(files) - max_saved_segments + 1]:
+                    os.remove(os.path.join(_VAD_SEG_DIR, old))
+        except Exception:
+            pass
+
+    def _save_segment_pcm(pcm_bytes, count_ref):
+        """Save raw PCM bytes as WAV."""
+        try:
+            import wave as _wave, time as _time2
+            os.makedirs(_VAD_SEG_DIR, exist_ok=True)
+            fname = os.path.join(_VAD_SEG_DIR, f"seg_{int(_time2.time()*1000)}.wav")
+            with _wave.open(fname, 'wb') as wf:
+                wf.setnchannels(1)
+                wf.setsampwidth(2)
+                wf.setframerate(SAMPLE_RATE)
+                wf.writeframes(pcm_bytes)
+            if count_ref[0] >= max_saved_segments:
+                files = sorted(os.listdir(_VAD_SEG_DIR))
+                for old in files[:len(files) - max_saved_segments + 1]:
+                    os.remove(os.path.join(_VAD_SEG_DIR, old))
+        except Exception:
+            pass
+
     while not stop_evt.is_set():
         try:
             pcm, ts = pcm_q.get(timeout=1)
@@ -506,24 +552,12 @@ def _vad_worker(pcm_q: multiprocessing.Queue, result_q: multiprocessing.Queue,
                         end_ts = ts
                         # Reset KWS stream for next wake
                         kws_stream = kws_spotter.create_stream()
-            # Drain any completed VAD segments (discard in wake-wait mode, but save debug)
+            # Drain any completed VAD segments (discard in wake-wait mode)
             while not vad.empty():
                 seg = vad.front
-                # Debug: save VAD segment even in waiting_wake mode
-                try:
-                    import wave as _wave, time as _time2
-                    seg_pcm = _struct.pack(f'<{len(seg.samples)}h',
-                                           *[int(max(-32768, min(32767, s * 32768))) for s in seg.samples])
-                    debug_dir = '/tmp/vad_debug'
-                    os.makedirs(debug_dir, exist_ok=True)
-                    fname = os.path.join(debug_dir, f"vad_seg_{int(_time2.time()*1000)}.wav")
-                    with _wave.open(fname, 'wb') as wf:
-                        wf.setnchannels(1)
-                        wf.setsampwidth(2)
-                        wf.setframerate(SAMPLE_RATE)
-                        wf.writeframes(seg_pcm)
-                except Exception:
-                    pass
+                if save_vad_segments:
+                    _save_segment(seg.samples, _seg_count)
+                    _seg_count[0] += 1
                 vad.pop()
 
         elif state == 'listening':
@@ -541,20 +575,9 @@ def _vad_worker(pcm_q: multiprocessing.Queue, result_q: multiprocessing.Queue,
                 # Output the segment as an utterance
                 if len(speech_buf) > SAMPLE_RATE:  # >500ms
                     _log.info(f"[vad-worker] utterance complete, len={len(speech_buf)} bytes")
-                    # Debug: save utterance as WAV file
-                    try:
-                        import wave as _wave, io as _io, time as _time2
-                        debug_dir = '/tmp/vad_debug'
-                        os.makedirs(debug_dir, exist_ok=True)
-                        fname = os.path.join(debug_dir, f"utt_{int(_time2.time()*1000)}.wav")
-                        with _wave.open(fname, 'wb') as wf:
-                            wf.setnchannels(1)
-                            wf.setsampwidth(2)
-                            wf.setframerate(SAMPLE_RATE)
-                            wf.writeframes(speech_buf)
-                        _log.info(f"[vad-worker] saved debug wav: {fname}")
-                    except Exception as e:
-                        _log.warning(f"[vad-worker] failed to save debug wav: {e}")
+                    if save_vad_segments:
+                        _save_segment_pcm(speech_buf, _seg_count)
+                        _seg_count[0] += 1
                     result_q.put((speech_buf, start_ts or ts, end_ts or ts))
                     speech_buf = b''
                     start_ts = None
@@ -571,7 +594,8 @@ def _vad_worker(pcm_q: multiprocessing.Queue, result_q: multiprocessing.Queue,
 class _ASRNode(Node):
     def __init__(self, input_topic: str, adapter: Optional[ASRAdapter], language: str,
                  vad_backend: str = 'sherpa_onnx', vad_threshold: float = SPEECH_THRESH, vad_silence_ms: int = 400,
-                 kws_cfg: dict = None, node_suffix: str = ''):
+                 kws_cfg: dict = None, node_suffix: str = '',
+                 save_vad_segments: bool = False, max_saved_segments: int = 1000):
         node_name = f"asr_{node_suffix}" if node_suffix else "asr"
         super().__init__(node_name)
         self._input_topic  = input_topic
@@ -586,6 +610,8 @@ class _ASRNode(Node):
         self._vad_threshold = vad_threshold
         self._vad_silence_ms = vad_silence_ms
         self._kws_cfg = kws_cfg or {}
+        self._save_vad_segments = save_vad_segments
+        self._max_saved_segments = max_saved_segments
         self._pcm_queue: Optional[multiprocessing.Queue] = None
         self._utterance_queue: Optional[multiprocessing.Queue] = None
         self._vad_stop: Optional[multiprocessing.Event] = None
@@ -612,7 +638,7 @@ class _ASRNode(Node):
             target=_vad_worker,
             args=(self._pcm_queue, self._utterance_queue, self._vad_stop,
                   self._vad_backend, self._vad_threshold, self._vad_silence_ms,
-                  self._kws_cfg),
+                  self._kws_cfg, self._save_vad_segments, self._max_saved_segments),
             daemon=True, name="vad_worker",
         )
         self._vad_proc.start()
@@ -728,6 +754,8 @@ class ASRPlugin:
         self._vad_threshold = float(vad_cfg.get('threshold', SPEECH_THRESH))
         self._vad_silence_ms = int(vad_cfg.get('silence_ms', 400))
         self._kws_cfg      = plugin_cfg.get('kws', {})
+        self._save_vad_segments = False
+        self._max_saved_segments = 1000
         self._nodes: dict[str, _ASRNode] = {}           # key = instance_id
         self._executor = executor
         log.info(f"[asr] plugin init: model={self._asr_model}, vad={self._vad_backend}, threshold={self._vad_threshold}, "
@@ -838,7 +866,9 @@ class ASRPlugin:
                 node = _ASRNode(input_topic, self._adapter, self._language,
                                 self._vad_backend, self._vad_threshold, self._vad_silence_ms,
                                 kws_cfg=self._kws_cfg,
-                                node_suffix=node_key.replace('/', '_').replace('-', '_'))
+                                node_suffix=node_key.replace('/', '_').replace('-', '_'),
+                                save_vad_segments=self._save_vad_segments,
+                                max_saved_segments=self._max_saved_segments)
                 self._executor.add_node(node)
                 self._nodes[node_key] = node
             else:
@@ -850,6 +880,8 @@ class ASRPlugin:
                 node._vad_threshold = self._vad_threshold
                 node._vad_silence_ms = self._vad_silence_ms
                 node._kws_cfg = self._kws_cfg
+                node._save_vad_segments = self._save_vad_segments
+                node._max_saved_segments = self._max_saved_segments
             return self._nodes[node_key].start()
 
         elif action == "stop":
@@ -885,6 +917,10 @@ class ASRPlugin:
                 self._kws_cfg['kws_model'] = cfg['kws_model']
             if 'kws_keywords' in cfg:
                 self._kws_cfg['keywords'] = [cfg['kws_keywords']]
+            if 'save_vad_segments' in cfg:
+                self._save_vad_segments = bool(cfg['save_vad_segments'])
+            if 'max_saved_segments' in cfg:
+                self._max_saved_segments = int(cfg['max_saved_segments'])
             # ASR model switch — load in background if changed
             if 'asr_model' in cfg and cfg['asr_model'] != self._asr_model:
                 # Stop all running nodes first

--- a/perception/plugins/asr.py
+++ b/perception/plugins/asr.py
@@ -751,13 +751,10 @@ class ASRPlugin:
 
         elif action == "start":
             if self._loading:
-                # Wait for model to finish loading (up to 60s)
+                # Wait for model to finish loading
                 import time as _time
-                deadline = _time.time() + 60
-                while self._loading and _time.time() < deadline:
+                while self._loading:
                     _time.sleep(0.5)
-                if self._loading:
-                    return {"state": "loading", "message": "Model is still downloading, please wait..."}
             if self._load_error:
                 return {"state": "error", "message": f"Model failed to load: {self._load_error}"}
             if not self._adapter:

--- a/perception/plugins/asr.py
+++ b/perception/plugins/asr.py
@@ -744,7 +744,13 @@ class ASRPlugin:
 
         elif action == "start":
             if self._loading:
-                return {"state": "loading", "message": "Model is being downloaded, please wait..."}
+                # Wait for model to finish loading (up to 60s)
+                import time as _time
+                deadline = _time.time() + 60
+                while self._loading and _time.time() < deadline:
+                    _time.sleep(0.5)
+                if self._loading:
+                    return {"state": "loading", "message": "Model is still downloading, please wait..."}
             if self._load_error:
                 return {"state": "error", "message": f"Model failed to load: {self._load_error}"}
             if not self._adapter:

--- a/perception/plugins/asr.py
+++ b/perception/plugins/asr.py
@@ -554,6 +554,13 @@ class _ASRNode(Node):
         # Transcription worker thread (reads from utterance_queue)
         self._worker_thread = threading.Thread(target=self._worker, daemon=True)
         self._worker_thread.start()
+        self.state = "starting"
+        log.info("[asr] waiting for first audio chunk...")
+        # Block until first audio chunk arrives or stop() cancels
+        self._first_chunk_event.wait()
+        if self._stop_event.is_set():
+            self.state = "idle"
+            return {"state": "idle"}
         self.state = "running"
         log.info("[asr] started, waiting for audio data...")
         return self._status_dict()

--- a/perception/plugins/asr.py
+++ b/perception/plugins/asr.py
@@ -526,6 +526,7 @@ class _ASRNode(Node):
         self._vad_proc: Optional[multiprocessing.Process] = None
         self._worker_thread: Optional[threading.Thread] = None
         self._stop_event = threading.Event()
+        self._first_chunk_event = threading.Event()
 
     def start(self) -> dict:
         if self.state == "running":
@@ -534,6 +535,7 @@ class _ASRNode(Node):
             raise RuntimeError("ASR adapter not configured")
         from audio_msgs.msg import AudioChunk
         log.info(f"[asr] subscribing to topic={self._input_topic}, publishing to={self._output_topic}")
+        self._first_chunk_event = threading.Event()
         self._sub = self.create_subscription(AudioChunk, self._input_topic, self._audio_cb, _LOW_LAT_QOS)
         self._stop_event.clear()
         # Start VAD in a child process
@@ -552,8 +554,13 @@ class _ASRNode(Node):
         # Transcription worker thread (reads from utterance_queue)
         self._worker_thread = threading.Thread(target=self._worker, daemon=True)
         self._worker_thread.start()
+        self.state = "starting"
+        log.info("[asr] waiting for first audio chunk (up to 30s)...")
+        # Block until first audio chunk arrives or timeout
+        if not self._first_chunk_event.wait(timeout=30):
+            log.warning("[asr] timeout waiting for first audio chunk — proceeding anyway")
         self.state = "running"
-        log.info("[asr] started, waiting for audio data...")
+        log.info("[asr] started, receiving audio data")
         return self._status_dict()
 
     def stop(self) -> dict:
@@ -561,6 +568,9 @@ class _ASRNode(Node):
         if self._sub:
             self.destroy_subscription(self._sub); self._sub = None
         self._stop_event.set()
+        # Unblock start() if it's waiting for first chunk
+        if hasattr(self, '_first_chunk_event'):
+            self._first_chunk_event.set()
         if self._vad_stop:
             self._vad_stop.set()
         # Cancel feeder threads immediately — avoids BrokenPipeError spam
@@ -583,6 +593,9 @@ class _ASRNode(Node):
     def _audio_cb(self, msg):
         if self._stop_event.is_set():
             return
+        # Signal first chunk arrival to unblock start()
+        if not self._first_chunk_event.is_set():
+            self._first_chunk_event.set()
         # Detect dead VAD subprocess to avoid BrokenPipeError in queue feeder
         if self._vad_proc and not self._vad_proc.is_alive():
             log.warning(f"[asr] VAD worker died (exitcode={self._vad_proc.exitcode}), stopping ASR")

--- a/perception/plugins/asr.py
+++ b/perception/plugins/asr.py
@@ -408,6 +408,13 @@ def _vad_worker(pcm_q: multiprocessing.Queue, result_q: multiprocessing.Queue,
     _log.info(f"[vad-worker] process started (pid={os.getpid()}, backend=sherpa_onnx, kws={kws_enabled})")
     audio_count = 0
 
+    # Pre-buffer: keep raw PCM frames before VAD detects speech.
+    # seg.samples does NOT include pre-speech audio, so we need this.
+    from collections import deque
+    PREBUF_FRAMES = 15  # ~480ms at 32ms/frame
+    prebuf = deque(maxlen=PREBUF_FRAMES)
+    prebuf_prepended = False
+
     while not stop_evt.is_set():
         try:
             pcm, ts = pcm_q.get(timeout=1)
@@ -454,13 +461,20 @@ def _vad_worker(pcm_q: multiprocessing.Queue, result_q: multiprocessing.Queue,
                 vad.pop()
 
         elif state == 'listening':
+            # Maintain prebuf only while VAD has not yet detected speech
+            if not vad.is_speech_detected():
+                prebuf.append(pcm)
+
             # Collect completed VAD segments (speech that ended)
-            # Note: sherpa-onnx VAD internally buffers pre-speech audio,
-            # so seg.samples already contains the full speech onset.
             while not vad.empty():
                 seg = vad.front
                 seg_pcm = _struct.pack(f'<{len(seg.samples)}h',
                                        *[int(max(-32768, min(32767, s * 32768))) for s in seg.samples])
+                # Prepend prebuf before first segment (covers VAD onset delay)
+                if not prebuf_prepended:
+                    for pb_pcm in prebuf:
+                        speech_buf += pb_pcm
+                    prebuf_prepended = True
                 if not start_ts:
                     start_ts = ts
                 speech_buf += seg_pcm
@@ -474,6 +488,7 @@ def _vad_worker(pcm_q: multiprocessing.Queue, result_q: multiprocessing.Queue,
                     speech_buf = b''
                     start_ts = None
                     end_ts = None
+                    prebuf_prepended = False
                     # Return to waiting for wake word (if KWS enabled)
                     if kws_enabled:
                         state = 'waiting_wake'

--- a/perception/plugins/asr.py
+++ b/perception/plugins/asr.py
@@ -410,7 +410,7 @@ def _vad_worker(pcm_q: multiprocessing.Queue, result_q: multiprocessing.Queue,
 
     # Pre-buffer: keep last N frames so first word isn't cut off by VAD onset delay
     from collections import deque
-    PREBUF_FRAMES = 5  # ~500ms at 100ms/frame — covers VAD onset lag
+    PREBUF_FRAMES = 25  # ~800ms at 32ms/frame (1024B chunks) — covers VAD onset lag
     prebuf = deque(maxlen=PREBUF_FRAMES)
     prebuf_used = False  # whether we already prepended prebuf to current utterance
 

--- a/perception/plugins/asr.py
+++ b/perception/plugins/asr.py
@@ -483,10 +483,8 @@ def _vad_worker(pcm_q: multiprocessing.Queue, result_q: multiprocessing.Queue,
             # Collect completed VAD segments
             while not vad.empty():
                 seg = vad.front
-                # Apply AGC gain to segment for ASR
-                seg_agc = [max(-1.0, min(1.0, s * _agc_gain[0])) for s in seg.samples]
-                seg_pcm = _struct.pack(f'<{len(seg_agc)}h',
-                                       *[int(max(-32768, min(32767, s * 32768))) for s in seg_agc])
+                seg_pcm = _struct.pack(f'<{len(seg.samples)}h',
+                                       *[int(max(-32768, min(32767, s * 32768))) for s in seg.samples])
                 if not start_ts:
                     start_ts = ts
                 speech_buf += seg_pcm

--- a/perception/plugins/asr.py
+++ b/perception/plugins/asr.py
@@ -70,7 +70,8 @@ TOOLS = [
             "properties": {
                 "asr_model":     {"type": "string", "enum": ["paraformer-zh-en", "zipformer-en", "sensevoice-small"], "description": "ASR model (paraformer-zh-en = bilingual streaming, zipformer-en = English only, sensevoice-small = multilingual non-autoregressive)", "default": "paraformer-zh-en", "scope": "shared"},
                 "trigger_mode":  {"type": "string", "enum": ["vad", "kws"], "description": "Trigger mode (vad = always listen, kws = wake word first)", "default": "kws", "scope": "shared"},
-                "kws_keywords":  {"type": "string", "description": "Wake word (pinyin format, e.g. 'x iǎo f àn x iǎo f àn @小范小范')", "scope": "shared", "x-show-when": {"trigger_mode": "kws"}},
+                "kws_model":     {"type": "string", "enum": ["zh", "en", "zh-en"], "description": "KWS 模型 (zh=纯中文, en=纯英文, zh-en=双语)", "default": "zh", "scope": "shared", "x-show-when": {"trigger_mode": "kws"}},
+                "kws_keywords":  {"type": "string", "description": "Wake word (zh: pinyin e.g. 'f àn sh ì x iǎo g ǒu @范式小狗', zh-en: phone+ppinyin, en: BPE)", "scope": "shared", "x-show-when": {"trigger_mode": "kws"}},
                 "vad_threshold": {"type": "number", "description": "VAD speech threshold (0-1, higher = stricter)", "default": 0.5, "scope": "shared"},
                 "vad_silence_ms":{"type": "integer", "description": "Silence duration (ms) before sentence end", "default": 400, "scope": "shared"},
             },
@@ -344,8 +345,17 @@ def _vad_worker(pcm_q: multiprocessing.Queue, result_q: multiprocessing.Queue,
     kws_stream = None
     kws_enabled = (kws_cfg.get('trigger_mode', 'kws') == 'kws') if kws_cfg else False
     if kws_enabled:
-        kws_model_dir = kws_cfg.get('model_dir', '/models/sherpa-onnx/kws')
-        ensure_model("kws", kws_model_dir)
+        # Select KWS model based on kws_model config
+        kws_model_variant = kws_cfg.get('kws_model', 'zh')
+        if kws_model_variant == 'zh':
+            kws_model_dir = '/models/sherpa-onnx/kws_zh'
+            ensure_model("kws_zh", kws_model_dir)
+        elif kws_model_variant == 'en':
+            kws_model_dir = '/models/sherpa-onnx/kws_en'
+            ensure_model("kws_en", kws_model_dir)
+        else:  # zh-en
+            kws_model_dir = kws_cfg.get('model_dir', '/models/sherpa-onnx/kws')
+            ensure_model("kws", kws_model_dir)
         keywords = kws_cfg.get('keywords', [])
         if keywords:
             import glob as _glob
@@ -794,6 +804,8 @@ class ASRPlugin:
                 self._vad_silence_ms = int(cfg['vad_silence_ms'])
             if 'trigger_mode' in cfg:
                 self._kws_cfg['trigger_mode'] = cfg['trigger_mode']
+            if 'kws_model' in cfg:
+                self._kws_cfg['kws_model'] = cfg['kws_model']
             if 'kws_keywords' in cfg:
                 self._kws_cfg['keywords'] = [cfg['kws_keywords']]
             # ASR model switch — load in background if changed

--- a/perception/utils/model_downloader.py
+++ b/perception/utils/model_downloader.py
@@ -55,6 +55,14 @@ MODELS = {
         "url": f"{COS_BASE}/sherpa-onnx-kws-zipformer-zh-en-3M-2025-12-20.tar.bz2",
         "check_file": "tokens.txt",
     },
+    "kws_zh": {
+        "url": f"{COS_BASE}/sherpa-onnx-kws-zipformer-wenetspeech-3.3M-2024-01-01.zip",
+        "check_file": "tokens.txt",
+    },
+    "kws_en": {
+        "url": f"{COS_BASE}/sherpa-onnx-kws-zipformer-gigaspeech-3.3M-2024-01-01.zip",
+        "check_file": "tokens.txt",
+    },
     "vad": {
         "url": f"{COS_BASE}/silero_vad.onnx",
         "check_file": "silero_vad.onnx",

--- a/perception/utils/model_downloader.py
+++ b/perception/utils/model_downloader.py
@@ -68,6 +68,11 @@ MODELS = {
         "check_file": "silero_vad.onnx",
         "single_file": True,  # Not an archive, just a single file download
     },
+    "denoise": {
+        "url": f"{COS_BASE}/gtcrn_simple.onnx",
+        "check_file": "gtcrn_simple.onnx",
+        "single_file": True,
+    },
 }
 
 

--- a/perception/utils/model_downloader.py
+++ b/perception/utils/model_downloader.py
@@ -42,6 +42,10 @@ MODELS = {
         "url": f"{COS_BASE}/sherpa-onnx-sense-voice-zh-en-ja-ko-yue-2024-07-17.zip",
         "check_file": "tokens.txt",
     },
+    "asr_paraformer_offline": {
+        "url": f"{COS_BASE}/sherpa-onnx-paraformer-zh-small-2024-03-09.tar.bz2",
+        "check_file": "tokens.txt",
+    },
     "tts": {
         "url": f"{COS_BASE}/matcha-icefall-zh-en.tar.bz2",
         "check_file": "model-steps-3.onnx",


### PR DESCRIPTION
## Summary

- Fix DDS RMW mismatch (Dockerfile ENV override)
- Fix ASR config race condition (KeyError on concurrent stop/config)
- Keep ASR node in executor on config (avoid DDS re-discovery delay)
- ASR start waits for model loading before proceeding
- Startup modal: parallel card init with progress indicators, two-phase (sources first)
- Config save failure alert (no more silent swallow)
- Fix R1 mic frame drops (remove list() conversion + enlarge recv buffer)
- Add KWS model selector (zh/en/zh-en)
- Add offline paraformer-zh-small ASR model
- Add configurable VAD segment saving
- KWS threshold tuning for noisy environments
- MCP call timeout set to None (user controls via cancel)

## Test plan

- [ ] Start/stop control multiple times — no hang, no KeyError
- [ ] ASR recognizes speech correctly with sensevoice-small
- [ ] KWS wake word detection in noisy environment
- [ ] VAD segment saving works to /opt/embodied/models/vad_segments/

🤖 Generated with [Claude Code](https://claude.com/claude-code)