### PR TITLE
fix: prevent trigger backlog when agent loop is busy

### DIFF
--- a/agent-core/src/collector.py
+++ b/agent-core/src/collector.py
@@ -23,6 +23,14 @@ _task: asyncio.Task | None = None
 # Per-source throttle: source → timestamp of last accepted event
 _last_accepted: dict[str, float] = {}
 _THROTTLE_INTERVAL = 1.0  # 每个 source 最多 1 条/秒
+# Agent loop busy flag — 忙时不发射 trigger，让事件继续积累
+_busy: bool = False
+
+
+def set_busy(busy: bool):
+    """由 agent loop 调用：标记当前是否正在执行 turn。"""
+    global _busy
+    _busy = busy
 
 
 def _get_interval_ms() -> int:
@@ -78,6 +86,10 @@ async def _trigger_loop():
         await asyncio.sleep(interval)
 
         if not _buffer:
+            continue
+
+        # 防堆积：agent loop 忙时不发射，让事件继续在 buffer 中积累
+        if _busy:
             continue
 
         # 取出当前所有积累的事件

--- a/agent-core/src/event/llm.py
+++ b/agent-core/src/event/llm.py
@@ -264,6 +264,7 @@ class Event:
         while True:
             ev = await collector.next_trigger()
             self._current_turn = []  # 本轮消息，无论成功失败都会保存
+            collector.set_busy(True)
             try:
                 await self._one_turn(ev)
             except asyncio.CancelledError:
@@ -277,6 +278,7 @@ class Event:
                 })
                 await push_event({'type': 'error', 'payload': {'message': str(e)}})
             finally:
+                collector.set_busy(False)
                 # 无论成功失败，只要有消息就持久化
                 if self._current_turn:
                     self._save_current_turn(ev)


### PR DESCRIPTION
## Summary
- Agent loop 忙时 collector 不再发射 trigger，事件留在 buffer 继续积累
- Turn 结束后下次 trigger 间隔会把所有积累的事件一次性打包发射
- 避免了长耗时 turn 导致队列堆积过时 trigger 的问题

## Test plan
- [ ] 启动 agent core，快速连续 POST 多个事件到 `/api/event`
- [ ] 验证 turn 执行期间无新 trigger 发射（日志无堆积）
- [ ] 验证 turn 结束后下一个 trigger 包含所有积累事件（event_count 增大）

🤖 Generated with [Claude Code](https://claude.com/claude-code)