### PR TITLE
feat: token-based authentication for Dashboard and API

### DIFF
--- a/agent-core/src/api/motus_stream.py
+++ b/agent-core/src/api/motus_stream.py
@@ -44,6 +44,12 @@ async def push_event(event: dict):
 
 @router.websocket('/ws/motus')
 async def motus_ws(websocket: fastapi.WebSocket):
+    # Token auth check
+    import auth
+    if not auth.check_ws_token(websocket):
+        await websocket.close(code=4001, reason='Unauthorized')
+        return
+
     await websocket.accept()
     queue: asyncio.Queue = asyncio.Queue(maxsize=256)
     _clients.add(queue)

--- a/agent-core/src/auth.py
+++ b/agent-core/src/auth.py
@@ -18,42 +18,53 @@ from fastapi.responses import JSONResponse
 
 
 _token: str = ''
+_auth_enabled: bool = False
 
 
 def init():
     """Initialize access token (call during startup)."""
-    global _token
+    global _token, _auth_enabled
     # Priority 1: env var
     token = os.environ.get('ACCESS_TOKEN', '').strip()
     if token:
         _token = token
-        print(f'[auth] Using ACCESS_TOKEN from environment')
+        _auth_enabled = True
+        print(f'[auth] Token authentication enabled (from environment)')
         return
 
     # Priority 2: DB
     token = config.main.get('access_token', '')
     if token:
         _token = token
+        _auth_enabled = True
         print(f'[auth] Access token: {_token}')
         return
 
-    # Auto-generate
-    _token = secrets.token_urlsafe(24)
-    config.main['access_token'] = _token
-    print(f'[auth] Generated access token: {_token}')
-    print(f'[auth] Use this token to access the Dashboard and API')
+    # No token configured — auth disabled
+    _auth_enabled = False
+    print(f'[auth] No ACCESS_TOKEN configured — authentication disabled')
+    print(f'[auth] Set ACCESS_TOKEN env var to enable authentication')
 
 
 def get_token() -> str:
     return _token
 
 
+def is_enabled() -> bool:
+    return _auth_enabled
+
+
 def verify(token: str) -> bool:
+    if not _auth_enabled:
+        return True
     return bool(token) and token == _token
 
 
 async def auth_middleware(request: Request, call_next):
     """FastAPI middleware: enforce token auth on /api/* and /ws/* paths."""
+    if not _auth_enabled:
+        return await call_next(request)
+
     path = request.url.path
 
     # Static files and HTML — no auth needed
@@ -83,6 +94,8 @@ async def auth_middleware(request: Request, call_next):
 
 def check_ws_token(websocket: WebSocket) -> bool:
     """Check token in WebSocket query params."""
+    if not _auth_enabled:
+        return True
     token = websocket.query_params.get('token', '')
     return verify(token)
 

--- a/agent-core/src/auth.py
+++ b/agent-core/src/auth.py
@@ -1,0 +1,97 @@
+"""
+auth.py — Access token authentication for Dashboard and API.
+
+Token source (priority):
+1. Environment variable ACCESS_TOKEN
+2. SQLite config table 'access_token' key (auto-generated on first startup)
+
+Protected: all /api/* (except /api/auth/verify, /api/channel/webhook/*), /ws/motus, /ws/bus/*
+Open: static files, /ws/mic
+"""
+
+import os
+import secrets
+
+import config
+from fastapi import Request, WebSocket
+from fastapi.responses import JSONResponse
+
+
+_token: str = ''
+
+
+def init():
+    """Initialize access token (call during startup)."""
+    global _token
+    # Priority 1: env var
+    token = os.environ.get('ACCESS_TOKEN', '').strip()
+    if token:
+        _token = token
+        print(f'[auth] Using ACCESS_TOKEN from environment')
+        return
+
+    # Priority 2: DB
+    token = config.main.get('access_token', '')
+    if token:
+        _token = token
+        print(f'[auth] Access token: {_token}')
+        return
+
+    # Auto-generate
+    _token = secrets.token_urlsafe(24)
+    config.main['access_token'] = _token
+    print(f'[auth] Generated access token: {_token}')
+    print(f'[auth] Use this token to access the Dashboard and API')
+
+
+def get_token() -> str:
+    return _token
+
+
+def verify(token: str) -> bool:
+    return bool(token) and token == _token
+
+
+async def auth_middleware(request: Request, call_next):
+    """FastAPI middleware: enforce token auth on /api/* and /ws/* paths."""
+    path = request.url.path
+
+    # Static files and HTML — no auth needed
+    if not path.startswith('/api/') and not path.startswith('/ws/'):
+        return await call_next(request)
+
+    # Exempt paths
+    if path == '/api/auth/verify':
+        return await call_next(request)
+    if path.startswith('/api/channel/webhook/'):
+        return await call_next(request)
+    # MCP registration from driver containers (localhost)
+    if path == '/api/mcp' and request.method == 'POST':
+        return await call_next(request)
+
+    # /ws/mic stays open (internal browser mic)
+    if path == '/ws/mic':
+        return await call_next(request)
+
+    # Check token
+    token = _extract_token(request)
+    if not verify(token):
+        return JSONResponse(status_code=401, content={'detail': 'Unauthorized'})
+
+    return await call_next(request)
+
+
+def check_ws_token(websocket: WebSocket) -> bool:
+    """Check token in WebSocket query params."""
+    token = websocket.query_params.get('token', '')
+    return verify(token)
+
+
+def _extract_token(request: Request) -> str:
+    """Extract token from Authorization header or query param."""
+    # Header: Authorization: Bearer xxx
+    auth = request.headers.get('authorization', '')
+    if auth.startswith('Bearer '):
+        return auth[7:]
+    # Query param: ?token=xxx
+    return request.query_params.get('token', '')

--- a/agent-core/src/auth.py
+++ b/agent-core/src/auth.py
@@ -10,9 +10,7 @@ Open: static files, /ws/mic
 """
 
 import os
-import secrets
 
-import config
 from fastapi import Request, WebSocket
 from fastapi.responses import JSONResponse
 
@@ -24,20 +22,12 @@ _auth_enabled: bool = False
 def init():
     """Initialize access token (call during startup)."""
     global _token, _auth_enabled
-    # Priority 1: env var
+    # Only source: ACCESS_TOKEN environment variable
     token = os.environ.get('ACCESS_TOKEN', '').strip()
     if token:
         _token = token
         _auth_enabled = True
         print(f'[auth] Token authentication enabled (from environment)')
-        return
-
-    # Priority 2: DB
-    token = config.main.get('access_token', '')
-    if token:
-        _token = token
-        _auth_enabled = True
-        print(f'[auth] Access token: {_token}')
         return
 
     # No token configured — auth disabled

--- a/agent-core/src/auth.py
+++ b/agent-core/src/auth.py
@@ -2,10 +2,9 @@
 auth.py — Access token authentication for Dashboard and API.
 
 Token source: /opt/phanthy-motus/.env file (volume-mounted from host).
-Read on every request so changes take effect immediately without restart.
+Read once at startup. Restart container to apply .env changes.
 """
 
-import os
 import pathlib
 
 from fastapi import Request, WebSocket
@@ -16,9 +15,12 @@ _ENV_PATH = pathlib.Path('/opt/phanthy-motus/.env')
 # Fallback for local dev
 _ENV_PATH_DEV = pathlib.Path('.env')
 
+_token: str = ''
+_auth_enabled: bool = False
 
-def _read_token() -> str:
-    """Read ACCESS_TOKEN from .env file (host volume mount)."""
+
+def _read_token_from_env() -> str:
+    """Read ACCESS_TOKEN from .env file."""
     env_file = _ENV_PATH if _ENV_PATH.exists() else _ENV_PATH_DEV
     if not env_file.exists():
         return ''
@@ -30,32 +32,33 @@ def _read_token() -> str:
 
 
 def init():
-    """Print auth status on startup."""
-    token = _read_token()
-    if token:
-        print(f'[auth] Token authentication enabled (from {_ENV_PATH})')
+    """Read token from .env and cache it. Called once at startup."""
+    global _token, _auth_enabled
+    _token = _read_token_from_env()
+    _auth_enabled = bool(_token)
+    if _auth_enabled:
+        print(f'[auth] Token authentication enabled')
     else:
         print(f'[auth] No ACCESS_TOKEN in .env — authentication disabled')
 
 
 def get_token() -> str:
-    return _read_token()
+    return _token
 
 
 def is_enabled() -> bool:
-    return bool(_read_token())
+    return _auth_enabled
 
 
 def verify(token: str) -> bool:
-    current = _read_token()
-    if not current:
-        return True  # Auth disabled
-    return bool(token) and token == current
+    if not _auth_enabled:
+        return True
+    return bool(token) and token == _token
 
 
 async def auth_middleware(request: Request, call_next):
     """FastAPI middleware: enforce token auth on /api/* and /ws/* paths."""
-    if not is_enabled():
+    if not _auth_enabled:
         return await call_next(request)
 
     path = request.url.path
@@ -86,7 +89,7 @@ async def auth_middleware(request: Request, call_next):
 
 def check_ws_token(websocket: WebSocket) -> bool:
     """Check token in WebSocket query params."""
-    if not is_enabled():
+    if not _auth_enabled:
         return True
     token = websocket.query_params.get('token', '')
     return verify(token)

--- a/agent-core/src/auth.py
+++ b/agent-core/src/auth.py
@@ -1,58 +1,61 @@
 """
 auth.py — Access token authentication for Dashboard and API.
 
-Token source (priority):
-1. Environment variable ACCESS_TOKEN
-2. SQLite config table 'access_token' key (auto-generated on first startup)
-
-Protected: all /api/* (except /api/auth/verify, /api/channel/webhook/*), /ws/motus, /ws/bus/*
-Open: static files, /ws/mic
+Token source: /opt/phanthy-motus/.env file (volume-mounted from host).
+Read on every request so changes take effect immediately without restart.
 """
 
 import os
+import pathlib
 
 from fastapi import Request, WebSocket
 from fastapi.responses import JSONResponse
 
 
-_token: str = ''
-_auth_enabled: bool = False
+_ENV_PATH = pathlib.Path('/opt/phanthy-motus/.env')
+# Fallback for local dev
+_ENV_PATH_DEV = pathlib.Path('.env')
+
+
+def _read_token() -> str:
+    """Read ACCESS_TOKEN from .env file (host volume mount)."""
+    env_file = _ENV_PATH if _ENV_PATH.exists() else _ENV_PATH_DEV
+    if not env_file.exists():
+        return ''
+    for line in env_file.read_text().splitlines():
+        line = line.strip()
+        if line.startswith('ACCESS_TOKEN=') and not line.startswith('#'):
+            return line.split('=', 1)[1].strip()
+    return ''
 
 
 def init():
-    """Initialize access token (call during startup)."""
-    global _token, _auth_enabled
-    # Only source: ACCESS_TOKEN environment variable
-    token = os.environ.get('ACCESS_TOKEN', '').strip()
+    """Print auth status on startup."""
+    token = _read_token()
     if token:
-        _token = token
-        _auth_enabled = True
-        print(f'[auth] Token authentication enabled (from environment)')
-        return
-
-    # No token configured — auth disabled
-    _auth_enabled = False
-    print(f'[auth] No ACCESS_TOKEN configured — authentication disabled')
-    print(f'[auth] Set ACCESS_TOKEN env var to enable authentication')
+        print(f'[auth] Token authentication enabled (from {_ENV_PATH})')
+    else:
+        print(f'[auth] No ACCESS_TOKEN in .env — authentication disabled')
 
 
 def get_token() -> str:
-    return _token
+    return _read_token()
 
 
 def is_enabled() -> bool:
-    return _auth_enabled
+    return bool(_read_token())
 
 
 def verify(token: str) -> bool:
-    if not _auth_enabled:
-        return True
-    return bool(token) and token == _token
+    current = _read_token()
+    if not current:
+        return True  # Auth disabled
+    return bool(token) and token == current
 
 
 async def auth_middleware(request: Request, call_next):
     """FastAPI middleware: enforce token auth on /api/* and /ws/* paths."""
-    if not _auth_enabled:
+    if not is_enabled():
         return await call_next(request)
 
     path = request.url.path
@@ -66,10 +69,9 @@ async def auth_middleware(request: Request, call_next):
         return await call_next(request)
     if path.startswith('/api/channel/webhook/'):
         return await call_next(request)
-    # MCP registration from driver containers (localhost)
+    # MCP registration from driver containers
     if path == '/api/mcp' and request.method == 'POST':
         return await call_next(request)
-
     # /ws/mic stays open (internal browser mic)
     if path == '/ws/mic':
         return await call_next(request)
@@ -84,7 +86,7 @@ async def auth_middleware(request: Request, call_next):
 
 def check_ws_token(websocket: WebSocket) -> bool:
     """Check token in WebSocket query params."""
-    if not _auth_enabled:
+    if not is_enabled():
         return True
     token = websocket.query_params.get('token', '')
     return verify(token)
@@ -92,9 +94,8 @@ def check_ws_token(websocket: WebSocket) -> bool:
 
 def _extract_token(request: Request) -> str:
     """Extract token from Authorization header or query param."""
-    # Header: Authorization: Bearer xxx
     auth = request.headers.get('authorization', '')
     if auth.startswith('Bearer '):
         return auth[7:]
-    # Query param: ?token=xxx
     return request.query_params.get('token', '')
+

--- a/agent-core/src/start.py
+++ b/agent-core/src/start.py
@@ -5,6 +5,7 @@ import shutil
 import subprocess
 
 import config
+import auth
 import event
 import collector
 import scheduler
@@ -211,6 +212,9 @@ async def _heartbeat_core_mcp():
 
 @contextlib.asynccontextmanager
 async def lifespan(app):
+    # 初始化 access token 认证
+    auth.init()
+
     # 初始化资源文件（从 defaults 拷贝缺失文件）
     _init_resource_files()
 
@@ -316,7 +320,13 @@ import api.channel
 app_api.include_router(api.channel.router)
 
 app = fastapi.FastAPI(lifespan=lifespan)
+app.middleware('http')(auth.auth_middleware)
 app.mount('/api', app_api)
+
+# Auth verify endpoint (must be on main app to match /api/auth/verify path through middleware)
+@app_api.get('/auth/verify')
+async def _auth_verify():
+    return {'code': 200, 'valid': True}
 
 import api.motus_stream
 app.include_router(api.motus_stream.router)

--- a/agent-core/src/start.py
+++ b/agent-core/src/start.py
@@ -323,10 +323,18 @@ app = fastapi.FastAPI(lifespan=lifespan)
 app.middleware('http')(auth.auth_middleware)
 app.mount('/api', app_api)
 
-# Auth verify endpoint (must be on main app to match /api/auth/verify path through middleware)
+# Auth verify endpoint (exempt from middleware, does its own token check)
 @app_api.get('/auth/verify')
-async def _auth_verify():
-    return {'code': 200, 'valid': True}
+async def _auth_verify(request: fastapi.Request):
+    if not auth.is_enabled():
+        return {'valid': True, 'auth_required': False}
+    token = auth._extract_token(request)
+    if auth.verify(token):
+        return {'valid': True, 'auth_required': True}
+    return fastapi.responses.JSONResponse(
+        status_code=401,
+        content={'valid': False, 'auth_required': True}
+    )
 
 import api.motus_stream
 app.include_router(api.motus_stream.router)

--- a/agent-core/web/css/style.css
+++ b/agent-core/web/css/style.css
@@ -5170,16 +5170,19 @@ html, body {
   max-width: 360px;
   width: 90%;
 }
-.login-logo {
-  width: 64px;
-  height: 64px;
-  margin-bottom: 16px;
+.login-brand {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 20px;
 }
-.login-title {
-  font-size: 1.5rem;
+.login-logo {
+  width: 36px;
+  height: 36px;
+}
+.login-brand-text {
+  font-size: 1.3rem;
   font-weight: 700;
-  margin: 0 0 4px;
-  color: var(--text);
 }
 .login-subtitle {
   font-size: 0.85rem;

--- a/agent-core/web/css/style.css
+++ b/agent-core/web/css/style.css
@@ -5151,3 +5151,78 @@ html, body {
   margin-top: 12px;
 }
 
+/* ── Login Screen ───────────────────────────────────────────────────────────── */
+
+.login-screen {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--bg);
+  z-index: 10000;
+}
+.login-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 40px;
+  max-width: 360px;
+  width: 90%;
+}
+.login-logo {
+  width: 64px;
+  height: 64px;
+  margin-bottom: 16px;
+}
+.login-title {
+  font-size: 1.5rem;
+  font-weight: 700;
+  margin: 0 0 4px;
+  color: var(--text);
+}
+.login-subtitle {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  margin: 0 0 24px;
+}
+.login-input {
+  width: 100%;
+  padding: 10px 14px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--bg-card);
+  color: var(--text);
+  font-size: 0.9rem;
+  text-align: center;
+  margin-bottom: 12px;
+}
+.login-input:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+.login-btn {
+  width: 100%;
+  padding: 10px;
+  border: none;
+  border-radius: var(--radius-sm);
+  background: var(--accent);
+  color: white;
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+.login-btn:hover { opacity: 0.9; }
+.login-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+.login-hint {
+  font-size: 0.8rem;
+  color: #ef4444;
+  margin: 8px 0 0;
+  min-height: 1.2em;
+}
+.login-footer {
+  font-size: 0.75rem;
+  color: var(--text-dim);
+  margin-top: 20px;
+}
+

--- a/agent-core/web/index.html
+++ b/agent-core/web/index.html
@@ -13,7 +13,7 @@
 <body>
 
 <!-- ── Main App Shell ──────────────────────────────────────────────────────── -->
-<div id="app">
+<div id="app" style="display:none">
 
   <!-- Top Bar -->
   <header class="topbar">

--- a/agent-core/web/js/app.js
+++ b/agent-core/web/js/app.js
@@ -23,9 +23,10 @@ let _topicStatuses = {};
 const _pingedIds = new Set();
 
 async function main() {
-  // Auth gate: check token before loading app
+  // Auth gate: check if auth is required
   const token = getToken();
-  if (!token || !(await verifyToken(token))) {
+  const noTokenValid = await verifyToken('');  // If no-token passes, auth is disabled
+  if (!noTokenValid && (!token || !(await verifyToken(token)))) {
     _showLoginScreen();
     return;
   }

--- a/agent-core/web/js/app.js
+++ b/agent-core/web/js/app.js
@@ -3,6 +3,7 @@
  * Mounts canvas, sidebar, deploy panel, settings panel, and activity log.
  */
 
+import { getToken, setToken, verifyToken } from './auth.js';
 import { initSidebar, renderSidebar } from './sidebar.js';
 import { initCanvas, updateCanvasMcps } from './canvas.js';
 import { initDeployPanel, showDeployConfirmModal } from './deploy-panel.js';
@@ -22,6 +23,13 @@ let _topicStatuses = {};
 const _pingedIds = new Set();
 
 async function main() {
+  // Auth gate: check token before loading app
+  const token = getToken();
+  if (!token || !(await verifyToken(token))) {
+    _showLoginScreen();
+    return;
+  }
+
   initMobile();
   initSidebar();
   initDetailPanel();
@@ -321,6 +329,56 @@ function _initSettingsDropdown() {
       dropdown.classList.add('hidden');
     });
   });
+}
+
+function _showLoginScreen() {
+  const app = document.getElementById('app');
+  if (app) app.style.display = 'none';
+
+  let loginEl = document.getElementById('login-screen');
+  if (!loginEl) {
+    loginEl = document.createElement('div');
+    loginEl.id = 'login-screen';
+    loginEl.className = 'login-screen';
+    loginEl.innerHTML = `
+      <div class="login-card">
+        <img class="login-logo" src="https://agi-phanthy-dev-1252788780.cos.ap-beijing.myqcloud.com/public/PhanthyMotus_Final_Refined_logo.png" alt="PhanthyMotus">
+        <h1 class="login-title">PhanthyMotus</h1>
+        <p class="login-subtitle">Enter access token to continue</p>
+        <input type="password" class="login-input" id="login-token-input" placeholder="Access Token" autocomplete="off" />
+        <button class="login-btn" id="login-btn">Login</button>
+        <p class="login-hint" id="login-hint"></p>
+        <p class="login-footer">Token is shown in server console on startup</p>
+      </div>
+    `;
+    document.body.appendChild(loginEl);
+  }
+  loginEl.style.display = 'flex';
+
+  const input = document.getElementById('login-token-input');
+  const btn = document.getElementById('login-btn');
+  const hint = document.getElementById('login-hint');
+
+  async function doLogin() {
+    const val = input.value.trim();
+    if (!val) { hint.textContent = 'Please enter a token'; return; }
+    hint.textContent = 'Verifying...';
+    btn.disabled = true;
+    const valid = await verifyToken(val);
+    if (valid) {
+      setToken(val);
+      loginEl.style.display = 'none';
+      if (app) app.style.display = '';
+      main();
+    } else {
+      hint.textContent = 'Invalid token';
+      btn.disabled = false;
+    }
+  }
+
+  btn.addEventListener('click', doLogin);
+  input.addEventListener('keydown', (e) => { if (e.key === 'Enter') doLogin(); });
+  input.focus();
 }
 
 main();

--- a/agent-core/web/js/app.js
+++ b/agent-core/web/js/app.js
@@ -343,8 +343,12 @@ function _showLoginScreen() {
     loginEl.className = 'login-screen';
     loginEl.innerHTML = `
       <div class="login-card">
-        <img class="login-logo" src="https://agi-phanthy-dev-1252788780.cos.ap-beijing.myqcloud.com/public/PhanthyMotus_Final_Refined_logo.png" alt="PhanthyMotus">
-        <h1 class="login-title">PhanthyMotus</h1>
+        <div class="login-brand">
+          <img class="login-logo" src="https://agi-phanthy-dev-1252788780.cos.ap-beijing.myqcloud.com/public/PhanthyMotus_Final_Refined_logo.png" alt="PhanthyMotus">
+          <div class="login-brand-text">
+            <span class="brand-name">Phanthy</span><span class="brand-name-accent">Motus</span>
+          </div>
+        </div>
         <p class="login-subtitle">Enter access token to continue</p>
         <input type="password" class="login-input" id="login-token-input" placeholder="Access Token" autocomplete="off" />
         <button class="login-btn" id="login-btn">Login</button>

--- a/agent-core/web/js/app.js
+++ b/agent-core/web/js/app.js
@@ -31,6 +31,9 @@ async function main() {
     return;
   }
 
+  // Auth passed — show app
+  document.getElementById('app').style.display = '';
+
   initMobile();
   initSidebar();
   initDetailPanel();

--- a/agent-core/web/js/auth.js
+++ b/agent-core/web/js/auth.js
@@ -1,0 +1,61 @@
+/**
+ * auth.js — Access token management for Dashboard.
+ *
+ * - Stores token in localStorage
+ * - Patches window.fetch to auto-attach Bearer header
+ * - Provides wsUrl() for authenticated WebSocket connections
+ */
+
+const TOKEN_KEY = 'phanthy_access_token';
+
+export function getToken() {
+  return localStorage.getItem(TOKEN_KEY) || '';
+}
+
+export function setToken(token) {
+  localStorage.setItem(TOKEN_KEY, token);
+}
+
+export function clearToken() {
+  localStorage.removeItem(TOKEN_KEY);
+}
+
+export async function verifyToken(token) {
+  try {
+    const res = await _origFetch('/api/auth/verify', {
+      headers: { 'Authorization': `Bearer ${token}` }
+    });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+/** Build authenticated WebSocket URL. */
+export function wsUrl(path) {
+  const proto = location.protocol === 'https:' ? 'wss:' : 'ws:';
+  const token = getToken();
+  const sep = path.includes('?') ? '&' : '?';
+  return `${proto}//${location.host}${path}${sep}token=${encodeURIComponent(token)}`;
+}
+
+// ── Patch fetch to auto-attach token ─────────────────────────────────────────
+
+const _origFetch = window.fetch.bind(window);
+
+window.fetch = function(url, opts = {}) {
+  const token = getToken();
+  if (token && typeof url === 'string' && url.startsWith('/api/')) {
+    if (!opts.headers) opts.headers = {};
+    if (opts.headers instanceof Headers) {
+      if (!opts.headers.has('Authorization')) {
+        opts.headers.set('Authorization', `Bearer ${token}`);
+      }
+    } else {
+      if (!opts.headers['Authorization']) {
+        opts.headers['Authorization'] = `Bearer ${token}`;
+      }
+    }
+  }
+  return _origFetch(url, opts);
+};

--- a/agent-core/web/js/motus-stream.js
+++ b/agent-core/web/js/motus-stream.js
@@ -19,7 +19,8 @@ export function connectMotus(onStatusChange) {
   const _cb = onStatusChange || (() => {});
   function connect() {
     const proto = location.protocol === 'https:' ? 'wss' : 'ws';
-    _ws = new WebSocket(`${proto}://${location.host}/ws/motus`);
+    const token = localStorage.getItem('phanthy_access_token') || '';
+    _ws = new WebSocket(`${proto}://${location.host}/ws/motus?token=${encodeURIComponent(token)}`);
 
     _ws.onopen = () => {
       _retryDelay = 1000;


### PR DESCRIPTION
## Summary

- Add ACCESS_TOKEN-based authentication for Dashboard and API
- Token read from `/opt/phanthy-motus/.env` (volume mount), cached at startup
- No token configured = auth disabled (backwards compatible)
- Frontend login page shown when auth is enabled and no valid token in localStorage
- WebSocket connections also require token via query param

## Key design

- Single source: host `.env` → volume mount → container reads at startup
- `/api/auth/verify` endpoint for frontend to check auth status
- Exempt paths: `/api/mcp` POST (driver registration), `/ws/mic`, static files
- Login page matches topbar brand layout, no flash of dashboard before auth

## Test plan

- [x] No ACCESS_TOKEN → auth disabled, dashboard works directly
- [x] With ACCESS_TOKEN → login page shown, correct token grants access
- [x] API returns 401 without valid token
- [x] MCP driver registration still works (exempt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)