### PR TITLE
feat: remote_audio tool + ASR fixes + generic file upload

### DIFF
--- a/agent-core/Dockerfile
+++ b/agent-core/Dockerfile
@@ -5,8 +5,12 @@ ARG PYPI_MIRROR
 
 RUN apt-get -o Acquire::AllowInsecureRepositories=true update && \
     apt-get install -y --no-install-recommends --allow-unauthenticated \
-        python3-pip docker.io docker-compose-v2 python3-dbus ffmpeg && \
+        python3-pip docker.io docker-compose-v2 python3-dbus && \
     rm -rf /var/lib/apt/lists/*
+
+# Install static ffmpeg (lightweight, no apt dependencies)
+RUN curl -L https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-linuxarm64-gpl.tar.xz \
+    | tar -xJ --strip-components=2 -C /usr/local/bin/ --wildcards '*/bin/ffmpeg'
 
 # Install uv
 RUN pip3 install --no-cache-dir -i ${PYPI_MIRROR} uv

--- a/agent-core/Dockerfile
+++ b/agent-core/Dockerfile
@@ -5,7 +5,7 @@ ARG PYPI_MIRROR
 
 RUN apt-get -o Acquire::AllowInsecureRepositories=true update && \
     apt-get install -y --no-install-recommends --allow-unauthenticated \
-        python3-pip docker.io docker-compose-v2 python3-dbus && \
+        python3-pip docker.io docker-compose-v2 python3-dbus ffmpeg && \
     rm -rf /var/lib/apt/lists/*
 
 # Install uv

--- a/agent-core/Dockerfile
+++ b/agent-core/Dockerfile
@@ -3,14 +3,10 @@ ARG ROS_BASE_IMAGE=bj-warehouse.tencentcloudcr.com/phanthy-motus/ros-base:latest
 FROM ${ROS_BASE_IMAGE}
 ARG PYPI_MIRROR
 
+# docker.io, python3-pip, python3-dbus already in ros-base; only add ffmpeg
 RUN apt-get -o Acquire::AllowInsecureRepositories=true update && \
-    apt-get install -y --no-install-recommends --allow-unauthenticated \
-        python3-pip docker.io docker-compose-v2 python3-dbus && \
+    apt-get install -y --no-install-recommends --allow-unauthenticated ffmpeg && \
     rm -rf /var/lib/apt/lists/*
-
-# Install static ffmpeg (lightweight, no apt dependencies)
-RUN curl -L https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-linuxarm64-gpl.tar.xz \
-    | tar -xJ --strip-components=2 -C /usr/local/bin/ --wildcards '*/bin/ffmpeg'
 
 # Install uv
 RUN pip3 install --no-cache-dir -i ${PYPI_MIRROR} uv

--- a/agent-core/src/api/mcp_manage.py
+++ b/agent-core/src/api/mcp_manage.py
@@ -745,9 +745,15 @@ async def mcp_call_tool(mcp_id: str, req: MCPCallRequest):
         if req.tool == 'remote_audio':
             action = req.arguments.get('action', 'start')
             if action == 'start':
-                return {'code': 200, 'data': {'state': 'running', 'upload_path': '/api/remote-audio/upload'}}
+                return {'code': 200, 'data': {'state': 'running'}}
             elif action == 'stop':
                 return {'code': 200, 'data': {'state': 'idle'}}
+            elif action == 'send_audio':
+                audio_file = req.arguments.get('audio_file', '')
+                if not audio_file:
+                    return {'code': 400, 'message': '缺少 audio_file 参数', 'data': None}
+                from start import publish_audio_file
+                return await publish_audio_file(audio_file)
             elif action == 'info':
                 return {'code': 200, 'data': {'state': 'running', 'topic_out': [{'topic': '/remote_control/audio', 'format': 'audio/pcm-16k'}]}}
             return {'code': 200, 'data': None}

--- a/agent-core/src/api/mcp_manage.py
+++ b/agent-core/src/api/mcp_manage.py
@@ -742,6 +742,15 @@ async def mcp_call_tool(mcp_id: str, req: MCPCallRequest):
                     return {'code': 200, 'data': {'status': 'sent', 'text': text}}
                 return {'code': 200, 'data': {'error': 'Missing text'}}
             return {'code': 200, 'data': None}
+        if req.tool == 'remote_audio':
+            action = req.arguments.get('action', 'start')
+            if action == 'start':
+                return {'code': 200, 'data': {'state': 'running', 'upload_path': '/api/remote-audio/upload'}}
+            elif action == 'stop':
+                return {'code': 200, 'data': {'state': 'idle'}}
+            elif action == 'info':
+                return {'code': 200, 'data': {'state': 'running', 'topic_out': [{'topic': '/remote_control/audio', 'format': 'audio/pcm-16k'}]}}
+            return {'code': 200, 'data': None}
         return await _handle_agentcore_call(req)
 
     # ── Handle internal channel MCP ──

--- a/agent-core/src/start.py
+++ b/agent-core/src/start.py
@@ -258,6 +258,9 @@ async def lifespan(app):
     _ros2_loop = asyncio.get_running_loop()
     await loop.run_in_executor(None, ros2_bridge.start, _ros2_loop)
 
+    # Pre-create audio publisher so DDS discovery completes before first use
+    _ensure_audio_pub()
+
     # 注册 AgentCore 自身为 MCP（含 decision_core 工具）
     await loop.run_in_executor(None, _register_core_mcp)
 
@@ -436,6 +439,18 @@ async def publish_audio_file(file_path: str) -> dict:
             sleep_time = expected_time - elapsed
             if sleep_time > 0.005:
                 await asyncio.sleep(sleep_time)
+
+    # Append silence so VAD detects end-of-speech and flushes the utterance
+    silence_ms = 800  # must exceed vad_silence_ms (default 400ms)
+    silence_bytes = int(16000 * 2 * silence_ms / 1000)  # 16kHz 16-bit mono
+    silence_chunk = [0] * chunk_size
+    for _ in range(silence_bytes // chunk_size):
+        msg = AudioChunk()
+        msg.format = "pcm_16k_16bit_mono"
+        msg.data = silence_chunk
+        pub.publish(msg)
+        chunks_sent += 1
+    await asyncio.sleep(0.1)
 
     duration_s = len(pcm_data) / (16000 * 2)
     return {'code': 200, 'data': {'chunks': chunks_sent, 'duration_s': round(duration_s, 2), 'bytes': len(pcm_data)}}

--- a/agent-core/src/start.py
+++ b/agent-core/src/start.py
@@ -151,9 +151,18 @@ def _register_core_mcp(silent=False):
                     'required': ['action', 'text'],
                 },
                 'topic_out': [{'topic': '/remote_control/message', 'format': 'data/json'}],
+            },
+            {
+                'name': 'remote_audio',
+                'type': 'sensor',
+                'description': '远程音频 — 从浏览器上传音频文件，转换为 PCM-16k 发布到 DDS',
+                'inputSchema': {'type': 'object', 'properties': {
+                    'action': {'type': 'string', 'enum': ['send_audio'], 'description': 'Action to perform'},
+                }},
+                'topic_out': [{'topic': '/remote_control/audio', 'format': 'audio/pcm-16k'}],
             }
         ],
-        'topic_out': [{'topic': '/decision_core', 'format': 'data/json'}, {'topic': '/remote_control/mic', 'format': 'audio/pcm-16k'}, {'topic': '/remote_control/message', 'format': 'data/json'}],
+        'topic_out': [{'topic': '/decision_core', 'format': 'data/json'}, {'topic': '/remote_control/mic', 'format': 'audio/pcm-16k'}, {'topic': '/remote_control/message', 'format': 'data/json'}, {'topic': '/remote_control/audio', 'format': 'audio/pcm-16k'}],
         'topic_in': [{'format': 'data/json'}],
     })
 
@@ -361,6 +370,73 @@ import api.motus_stream
 app.include_router(api.motus_stream.router)
 
 app.include_router(api.inspection.ws_router)
+
+# ── Remote Audio upload endpoint (receive audio file, convert to PCM-16k, publish to ROS2) ──
+_audio_pub = None
+
+@app_api.post('/remote-audio/upload')
+async def _remote_audio_upload(file: fastapi.UploadFile = fastapi.File()):
+    """Upload audio file, convert to PCM-16k mono, publish to ROS2 topic."""
+    global _audio_pub
+    import subprocess, tempfile, os
+
+    # Initialize publisher if needed
+    if _audio_pub is None:
+        try:
+            from audio_msgs.msg import AudioChunk
+            import ros2_bridge
+            node = ros2_bridge._node_main
+            if node:
+                from rclpy.qos import QoSProfile, ReliabilityPolicy, HistoryPolicy, DurabilityPolicy
+                qos = QoSProfile(reliability=ReliabilityPolicy.BEST_EFFORT,
+                                 history=HistoryPolicy.KEEP_LAST, depth=200,
+                                 durability=DurabilityPolicy.VOLATILE)
+                _audio_pub = node.create_publisher(AudioChunk, "/remote_control/audio", qos)
+        except Exception as e:
+            return {'code': 500, 'message': f'ROS2 publisher init failed: {e}'}
+
+    if not _audio_pub:
+        return {'code': 500, 'message': 'ROS2 not available'}
+
+    # Save uploaded file to temp
+    suffix = os.path.splitext(file.filename or '')[1] or '.wav'
+    with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as tmp:
+        tmp_path = tmp.name
+        content = await file.read()
+        tmp.write(content)
+
+    try:
+        # Convert to PCM-16k mono via ffmpeg
+        proc = subprocess.run(
+            ['ffmpeg', '-y', '-i', tmp_path, '-f', 's16le', '-acodec', 'pcm_s16le',
+             '-ar', '16000', '-ac', '1', 'pipe:1'],
+            capture_output=True, timeout=30,
+        )
+        if proc.returncode != 0:
+            return {'code': 400, 'message': f'ffmpeg error: {proc.stderr.decode()[:200]}'}
+
+        pcm_data = proc.stdout
+        if not pcm_data:
+            return {'code': 400, 'message': 'No audio data after conversion'}
+
+        # Publish PCM chunks to DDS
+        from audio_msgs.msg import AudioChunk
+        chunk_size = 1024
+        offset = 0
+        chunks_sent = 0
+        while offset < len(pcm_data):
+            chunk = pcm_data[offset:offset + chunk_size]
+            offset += chunk_size
+            msg = AudioChunk()
+            msg.format = "pcm_16k_16bit_mono"
+            msg.data = list(chunk)
+            _audio_pub.publish(msg)
+            chunks_sent += 1
+
+        duration_s = len(pcm_data) / (16000 * 2)  # 16kHz, 16-bit = 2 bytes/sample
+        return {'code': 200, 'data': {'chunks': chunks_sent, 'duration_s': round(duration_s, 2), 'bytes': len(pcm_data)}}
+    finally:
+        os.unlink(tmp_path)
 
 # ── Mic WebSocket endpoint (receive browser PCM and publish to ROS2) ──────────
 _mic_pub = None

--- a/agent-core/src/start.py
+++ b/agent-core/src/start.py
@@ -421,6 +421,17 @@ async def publish_audio_file(file_path: str) -> dict:
     from audio_msgs.msg import AudioChunk
     chunk_size = 1024  # 512 samples @ 16-bit = 32ms per chunk
     batch_size = 4     # send 4 chunks (~128ms) then pace
+    silence_chunk = [0] * chunk_size
+
+    # Prepend silence to warm up DDS link (avoid losing initial chunks)
+    warmup_chunks = int(0.5 * 16000 * 2 / chunk_size)  # 500ms
+    for _ in range(warmup_chunks):
+        msg = AudioChunk()
+        msg.format = "pcm_16k_16bit_mono"
+        msg.data = silence_chunk
+        pub.publish(msg)
+    await asyncio.sleep(0.3)  # let DDS settle
+
     offset = 0
     chunks_sent = 0
     start_time = time.monotonic()

--- a/agent-core/src/start.py
+++ b/agent-core/src/start.py
@@ -158,7 +158,8 @@ def _register_core_mcp(silent=False):
                 'description': '远程音频 — 从浏览器上传音频文件，转换为 PCM-16k 发布到 DDS',
                 'inputSchema': {'type': 'object', 'properties': {
                     'action': {'type': 'string', 'enum': ['send_audio'], 'description': 'Action to perform'},
-                }},
+                    'audio_file': {'type': 'string', 'format': 'file', 'accept': 'audio/*', 'description': '音频文件'},
+                }, 'required': ['action', 'audio_file']},
                 'topic_out': [{'topic': '/remote_control/audio', 'format': 'audio/pcm-16k'}],
             }
         ],
@@ -371,70 +372,85 @@ app.include_router(api.motus_stream.router)
 
 app.include_router(api.inspection.ws_router)
 
-# ── Remote Audio upload endpoint (receive audio file, convert to PCM-16k, publish to ROS2) ──
+# ── Remote Audio: convert file to PCM-16k and publish to ROS2 ──────────────────
 _audio_pub = None
+
+def _ensure_audio_pub():
+    """Lazily create the ROS2 publisher for /remote_control/audio."""
+    global _audio_pub
+    if _audio_pub is not None:
+        return _audio_pub
+    try:
+        from audio_msgs.msg import AudioChunk
+        import ros2_bridge
+        node = ros2_bridge._node_main
+        if node:
+            from rclpy.qos import QoSProfile, ReliabilityPolicy, HistoryPolicy, DurabilityPolicy
+            qos = QoSProfile(reliability=ReliabilityPolicy.BEST_EFFORT,
+                             history=HistoryPolicy.KEEP_LAST, depth=200,
+                             durability=DurabilityPolicy.VOLATILE)
+            _audio_pub = node.create_publisher(AudioChunk, "/remote_control/audio", qos)
+    except Exception:
+        pass
+    return _audio_pub
+
+async def publish_audio_file(file_path: str) -> dict:
+    """Convert audio file to PCM-16k via ffmpeg and publish chunks to DDS at real-time rate."""
+    import subprocess, os, asyncio, time
+    pub = _ensure_audio_pub()
+    if not pub:
+        return {'code': 500, 'message': 'ROS2 not available'}
+    if not os.path.isfile(file_path):
+        return {'code': 400, 'message': f'文件不存在: {file_path}'}
+
+    proc = subprocess.run(
+        ['ffmpeg', '-y', '-i', file_path, '-f', 's16le', '-acodec', 'pcm_s16le',
+         '-ar', '16000', '-ac', '1', 'pipe:1'],
+        capture_output=True, timeout=30,
+    )
+    if proc.returncode != 0:
+        return {'code': 400, 'message': f'ffmpeg error: {proc.stderr.decode()[:200]}'}
+
+    pcm_data = proc.stdout
+    if not pcm_data:
+        return {'code': 400, 'message': 'No audio data after conversion'}
+
+    from audio_msgs.msg import AudioChunk
+    chunk_size = 1024  # 512 samples @ 16-bit = 32ms per chunk
+    batch_size = 4     # send 4 chunks (~128ms) then pace
+    offset = 0
+    chunks_sent = 0
+    start_time = time.monotonic()
+    while offset < len(pcm_data):
+        chunk = pcm_data[offset:offset + chunk_size]
+        offset += chunk_size
+        msg = AudioChunk()
+        msg.format = "pcm_16k_16bit_mono"
+        msg.data = list(chunk)
+        pub.publish(msg)
+        chunks_sent += 1
+        # Pace every batch_size chunks at real-time
+        if chunks_sent % batch_size == 0:
+            expected_time = chunks_sent * 0.032
+            elapsed = time.monotonic() - start_time
+            sleep_time = expected_time - elapsed
+            if sleep_time > 0.005:
+                await asyncio.sleep(sleep_time)
+
+    duration_s = len(pcm_data) / (16000 * 2)
+    return {'code': 200, 'data': {'chunks': chunks_sent, 'duration_s': round(duration_s, 2), 'bytes': len(pcm_data)}}
 
 @app_api.post('/remote-audio/upload')
 async def _remote_audio_upload(file: fastapi.UploadFile = fastapi.File()):
     """Upload audio file, convert to PCM-16k mono, publish to ROS2 topic."""
-    global _audio_pub
-    import subprocess, tempfile, os
-
-    # Initialize publisher if needed
-    if _audio_pub is None:
-        try:
-            from audio_msgs.msg import AudioChunk
-            import ros2_bridge
-            node = ros2_bridge._node_main
-            if node:
-                from rclpy.qos import QoSProfile, ReliabilityPolicy, HistoryPolicy, DurabilityPolicy
-                qos = QoSProfile(reliability=ReliabilityPolicy.BEST_EFFORT,
-                                 history=HistoryPolicy.KEEP_LAST, depth=200,
-                                 durability=DurabilityPolicy.VOLATILE)
-                _audio_pub = node.create_publisher(AudioChunk, "/remote_control/audio", qos)
-        except Exception as e:
-            return {'code': 500, 'message': f'ROS2 publisher init failed: {e}'}
-
-    if not _audio_pub:
-        return {'code': 500, 'message': 'ROS2 not available'}
-
-    # Save uploaded file to temp
+    import tempfile, os
     suffix = os.path.splitext(file.filename or '')[1] or '.wav'
     with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as tmp:
         tmp_path = tmp.name
         content = await file.read()
         tmp.write(content)
-
     try:
-        # Convert to PCM-16k mono via ffmpeg
-        proc = subprocess.run(
-            ['ffmpeg', '-y', '-i', tmp_path, '-f', 's16le', '-acodec', 'pcm_s16le',
-             '-ar', '16000', '-ac', '1', 'pipe:1'],
-            capture_output=True, timeout=30,
-        )
-        if proc.returncode != 0:
-            return {'code': 400, 'message': f'ffmpeg error: {proc.stderr.decode()[:200]}'}
-
-        pcm_data = proc.stdout
-        if not pcm_data:
-            return {'code': 400, 'message': 'No audio data after conversion'}
-
-        # Publish PCM chunks to DDS
-        from audio_msgs.msg import AudioChunk
-        chunk_size = 1024
-        offset = 0
-        chunks_sent = 0
-        while offset < len(pcm_data):
-            chunk = pcm_data[offset:offset + chunk_size]
-            offset += chunk_size
-            msg = AudioChunk()
-            msg.format = "pcm_16k_16bit_mono"
-            msg.data = list(chunk)
-            _audio_pub.publish(msg)
-            chunks_sent += 1
-
-        duration_s = len(pcm_data) / (16000 * 2)  # 16kHz, 16-bit = 2 bytes/sample
-        return {'code': 200, 'data': {'chunks': chunks_sent, 'duration_s': round(duration_s, 2), 'bytes': len(pcm_data)}}
+        return await publish_audio_file(tmp_path)
     finally:
         os.unlink(tmp_path)
 

--- a/agent-core/web/css/style.css
+++ b/agent-core/web/css/style.css
@@ -1444,6 +1444,23 @@ html, body {
   0%, 100% { box-shadow: 0 0 0 0 rgba(239, 68, 68, 0.4); }
   50% { box-shadow: 0 0 0 6px rgba(239, 68, 68, 0); }
 }
+.canvas-field-file { display: inline-flex; align-items: center; gap: 6px; width: 100%; }
+.canvas-file-btn {
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 10px;
+  border-radius: var(--radius-xs);
+  font-size: 11.5px;
+  font-weight: 500;
+  background: rgba(99, 102, 241, 0.1);
+  color: #6366f1;
+  border: 1px solid rgba(99, 102, 241, 0.3);
+  transition: all 0.2s;
+  outline: none;
+}
+.canvas-file-btn:hover { background: rgba(99, 102, 241, 0.2); }
+.canvas-file-name { font-size: 11px; opacity: 0.7; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: 100px; }
 
 .canvas-result {
   padding: 0 10px 10px;

--- a/agent-core/web/js/canvas.js
+++ b/agent-core/web/js/canvas.js
@@ -911,6 +911,44 @@ function _buildCardEl({ id, mcpId, toolName, driverName, x, y, topicIn: savedTop
       });
       footer.prepend(micBtn);
     }
+
+    // remote_audio 特殊渲染：音频上传按钮
+    if (toolName === 'remote_audio') {
+      const footer = el.querySelector('.canvas-card-footer');
+      const uploadBtn = document.createElement('button');
+      uploadBtn.className = 'canvas-mic-btn';
+      uploadBtn.textContent = '\uD83D\uDCC1 上传音频';
+      uploadBtn.addEventListener('click', (e) => {
+        e.stopPropagation();
+        const input = document.createElement('input');
+        input.type = 'file';
+        input.accept = 'audio/*';
+        input.onchange = async () => {
+          if (!input.files[0]) return;
+          uploadBtn.textContent = '\u23F3 上传中...';
+          const form = new FormData();
+          form.append('file', input.files[0]);
+          try {
+            const res = await fetch('/api/remote-audio/upload', { method: 'POST', body: form });
+            const data = await res.json();
+            if (data.code === 200) {
+              uploadBtn.textContent = '\u2705 已发送';
+              setTimeout(() => { uploadBtn.textContent = '\uD83D\uDCC1 上传音频'; }, 2000);
+            } else {
+              _logActivity('error', 'remote_audio: ' + (data.message || '上传失败'));
+              uploadBtn.textContent = '\u274C 失败';
+              setTimeout(() => { uploadBtn.textContent = '\uD83D\uDCC1 上传音频'; }, 2000);
+            }
+          } catch (err) {
+            _logActivity('error', 'remote_audio: ' + err.message);
+            uploadBtn.textContent = '\u274C 错误';
+            setTimeout(() => { uploadBtn.textContent = '\uD83D\uDCC1 上传音频'; }, 2000);
+          }
+        };
+        input.click();
+      });
+      footer.prepend(uploadBtn);
+    }
   }
 
   return el;

--- a/agent-core/web/js/canvas.js
+++ b/agent-core/web/js/canvas.js
@@ -662,6 +662,9 @@ function _buildCardEl({ id, mcpId, toolName, driverName, x, y, topicIn: savedTop
           if (!enumVals.length) return '';
           const opts = enumVals.map(v => `<option value="${_esc(v)}">${_esc(titleMap[v] || v)}</option>`).join('');
           inputHtml = `<select class="canvas-field-input" data-key="${_esc(key)}">${opts}</select>`;
+        } else if (def.format === 'file') {
+          const accept = def.accept || '*/*';
+          inputHtml = `<div class="canvas-field-file"><input type="hidden" class="canvas-field-input" data-key="${_esc(key)}"><button type="button" class="canvas-file-btn" data-accept="${_esc(accept)}">Choose File</button><span class="canvas-file-name"></span></div>`;
         } else {
           const type = def.type === 'number' || def.type === 'integer' ? 'number' : 'text';
           const desc = def.description || '';
@@ -741,6 +744,43 @@ function _buildCardEl({ id, mcpId, toolName, driverName, x, y, topicIn: savedTop
         await _executeCard(el, mcpId, toolName, id);
       });
     }
+
+    // Generic file upload buttons for sensor cards (format: 'file' in schema)
+    el.querySelectorAll('.canvas-file-btn').forEach(btn => {
+      btn.addEventListener('click', (e) => {
+        e.stopPropagation();
+        e.preventDefault();
+        const wrapper = btn.closest('.canvas-field-file');
+        const hiddenInput = wrapper.querySelector('.canvas-field-input');
+        const nameSpan = wrapper.querySelector('.canvas-file-name');
+        const fileInput = document.createElement('input');
+        fileInput.type = 'file';
+        fileInput.accept = btn.dataset.accept || '*/*';
+        fileInput.onchange = async () => {
+          if (!fileInput.files[0]) return;
+          btn.textContent = 'Uploading...';
+          const form = new FormData();
+          form.append('file', fileInput.files[0]);
+          form.append('path', '/tmp/uploads');
+          try {
+            const res = await fetch('/api/file/upload', { method: 'POST', body: form });
+            const data = await res.json();
+            if (data.code === 200) {
+              hiddenInput.value = '/tmp/uploads/' + fileInput.files[0].name;
+              nameSpan.textContent = fileInput.files[0].name;
+              btn.textContent = 'Re-select';
+            } else {
+              btn.textContent = 'Failed';
+              setTimeout(() => { btn.textContent = 'Choose File'; }, 2000);
+            }
+          } catch (err) {
+            btn.textContent = 'Error';
+            setTimeout(() => { btn.textContent = 'Choose File'; }, 2000);
+          }
+        };
+        fileInput.click();
+      });
+    });
   } else {
     // Actuator/processor/default card
     const props   = schema?.properties || {};
@@ -763,6 +803,9 @@ function _buildCardEl({ id, mcpId, toolName, driverName, x, y, topicIn: savedTop
         if (!enumVals.length) return '';  // hide field entirely if no options left
         const opts = enumVals.map(v => `<option value="${_esc(v)}">${_esc(v)}</option>`).join('');
         inputHtml = `<select class="canvas-field-input" data-key="${_esc(key)}">${opts}</select>`;
+      } else if (def.format === 'file') {
+        const accept = def.accept || '*/*';
+        inputHtml = `<div class="canvas-field-file"><input type="hidden" class="canvas-field-input" data-key="${_esc(key)}"><button class="canvas-file-btn" data-accept="${_esc(accept)}">选择文件</button><span class="canvas-file-name"></span></div>`;
       } else {
         const type = def.type === 'number' || def.type === 'integer' ? 'number' : 'text';
         const desc = def.description || '';
@@ -912,43 +955,42 @@ function _buildCardEl({ id, mcpId, toolName, driverName, x, y, topicIn: savedTop
       footer.prepend(micBtn);
     }
 
-    // remote_audio 特殊渲染：音频上传按钮
-    if (toolName === 'remote_audio') {
-      const footer = el.querySelector('.canvas-card-footer');
-      const uploadBtn = document.createElement('button');
-      uploadBtn.className = 'canvas-mic-btn';
-      uploadBtn.textContent = '\uD83D\uDCC1 上传音频';
-      uploadBtn.addEventListener('click', (e) => {
+    // Generic file upload buttons (format: 'file' in schema)
+    el.querySelectorAll('.canvas-file-btn').forEach(btn => {
+      btn.addEventListener('click', (e) => {
         e.stopPropagation();
-        const input = document.createElement('input');
-        input.type = 'file';
-        input.accept = 'audio/*';
-        input.onchange = async () => {
-          if (!input.files[0]) return;
-          uploadBtn.textContent = '\u23F3 上传中...';
+        e.preventDefault();
+        const wrapper = btn.closest('.canvas-field-file');
+        const hiddenInput = wrapper.querySelector('.canvas-field-input');
+        const nameSpan = wrapper.querySelector('.canvas-file-name');
+        const fileInput = document.createElement('input');
+        fileInput.type = 'file';
+        fileInput.accept = btn.dataset.accept || '*/*';
+        fileInput.onchange = async () => {
+          if (!fileInput.files[0]) return;
+          btn.textContent = 'Uploading...';
           const form = new FormData();
-          form.append('file', input.files[0]);
+          form.append('file', fileInput.files[0]);
+          form.append('path', '/tmp/uploads');
           try {
-            const res = await fetch('/api/remote-audio/upload', { method: 'POST', body: form });
+            const res = await fetch('/api/file/upload', { method: 'POST', body: form });
             const data = await res.json();
             if (data.code === 200) {
-              uploadBtn.textContent = '\u2705 已发送';
-              setTimeout(() => { uploadBtn.textContent = '\uD83D\uDCC1 上传音频'; }, 2000);
+              hiddenInput.value = '/tmp/uploads/' + fileInput.files[0].name;
+              nameSpan.textContent = fileInput.files[0].name;
+              btn.textContent = 'Re-select';
             } else {
-              _logActivity('error', 'remote_audio: ' + (data.message || '上传失败'));
-              uploadBtn.textContent = '\u274C 失败';
-              setTimeout(() => { uploadBtn.textContent = '\uD83D\uDCC1 上传音频'; }, 2000);
+              btn.textContent = 'Failed';
+              setTimeout(() => { btn.textContent = 'Choose File'; }, 2000);
             }
           } catch (err) {
-            _logActivity('error', 'remote_audio: ' + err.message);
-            uploadBtn.textContent = '\u274C 错误';
-            setTimeout(() => { uploadBtn.textContent = '\uD83D\uDCC1 上传音频'; }, 2000);
+            btn.textContent = 'Error';
+            setTimeout(() => { btn.textContent = 'Choose File'; }, 2000);
           }
         };
-        input.click();
+        fileInput.click();
       });
-      footer.prepend(uploadBtn);
-    }
+    });
   }
 
   return el;

--- a/perception/plugins/asr.py
+++ b/perception/plugins/asr.py
@@ -103,22 +103,33 @@ def _phoneme_edit_distance(seq1: list, seq2: list) -> float:
 
 # Similar phoneme groups — substitution cost 0.3 instead of 1.0
 _SIMILAR_GROUPS = [
-    {'t', 'd'},       # alveolar stops
-    {'p', 'b'},       # bilabial stops
-    {'k', 'g'},       # velar stops
-    {'f', 'v'},       # labiodental fricatives
-    {'s', 'z'},       # alveolar fricatives
-    {'s.', 'z.'},     # retroflex fricatives
-    {'ɕ', 'ʃ', 'ʂ'}, # postalveolar/retroflex sibilants
-    {'tsh', 'dz'},    # affricates
-    {'n', 'ŋ'},       # nasals
-    {'l', 'r', 'ɹ'},  # liquids
-    {'t', 'tsh'},     # stop ~ affricate
-    {'f', 't'},       # common confusion in noisy env
-    {'x', 'h'},       # velar/glottal fricatives
+    {'t', 'd'},           # alveolar stops
+    {'p', 'b'},           # bilabial stops
+    {'k', 'g'},           # velar stops
+    {'f', 'v'},           # labiodental fricatives
+    {'s', 'z'},           # alveolar fricatives
+    {'s.', 'z.'},         # retroflex fricatives
+    {'ɕ', 'ʃ', 'ʂ'},     # postalveolar/retroflex sibilants
+    {'tsh', 'dz'},        # affricates
+    {'n', 'ŋ'},           # nasals
+    {'l', 'r', 'ɹ'},      # liquids
+    {'t', 'tsh'},         # stop ~ affricate
+    {'f', 't'},           # common confusion in noisy env
+    {'x', 'h'},           # velar/glottal fricatives
     {'ɑu', 'au', 'ɑo', 'ao'},  # diphthong variants
-    {'ou', 'uo'},     # vowel variants
-    {'i', 'i.'},      # apical vowel variant
+    {'ou', 'uo'},         # vowel variants
+    {'i', 'i.'},          # apical vowel variant
+    # ── Chinese ASR common confusions ──
+    {'a', 'ɑ'},           # open vowels (same sound, different notation)
+    {'an', 'ɑn'},         # front nasal variants
+    {'f', 'kh'},          # 范/康 confusion in noisy env
+    {'f', 'x'},           # 范/欢 confusion
+    {'ts.', 'tɕh'},       # retroflex/palatal affricate confusion
+    {'ɑ', 'ɑu'},          # vowel truncation
+    {'ai', 'a'},          # diphthong simplification
+    {'aiɜ', 'ai', 'a'},   # diphthong variants
+    {'iɜ', 'i'},          # rhotacized vowel
+    {'əɜ', 'ə', 'e'},     # schwa variants
 ]
 
 
@@ -796,13 +807,15 @@ class _ASRNode(Node):
         self.state = "starting"
         self._worker_ready = threading.Event()
         log.info("[asr] waiting for first audio chunk...")
-        # Block until first audio chunk arrives or stop() cancels
-        self._first_chunk_event.wait()
+        # Block until first audio chunk arrives or stop() cancels (timeout to avoid infinite hang)
+        got_chunk = self._first_chunk_event.wait(timeout=10)
         if self._stop_event.is_set():
             self.state = "idle"
             return {"state": "idle"}
+        if not got_chunk:
+            log.warning("[asr] timeout waiting for first audio chunk (10s), starting anyway")
         # Wait for worker to finish initialization (IPA precompute etc.)
-        self._worker_ready.wait()
+        self._worker_ready.wait(timeout=5)
         if self.state == "error":
             return {"state": "error", "message": "ASR worker failed to initialize (check logs)"}
         self.state = "running"
@@ -1132,11 +1145,12 @@ class ASRPlugin:
                 self._load_model_async(self._asr_model)
                 return {"status": "loading", "asr_model": self._asr_model,
                         "message": f"Switching to model '{self._asr_model}', downloading..."}
-            # Stop all nodes (they'll use new config on next start)
-            # Only stop VAD internals — keep node in executor to avoid DDS re-discovery delay
+            # Remove all nodes completely (they'll be recreated on next start with new config)
+            # Must fully remove from executor to avoid rclpy InvalidHandle errors on restart
             for key in list(self._nodes.keys()):
-                node = self._nodes[key]
+                node = self._nodes.pop(key)
                 node.stop()
+                self._executor.remove_node(node)
             return {"status": "configured", "asr_model": self._asr_model}
 
         return None


### PR DESCRIPTION
## Summary

- Add `remote_audio` as internal agentcore tool (file upload → ffmpeg PCM-16k → DDS publish)
- Add generic `format: "file"` support in inputSchema for canvas card file upload UI
- Fix ASR startup hanging indefinitely (`_first_chunk_event.wait()` timeout + config cleanup)
- Expand phoneme similarity groups for better Chinese keyword matching (asr_kws mode)
- Fix DDS chunk loss: pre-create publisher at startup + prepend/append silence
- Add ffmpeg to Dockerfile

## Test plan

- [x] ASR start no longer hangs on canvas "智能控制" startup
- [x] asr_kws matches "小范小狗" variants (小康小狗, 小看小狗, etc.)
- [x] remote_audio file upload works from canvas UI
- [x] Uploaded audio reaches ASR pipeline intact (with silence warmup)
- [x] sensevoice-small int8 vs fp32 comparison (int8 preferred: 3x faster, similar quality)

🤖 Generated with [Claude Code](https://claude.com/claude-code)