### PR TITLE
feat(perception): asr_kws trigger mode — phoneme-based wake word

### DIFF
--- a/agent-core/deploy/docker-compose.yml
+++ b/agent-core/deploy/docker-compose.yml
@@ -13,6 +13,7 @@ services:
     environment:
       - DB_PATH=/work/resource/data.db
       - COMPOSE_DIR=/opt/phanthy-motus
+      - CONTAINER_NAME=phanthy-motus-agent-core-1
       - ROS_DOMAIN_ID=42
       - RMW_IMPLEMENTATION=rmw_fastrtps_cpp
       - FASTDDS_BUILTIN_TRANSPORTS=DEFAULT

--- a/perception/Dockerfile
+++ b/perception/Dockerfile
@@ -22,6 +22,8 @@ RUN pip3 install --no-cache-dir -i ${PYPI_MIRROR} \
     ultralytics
 RUN pip3 install --no-cache-dir -i ${PYPI_MIRROR} \
     sherpa-onnx
+RUN pip3 install --no-cache-dir -i ${PYPI_MIRROR} \
+    epitran
 
 # Override base image RMW (some ros-base tags ship cyclonedds by default)
 ENV RMW_IMPLEMENTATION=rmw_fastrtps_cpp

--- a/perception/Dockerfile
+++ b/perception/Dockerfile
@@ -22,8 +22,10 @@ RUN pip3 install --no-cache-dir -i ${PYPI_MIRROR} \
     ultralytics
 RUN pip3 install --no-cache-dir -i ${PYPI_MIRROR} \
     sherpa-onnx
+RUN apt-get update && apt-get install -y --no-install-recommends espeak-ng && \
+    rm -rf /var/lib/apt/lists/*
 RUN pip3 install --no-cache-dir -i ${PYPI_MIRROR} \
-    epitran importlib-resources
+    phonemizer
 
 # Override base image RMW (some ros-base tags ship cyclonedds by default)
 ENV RMW_IMPLEMENTATION=rmw_fastrtps_cpp

--- a/perception/Dockerfile
+++ b/perception/Dockerfile
@@ -23,7 +23,7 @@ RUN pip3 install --no-cache-dir -i ${PYPI_MIRROR} \
 RUN pip3 install --no-cache-dir -i ${PYPI_MIRROR} \
     sherpa-onnx
 RUN pip3 install --no-cache-dir -i ${PYPI_MIRROR} \
-    epitran
+    epitran importlib-resources
 
 # Override base image RMW (some ros-base tags ship cyclonedds by default)
 ENV RMW_IMPLEMENTATION=rmw_fastrtps_cpp

--- a/perception/Dockerfile.jetson
+++ b/perception/Dockerfile.jetson
@@ -79,8 +79,10 @@ ENV YOLO_CONFIG_DIR=/work
 # ── sherpa-onnx (on-device ASR/TTS/KWS) ──────────────────────────
 RUN pip3 install --no-cache-dir -i ${PYPI_MIRROR} sherpa-onnx
 
-# ── pypinyin (Chinese text to pinyin for asr_kws phoneme matching) ─
-RUN pip3 install --no-cache-dir -i ${PYPI_MIRROR} epitran importlib-resources
+# ── phonemizer (multilingual IPA via espeak-ng for asr_kws mode) ──
+RUN apt-get update && apt-get install -y --no-install-recommends espeak-ng && \
+    rm -rf /var/lib/apt/lists/*
+RUN pip3 install --no-cache-dir -i ${PYPI_MIRROR} phonemizer
 
 # ── Application code ───────────────────────────────────────────────
 WORKDIR /work

--- a/perception/Dockerfile.jetson
+++ b/perception/Dockerfile.jetson
@@ -79,6 +79,9 @@ ENV YOLO_CONFIG_DIR=/work
 # ── sherpa-onnx (on-device ASR/TTS/KWS) ──────────────────────────
 RUN pip3 install --no-cache-dir -i ${PYPI_MIRROR} sherpa-onnx
 
+# ── epitran (IPA phoneme conversion for asr_kws mode) ────────────
+RUN pip3 install --no-cache-dir -i ${PYPI_MIRROR} epitran
+
 # ── Application code ───────────────────────────────────────────────
 WORKDIR /work
 COPY perception/main.py    /work/main.py

--- a/perception/Dockerfile.jetson
+++ b/perception/Dockerfile.jetson
@@ -79,8 +79,8 @@ ENV YOLO_CONFIG_DIR=/work
 # ── sherpa-onnx (on-device ASR/TTS/KWS) ──────────────────────────
 RUN pip3 install --no-cache-dir -i ${PYPI_MIRROR} sherpa-onnx
 
-# ── epitran (IPA phoneme conversion for asr_kws mode) ────────────
-RUN pip3 install --no-cache-dir -i ${PYPI_MIRROR} epitran
+# ── pypinyin (Chinese text to pinyin for asr_kws phoneme matching) ─
+RUN pip3 install --no-cache-dir -i ${PYPI_MIRROR} epitran importlib-resources
 
 # ── Application code ───────────────────────────────────────────────
 WORKDIR /work

--- a/perception/plugins/asr.py
+++ b/perception/plugins/asr.py
@@ -71,6 +71,9 @@ def _text_to_ipa(text: str) -> list:
         try:
             ipa = phonemize(seg_text, language=lang, backend='espeak',
                            separator=sep, strip=True, language_switch='remove-flags')
+            # Remove tone/stress marks for fuzzy matching
+            import re
+            ipa = re.sub(r'[ˈˌːˑ̃ˀ¹²³⁴⁵˥˦˧˨˩↓↑]', '', ipa)
             phones = [p for p in ipa.split() if p]
             ipa_seq.extend(phones)
         except Exception:

--- a/perception/plugins/asr.py
+++ b/perception/plugins/asr.py
@@ -73,6 +73,9 @@ def _text_to_ipa(text: str) -> list:
                            separator=sep, strip=True,
                            with_stress=False, tie=False,
                            language_switch='remove-flags')
+            # Remove tone numbers and diacritics for fuzzy matching
+            import re
+            ipa = re.sub(r'[0-9˥˦˧˨˩¹²³⁴⁵]', '', ipa)
             phones = [p for p in ipa.split() if p]
             ipa_seq.extend(phones)
         except Exception:
@@ -82,7 +85,7 @@ def _text_to_ipa(text: str) -> list:
 
 
 def _phoneme_edit_distance(seq1: list, seq2: list) -> float:
-    """Normalized edit distance between two phoneme sequences (0=match, 1=different)."""
+    """Normalized edit distance with phoneme similarity (0=match, 1=different)."""
     m, n = len(seq1), len(seq2)
     if m == 0 or n == 0:
         return 1.0
@@ -93,9 +96,40 @@ def _phoneme_edit_distance(seq1: list, seq2: list) -> float:
         dp[0][j] = j
     for i in range(1, m + 1):
         for j in range(1, n + 1):
-            cost = 0 if seq1[i - 1] == seq2[j - 1] else 1
+            cost = _phoneme_sub_cost(seq1[i - 1], seq2[j - 1])
             dp[i][j] = min(dp[i - 1][j] + 1, dp[i][j - 1] + 1, dp[i - 1][j - 1] + cost)
     return dp[m][n] / max(m, n)
+
+
+# Similar phoneme groups — substitution cost 0.3 instead of 1.0
+_SIMILAR_GROUPS = [
+    {'t', 'd'},       # alveolar stops
+    {'p', 'b'},       # bilabial stops
+    {'k', 'g'},       # velar stops
+    {'f', 'v'},       # labiodental fricatives
+    {'s', 'z'},       # alveolar fricatives
+    {'s.', 'z.'},     # retroflex fricatives
+    {'ɕ', 'ʃ', 'ʂ'}, # postalveolar/retroflex sibilants
+    {'tsh', 'dz'},    # affricates
+    {'n', 'ŋ'},       # nasals
+    {'l', 'r', 'ɹ'},  # liquids
+    {'t', 'tsh'},     # stop ~ affricate
+    {'f', 't'},       # common confusion in noisy env
+    {'x', 'h'},       # velar/glottal fricatives
+    {'ɑu', 'au', 'ɑo', 'ao'},  # diphthong variants
+    {'ou', 'uo'},     # vowel variants
+    {'i', 'i.'},      # apical vowel variant
+]
+
+
+def _phoneme_sub_cost(a: str, b: str) -> float:
+    """Substitution cost: 0 if same, 0.3 if similar, 1.0 otherwise."""
+    if a == b:
+        return 0
+    for group in _SIMILAR_GROUPS:
+        if a in group and b in group:
+            return 0.3
+    return 1.0
 
 
 def _find_keyword_in_ipa(text_ipa: list, keyword_ipa: list, threshold: float):

--- a/perception/plugins/asr.py
+++ b/perception/plugins/asr.py
@@ -149,22 +149,30 @@ def _find_keyword_in_ipa(text_ipa: list, keyword_ipa: list, threshold: float):
     return best_dist <= threshold, best_end
 
 
-def _extract_after_keyword(text: str, keyword_ipa: list, end_pos: int) -> str:
-    """Extract text after the matched keyword position.
-    end_pos is the IPA phoneme index where keyword ends.
-    Maps back to character position by counting phoneme-producing chars.
+def _extract_after_keyword(text: str, keyword_text: str, end_pos: int) -> str:
+    """Extract text after the matched keyword.
+    Uses keyword text length to determine how many characters to skip,
+    then handles the case where ASR text has slightly different char count.
     """
-    ipa_count = 0
+    # Count phoneme-producing characters in original text up to end_pos
+    # Simpler approach: use the keyword character length as skip count
+    kw_chars = len([c for c in keyword_text if '\u4e00' <= c <= '\u9fff' or c.isalpha()])
+
+    # Skip that many phoneme-producing characters in text
+    skipped = 0
+    cut_idx = 0
     for i, char in enumerate(text):
-        if '\u4e00' <= char <= '\u9fff' or char.isalpha() or '\u3040' <= char <= '\u30ff' or '\uac00' <= char <= '\ud7af':
-            ipa_count += 1
-        if ipa_count >= end_pos:
-            # Return everything after this character, stripping punctuation prefix
-            remaining = text[i + 1:]
-            # Strip leading punctuation/spaces
-            remaining = remaining.lstrip('，。！？、；：,.!?;: ')
-            return remaining
-    return ''
+        if '\u4e00' <= char <= '\u9fff' or char.isalpha():
+            skipped += 1
+        if skipped >= kw_chars:
+            cut_idx = i + 1
+            break
+
+    if cut_idx == 0:
+        return ''
+    remaining = text[cut_idx:]
+    remaining = remaining.lstrip('，。！？、；：,.!?;: ')
+    return remaining
 
 _ASR_PUB_QOS = QoSProfile(
     reliability=ReliabilityPolicy.BEST_EFFORT,
@@ -902,7 +910,7 @@ class _ASRNode(Node):
                     if not matched:
                         continue
                     # Extract text after keyword
-                    remaining = _extract_after_keyword(text, keyword_ipa, end_pos)
+                    remaining = _extract_after_keyword(text, kw_text, end_pos)
                     log.info(f"[asr] asr_kws TRIGGERED: '{text}' → '{remaining}'")
                     if not remaining.strip():
                         continue

--- a/perception/plugins/asr.py
+++ b/perception/plugins/asr.py
@@ -794,7 +794,12 @@ class _ASRNode(Node):
         if trigger_mode == 'asr_kws':
             kw_text = self._kws_cfg.get('asr_kws_keyword', '')
             if kw_text:
-                keyword_ipa = _text_to_ipa(kw_text)
+                try:
+                    keyword_ipa = _text_to_ipa(kw_text)
+                except Exception as e:
+                    log.error(f"[asr] asr_kws: failed to compute IPA for keyword '{kw_text}': {e}")
+                    self.state = "error"
+                    return
                 log.info(f"[asr] asr_kws mode: keyword='{kw_text}' ipa={keyword_ipa} threshold={asr_kws_threshold}")
             else:
                 log.warning("[asr] asr_kws mode but no keyword configured, falling back to vad mode")

--- a/perception/plugins/asr.py
+++ b/perception/plugins/asr.py
@@ -40,28 +40,43 @@ _LOW_LAT_QOS = QoSProfile(
 
 # ── IPA phoneme matching for asr_kws mode ────────────────────────────────────
 
-_epi_cache = {}
-
-def _get_epi(lang: str):
-    if lang not in _epi_cache:
-        import epitran
-        _epi_cache[lang] = epitran.Epitran(lang)
-    return _epi_cache[lang]
-
-
 def _text_to_ipa(text: str) -> list:
-    """Convert text to IPA phoneme sequence. Auto-detects language per character."""
-    ipa_seq = []
+    """Convert text to IPA phoneme sequence using phonemizer (espeak-ng backend).
+    Returns a list of IPA phoneme strings (one per word/character).
+    """
+    from phonemizer import phonemize
+    from phonemizer.separator import Separator
+
+    # Separate Chinese and non-Chinese segments
+    segments = []
+    current = ''
+    current_is_cjk = None
     for char in text:
-        if '\u4e00' <= char <= '\u9fff':
-            ipa_seq.append(_get_epi('cmn-Hani').transliterate(char))
-        elif '\u3040' <= char <= '\u309f' or '\u30a0' <= char <= '\u30ff':
-            ipa_seq.append(_get_epi('jpn-Hrgn').transliterate(char))
-        elif '\uac00' <= char <= '\ud7af':
-            ipa_seq.append(_get_epi('kor-Hang').transliterate(char))
-        elif char.isalpha():
-            ipa_seq.append(_get_epi('eng-Latn').transliterate(char))
-    return [s for s in ipa_seq if s]
+        is_cjk = '\u4e00' <= char <= '\u9fff'
+        if current_is_cjk is None:
+            current_is_cjk = is_cjk
+        if is_cjk != current_is_cjk:
+            if current.strip():
+                segments.append((current.strip(), current_is_cjk))
+            current = ''
+            current_is_cjk = is_cjk
+        current += char
+    if current.strip():
+        segments.append((current.strip(), current_is_cjk))
+
+    ipa_seq = []
+    sep = Separator(phone=' ', word=' ', syllable='')
+    for seg_text, is_cjk in segments:
+        lang = 'cmn' if is_cjk else 'en-us'
+        try:
+            ipa = phonemize(seg_text, language=lang, backend='espeak',
+                           separator=sep, strip=True, language_switch='remove-flags')
+            phones = [p for p in ipa.split() if p]
+            ipa_seq.extend(phones)
+        except Exception:
+            # Fallback: use characters as-is
+            ipa_seq.extend(list(seg_text))
+    return ipa_seq
 
 
 def _phoneme_edit_distance(seq1: list, seq2: list) -> float:

--- a/perception/plugins/asr.py
+++ b/perception/plugins/asr.py
@@ -37,6 +37,79 @@ _LOW_LAT_QOS = QoSProfile(
     durability=DurabilityPolicy.VOLATILE,
 )
 
+
+# ── IPA phoneme matching for asr_kws mode ────────────────────────────────────
+
+_epi_cache = {}
+
+def _get_epi(lang: str):
+    if lang not in _epi_cache:
+        import epitran
+        _epi_cache[lang] = epitran.Epitran(lang)
+    return _epi_cache[lang]
+
+
+def _text_to_ipa(text: str) -> list:
+    """Convert text to IPA phoneme sequence. Auto-detects language per character."""
+    ipa_seq = []
+    for char in text:
+        if '\u4e00' <= char <= '\u9fff':
+            ipa_seq.append(_get_epi('cmn-Hani').transliterate(char))
+        elif '\u3040' <= char <= '\u309f' or '\u30a0' <= char <= '\u30ff':
+            ipa_seq.append(_get_epi('jpn-Hrgn').transliterate(char))
+        elif '\uac00' <= char <= '\ud7af':
+            ipa_seq.append(_get_epi('kor-Hang').transliterate(char))
+        elif char.isalpha():
+            ipa_seq.append(_get_epi('eng-Latn').transliterate(char))
+    return [s for s in ipa_seq if s]
+
+
+def _phoneme_edit_distance(seq1: list, seq2: list) -> float:
+    """Normalized edit distance between two phoneme sequences (0=match, 1=different)."""
+    m, n = len(seq1), len(seq2)
+    if m == 0 or n == 0:
+        return 1.0
+    dp = [[0] * (n + 1) for _ in range(m + 1)]
+    for i in range(m + 1):
+        dp[i][0] = i
+    for j in range(n + 1):
+        dp[0][j] = j
+    for i in range(1, m + 1):
+        for j in range(1, n + 1):
+            cost = 0 if seq1[i - 1] == seq2[j - 1] else 1
+            dp[i][j] = min(dp[i - 1][j] + 1, dp[i][j - 1] + 1, dp[i - 1][j - 1] + cost)
+    return dp[m][n] / max(m, n)
+
+
+def _find_keyword_in_ipa(text_ipa: list, keyword_ipa: list, threshold: float):
+    """Sliding window search for keyword in text IPA. Returns (matched, end_position)."""
+    kw_len = len(keyword_ipa)
+    if kw_len == 0 or len(text_ipa) < kw_len:
+        return False, -1
+    best_dist = float('inf')
+    best_end = -1
+    for i in range(len(text_ipa) - kw_len + 1):
+        window = text_ipa[i:i + kw_len]
+        dist = _phoneme_edit_distance(window, keyword_ipa)
+        if dist < best_dist:
+            best_dist = dist
+            best_end = i + kw_len
+    return best_dist <= threshold, best_end
+
+
+def _extract_after_keyword(text: str, keyword_ipa: list, end_pos: int) -> str:
+    """Extract text characters after the matched keyword position."""
+    # Map IPA positions back to character positions
+    char_pos = 0
+    ipa_count = 0
+    for char in text:
+        if '\u4e00' <= char <= '\u9fff' or char.isalpha() or '\u3040' <= char <= '\u30ff' or '\uac00' <= char <= '\ud7af':
+            ipa_count += 1
+        if ipa_count >= end_pos:
+            char_pos = text.index(char) + 1
+            break
+    return text[char_pos:].strip() if char_pos > 0 else ''
+
 _ASR_PUB_QOS = QoSProfile(
     reliability=ReliabilityPolicy.BEST_EFFORT,
     history=HistoryPolicy.KEEP_LAST,
@@ -69,9 +142,11 @@ TOOLS = [
             "type": "object",
             "properties": {
                 "asr_model":     {"type": "string", "enum": ["paraformer-zh-en", "paraformer-offline", "zipformer-en", "sensevoice-small"], "description": "ASR model (paraformer-zh-en = bilingual streaming, paraformer-offline = bilingual offline, zipformer-en = English streaming, sensevoice-small = multilingual offline)", "default": "sensevoice-small", "scope": "shared"},
-                "trigger_mode":  {"type": "string", "enum": ["vad", "kws"], "description": "Trigger mode (vad = always listen, kws = wake word first)", "default": "kws", "scope": "shared"},
+                "trigger_mode":  {"type": "string", "enum": ["vad", "kws", "asr_kws"], "description": "Trigger mode (vad = always listen, kws = KWS model, asr_kws = ASR + phoneme matching)", "default": "kws", "scope": "shared"},
                 "kws_model":     {"type": "string", "enum": ["zh", "en", "zh-en"], "description": "KWS 模型 (zh=纯中文, en=纯英文, zh-en=双语)", "default": "zh", "scope": "shared", "x-show-when": {"trigger_mode": "kws"}},
                 "kws_keywords":  {"type": "string", "description": "Wake word (zh: 'f àn sh ì x iǎo g ǒu @范式小狗', en: '▁FA N C Y ▁RO B O T @FANCY_ROBOT')", "scope": "shared", "x-show-when": {"trigger_mode": "kws"}},
+                "asr_kws_keyword": {"type": "string", "description": "唤醒词文本（如'范式小狗'、'hello robot'）", "scope": "shared", "x-show-when": {"trigger_mode": "asr_kws"}},
+                "asr_kws_threshold": {"type": "number", "description": "音素匹配阈值（0-1，越小越严格，推荐0.3）", "default": 0.3, "scope": "shared", "x-show-when": {"trigger_mode": "asr_kws"}},
                 "vad_threshold": {"type": "number", "description": "VAD speech threshold (0-1, higher = stricter)", "default": 0.5, "scope": "shared"},
                 "vad_silence_ms":{"type": "integer", "description": "Silence duration (ms) before sentence end", "default": 400, "scope": "shared"},
                 "save_vad_segments": {"type": "boolean", "description": "Save VAD segments as WAV to /opt/embodied/models/vad_segments/", "default": False, "scope": "shared"},
@@ -712,6 +787,19 @@ class _ASRNode(Node):
             pass  # drop if severely behind
 
     def _worker(self):
+        # Pre-compute keyword IPA if in asr_kws mode
+        trigger_mode = self._kws_cfg.get('trigger_mode', 'kws')
+        keyword_ipa = None
+        asr_kws_threshold = float(self._kws_cfg.get('asr_kws_threshold', 0.3))
+        if trigger_mode == 'asr_kws':
+            kw_text = self._kws_cfg.get('asr_kws_keyword', '')
+            if kw_text:
+                keyword_ipa = _text_to_ipa(kw_text)
+                log.info(f"[asr] asr_kws mode: keyword='{kw_text}' ipa={keyword_ipa} threshold={asr_kws_threshold}")
+            else:
+                log.warning("[asr] asr_kws mode but no keyword configured, falling back to vad mode")
+                trigger_mode = 'vad'
+
         while not self._stop_event.is_set():
             try:
                 utterance, start_ts, end_ts = self._utterance_queue.get(timeout=1)
@@ -721,6 +809,21 @@ class _ASRNode(Node):
                 wav   = _pcm16_to_wav(utterance)
                 text  = self._adapter.transcribe(wav, self._language)
                 if not text.strip(): continue
+
+                # ASR-based keyword spotting
+                if trigger_mode == 'asr_kws' and keyword_ipa:
+                    text_ipa = _text_to_ipa(text)
+                    matched, end_pos = _find_keyword_in_ipa(text_ipa, keyword_ipa, asr_kws_threshold)
+                    if not matched:
+                        log.debug(f"[asr] asr_kws: no match in '{text}'")
+                        continue
+                    # Extract text after keyword
+                    remaining = _extract_after_keyword(text, keyword_ipa, end_pos)
+                    log.info(f"[asr] asr_kws TRIGGERED: '{text}' → '{remaining}'")
+                    if not remaining.strip():
+                        continue
+                    text = remaining
+
                 result = {"text": text, "audio_start_ts": start_ts,
                           "audio_end_ts": end_ts, "asr_complete_ts": time.time()}
                 msg = String(); msg.data = json.dumps(result, ensure_ascii=False)
@@ -917,6 +1020,10 @@ class ASRPlugin:
                 self._kws_cfg['kws_model'] = cfg['kws_model']
             if 'kws_keywords' in cfg:
                 self._kws_cfg['keywords'] = [cfg['kws_keywords']]
+            if 'asr_kws_keyword' in cfg:
+                self._kws_cfg['asr_kws_keyword'] = cfg['asr_kws_keyword']
+            if 'asr_kws_threshold' in cfg:
+                self._kws_cfg['asr_kws_threshold'] = float(cfg['asr_kws_threshold'])
             if 'save_vad_segments' in cfg:
                 self._save_vad_segments = bool(cfg['save_vad_segments'])
             if 'max_saved_segments' in cfg:

--- a/perception/plugins/asr.py
+++ b/perception/plugins/asr.py
@@ -150,17 +150,21 @@ def _find_keyword_in_ipa(text_ipa: list, keyword_ipa: list, threshold: float):
 
 
 def _extract_after_keyword(text: str, keyword_ipa: list, end_pos: int) -> str:
-    """Extract text characters after the matched keyword position."""
-    # Map IPA positions back to character positions
-    char_pos = 0
+    """Extract text after the matched keyword position.
+    end_pos is the IPA phoneme index where keyword ends.
+    Maps back to character position by counting phoneme-producing chars.
+    """
     ipa_count = 0
-    for char in text:
+    for i, char in enumerate(text):
         if '\u4e00' <= char <= '\u9fff' or char.isalpha() or '\u3040' <= char <= '\u30ff' or '\uac00' <= char <= '\ud7af':
             ipa_count += 1
         if ipa_count >= end_pos:
-            char_pos = text.index(char) + 1
-            break
-    return text[char_pos:].strip() if char_pos > 0 else ''
+            # Return everything after this character, stripping punctuation prefix
+            remaining = text[i + 1:]
+            # Strip leading punctuation/spaces
+            remaining = remaining.lstrip('，。！？、；：,.!?;: ')
+            return remaining
+    return ''
 
 _ASR_PUB_QOS = QoSProfile(
     reliability=ReliabilityPolicy.BEST_EFFORT,

--- a/perception/plugins/asr.py
+++ b/perception/plugins/asr.py
@@ -699,7 +699,15 @@ class _ASRNode(Node):
         if self.state == "running":
             return self._status_dict()
         if not self._adapter:
-            raise RuntimeError("ASR adapter not configured")
+            return {"state": "error", "message": "ASR adapter not configured"}
+        try:
+            return self._start_inner()
+        except Exception as e:
+            log.error(f"[asr] start failed: {e}", exc_info=True)
+            self.state = "error"
+            return {"state": "error", "message": str(e)}
+
+    def _start_inner(self) -> dict:
         from audio_msgs.msg import AudioChunk
         log.info(f"[asr] subscribing to topic={self._input_topic}, publishing to={self._output_topic}")
         self._first_chunk_event = threading.Event()
@@ -787,6 +795,13 @@ class _ASRNode(Node):
             pass  # drop if severely behind
 
     def _worker(self):
+        try:
+            self._worker_inner()
+        except Exception as e:
+            log.error(f"[asr] worker fatal error: {e}", exc_info=True)
+            self.state = "error"
+
+    def _worker_inner(self):
         # Pre-compute keyword IPA if in asr_kws mode
         trigger_mode = self._kws_cfg.get('trigger_mode', 'kws')
         keyword_ipa = None
@@ -794,12 +809,7 @@ class _ASRNode(Node):
         if trigger_mode == 'asr_kws':
             kw_text = self._kws_cfg.get('asr_kws_keyword', '')
             if kw_text:
-                try:
-                    keyword_ipa = _text_to_ipa(kw_text)
-                except Exception as e:
-                    log.error(f"[asr] asr_kws: failed to compute IPA for keyword '{kw_text}': {e}")
-                    self.state = "error"
-                    return
+                keyword_ipa = _text_to_ipa(kw_text)
                 log.info(f"[asr] asr_kws mode: keyword='{kw_text}' ipa={keyword_ipa} threshold={asr_kws_threshold}")
             else:
                 log.warning("[asr] asr_kws mode but no keyword configured, falling back to vad mode")

--- a/perception/plugins/asr.py
+++ b/perception/plugins/asr.py
@@ -133,40 +133,19 @@ def _phoneme_sub_cost(a: str, b: str) -> float:
 
 
 def _find_keyword_in_ipa(text_ipa: list, keyword_ipa: list, threshold: float):
-    """Sliding window search for keyword in text IPA. Returns (matched, end_position).
-    Also handles case where ASR truncated the beginning of the keyword.
-    """
+    """Sliding window search for keyword in text IPA. Returns (matched, end_position)."""
     kw_len = len(keyword_ipa)
-    if kw_len == 0:
+    if kw_len == 0 or len(text_ipa) < kw_len:
         return False, -1
 
     best_dist = float('inf')
     best_end = -1
-
-    # Standard sliding window (text >= keyword length)
-    for i in range(max(1, len(text_ipa) - kw_len + 1)):
+    for i in range(len(text_ipa) - kw_len + 1):
         window = text_ipa[i:i + kw_len]
-        if len(window) < kw_len:
-            break
         dist = _phoneme_edit_distance(window, keyword_ipa)
         if dist < best_dist:
             best_dist = dist
             best_end = i + kw_len
-
-    # Handle truncated keyword: match keyword suffix against text prefix
-    # e.g. keyword="范式小狗" but ASR only got "小狗你好"
-    if len(text_ipa) < kw_len:
-        # Try matching text prefix against keyword suffix of same length
-        for trim in range(1, kw_len):
-            kw_suffix = keyword_ipa[trim:]
-            text_prefix = text_ipa[:len(kw_suffix)]
-            if len(text_prefix) < len(kw_suffix):
-                continue
-            dist = _phoneme_edit_distance(text_prefix, kw_suffix)
-            if dist < best_dist:
-                best_dist = dist
-                best_end = len(kw_suffix)
-
     return best_dist <= threshold, best_end
 
 

--- a/perception/plugins/asr.py
+++ b/perception/plugins/asr.py
@@ -70,10 +70,9 @@ def _text_to_ipa(text: str) -> list:
         lang = 'cmn' if is_cjk else 'en-us'
         try:
             ipa = phonemize(seg_text, language=lang, backend='espeak',
-                           separator=sep, strip=True, language_switch='remove-flags')
-            # Remove tone/stress marks for fuzzy matching
-            import re
-            ipa = re.sub(r'[ˈˌːˑ̃ˀ¹²³⁴⁵˥˦˧˨˩↓↑]', '', ipa)
+                           separator=sep, strip=True,
+                           with_stress=False, tie=False,
+                           language_switch='remove-flags')
             phones = [p for p in ipa.split() if p]
             ipa_seq.extend(phones)
         except Exception:

--- a/perception/plugins/asr.py
+++ b/perception/plugins/asr.py
@@ -65,7 +65,7 @@ def _text_to_ipa(text: str) -> list:
         segments.append((current.strip(), current_is_cjk))
 
     ipa_seq = []
-    sep = Separator(phone=' ', word=' ', syllable='')
+    sep = Separator(phone=' ', word='  ', syllable='')
     for seg_text, is_cjk in segments:
         lang = 'cmn' if is_cjk else 'en-us'
         try:

--- a/perception/plugins/asr.py
+++ b/perception/plugins/asr.py
@@ -747,14 +747,19 @@ class _ASRNode(Node):
         self._worker_thread = threading.Thread(target=self._worker, daemon=True)
         self._worker_thread.start()
         self.state = "starting"
+        self._worker_ready = threading.Event()
         log.info("[asr] waiting for first audio chunk...")
         # Block until first audio chunk arrives or stop() cancels
         self._first_chunk_event.wait()
         if self._stop_event.is_set():
             self.state = "idle"
             return {"state": "idle"}
+        # Wait for worker to finish initialization (IPA precompute etc.)
+        self._worker_ready.wait()
+        if self.state == "error":
+            return {"state": "error", "message": "ASR worker failed to initialize (check logs)"}
         self.state = "running"
-        log.info("[asr] started, waiting for audio data...")
+        log.info("[asr] started, receiving audio data")
         return self._status_dict()
 
     def stop(self) -> dict:
@@ -762,9 +767,11 @@ class _ASRNode(Node):
         if self._sub:
             self.destroy_subscription(self._sub); self._sub = None
         self._stop_event.set()
-        # Unblock start() if it's waiting for first chunk
+        # Unblock start() if it's waiting
         if hasattr(self, '_first_chunk_event'):
             self._first_chunk_event.set()
+        if hasattr(self, '_worker_ready'):
+            self._worker_ready.set()
         if self._vad_stop:
             self._vad_stop.set()
         # Cancel feeder threads immediately — avoids BrokenPipeError spam
@@ -817,6 +824,8 @@ class _ASRNode(Node):
         except Exception as e:
             log.error(f"[asr] worker fatal error: {e}", exc_info=True)
             self.state = "error"
+            if hasattr(self, '_worker_ready'):
+                self._worker_ready.set()
 
     def _worker_inner(self):
         # Pre-compute keyword IPA if in asr_kws mode
@@ -831,6 +840,10 @@ class _ASRNode(Node):
             else:
                 log.warning("[asr] asr_kws mode but no keyword configured, falling back to vad mode")
                 trigger_mode = 'vad'
+
+        # Signal that worker init is complete
+        if hasattr(self, '_worker_ready'):
+            self._worker_ready.set()
 
         while not self._stop_event.is_set():
             try:

--- a/perception/plugins/asr.py
+++ b/perception/plugins/asr.py
@@ -859,8 +859,8 @@ class _ASRNode(Node):
                 if trigger_mode == 'asr_kws' and keyword_ipa:
                     text_ipa = _text_to_ipa(text)
                     matched, end_pos = _find_keyword_in_ipa(text_ipa, keyword_ipa, asr_kws_threshold)
+                    log.info(f"[asr] asr_kws: text='{text}' ipa={text_ipa} dist_matched={matched} end={end_pos}")
                     if not matched:
-                        log.debug(f"[asr] asr_kws: no match in '{text}'")
                         continue
                     # Extract text after keyword
                     remaining = _extract_after_keyword(text, keyword_ipa, end_pos)

--- a/perception/plugins/asr.py
+++ b/perception/plugins/asr.py
@@ -133,18 +133,40 @@ def _phoneme_sub_cost(a: str, b: str) -> float:
 
 
 def _find_keyword_in_ipa(text_ipa: list, keyword_ipa: list, threshold: float):
-    """Sliding window search for keyword in text IPA. Returns (matched, end_position)."""
+    """Sliding window search for keyword in text IPA. Returns (matched, end_position).
+    Also handles case where ASR truncated the beginning of the keyword.
+    """
     kw_len = len(keyword_ipa)
-    if kw_len == 0 or len(text_ipa) < kw_len:
+    if kw_len == 0:
         return False, -1
+
     best_dist = float('inf')
     best_end = -1
-    for i in range(len(text_ipa) - kw_len + 1):
+
+    # Standard sliding window (text >= keyword length)
+    for i in range(max(1, len(text_ipa) - kw_len + 1)):
         window = text_ipa[i:i + kw_len]
+        if len(window) < kw_len:
+            break
         dist = _phoneme_edit_distance(window, keyword_ipa)
         if dist < best_dist:
             best_dist = dist
             best_end = i + kw_len
+
+    # Handle truncated keyword: match keyword suffix against text prefix
+    # e.g. keyword="范式小狗" but ASR only got "小狗你好"
+    if len(text_ipa) < kw_len:
+        # Try matching text prefix against keyword suffix of same length
+        for trim in range(1, kw_len):
+            kw_suffix = keyword_ipa[trim:]
+            text_prefix = text_ipa[:len(kw_suffix)]
+            if len(text_prefix) < len(kw_suffix):
+                continue
+            dist = _phoneme_edit_distance(text_prefix, kw_suffix)
+            if dist < best_dist:
+                best_dist = dist
+                best_end = len(kw_suffix)
+
     return best_dist <= threshold, best_end
 
 


### PR DESCRIPTION
## Summary

New `trigger_mode: "asr_kws"` — VAD segments all go through ASR, then text is converted to IPA phonemes (via phonemizer/espeak-ng) and matched against configured wake word using weighted edit distance.

- Phonemizer (espeak-ng backend) for multilingual IPA conversion
- Weighted edit distance with phoneme similarity matrix (t/d, p/b, k/g, f/v etc. cost 0.3)
- Tone/stress stripping for fuzzy matching
- Sliding window to find keyword anywhere in utterance
- Extracts and outputs only text after the wake word
- Config: `asr_kws_keyword` (text), `asr_kws_threshold` (0-1, default 0.3)
- Also includes: CONTAINER_NAME env fix for deploy, start() error handling

## Test plan

- [ ] Configure trigger_mode=asr_kws, keyword=范式小狗
- [ ] Say "范式小狗你好" → outputs "你好"
- [ ] Say unrelated text → no output
- [ ] Worker init failure shows error in dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)