### PR TITLE
fix: startup modal overflow and error display

### DIFF
--- a/agent-core/web/css/style.css
+++ b/agent-core/web/css/style.css
@@ -4463,6 +4463,9 @@ html, body {
   list-style: none;
   padding: 14px 22px;
   margin: 0;
+  flex: 1;
+  overflow-y: auto;
+  min-height: 0;
 }
 .startup-modal-item {
   display: flex;

--- a/agent-core/web/js/canvas.js
+++ b/agent-core/web/js/canvas.js
@@ -1478,7 +1478,7 @@ async function _startProject() {
         if (startResult && startResult.code !== 200) {
           updateItem(i, 'error', startResult.message || '启动失败');
           _logActivity('error', `${card.toolName} 启动失败: ${startResult.message || '未知错误'}`);
-          if (!aborted) { aborted = true; modal.onCancel?.(); }
+          if (!aborted) { aborted = true; _stopProject(); _showStartupError(modal, close); }
           return;
         }
         // Auto-start mic stream for remote_mic card
@@ -1509,7 +1509,8 @@ async function _startProject() {
         if (!aborted) {
           updateItem(i, 'error', e.message || '异常');
           aborted = true;
-          modal.onCancel?.();
+          _stopProject();
+          _showStartupError(modal, close);
         }
       }
     })());
@@ -1608,6 +1609,19 @@ async function _triggerAction(mcpId, toolName, action, extraArgs = {}) {
 }
 
 // ── Startup Modal ──────────────────────────────────────────────────────────────
+
+function _showStartupError(modal, close) {
+  const cancelBtn = modal.querySelector('.startup-cancel-btn');
+  if (cancelBtn) {
+    cancelBtn.textContent = '关闭';
+    cancelBtn.onclick = close;
+  }
+  modal.onCancel = null;
+  // Update modal title to indicate failure
+  const title = modal.querySelector('.modal-title');
+  if (title) title.textContent = '启动失败';
+}
+
 function _showStartupModal(items) {
   const overlay = document.createElement('div');
   overlay.className = 'modal-overlay';


### PR DESCRIPTION
## Summary
- Fix startup modal list not scrollable when many cards are present, making stop/close button unreachable
- Keep modal open on startup failure to show error states, instead of immediately dismissing it

## Test plan
- [ ] Add 5+ cards to canvas, start project — verify list scrolls and close button is visible
- [ ] Disconnect a driver, start project — verify modal stays open showing the error

🤖 Generated with [Claude Code](https://claude.com/claude-code)