### PR TITLE
fix: mobile update progress sync

### DIFF
--- a/agent-core/web/js/mobile.js
+++ b/agent-core/web/js/mobile.js
@@ -278,9 +278,27 @@ function _observeUpdateBanner() {
     });
   }
 
-  // Observe class changes on desktop banner
+  // Observe class changes on desktop banner (show/hide)
   const observer = new MutationObserver(sync);
   observer.observe(desktopBanner, { attributes: true, attributeFilter: ['class'] });
+
+  // Observe text changes in desktop banner text (progress updates)
+  const desktopText = document.getElementById('update-banner-text');
+  if (desktopText && mobileText) {
+    const textObserver = new MutationObserver(() => {
+      mobileText.textContent = desktopText.textContent;
+    });
+    textObserver.observe(desktopText, { childList: true, characterData: true, subtree: true });
+  }
+
+  // Observe disabled state on desktop button (syncs to mobile button)
+  const desktopBtn = document.getElementById('btn-update');
+  if (desktopBtn && mobileBtn) {
+    const btnObserver = new MutationObserver(() => {
+      mobileBtn.disabled = desktopBtn.disabled;
+    });
+    btnObserver.observe(desktopBtn, { attributes: true, attributeFilter: ['disabled'] });
+  }
 
   // Initial sync
   sync();


### PR DESCRIPTION
## Summary
- 移动端点击更新后现在能看到进度信息（"正在升级…"、"升级完成"等）
- 通过 MutationObserver 实时同步桌面端 `#update-banner-text` 的文本变化到移动端
- 同步按钮 disabled 状态防止重复点击

🤖 Generated with [Claude Code](https://claude.com/claude-code)