### PR TITLE
feat: redesign deploy modal + fix sidebar/update for stopped drivers

### DIFF
--- a/agent-core/Dockerfile
+++ b/agent-core/Dockerfile
@@ -3,11 +3,14 @@ ARG ROS_BASE_IMAGE=bj-warehouse.tencentcloudcr.com/phanthy-motus/ros-base:latest
 FROM ${ROS_BASE_IMAGE}
 ARG PYPI_MIRROR
 
-# Install ffmpeg + docker CLI (docker.io installed separately to avoid libc trigger under QEMU)
+# Install ffmpeg + docker CLI
+# docker.io triggers libc-bin post-install which segfaults under QEMU;
+# install it last and ignore the trigger failure, then force-configure
 RUN apt-get -o Acquire::AllowInsecureRepositories=true update && \
-    apt-get install -y --no-install-recommends --allow-unauthenticated ffmpeg && \
-    apt-get install -y --no-install-recommends --allow-unauthenticated --no-triggers docker.io docker-compose-v2 && \
-    apt-get install -y --no-install-recommends --allow-unauthenticated python3-pip python3-dbus && \
+    apt-get install -y --no-install-recommends --allow-unauthenticated \
+        python3-pip python3-dbus ffmpeg && \
+    apt-get install -y --no-install-recommends --allow-unauthenticated \
+        docker.io docker-compose-v2 || true && \
     rm -rf /var/lib/apt/lists/*
 
 # Install uv

--- a/agent-core/Dockerfile
+++ b/agent-core/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get -o Acquire::AllowInsecureRepositories=true update && \
     curl -fsSL https://mirrors.tuna.tsinghua.edu.cn/docker-ce/linux/static/stable/aarch64/docker-27.5.1.tgz \
         | tar -xz --strip-components=1 -C /usr/local/bin/ docker/docker && \
     mkdir -p /usr/local/lib/docker/cli-plugins && \
-    curl -fsSL https://mirrors.tuna.tsinghua.edu.cn/docker-ce/linux/cli-plugins/docker-compose-linux-aarch64 \
+    curl -fsSL https://github.com/docker/compose/releases/download/v2.21.0/docker-compose-linux-aarch64 \
         -o /usr/local/lib/docker/cli-plugins/docker-compose && \
     chmod +x /usr/local/lib/docker/cli-plugins/docker-compose && \
     rm -rf /var/lib/apt/lists/*

--- a/agent-core/Dockerfile
+++ b/agent-core/Dockerfile
@@ -3,12 +3,16 @@ ARG ROS_BASE_IMAGE=bj-warehouse.tencentcloudcr.com/phanthy-motus/ros-base:latest
 FROM ${ROS_BASE_IMAGE}
 ARG PYPI_MIRROR
 
-# Install ffmpeg + docker CLI static binary (avoid docker.io apt which segfaults under QEMU)
+# Install ffmpeg + docker CLI + compose plugin (static binaries, avoid apt docker.io QEMU segfault)
 RUN apt-get -o Acquire::AllowInsecureRepositories=true update && \
     apt-get install -y --no-install-recommends --allow-unauthenticated \
         python3-pip python3-dbus ffmpeg curl && \
     curl -fsSL https://mirrors.tuna.tsinghua.edu.cn/docker-ce/linux/static/stable/aarch64/docker-27.5.1.tgz \
         | tar -xz --strip-components=1 -C /usr/local/bin/ docker/docker && \
+    mkdir -p /usr/local/lib/docker/cli-plugins && \
+    curl -fsSL https://mirrors.tuna.tsinghua.edu.cn/docker-ce/linux/cli-plugins/docker-compose-linux-aarch64 \
+        -o /usr/local/lib/docker/cli-plugins/docker-compose && \
+    chmod +x /usr/local/lib/docker/cli-plugins/docker-compose && \
     rm -rf /var/lib/apt/lists/*
 
 # Install uv

--- a/agent-core/Dockerfile
+++ b/agent-core/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get -o Acquire::AllowInsecureRepositories=true update && \
     curl -fsSL https://mirrors.tuna.tsinghua.edu.cn/docker-ce/linux/static/stable/aarch64/docker-27.5.1.tgz \
         | tar -xz --strip-components=1 -C /usr/local/bin/ docker/docker && \
     mkdir -p /usr/local/lib/docker/cli-plugins && \
-    curl -fsSL https://github.com/docker/compose/releases/download/v2.21.0/docker-compose-linux-aarch64 \
+    curl -fsSL https://agi-phanthy-dev-1252788780.cos.ap-beijing.myqcloud.com/public/docker-compose-linux-aarch64 \
         -o /usr/local/lib/docker/cli-plugins/docker-compose && \
     chmod +x /usr/local/lib/docker/cli-plugins/docker-compose && \
     rm -rf /var/lib/apt/lists/*

--- a/agent-core/Dockerfile
+++ b/agent-core/Dockerfile
@@ -3,14 +3,12 @@ ARG ROS_BASE_IMAGE=bj-warehouse.tencentcloudcr.com/phanthy-motus/ros-base:latest
 FROM ${ROS_BASE_IMAGE}
 ARG PYPI_MIRROR
 
-# Install ffmpeg + docker CLI
-# docker.io triggers libc-bin post-install which segfaults under QEMU;
-# install it last and ignore the trigger failure, then force-configure
+# Install ffmpeg + docker CLI static binary (avoid docker.io apt which segfaults under QEMU)
 RUN apt-get -o Acquire::AllowInsecureRepositories=true update && \
     apt-get install -y --no-install-recommends --allow-unauthenticated \
-        python3-pip python3-dbus ffmpeg && \
-    apt-get install -y --no-install-recommends --allow-unauthenticated \
-        docker.io docker-compose-v2 || true && \
+        python3-pip python3-dbus ffmpeg curl && \
+    curl -fsSL https://mirrors.tuna.tsinghua.edu.cn/docker-ce/linux/static/stable/aarch64/docker-27.5.1.tgz \
+        | tar -xz --strip-components=1 -C /usr/local/bin/ docker/docker && \
     rm -rf /var/lib/apt/lists/*
 
 # Install uv

--- a/agent-core/src/api/drivers.py
+++ b/agent-core/src/api/drivers.py
@@ -240,6 +240,21 @@ def _stop_sync(driver_id: str) -> dict:
         raise RuntimeError(str(e))
 
 
+def _remove_sync(driver_id: str) -> dict:
+    """Stop and remove container."""
+    import docker as docker_sdk
+    try:
+        client = _docker()
+        name = _container_name(driver_id)
+        container = client.containers.get(name)
+        container.remove(force=True)
+        return {'status': 'removed'}
+    except docker_sdk.errors.NotFound:
+        return {'status': 'not_found'}
+    except Exception as e:
+        raise RuntimeError(str(e))
+
+
 async def _run_in_executor(fn, *args):
     loop = asyncio.get_event_loop()
     return await loop.run_in_executor(None, fn, *args)
@@ -437,6 +452,21 @@ async def driver_stop(driver_id: str):
         return {'code': 200, 'data': result}
     except Exception as e:
         return {'code': 500, 'message': str(e)}
+
+
+@router.post('/{driver_id}/remove')
+async def driver_remove(driver_id: str):
+    """Stop + remove container, clear last_deploy from manifest."""
+    try:
+        result = await _run_in_executor(_remove_sync, driver_id)
+    except Exception as e:
+        return {'code': 500, 'message': str(e)}
+    manifest = _load_manifest()
+    entry = next((d for d in manifest if d.get('id') == driver_id), None)
+    if entry:
+        entry.pop('last_deploy', None)
+        _save_manifest(manifest)
+    return {'code': 200, 'data': result}
 
 
 @router.get('/{driver_id}/status')

--- a/agent-core/src/api/registry.py
+++ b/agent-core/src/api/registry.py
@@ -79,6 +79,7 @@ def _build_catalog_sync() -> dict:
                 'created': created,
                 'size': '',
                 'imageRef': t.get('imageRef', ''),
+                'channel': t.get('channel', ''),
             })
 
         entry = {

--- a/agent-core/web/css/style.css
+++ b/agent-core/web/css/style.css
@@ -2122,11 +2122,11 @@ html, body {
 .mp-card-provider {
   font-size: 10px;
   font-weight: 500;
-  color: var(--text-dim);
-  background: var(--bg-secondary);
-  border: 1px solid var(--border);
+  color: var(--text-muted);
+  background: var(--bg-hover);
+  border: none;
   border-radius: 10px;
-  padding: 1px 8px;
+  padding: 2px 8px;
   white-space: nowrap;
   flex-shrink: 0;
 }

--- a/agent-core/web/css/style.css
+++ b/agent-core/web/css/style.css
@@ -1916,6 +1916,9 @@ html, body {
 .svc-btn-start { color: var(--green); border-color: rgba(63,185,80,.3); }
 .svc-btn-start:hover:not(:disabled) { background: var(--green-bg); border-color: var(--green); }
 
+.svc-btn-remove { color: var(--text-dim); }
+.svc-btn-remove:hover:not(:disabled) { color: var(--red); border-color: var(--red); }
+
 /* ══════════════════════════════════════════════════════════════════════════
    TAB 2: 驱动市场
 ══════════════════════════════════════════════════════════════════════════ */

--- a/agent-core/web/css/style.css
+++ b/agent-core/web/css/style.css
@@ -1924,24 +1924,24 @@ html, body {
 .svc-btn-ver { color: var(--text-muted); }
 .svc-ver-dropdown {
   position: absolute;
-  top: calc(100% + 4px);
+  top: calc(100% + 6px);
   right: 0;
-  min-width: 200px;
+  min-width: 240px;
   background: var(--bg-card);
   border: 1px solid var(--border);
   border-radius: var(--radius-sm);
   box-shadow: var(--shadow-lg);
   z-index: 9999;
-  max-height: 200px;
+  max-height: 220px;
   overflow-y: auto;
+  overflow-x: hidden;
 }
 .svc-ver-dropdown.hidden { display: none; }
 .svc-ver-opt {
   display: flex;
   align-items: center;
-  justify-content: space-between;
   gap: 8px;
-  padding: 8px 12px;
+  padding: 9px 14px;
   cursor: pointer;
   transition: background .1s;
 }
@@ -1952,6 +1952,7 @@ html, body {
   font-size: 12px;
   font-family: var(--font-mono);
   color: var(--text);
+  white-space: nowrap;
 }
 .svc-ver-badge {
   font-size: 10px;
@@ -1959,7 +1960,19 @@ html, body {
   color: var(--green);
   background: var(--green-bg);
   border-radius: 3px;
-  padding: 1px 5px;
+  padding: 2px 6px;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+.svc-ver-channel {
+  font-size: 10px;
+  font-weight: 500;
+  color: var(--text-dim);
+  background: var(--bg-secondary);
+  border-radius: 3px;
+  padding: 2px 6px;
+  white-space: nowrap;
+  flex-shrink: 0;
 }
 
 /* ══════════════════════════════════════════════════════════════════════════

--- a/agent-core/web/css/style.css
+++ b/agent-core/web/css/style.css
@@ -2094,41 +2094,54 @@ html, body {
   position: relative;
   display: flex;
   flex-direction: column;
-  padding: 16px 14px 14px;
+  padding: 12px 14px;
   background: var(--bg-card);
   border: 1px solid var(--border);
   border-radius: var(--radius);
   cursor: pointer;
   transition: border-color .15s, box-shadow .15s;
+  gap: 6px;
 }
 .mp-card:hover { border-color: var(--border-med); box-shadow: var(--shadow-sm); }
 
-.mp-card-body { flex: 1; text-align: center; }
+.mp-card-header {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  flex-wrap: wrap;
+}
 .mp-card-name {
   font-size: 14px;
   font-weight: 600;
   color: var(--text);
-  margin-bottom: 3px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 .mp-card-provider {
-  font-size: 11px;
+  font-size: 10px;
+  font-weight: 500;
   color: var(--text-dim);
-  margin-bottom: 6px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 1px 8px;
+  white-space: nowrap;
+  flex-shrink: 0;
 }
 .mp-card-desc {
-  font-size: 11px;
+  font-size: 10.5px;
   color: var(--text-muted);
-  line-height: 1.4;
+  line-height: 1.5;
+  text-align: center;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
   overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  margin-bottom: 4px;
 }
 .mp-card-action {
-  margin-top: 10px;
+  margin-top: 4px;
   text-align: center;
 }
 
@@ -5180,9 +5193,11 @@ html, body {
     grid-template-columns: repeat(2, 1fr);
     gap: 8px;
   }
-  .mp-card { padding: 16px 10px 14px; }
+  .mp-card { padding: 10px; gap: 4px; }
   .mp-card-name { font-size: 13px; }
-  .mp-install-btn { min-height: 36px; padding: 6px 12px; }
+  .mp-card-desc { font-size: 10px; -webkit-line-clamp: 2; }
+  .mp-card-provider { font-size: 9px; padding: 1px 6px; }
+  .mp-action-btn { min-height: 34px; padding: 6px 12px; font-size: 11px; }
   .marketplace-search-bar input { min-height: 40px; font-size: 14px; }
   .marketplace-filters { gap: 6px; }
   .mp-chip { min-height: 32px; padding: 6px 12px; font-size: 12px; }

--- a/agent-core/web/css/style.css
+++ b/agent-core/web/css/style.css
@@ -1923,15 +1923,13 @@ html, body {
 .svc-ver-wrap { position: relative; }
 .svc-btn-ver { color: var(--text-muted); }
 .svc-ver-dropdown {
-  position: absolute;
-  top: calc(100% + 6px);
-  right: 0;
+  position: fixed;
   min-width: 240px;
   background: var(--bg-card);
   border: 1px solid var(--border);
   border-radius: var(--radius-sm);
   box-shadow: var(--shadow-lg);
-  z-index: 9999;
+  z-index: 10000;
   max-height: 220px;
   overflow-y: auto;
   overflow-x: hidden;

--- a/agent-core/web/css/style.css
+++ b/agent-core/web/css/style.css
@@ -2037,6 +2037,26 @@ html, body {
   font-size: 11px;
   padding: 3px 8px;
 }
+.ver-sheet-body .mp-version-opt {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 14px 20px;
+  min-height: 48px;
+  cursor: pointer;
+  transition: background .1s;
+}
+.ver-sheet-body .mp-version-opt:hover { background: var(--bg-hover); }
+.ver-sheet-body .mp-version-tag {
+  font-size: 14px;
+  font-family: var(--font-mono);
+  color: var(--text);
+}
+.ver-sheet-body .mp-version-date {
+  font-size: 11px;
+  color: var(--text-dim);
+}
 
 /* ══════════════════════════════════════════════════════════════════════════
    TAB 2: 驱动市场
@@ -2179,17 +2199,14 @@ html, body {
 }
 
 .mp-versions {
-  position: absolute;
-  top: calc(100% + 4px);
-  left: 50%;
-  transform: translateX(-50%);
-  min-width: 180px;
+  position: fixed;
+  min-width: 240px;
   background: var(--bg-card);
   border: 1px solid var(--border);
   border-radius: var(--radius-sm);
   box-shadow: var(--shadow-lg);
-  z-index: 9999;
-  max-height: 200px;
+  z-index: 10000;
+  max-height: 220px;
   overflow-y: auto;
 }
 .mp-versions.hidden { display: none; }
@@ -5207,12 +5224,8 @@ html, body {
   .marketplace-filters { gap: 6px; }
   .mp-chip { min-height: 32px; padding: 6px 12px; font-size: 12px; }
 
-  /* Marketplace version dropdown */
-  .mp-versions {
-    min-width: 160px;
-    max-height: 160px;
-  }
-  .mp-version-opt { padding: 10px 12px; min-height: 40px; }
+  /* Marketplace version dropdown: hidden on mobile (replaced by sheet) */
+  .mp-versions { display: none !important; }
 
   /* ── Touch targets ── */
   .topbar-btn,

--- a/agent-core/web/css/style.css
+++ b/agent-core/web/css/style.css
@@ -4998,6 +4998,64 @@ html, body {
   .deploy-confirm-item-versions { flex-wrap: wrap; }
   .deploy-confirm-tag { font-size: 11px; word-break: break-all; max-width: 100%; }
 
+  /* ── Deploy modal: mobile adaptations ── */
+  .deploy-tabs { padding: 0 16px; }
+  .deploy-tab { padding: 10px 14px; font-size: 14px; min-height: 44px; }
+  .deploy-tab-pane { padding: 16px; max-height: calc(100vh - 180px); }
+
+  .deploy-channel-selector { margin-right: 8px; }
+  .deploy-channel-label { display: none; }
+  .deploy-channel-select { font-size: 11px; padding: 4px 6px; }
+
+  /* My Services: rows stack actions */
+  .svc-row {
+    flex-wrap: wrap;
+    gap: 8px;
+    padding: 10px 12px;
+  }
+  .svc-row-info {
+    flex-basis: 100%;
+    order: 1;
+  }
+  .svc-row-dot { order: 0; }
+  .svc-row-actions {
+    order: 2;
+    flex-basis: 100%;
+    flex-wrap: wrap;
+    padding-left: 20px;
+  }
+  .svc-btn { min-height: 36px; padding: 6px 14px; font-size: 12px; }
+  .svc-group-header { margin-bottom: 6px; }
+
+  /* Version dropdown: use absolute on mobile (modal is full-screen, no clip) */
+  .svc-ver-dropdown {
+    position: absolute !important;
+    top: calc(100% + 4px) !important;
+    right: 0 !important;
+    left: auto !important;
+    min-width: 200px;
+    max-height: 180px;
+  }
+
+  /* Marketplace: 2-column grid */
+  .marketplace-grid {
+    grid-template-columns: repeat(2, 1fr);
+    gap: 8px;
+  }
+  .mp-card { padding: 16px 10px 14px; }
+  .mp-card-name { font-size: 13px; }
+  .mp-install-btn { min-height: 36px; padding: 6px 12px; }
+  .marketplace-search-bar input { min-height: 40px; font-size: 14px; }
+  .marketplace-filters { gap: 6px; }
+  .mp-chip { min-height: 32px; padding: 6px 12px; font-size: 12px; }
+
+  /* Marketplace version dropdown */
+  .mp-versions {
+    min-width: 160px;
+    max-height: 160px;
+  }
+  .mp-version-opt { padding: 10px 12px; min-height: 40px; }
+
   /* ── Touch targets ── */
   .topbar-btn,
   .btn-ghost { min-height: 44px; padding: 10px 14px; }

--- a/agent-core/web/css/style.css
+++ b/agent-core/web/css/style.css
@@ -1919,6 +1919,49 @@ html, body {
 .svc-btn-remove { color: var(--text-dim); }
 .svc-btn-remove:hover:not(:disabled) { color: var(--red); border-color: var(--red); }
 
+/* Version switcher in My Services */
+.svc-ver-wrap { position: relative; }
+.svc-btn-ver { color: var(--text-muted); }
+.svc-ver-dropdown {
+  position: absolute;
+  top: calc(100% + 4px);
+  right: 0;
+  min-width: 200px;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  box-shadow: var(--shadow-lg);
+  z-index: 9999;
+  max-height: 200px;
+  overflow-y: auto;
+}
+.svc-ver-dropdown.hidden { display: none; }
+.svc-ver-opt {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 8px 12px;
+  cursor: pointer;
+  transition: background .1s;
+}
+.svc-ver-opt:hover { background: var(--bg-hover); }
+.svc-ver-opt.current { opacity: .5; cursor: default; }
+.svc-ver-opt.current:hover { background: transparent; }
+.svc-ver-tag {
+  font-size: 12px;
+  font-family: var(--font-mono);
+  color: var(--text);
+}
+.svc-ver-badge {
+  font-size: 10px;
+  font-weight: 600;
+  color: var(--green);
+  background: var(--green-bg);
+  border-radius: 3px;
+  padding: 1px 5px;
+}
+
 /* ══════════════════════════════════════════════════════════════════════════
    TAB 2: 驱动市场
 ══════════════════════════════════════════════════════════════════════════ */

--- a/agent-core/web/css/style.css
+++ b/agent-core/web/css/style.css
@@ -1973,6 +1973,71 @@ html, body {
   flex-shrink: 0;
 }
 
+/* ── Mobile version action sheet ─────────────────────────────────────────── */
+.ver-sheet-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,.4);
+  z-index: 10001;
+  display: flex;
+  align-items: flex-end;
+  opacity: 0;
+  transition: opacity .2s;
+}
+.ver-sheet-overlay.active { opacity: 1; }
+.ver-sheet {
+  width: 100%;
+  background: var(--bg-card);
+  border-radius: 16px 16px 0 0;
+  max-height: 60vh;
+  display: flex;
+  flex-direction: column;
+  transform: translateY(100%);
+  transition: transform .25s ease;
+}
+.ver-sheet-overlay.active .ver-sheet { transform: translateY(0); }
+.ver-sheet-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 20px 12px;
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+}
+.ver-sheet-title {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--text);
+}
+.ver-sheet-close {
+  background: none;
+  border: none;
+  font-size: 18px;
+  color: var(--text-muted);
+  cursor: pointer;
+  padding: 4px 8px;
+}
+.ver-sheet-body {
+  overflow-y: auto;
+  padding: 8px 0;
+  -webkit-overflow-scrolling: touch;
+}
+.ver-sheet-body .svc-ver-opt {
+  padding: 14px 20px;
+  min-height: 48px;
+}
+.ver-sheet-body .svc-ver-tag {
+  font-size: 14px;
+}
+.ver-sheet-body .svc-ver-badge {
+  font-size: 11px;
+  padding: 3px 8px;
+}
+.ver-sheet-body .svc-ver-channel {
+  font-size: 11px;
+  padding: 3px 8px;
+}
+
 /* ══════════════════════════════════════════════════════════════════════════
    TAB 2: 驱动市场
 ══════════════════════════════════════════════════════════════════════════ */
@@ -5027,14 +5092,9 @@ html, body {
   .svc-btn { min-height: 36px; padding: 6px 14px; font-size: 12px; }
   .svc-group-header { margin-bottom: 6px; }
 
-  /* Version dropdown: use absolute on mobile (modal is full-screen, no clip) */
+  /* Version dropdown: hidden on mobile (replaced by action sheet) */
   .svc-ver-dropdown {
-    position: absolute !important;
-    top: calc(100% + 4px) !important;
-    right: 0 !important;
-    left: auto !important;
-    min-width: 200px;
-    max-height: 180px;
+    display: none !important;
   }
 
   /* Marketplace: 2-column grid */

--- a/agent-core/web/css/style.css
+++ b/agent-core/web/css/style.css
@@ -5166,14 +5166,19 @@ html, body {
   /* My Services: rows stack actions */
   .svc-row {
     flex-wrap: wrap;
-    gap: 8px;
+    gap: 6px;
     padding: 10px 12px;
   }
+  .svc-row-dot {
+    order: 0;
+    align-self: center;
+    margin-right: 4px;
+  }
   .svc-row-info {
-    flex-basis: 100%;
+    flex: 1;
+    min-width: 0;
     order: 1;
   }
-  .svc-row-dot { order: 0; }
   .svc-row-actions {
     order: 2;
     flex-basis: 100%;

--- a/agent-core/web/css/style.css
+++ b/agent-core/web/css/style.css
@@ -5277,7 +5277,7 @@ html, body {
     background: var(--bg-card);
     border-top: 1px solid var(--border);
     box-shadow: 0 -1px 8px rgba(0,0,0,.06);
-    z-index: 58;
+    z-index: 200;
     padding: 0;
     padding-bottom: env(safe-area-inset-bottom, 0px);
   }

--- a/agent-core/web/css/style.css
+++ b/agent-core/web/css/style.css
@@ -1753,245 +1753,314 @@ html, body {
   border-color: var(--accent);
 }
 
-/* Section heading with left accent bar */
-.drivers-section {
+/* ── Deploy Tabs ─────────────────────────────────────────────────────────── */
+.deploy-tabs {
+  display: flex;
+  gap: 0;
+  padding: 0 24px;
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+}
+.deploy-tab {
+  background: transparent;
+  border: none;
+  border-bottom: 2px solid transparent;
+  padding: 10px 16px;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: color .15s, border-color .15s;
+  font-family: var(--font-ui);
+}
+.deploy-tab:hover { color: var(--text); }
+.deploy-tab.active { color: var(--accent); border-bottom-color: var(--accent); }
+
+.deploy-tab-pane {
+  display: none;
+  overflow-y: auto;
+  max-height: 60vh;
+  padding: 20px 24px;
+}
+.deploy-tab-pane.active { display: block; }
+
+/* ══════════════════════════════════════════════════════════════════════════
+   TAB 1: 我的服务
+══════════════════════════════════════════════════════════════════════════ */
+.svc-empty {
   display: flex;
   flex-direction: column;
-  gap: 0;
+  align-items: center;
+  justify-content: center;
+  padding: 40px 20px;
+  gap: 8px;
 }
+.svc-empty-title { font-size: 13px; font-weight: 600; color: var(--text-muted); }
+.svc-empty-hint  { font-size: 12px; color: var(--text-dim); }
 
-.drivers-section-label {
-  font-size: 10.5px;
+.svc-group { margin-bottom: 20px; }
+.svc-group:last-child { margin-bottom: 0; }
+.svc-group-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+.svc-group-title {
+  font-size: 11px;
   font-weight: 700;
   color: var(--text-dim);
   text-transform: uppercase;
-  letter-spacing: 1px;
-  margin-bottom: 12px;
-  display: flex;
-  align-items: center;
-  gap: 8px;
+  letter-spacing: .8px;
 }
-.drivers-section-label::before {
-  content: '';
-  display: inline-block;
-  width: 3px;
-  height: 12px;
-  border-radius: 2px;
-  background: var(--accent);
-  flex-shrink: 0;
+.svc-group-count {
+  font-size: 10px;
+  color: var(--text-dim);
+  background: var(--bg-secondary);
+  padding: 1px 6px;
+  border-radius: 10px;
 }
 
-.drivers-grid {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-}
+/* Accent left border for updatable group */
+.svc-group.updatable .svc-row { border-left: 3px solid var(--accent); }
 
-/* ── Driver card ── */
-.driver-card {
+.svc-row {
   display: flex;
   align-items: center;
-  gap: 14px;
+  gap: 12px;
+  padding: 10px 14px;
   background: var(--bg-card);
   border: 1px solid var(--border);
-  border-radius: var(--radius);
-  padding: 14px 16px;
-  box-shadow: var(--shadow-sm);
-  transition: border-color .15s, box-shadow .15s;
+  border-radius: var(--radius-sm);
+  margin-bottom: 6px;
+  transition: border-color .15s;
 }
-.driver-card:hover {
-  border-color: var(--border-med);
-  box-shadow: var(--shadow-md);
-}
+.svc-row:hover { border-color: var(--border-med); }
 
-.driver-card-info {
-  flex: 1;
-  min-width: 0;
+.svc-row-dot {
+  width: 8px; height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
 }
-.driver-card-name  {
+.svc-row-dot.running { background: var(--green); box-shadow: 0 0 0 3px var(--green-bg); }
+.svc-row-dot.stopped { background: var(--border-med); }
+.svc-row-dot.error   { background: var(--red); box-shadow: 0 0 0 3px var(--red-bg); }
+
+.svc-row-info {
+  flex: 1;
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: 8px;
+  min-width: 0;
+}
+.svc-row-name {
   font-size: 13px;
   font-weight: 600;
   color: var(--text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
-.driver-card-desc  { font-size: 11px; color: var(--text-muted); margin-top: 2px; }
-.driver-card-image {
-  font-size: 10.5px;
-  color: var(--text-dim);
-  font-family: var(--font-mono);
-  margin-top: 4px;
-}
-.driver-card-deployed {
+.svc-row-version {
   font-size: 11px;
   font-family: var(--font-mono);
   color: var(--text-muted);
-  margin-top: 5px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  flex-shrink: 0;
 }
-
-/* Version selector row inside card info */
-.driver-card-vsel {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  margin-top: 8px;
+.svc-row-arrow {
+  font-size: 12px;
+  color: var(--text-dim);
+  flex-shrink: 0;
 }
-.driver-card-vsel .vsel {
-  flex: 1;
-  min-width: 0;
-}
-
-.driver-card-ctrl {
-  display: flex;
-  align-items: center;
-  gap: 8px;
+.svc-row-new-version {
+  font-size: 11px;
+  font-family: var(--font-mono);
+  color: var(--accent);
+  font-weight: 600;
   flex-shrink: 0;
 }
 
-/* ── Custom version selector ─────────────────────────────────────────────── */
-.vsel {
-  position: relative;
-  flex-shrink: 0;
-}
-.vsel-btn {
+.svc-row-actions {
   display: flex;
   align-items: center;
   gap: 6px;
-  padding: 5px 10px 5px 12px;
+  flex-shrink: 0;
+}
+
+.svc-btn {
+  padding: 4px 12px;
+  font-size: 11px;
+  font-weight: 500;
   border-radius: var(--radius-sm);
   border: 1px solid var(--border);
   background: var(--bg-input);
-  color: var(--text);
+  color: var(--text-muted);
   cursor: pointer;
-  font-size: 12px;
-  font-family: var(--font-mono);
-  width: 100%;
-  text-align: left;
-  transition: border-color .15s, background .15s;
-}
-.vsel-btn:hover { border-color: var(--border-med); background: var(--bg-hover); }
-.vsel.open .vsel-btn { border-color: var(--accent); box-shadow: 0 0 0 3px var(--accent-glow); background: var(--bg-card); }
-.vsel-label {
-  flex: 1;
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  transition: background .15s, border-color .15s, color .15s;
+  font-family: var(--font-ui);
   white-space: nowrap;
+}
+.svc-btn:hover:not(:disabled) { background: var(--bg-hover); border-color: var(--border-med); color: var(--text); }
+.svc-btn:disabled { opacity: .4; cursor: default; }
+
+.svc-btn-upgrade {
+  color: var(--accent);
+  border-color: var(--accent);
+  background: transparent;
+}
+.svc-btn-upgrade:hover:not(:disabled) { background: var(--accent-dim); }
+
+.svc-btn-stop { color: var(--red); border-color: rgba(192,57,43,.3); }
+.svc-btn-stop:hover:not(:disabled) { background: var(--red-bg); border-color: var(--red); }
+
+.svc-btn-start { color: var(--green); border-color: rgba(63,185,80,.3); }
+.svc-btn-start:hover:not(:disabled) { background: var(--green-bg); border-color: var(--green); }
+
+/* ══════════════════════════════════════════════════════════════════════════
+   TAB 2: 驱动市场
+══════════════════════════════════════════════════════════════════════════ */
+.marketplace-search-bar {
+  margin-bottom: 12px;
+}
+.marketplace-search-bar input {
+  width: 100%;
+  padding: 8px 12px;
+  font-size: 13px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--bg-input);
+  color: var(--text);
+  outline: none;
+  transition: border-color .15s;
+}
+.marketplace-search-bar input:focus { border-color: var(--accent); }
+.marketplace-search-bar input::placeholder { color: var(--text-dim); }
+
+.marketplace-filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-bottom: 16px;
+}
+.mp-chip {
+  padding: 4px 12px;
+  font-size: 11px;
+  font-weight: 500;
+  border-radius: 20px;
+  border: 1px solid var(--border);
+  background: var(--bg-input);
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: all .15s;
+  font-family: var(--font-ui);
+}
+.mp-chip:hover { border-color: var(--border-med); color: var(--text); }
+.mp-chip.active {
+  background: var(--accent-dim);
+  border-color: var(--accent);
+  color: var(--accent);
+  font-weight: 600;
+}
+
+.marketplace-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+  gap: 10px;
+}
+
+.mp-card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 20px 14px 16px;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  text-align: center;
+  transition: border-color .15s, box-shadow .15s;
+}
+.mp-card:hover { border-color: var(--border-med); box-shadow: var(--shadow-sm); }
+
+.mp-card-name {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text);
+  margin-bottom: 4px;
+}
+.mp-card-provider {
+  font-size: 11px;
+  color: var(--text-dim);
+  margin-bottom: 12px;
+}
+.mp-card-action {
+  margin-top: auto;
+}
+
+.mp-install-btn {
+  padding: 5px 14px;
+  font-size: 12px;
+  font-weight: 500;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--accent);
+  background: transparent;
+  color: var(--accent);
+  cursor: pointer;
+  transition: background .15s;
+  font-family: var(--font-ui);
+}
+.mp-install-btn:hover { background: var(--accent-dim); }
+
+.mp-installed-badge {
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--green);
+  padding: 4px 10px;
+  border: 1px solid rgba(63,185,80,.25);
+  border-radius: var(--radius-sm);
+  background: var(--green-bg);
+}
+
+.mp-no-version {
+  font-size: 11px;
   color: var(--text-dim);
 }
-.vsel.has-value .vsel-label { color: var(--text); }
-.vsel-chevron {
-  flex-shrink: 0;
-  color: var(--text-dim);
-  transition: transform .15s;
-}
-.vsel.open .vsel-chevron { transform: rotate(180deg); }
-.vsel-dropdown {
-  display: none;
+
+.mp-versions {
   position: absolute;
-  right: 0;
-  top: calc(100% + 5px);
-  min-width: 100%;
-  max-width: 340px;
+  top: calc(100% + 4px);
+  left: 50%;
+  transform: translateX(-50%);
+  min-width: 180px;
   background: var(--bg-card);
   border: 1px solid var(--border);
   border-radius: var(--radius-sm);
   box-shadow: var(--shadow-lg);
   z-index: 9999;
-  overflow: hidden;
-  max-height: 220px;
+  max-height: 200px;
   overflow-y: auto;
 }
-.vsel.open .vsel-dropdown { display: block; }
-.vsel-option {
+.mp-versions.hidden { display: none; }
+
+.mp-version-opt {
   display: flex;
-  align-items: baseline;
+  align-items: center;
+  justify-content: space-between;
   gap: 8px;
   padding: 8px 12px;
   cursor: pointer;
   transition: background .1s;
 }
-.vsel-option:hover { background: var(--bg-hover); }
-.vsel-option.selected { background: var(--accent-dim); }
-.vsel-option-tag {
-  flex: 1;
-  font-size: 11.5px;
+.mp-version-opt:hover { background: var(--bg-hover); }
+.mp-version-tag {
+  font-size: 12px;
   font-family: var(--font-mono);
   color: var(--text);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
 }
-.vsel-option-date {
-  font-size: 11px;
+.mp-version-date {
+  font-size: 10px;
   color: var(--text-dim);
-  white-space: nowrap;
-  flex-shrink: 0;
 }
-.vsel-option-current {
-  font-size: 10px;
-  font-weight: 700;
-  color: var(--green);
-  background: var(--green-bg);
-  border-radius: 3px;
-  padding: 1px 5px;
-  flex-shrink: 0;
-  letter-spacing: .02em;
-}
-.vsel-option-latest {
-  font-size: 10px;
-  font-weight: 700;
-  color: var(--yellow, #d08000);
-  background: rgba(208,128,0,.12);
-  border-radius: 3px;
-  padding: 1px 5px;
-  flex-shrink: 0;
-  letter-spacing: .02em;
-}
-.vsel-option.disabled {
-  opacity: .45;
-  cursor: default;
-}
-.vsel-option.disabled:hover { background: transparent; }
-
-/* Status tags */
-.driver-running-badge {
-  font-size: 10px;
-  font-weight: 600;
-  color: var(--green);
-  padding: 2px 8px;
-  border: 1px solid rgba(63,185,80,.25);
-  border-radius: 20px;
-  background: var(--green-bg);
-  flex-shrink: 0;
-}
-.driver-upgrade-badge {
-  font-size: 10px;
-  font-weight: 600;
-  color: var(--yellow, #d08000);
-  padding: 2px 7px;
-  border: 1px solid rgba(208,128,0,.3);
-  border-radius: 20px;
-  background: rgba(208,128,0,.1);
-  flex-shrink: 0;
-}
-.btn-upgrade {
-  font-size: 10px;
-  font-weight: 600;
-  color: var(--yellow, #d08000);
-  padding: 2px 7px;
-  border: 1px solid rgba(208,128,0,.3);
-  border-radius: 20px;
-  background: rgba(208,128,0,.1);
-  cursor: pointer;
-  flex-shrink: 0;
-  transition: background .15s, border-color .15s;
-}
-.btn-upgrade:hover { background: rgba(208,128,0,.16); border-color: rgba(208,128,0,.6); }
 
 /* ── Deploy confirm modal ─────────────────────────────────────────────────── */
 #deploy-confirm-overlay { z-index: 150; }
@@ -2772,75 +2841,7 @@ html, body {
 ::-webkit-scrollbar-thumb { background: var(--border); border-radius: 3px; }
 ::-webkit-scrollbar-thumb:hover { background: var(--border-med); }
 
-/* ── Hardware driver: search bar ─────────────────────────────────────────── */
-.hw-search-bar {
-  margin-bottom: 10px;
-}
-.hw-search-bar input {
-  width: 100%;
-  box-sizing: border-box;
-  padding: 7px 12px;
-  font-size: 12px;
-  font-family: var(--font-ui);
-  color: var(--text);
-  background: var(--bg-input);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-sm);
-  outline: none;
-  transition: border-color .15s;
-}
-.hw-search-bar input:focus { border-color: var(--accent); }
-.hw-search-bar input::placeholder { color: var(--text-dim); }
-/* hide browser clear button on search inputs */
-.hw-search-bar input::-webkit-search-cancel-button { display: none; }
-
-/* ── Hardware driver: provider accordion groups ───────────────────────────── */
-.hw-provider-group {
-  margin-bottom: 4px;
-}
-.hw-provider-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 8px 12px;
-  border-radius: var(--radius-sm);
-  background: var(--bg-hover);
-  border: 1px solid var(--border);
-  cursor: pointer;
-  user-select: none;
-  font-size: 11px;
-  font-weight: 700;
-  color: var(--text-muted);
-  text-transform: uppercase;
-  letter-spacing: .7px;
-  transition: background .12s, border-color .12s;
-}
-.hw-provider-header:hover { background: var(--bg-card); border-color: var(--border-med); }
-.hw-provider-left { display: flex; align-items: center; gap: 8px; }
-.hw-provider-count {
-  font-size: 10px;
-  font-weight: 500;
-  color: var(--text-dim);
-  background: var(--bg-input);
-  border: 1px solid var(--border);
-  border-radius: 20px;
-  padding: 1px 7px;
-  letter-spacing: 0;
-  text-transform: none;
-}
-.hw-provider-chevron {
-  color: var(--text-dim);
-  transition: transform .15s;
-  flex-shrink: 0;
-}
-.hw-provider-group.open .hw-provider-chevron { transform: rotate(180deg); }
-.hw-provider-body {
-  display: none;
-  flex-direction: column;
-  gap: 6px;
-  padding: 8px 0 2px;
-}
-.hw-provider-group.open .hw-provider-body { display: flex; }
+/* (hw-search-bar and hw-provider styles removed — replaced by marketplace UI) */
 
 /* ══════════════════════════════════════════════════════════════════════════
    DRIVERS OVERVIEW SIDEBAR

--- a/agent-core/web/css/style.css
+++ b/agent-core/web/css/style.css
@@ -2094,58 +2094,75 @@ html, body {
   position: relative;
   display: flex;
   flex-direction: column;
-  align-items: center;
-  padding: 20px 14px 16px;
+  padding: 16px 14px 14px;
   background: var(--bg-card);
   border: 1px solid var(--border);
   border-radius: var(--radius);
-  text-align: center;
+  cursor: pointer;
   transition: border-color .15s, box-shadow .15s;
 }
 .mp-card:hover { border-color: var(--border-med); box-shadow: var(--shadow-sm); }
 
+.mp-card-body { flex: 1; text-align: center; }
 .mp-card-name {
   font-size: 14px;
   font-weight: 600;
   color: var(--text);
-  margin-bottom: 4px;
+  margin-bottom: 3px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 .mp-card-provider {
   font-size: 11px;
   color: var(--text-dim);
-  margin-bottom: 12px;
+  margin-bottom: 6px;
+}
+.mp-card-desc {
+  font-size: 11px;
+  color: var(--text-muted);
+  line-height: 1.4;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  margin-bottom: 4px;
 }
 .mp-card-action {
-  margin-top: auto;
+  margin-top: 10px;
+  text-align: center;
 }
 
-.mp-install-btn {
-  padding: 5px 14px;
+/* Unified action button size */
+.mp-action-btn {
+  display: inline-block;
+  min-width: 72px;
+  padding: 6px 14px;
   font-size: 12px;
   font-weight: 500;
   border-radius: var(--radius-sm);
+  text-align: center;
+  font-family: var(--font-ui);
+  box-sizing: border-box;
+}
+.mp-install-btn {
   border: 1px solid var(--accent);
   background: transparent;
   color: var(--accent);
   cursor: pointer;
   transition: background .15s;
-  font-family: var(--font-ui);
 }
 .mp-install-btn:hover { background: var(--accent-dim); }
 
 .mp-installed-badge {
-  font-size: 11px;
-  font-weight: 500;
   color: var(--green);
-  padding: 4px 10px;
   border: 1px solid rgba(63,185,80,.25);
-  border-radius: var(--radius-sm);
   background: var(--green-bg);
 }
 
 .mp-no-version {
-  font-size: 11px;
   color: var(--text-dim);
+  border: 1px solid var(--border);
+  background: transparent;
 }
 
 .mp-versions {
@@ -2182,6 +2199,67 @@ html, body {
 .mp-version-date {
   font-size: 10px;
   color: var(--text-dim);
+}
+
+/* ── Driver detail (in-pane view) ────────────────────────────────────────── */
+.mp-detail {
+  animation: fadeIn .15s ease;
+}
+@keyframes fadeIn { from { opacity: 0; } to { opacity: 1; } }
+.mp-detail-back {
+  background: none;
+  border: none;
+  color: var(--accent);
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  padding: 4px 0;
+  margin-bottom: 16px;
+  font-family: var(--font-ui);
+}
+.mp-detail-back:hover { text-decoration: underline; }
+.mp-detail-header { margin-bottom: 16px; }
+.mp-detail-title {
+  font-size: 18px;
+  font-weight: 700;
+  color: var(--text);
+  margin-bottom: 4px;
+}
+.mp-detail-provider {
+  font-size: 12px;
+  color: var(--text-dim);
+}
+.mp-detail-desc {
+  font-size: 13px;
+  color: var(--text-muted);
+  line-height: 1.6;
+  margin-bottom: 20px;
+  white-space: pre-wrap;
+}
+.mp-detail-section-title {
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--text-dim);
+  text-transform: uppercase;
+  letter-spacing: .8px;
+  margin-bottom: 10px;
+}
+.mp-detail-versions {
+  border-top: 1px solid var(--border);
+  padding-top: 16px;
+}
+.detail-ver-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 0;
+  border-bottom: 1px solid var(--border);
+}
+.detail-ver-row:last-child { border-bottom: none; }
+.detail-ver-tag {
+  font-size: 12px;
+  font-family: var(--font-mono);
+  color: var(--text);
 }
 
 /* ── Deploy confirm modal ─────────────────────────────────────────────────── */

--- a/agent-core/web/index.html
+++ b/agent-core/web/index.html
@@ -295,22 +295,17 @@
       </div>
       <button class="btn-icon" id="deploy-close">✕</button>
     </div>
-    <div class="modal-body deploy-modal-body">
-      <div class="drivers-section">
-        <div class="drivers-section-label">核心服务</div>
-        <div class="drivers-grid" id="drivers-core"></div>
+    <div class="deploy-tabs">
+      <button class="deploy-tab active" data-tab="my-services">我的服务</button>
+      <button class="deploy-tab" data-tab="marketplace">驱动市场</button>
+    </div>
+    <div class="deploy-tab-pane active" id="pane-my-services"></div>
+    <div class="deploy-tab-pane" id="pane-marketplace">
+      <div class="marketplace-search-bar">
+        <input id="marketplace-search" type="search" placeholder="搜索驱动…" autocomplete="off" spellcheck="false">
       </div>
-      <div class="drivers-section">
-        <div class="drivers-section-label">硬件驱动</div>
-        <div class="hw-search-bar">
-          <input id="hw-search" type="search" placeholder="搜索驱动…" autocomplete="off" spellcheck="false">
-        </div>
-        <div id="drivers-hardware-inner"></div>
-      </div>
-      <div class="drivers-section">
-        <div class="drivers-section-label">感知服务</div>
-        <div class="drivers-grid" id="drivers-perception"></div>
-      </div>
+      <div class="marketplace-filters" id="marketplace-filters"></div>
+      <div class="marketplace-grid" id="marketplace-grid"></div>
     </div>
     <div class="modal-footer" id="deploy-modal-footer" style="display:none">
       <span class="deploy-footer-hint" id="deploy-footer-hint"></span>

--- a/agent-core/web/js/app.js
+++ b/agent-core/web/js/app.js
@@ -108,6 +108,7 @@ async function checkForUpdate() {
 
     // Find services that have a newer image available vs what's running
     const updatable = json.data.filter(d => {
+      if (!d.running) return false;  // 只提示正在运行的服务
       if (!d.image || !d.running_image) return false;
       const latestTag  = _tagFromImage(d.image);
       const runningTag = _tagFromImage(d.running_image);

--- a/agent-core/web/js/deploy-panel.js
+++ b/agent-core/web/js/deploy-panel.js
@@ -418,16 +418,24 @@ function _renderMarketplace() {
     });
   });
 
+  // Bind card click → detail
+  gridEl.querySelectorAll('.mp-card').forEach(card => {
+    card.addEventListener('click', (e) => {
+      // Don't open detail if clicking install button or version dropdown
+      if (e.target.closest('.mp-install-btn') || e.target.closest('.mp-versions') || e.target.closest('.mp-installed-badge')) return;
+      _showDriverDetail(card);
+    });
+  });
+
   // Bind version options
   gridEl.querySelectorAll('.mp-version-opt').forEach(opt => {
-    opt.addEventListener('click', () => {
+    opt.addEventListener('click', (e) => {
+      e.stopPropagation();
       const driverId = opt.dataset.driverId;
       const image = opt.dataset.fullImage;
       const label = opt.dataset.label;
       const tag = opt.dataset.tag;
-      // Close dropdown
       opt.closest('.mp-card').querySelector('.mp-versions').classList.add('hidden');
-      // Show confirm and deploy
       showDeployConfirmModal(
         [{ label, currentTag: '—', newTag: tag }],
         () => _executeDeploys([[driverId, { image }]])
@@ -445,6 +453,8 @@ function _mpCardHTML(item) {
   const isInstalled = s && (s.running || s.last_deploy);
   const tags = item.tags || [];
   const imageBase = item.full_repo || item.image;
+  const desc = item.description || '';
+  const fullName = item.name || label;
 
   const versionOpts = tags.map(t => {
     const fullImg = t.imageRef || (imageBase + ':' + t.tag);
@@ -455,19 +465,25 @@ function _mpCardHTML(item) {
   }).join('');
 
   const installBtn = isInstalled
-    ? `<span class="mp-installed-badge">已安装</span>`
+    ? `<span class="mp-action-btn mp-installed-badge">已安装</span>`
     : tags.length > 0
-      ? `<button class="mp-install-btn">安装 ▾</button>`
-      : `<span class="mp-no-version">暂无版本</span>`;
+      ? `<button class="mp-action-btn mp-install-btn">安装 ▾</button>`
+      : `<span class="mp-action-btn mp-no-version">暂无版本</span>`;
 
   return `
-    <div class="mp-card" data-driver-id="${driverId}">
-      <div class="mp-card-name">${label}</div>
-      ${provider ? `<div class="mp-card-provider">${provider}</div>` : ''}
+    <div class="mp-card" data-driver-id="${driverId}" data-name="${_escAttr(fullName)}" data-desc="${_escAttr(desc)}" data-provider="${_escAttr(provider)}">
+      <div class="mp-card-body">
+        <div class="mp-card-name">${label}</div>
+        ${provider ? `<div class="mp-card-provider">${provider}</div>` : ''}
+        ${desc ? `<div class="mp-card-desc">${_escHTML(desc)}</div>` : ''}
+      </div>
       <div class="mp-card-action">${installBtn}</div>
       <div class="mp-versions hidden">${versionOpts}</div>
     </div>`;
 }
+
+function _escAttr(s) { return s.replace(/"/g, '&quot;').replace(/</g, '&lt;'); }
+function _escHTML(s) { return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;'); }
 
 function _toggleInstallDropdown(btn) {
   const card = btn.closest('.mp-card');
@@ -491,6 +507,68 @@ document.addEventListener('click', (e) => {
     document.querySelectorAll('.svc-ver-dropdown').forEach(d => d.classList.add('hidden'));
   }
 });
+
+// ── Driver detail (in-modal view) ────────────────────────────────────────
+
+function _showDriverDetail(card) {
+  const name = card.dataset.name || '';
+  const desc = card.dataset.desc || '';
+  const provider = card.dataset.provider || '';
+  const driverId = card.dataset.driverId || '';
+  const s = _statuses[driverId];
+  const isInstalled = s && (s.running || s.last_deploy);
+
+  // Get tags from the card's versions dropdown
+  const versions = [...card.querySelectorAll('.mp-version-opt')].map(opt => ({
+    tag: opt.dataset.tag,
+    fullImage: opt.dataset.fullImage,
+    label: opt.dataset.label,
+  }));
+
+  const pane = document.getElementById('pane-marketplace');
+  // Save current content for back navigation
+  const savedHTML = pane.innerHTML;
+
+  const versionsHTML = versions.map(v => `
+    <div class="detail-ver-row" data-full-image="${v.fullImage}" data-tag="${v.tag}" data-label="${v.label}" data-driver-id="${driverId}">
+      <span class="detail-ver-tag">${v.tag}</span>
+      <button class="svc-btn svc-btn-upgrade">部署此版本</button>
+    </div>
+  `).join('');
+
+  pane.innerHTML = `
+    <div class="mp-detail">
+      <button class="mp-detail-back">← 返回</button>
+      <div class="mp-detail-header">
+        <div class="mp-detail-title">${name}</div>
+        ${provider ? `<div class="mp-detail-provider">${provider}</div>` : ''}
+        ${isInstalled ? '<span class="mp-installed-badge" style="margin-top:8px;display:inline-block">已安装</span>' : ''}
+      </div>
+      ${desc ? `<div class="mp-detail-desc">${desc}</div>` : '<div class="mp-detail-desc" style="color:var(--text-dim)">暂无描述</div>'}
+      <div class="mp-detail-versions">
+        <div class="mp-detail-section-title">可用版本</div>
+        ${versionsHTML || '<div style="color:var(--text-dim);font-size:12px">暂无版本</div>'}
+      </div>
+    </div>
+  `;
+
+  // Bind back
+  pane.querySelector('.mp-detail-back').addEventListener('click', () => {
+    pane.innerHTML = savedHTML;
+    _renderMarketplace();
+  });
+
+  // Bind deploy buttons
+  pane.querySelectorAll('.detail-ver-row .svc-btn').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const row = btn.closest('.detail-ver-row');
+      showDeployConfirmModal(
+        [{ label: row.dataset.label, currentTag: '—', newTag: row.dataset.tag }],
+        () => _executeDeploys([[row.dataset.driverId, { image: row.dataset.fullImage }]])
+      );
+    });
+  });
+}
 
 // ══════════════════════════════════════════════════════════════════════════
 //  SHARED UTILITIES

--- a/agent-core/web/js/deploy-panel.js
+++ b/agent-core/web/js/deploy-panel.js
@@ -261,7 +261,9 @@ function _svcRowHTML({ item, id, s, latestTag, currentTag, hasUpdate }) {
     const latestImage = tags[0]?.imageRef || (imageBase + ':' + latestTag);
     actions = `<button class="svc-btn svc-btn-upgrade" data-action="upgrade" data-driver-id="${id}" data-current-tag="${currentTag}" data-latest-tag="${latestTag}" data-latest-image="${latestImage}" data-label="${label}">升级到 ${latestTag}</button>`;
   }
-  if (isRunning) {
+  if (item._cat === 'core') {
+    // Core cannot stop itself — no stop button
+  } else if (isRunning) {
     actions += `<button class="svc-btn svc-btn-stop" data-action="stop" data-driver-id="${id}">停止</button>`;
   } else {
     // Stopped: show start + remove

--- a/agent-core/web/js/deploy-panel.js
+++ b/agent-core/web/js/deploy-panel.js
@@ -197,9 +197,9 @@ function _renderMyServices() {
 
     const entry = { item, id, s, latestTag, currentTag, hasUpdate };
 
-    if (s.running && hasUpdate) {
+    if ((s.running || item._cat === 'core') && hasUpdate) {
       updatable.push(entry);
-    } else if (s.running) {
+    } else if (s.running || item._cat === 'core') {
       running.push(entry);
     } else {
       stopped.push(entry);
@@ -236,6 +236,9 @@ function _renderMyServices() {
   container.querySelectorAll('[data-action="start"]').forEach(btn => {
     btn.addEventListener('click', () => _startDriver(btn.dataset.driverId, btn.dataset.image, btn));
   });
+  container.querySelectorAll('[data-action="remove"]').forEach(btn => {
+    btn.addEventListener('click', () => _removeDriver(btn.dataset.driverId, btn));
+  });
 }
 
 function _svcGroupHTML(title, count, cls) {
@@ -261,11 +264,12 @@ function _svcRowHTML({ item, id, s, latestTag, currentTag, hasUpdate }) {
   if (isRunning) {
     actions += `<button class="svc-btn svc-btn-stop" data-action="stop" data-driver-id="${id}">停止</button>`;
   } else {
-    // Stopped: show start
+    // Stopped: show start + remove
     const lastImage = s.running_image || s.last_deploy?.image || s.image || '';
     if (lastImage) {
       actions += `<button class="svc-btn svc-btn-start" data-action="start" data-driver-id="${id}" data-image="${lastImage}">启动</button>`;
     }
+    actions += `<button class="svc-btn svc-btn-remove" data-action="remove" data-driver-id="${id}">卸载</button>`;
   }
 
   const versionText = currentTag || (s.running_image?.split(':').pop()) || '—';
@@ -528,6 +532,18 @@ async function _startDriver(driverId, image, btn) {
   } catch (e) {
     _appendLog(driverId, `✗ 网络错误: ${e.message}`, 'error');
   }
+}
+
+async function _removeDriver(driverId, btn) {
+  if (!confirm('确定卸载此服务？将移除容器并释放空间。')) return;
+  btn.disabled = true;
+  btn.textContent = '卸载中…';
+  try {
+    await fetch(`/api/drivers/${driverId}/remove`, { method: 'POST' });
+  } catch (e) {
+    console.error('[deploy] remove', e);
+  }
+  setTimeout(async () => { await _loadStatuses(); _render(); }, 1500);
 }
 
 // ── Confirm all pending deploys ───────────────────────────────────────────

--- a/agent-core/web/js/deploy-panel.js
+++ b/agent-core/web/js/deploy-panel.js
@@ -273,10 +273,10 @@ function _renderMyServices() {
   container.querySelectorAll('.svc-ver-opt').forEach(opt => {
     opt.addEventListener('click', () => {
       if (opt.classList.contains('current')) return;
-      const { driverId, fullImage, tag, label } = opt.dataset;
+      const { driverId, fullImage, tag, label, channel } = opt.dataset;
       opt.closest('.svc-ver-dropdown').classList.add('hidden');
       showDeployConfirmModal(
-        [{ label, currentTag: '—', newTag: tag }],
+        [{ label, currentTag: '—', newTag: tag, channel: channel || '' }],
         () => _executeDeploys([[driverId, { image: fullImage }]])
       );
     });
@@ -305,7 +305,7 @@ function _svcRowHTML({ item, id, s, latestTag, currentTag, hasUpdate }) {
       const fullImg = t.imageRef || (imageBase + ':' + t.tag);
       const isCurrent = currentTag && t.tag === currentTag;
       const ch = _channelLabel(t.channel);
-      return `<div class="svc-ver-opt${isCurrent ? ' current' : ''}" data-driver-id="${id}" data-full-image="${fullImg}" data-tag="${t.tag}" data-label="${label}">
+      return `<div class="svc-ver-opt${isCurrent ? ' current' : ''}" data-driver-id="${id}" data-full-image="${fullImg}" data-tag="${t.tag}" data-label="${label}" data-channel="${t.channel || ''}">
         <span class="svc-ver-tag">${t.tag}</span>
         ${ch ? `<span class="svc-ver-channel">${ch}</span>` : ''}
         ${isCurrent ? '<span class="svc-ver-badge">当前</span>' : ''}
@@ -428,9 +428,10 @@ function _renderMarketplace() {
       const image = opt.dataset.fullImage;
       const label = opt.dataset.label;
       const tag = opt.dataset.tag;
+      const channel = opt.dataset.channel || '';
       opt.closest('.mp-card').querySelector('.mp-versions').classList.add('hidden');
       showDeployConfirmModal(
-        [{ label, currentTag: '—', newTag: tag }],
+        [{ label, currentTag: '—', newTag: tag, channel }],
         () => _executeDeploys([[driverId, { image }]])
       );
     });
@@ -452,7 +453,7 @@ function _mpCardHTML(item) {
   const versionOpts = tags.map(t => {
     const fullImg = t.imageRef || (imageBase + ':' + t.tag);
     const ch = _channelLabel(t.channel);
-    return `<div class="mp-version-opt" data-driver-id="${driverId}" data-full-image="${fullImg}" data-tag="${t.tag}" data-label="${label}">
+    return `<div class="mp-version-opt" data-driver-id="${driverId}" data-full-image="${fullImg}" data-tag="${t.tag}" data-label="${label}" data-channel="${t.channel || ''}">
       <span class="mp-version-tag">${t.tag}</span>
       ${ch ? `<span class="svc-ver-channel">${ch}</span>` : ''}
       ${t.created ? `<span class="mp-version-date">${t.created.replace(/\s+\d{2}:\d{2}$/, '')}</span>` : ''}
@@ -539,10 +540,10 @@ function _showInstallSheet(optionsHTML, title) {
 
   overlay.querySelectorAll('.mp-version-opt').forEach(opt => {
     opt.addEventListener('click', () => {
-      const { driverId, fullImage, tag, label } = opt.dataset;
+      const { driverId, fullImage, tag, label, channel } = opt.dataset;
       close();
       showDeployConfirmModal(
-        [{ label, currentTag: '—', newTag: tag }],
+        [{ label, currentTag: '—', newTag: tag, channel: channel || '' }],
         () => _executeDeploys([[driverId, { image: fullImage }]])
       );
     });
@@ -574,18 +575,22 @@ function _showDriverDetail(card) {
     tag: opt.dataset.tag,
     fullImage: opt.dataset.fullImage,
     label: opt.dataset.label,
+    channel: opt.dataset.channel || '',
   }));
 
   const pane = document.getElementById('pane-marketplace');
   // Save current content for back navigation
   const savedHTML = pane.innerHTML;
 
-  const versionsHTML = versions.map(v => `
-    <div class="detail-ver-row" data-full-image="${v.fullImage}" data-tag="${v.tag}" data-label="${v.label}" data-driver-id="${driverId}">
+  const versionsHTML = versions.map(v => {
+    const ch = _channelLabel(v.channel);
+    return `
+    <div class="detail-ver-row" data-full-image="${v.fullImage}" data-tag="${v.tag}" data-label="${v.label}" data-driver-id="${driverId}" data-channel="${v.channel}">
       <span class="detail-ver-tag">${v.tag}</span>
+      ${ch ? `<span class="svc-ver-channel">${ch}</span>` : ''}
       <button class="svc-btn svc-btn-upgrade">部署此版本</button>
-    </div>
-  `).join('');
+    </div>`;
+  }).join('');
 
   pane.innerHTML = `
     <div class="mp-detail">
@@ -614,7 +619,7 @@ function _showDriverDetail(card) {
     btn.addEventListener('click', () => {
       const row = btn.closest('.detail-ver-row');
       showDeployConfirmModal(
-        [{ label: row.dataset.label, currentTag: '—', newTag: row.dataset.tag }],
+        [{ label: row.dataset.label, currentTag: '—', newTag: row.dataset.tag, channel: row.dataset.channel || '' }],
         () => _executeDeploys([[row.dataset.driverId, { image: row.dataset.fullImage }]])
       );
     });
@@ -660,10 +665,10 @@ function _showVersionSheet(optionsHTML) {
   overlay.querySelectorAll('.svc-ver-opt').forEach(opt => {
     opt.addEventListener('click', () => {
       if (opt.classList.contains('current')) return;
-      const { driverId, fullImage, tag, label } = opt.dataset;
+      const { driverId, fullImage, tag, label, channel } = opt.dataset;
       close();
       showDeployConfirmModal(
-        [{ label, currentTag: '—', newTag: tag }],
+        [{ label, currentTag: '—', newTag: tag, channel: channel || '' }],
         () => _executeDeploys([[driverId, { image: fullImage }]])
       );
     });
@@ -714,15 +719,19 @@ export function showDeployConfirmModal(items, onConfirm) {
   const overlay = document.getElementById('deploy-confirm-overlay');
   const body    = document.getElementById('deploy-confirm-body');
 
-  body.innerHTML = items.map(it => `
+  body.innerHTML = items.map(it => {
+    const ch = it.channel ? _channelLabel(it.channel) : '';
+    return `
     <div class="deploy-confirm-item">
       <div class="deploy-confirm-item-name">${it.label}</div>
       <div class="deploy-confirm-item-versions">
         <span class="deploy-confirm-tag current">${it.currentTag || '—'}</span>
         <span class="deploy-confirm-arrow">→</span>
         <span class="deploy-confirm-tag latest">${it.newTag}</span>
+        ${ch ? `<span class="svc-ver-channel">${ch}</span>` : ''}
       </div>
-    </div>`).join('');
+    </div>`;
+  }).join('');
 
   overlay.classList.remove('hidden');
 

--- a/agent-core/web/js/deploy-panel.js
+++ b/agent-core/web/js/deploy-panel.js
@@ -239,6 +239,29 @@ function _renderMyServices() {
   container.querySelectorAll('[data-action="remove"]').forEach(btn => {
     btn.addEventListener('click', () => _removeDriver(btn.dataset.driverId, btn));
   });
+  // Version switcher dropdowns
+  container.querySelectorAll('[data-action="switch-version"]').forEach(btn => {
+    btn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      const wrap = btn.closest('.svc-ver-wrap');
+      const dd = wrap.querySelector('.svc-ver-dropdown');
+      const wasHidden = dd.classList.contains('hidden');
+      // Close all others
+      container.querySelectorAll('.svc-ver-dropdown').forEach(d => d.classList.add('hidden'));
+      if (wasHidden) dd.classList.remove('hidden');
+    });
+  });
+  container.querySelectorAll('.svc-ver-opt').forEach(opt => {
+    opt.addEventListener('click', () => {
+      if (opt.classList.contains('current')) return;
+      const { driverId, fullImage, tag, label } = opt.dataset;
+      opt.closest('.svc-ver-dropdown').classList.add('hidden');
+      showDeployConfirmModal(
+        [{ label, currentTag: '—', newTag: tag }],
+        () => _executeDeploys([[driverId, { image: fullImage }]])
+      );
+    });
+  });
 }
 
 function _svcGroupHTML(title, count, cls) {
@@ -257,9 +280,24 @@ function _svcRowHTML({ item, id, s, latestTag, currentTag, hasUpdate }) {
   const tags = item.tags || [];
 
   let actions = '';
+  // Version switcher (dropdown)
+  if (tags.length > 1) {
+    const versionOpts = tags.map(t => {
+      const fullImg = t.imageRef || (imageBase + ':' + t.tag);
+      const isCurrent = currentTag && t.tag === currentTag;
+      return `<div class="svc-ver-opt${isCurrent ? ' current' : ''}" data-driver-id="${id}" data-full-image="${fullImg}" data-tag="${t.tag}" data-label="${label}">
+        <span class="svc-ver-tag">${t.tag}</span>
+        ${isCurrent ? '<span class="svc-ver-badge">当前</span>' : ''}
+      </div>`;
+    }).join('');
+    actions += `<div class="svc-ver-wrap">
+      <button class="svc-btn svc-btn-ver" data-action="switch-version">切换版本 ▾</button>
+      <div class="svc-ver-dropdown hidden">${versionOpts}</div>
+    </div>`;
+  }
   if (hasUpdate) {
     const latestImage = tags[0]?.imageRef || (imageBase + ':' + latestTag);
-    actions = `<button class="svc-btn svc-btn-upgrade" data-action="upgrade" data-driver-id="${id}" data-current-tag="${currentTag}" data-latest-tag="${latestTag}" data-latest-image="${latestImage}" data-label="${label}">升级到 ${latestTag}</button>`;
+    actions += `<button class="svc-btn svc-btn-upgrade" data-action="upgrade" data-driver-id="${id}" data-current-tag="${currentTag}" data-latest-tag="${latestTag}" data-latest-image="${latestImage}" data-label="${label}">升级到 ${latestTag}</button>`;
   }
   if (item._cat === 'core') {
     // Core cannot stop itself — no stop button
@@ -421,6 +459,9 @@ function _toggleInstallDropdown(btn) {
 document.addEventListener('click', (e) => {
   if (!e.target.closest('.mp-card')) {
     document.querySelectorAll('.mp-versions').forEach(d => d.classList.add('hidden'));
+  }
+  if (!e.target.closest('.svc-ver-wrap')) {
+    document.querySelectorAll('.svc-ver-dropdown').forEach(d => d.classList.add('hidden'));
   }
 });
 

--- a/agent-core/web/js/deploy-panel.js
+++ b/agent-core/web/js/deploy-panel.js
@@ -472,11 +472,11 @@ function _mpCardHTML(item) {
 
   return `
     <div class="mp-card" data-driver-id="${driverId}" data-name="${_escAttr(fullName)}" data-desc="${_escAttr(desc)}" data-provider="${_escAttr(provider)}">
-      <div class="mp-card-body">
-        <div class="mp-card-name">${label}</div>
-        ${provider ? `<div class="mp-card-provider">${provider}</div>` : ''}
-        ${desc ? `<div class="mp-card-desc">${_escHTML(desc)}</div>` : ''}
+      <div class="mp-card-header">
+        <span class="mp-card-name">${label}</span>
+        ${provider ? `<span class="mp-card-provider">${provider}</span>` : ''}
       </div>
+      ${desc ? `<div class="mp-card-desc">${_escHTML(desc)}</div>` : ''}
       <div class="mp-card-action">${installBtn}</div>
       <div class="mp-versions hidden">${versionOpts}</div>
     </div>`;

--- a/agent-core/web/js/deploy-panel.js
+++ b/agent-core/web/js/deploy-panel.js
@@ -282,11 +282,19 @@ function _svcRowHTML({ item, id, s, latestTag, currentTag, hasUpdate }) {
   let actions = '';
   // Version switcher (dropdown)
   if (tags.length > 1) {
+    const _channelLabel = (tag) => {
+      if (tag.startsWith('ga.')) return '稳定';
+      if (tag.startsWith('release.')) return '正式';
+      if (tag.startsWith('preview.')) return '预览';
+      return '';
+    };
     const versionOpts = tags.map(t => {
       const fullImg = t.imageRef || (imageBase + ':' + t.tag);
       const isCurrent = currentTag && t.tag === currentTag;
+      const ch = _channelLabel(t.tag);
       return `<div class="svc-ver-opt${isCurrent ? ' current' : ''}" data-driver-id="${id}" data-full-image="${fullImg}" data-tag="${t.tag}" data-label="${label}">
         <span class="svc-ver-tag">${t.tag}</span>
+        ${ch ? `<span class="svc-ver-channel">${ch}</span>` : ''}
         ${isCurrent ? '<span class="svc-ver-badge">当前</span>' : ''}
       </div>`;
     }).join('');

--- a/agent-core/web/js/deploy-panel.js
+++ b/agent-core/web/js/deploy-panel.js
@@ -301,12 +301,6 @@ function _svcRowHTML({ item, id, s, latestTag, currentTag, hasUpdate }) {
   let actions = '';
   // Version switcher (dropdown)
   if (tags.length > 1) {
-    const _channelLabel = (tag) => {
-      if (tag.startsWith('ga.')) return '稳定';
-      if (tag.startsWith('release.')) return '正式';
-      if (tag.startsWith('preview.')) return '预览';
-      return '';
-    };
     const versionOpts = tags.map(t => {
       const fullImg = t.imageRef || (imageBase + ':' + t.tag);
       const isCurrent = currentTag && t.tag === currentTag;
@@ -457,8 +451,10 @@ function _mpCardHTML(item) {
 
   const versionOpts = tags.map(t => {
     const fullImg = t.imageRef || (imageBase + ':' + t.tag);
+    const ch = _channelLabel(t.tag);
     return `<div class="mp-version-opt" data-driver-id="${driverId}" data-full-image="${fullImg}" data-tag="${t.tag}" data-label="${label}">
       <span class="mp-version-tag">${t.tag}</span>
+      ${ch ? `<span class="svc-ver-channel">${ch}</span>` : ''}
       ${t.created ? `<span class="mp-version-date">${t.created.replace(/\s+\d{2}:\d{2}$/, '')}</span>` : ''}
     </div>`;
   }).join('');
@@ -677,6 +673,13 @@ function _showVersionSheet(optionsHTML) {
 function _driverIdForItem(item, category) {
   if (category === 'driver') return `${item.provider}-${item.model}`;
   return item.image;
+}
+
+function _channelLabel(tag) {
+  if (tag.startsWith('ga.')) return 'GA';
+  if (tag.startsWith('release.')) return 'Release';
+  if (tag.startsWith('preview.')) return 'Preview';
+  return '';
 }
 
 function _updateStatusDots() {

--- a/agent-core/web/js/deploy-panel.js
+++ b/agent-core/web/js/deploy-panel.js
@@ -251,7 +251,7 @@ function _svcGroupHTML(title, count, cls) {
 
 function _svcRowHTML({ item, id, s, latestTag, currentTag, hasUpdate }) {
   const label = item._cat === 'driver' ? (item.model || item.image) : (item.name || item.image);
-  const isRunning = s.running;
+  const isRunning = s.running || item._cat === 'core';
   const statusDot = isRunning ? 'running' : s.status === 'error' ? 'error' : 'stopped';
   const imageBase = item.full_repo || item.image;
   const tags = item.tags || [];

--- a/agent-core/web/js/deploy-panel.js
+++ b/agent-core/web/js/deploy-panel.js
@@ -676,7 +676,7 @@ function _driverIdForItem(item, category) {
 }
 
 function _channelLabel(tag) {
-  if (tag.startsWith('ga.')) return 'GA';
+  if (tag.startsWith('ga.')) return 'Stable';
   if (tag.startsWith('release.')) return 'Release';
   if (tag.startsWith('preview.')) return 'Preview';
   return '';

--- a/agent-core/web/js/deploy-panel.js
+++ b/agent-core/web/js/deploy-panel.js
@@ -361,11 +361,10 @@ function _svcRowHTML({ item, id, s, latestTag, currentTag, hasUpdate }) {
 function _renderMarketplace() {
   const q = (document.getElementById('marketplace-search')?.value || '').trim().toLowerCase();
 
-  // Merge all non-core categories for the marketplace
+  // Merge driver + perception for marketplace (core is managed in My Services only)
   const allItems = [
     ...(_catalog.driver || []).map(it => ({ ...it, _cat: 'driver' })),
     ...(_catalog.perception || []).map(it => ({ ...it, _cat: 'perception' })),
-    ...(_catalog.core || []).map(it => ({ ...it, _cat: 'core' })),
   ];
 
   // Build provider list for filter chips

--- a/agent-core/web/js/deploy-panel.js
+++ b/agent-core/web/js/deploy-panel.js
@@ -304,7 +304,7 @@ function _svcRowHTML({ item, id, s, latestTag, currentTag, hasUpdate }) {
     const versionOpts = tags.map(t => {
       const fullImg = t.imageRef || (imageBase + ':' + t.tag);
       const isCurrent = currentTag && t.tag === currentTag;
-      const ch = _channelLabel(t.tag);
+      const ch = _channelLabel(t.channel);
       return `<div class="svc-ver-opt${isCurrent ? ' current' : ''}" data-driver-id="${id}" data-full-image="${fullImg}" data-tag="${t.tag}" data-label="${label}">
         <span class="svc-ver-tag">${t.tag}</span>
         ${ch ? `<span class="svc-ver-channel">${ch}</span>` : ''}
@@ -675,10 +675,10 @@ function _driverIdForItem(item, category) {
   return item.image;
 }
 
-function _channelLabel(tag) {
-  if (tag.startsWith('ga.')) return 'Stable';
-  if (tag.startsWith('release.')) return 'Release';
-  if (tag.startsWith('preview.')) return 'Preview';
+function _channelLabel(channel) {
+  if (channel === 'ga') return 'Stable';
+  if (channel === 'release') return 'Release';
+  if (channel === 'preview') return 'Preview';
   return '';
 }
 

--- a/agent-core/web/js/deploy-panel.js
+++ b/agent-core/web/js/deploy-panel.js
@@ -1,19 +1,23 @@
 /**
  * deploy-panel.js — 部署服务 modal
  *
- * 单一 modal，展示所有驱动类别。每张卡内联版本下拉选择器。
- * 底部确认按钮触发部署，支持同时操作多个驱动（stop 仍为卡片内即时操作）。
+ * 双 Tab 设计：
+ *   Tab 1 「我的服务」— 管理已安装的服务（升级/停止/启动/卸载）
+ *   Tab 2 「驱动市场」— 浏览和安装新驱动（flat grid + filter chips）
  */
 
 let _overlay  = null;
 let _polling  = null;
 
 let _catalog  = { core: [], driver: [], perception: [], inspection: [] };
-let _statuses = {};   // driver_id → { running, status }
+let _statuses = {};   // driver_id → { running, status, running_image, image, last_deploy }
 let _logPolls = {};   // driver_id → intervalId
 
-// { driverId → { registry_image, tag } }
+// { driverId → { image } }
 let _pending = {};
+
+let _activeTab = 'my-services';
+let _activeFilter = null; // null = all providers
 
 export function initDeployPanel() {
   _overlay = document.getElementById('deploy-overlay');
@@ -21,7 +25,14 @@ export function initDeployPanel() {
   document.getElementById('btn-deploy').addEventListener('click', _open);
   document.getElementById('deploy-close').addEventListener('click', _close);
   document.getElementById('deploy-modal-confirm').addEventListener('click', _confirmAll);
-  document.getElementById('hw-search').addEventListener('input', () => _renderHardwareSection(_catalog.driver));
+
+  // Tab switching
+  _overlay.querySelectorAll('.deploy-tab').forEach(tab => {
+    tab.addEventListener('click', () => _switchTab(tab.dataset.tab));
+  });
+
+  // Marketplace search
+  document.getElementById('marketplace-search').addEventListener('input', _renderMarketplace);
 
   // Channel selector
   const channelSelect = document.getElementById('deploy-channel-select');
@@ -47,7 +58,6 @@ async function _onChannelChange(e) {
     release: '正式版已通过基础测试，但未经长期稳定性验证。确定切换？',
   };
   if (warnings[channel] && !confirm(warnings[channel])) {
-    // Revert selection
     await _loadChannel();
     return;
   }
@@ -57,11 +67,25 @@ async function _onChannelChange(e) {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ channel }),
     });
-    // Reload catalog with new channel
     await _loadCatalog(true);
     _render();
   } catch { /* ignore */ }
 }
+
+// ── Tab switching ─────────────────────────────────────────────────────────
+
+function _switchTab(tabId) {
+  _activeTab = tabId;
+  _overlay.querySelectorAll('.deploy-tab').forEach(t => {
+    t.classList.toggle('active', t.dataset.tab === tabId);
+  });
+  _overlay.querySelectorAll('.deploy-tab-pane').forEach(p => {
+    p.classList.toggle('active', p.id === `pane-${tabId}`);
+  });
+  _render();
+}
+
+// ── Open / Close ──────────────────────────────────────────────────────────
 
 function _open() {
   _pending = {};
@@ -79,7 +103,6 @@ function _close() {
 // ── Data loading ──────────────────────────────────────────────────────────
 
 async function _load() {
-  // Auto-sync from registry on every open (transparent to user)
   try {
     await fetch('/api/drivers/sync', { method: 'POST' });
   } catch { /* ignore */ }
@@ -93,9 +116,7 @@ async function _loadCatalog(refresh = false) {
     const res  = await fetch(url);
     const json = await res.json();
     if (json.data) _catalog = json.data;
-  } catch {
-    // keep existing catalog
-  }
+  } catch { /* keep existing */ }
 }
 
 async function _loadStatuses() {
@@ -104,308 +125,313 @@ async function _loadStatuses() {
     const json = await res.json();
     _statuses = {};
     for (const d of (json.data || [])) {
-    _statuses[d.id] = {
+      _statuses[d.id] = {
         running:       d.running,
         status:        d.status,
         logs:          d.logs || '',
         running_image: d.running_image || '',
         image:         d.image || '',
         last_deploy:   d.last_deploy || null,
+        name:          d.name || '',
+        category:      d.category || 'driver',
       };
     }
-  } catch {
-    // keep existing statuses
-  }
+  } catch { /* keep existing */ }
+  // Update dots if visible
   _updateStatusDots();
-}
-
-// ── Empty state illustrations ─────────────────────────────────────────────
-
-const _EMPTY_ICONS = {
-  core:       `<svg width="36" height="36" viewBox="0 0 36 36" fill="none" xmlns="http://www.w3.org/2000/svg"><rect x="4" y="10" width="28" height="18" rx="3.5" stroke="currentColor" stroke-width="1.4"/><path d="M4 15h28" stroke="currentColor" stroke-width="1.2"/><circle cx="8.5" cy="12.5" r="1" fill="currentColor"/><circle cx="12" cy="12.5" r="1" fill="currentColor"/><rect x="9" y="19" width="8" height="4" rx="1.2" stroke="currentColor" stroke-width="1.1"/><rect x="19" y="19" width="8" height="4" rx="1.2" stroke="currentColor" stroke-width="1.1"/></svg>`,
-  driver:     `<svg width="36" height="36" viewBox="0 0 36 36" fill="none" xmlns="http://www.w3.org/2000/svg"><rect x="4" y="11" width="28" height="18" rx="3.5" stroke="currentColor" stroke-width="1.4"/><path d="M9 8v3M14 8v3M22 8v3M27 8v3" stroke="currentColor" stroke-width="1.4" stroke-linecap="round"/><rect x="9" y="17" width="7" height="5" rx="1.2" stroke="currentColor" stroke-width="1.1"/><rect x="20" y="17" width="7" height="5" rx="1.2" stroke="currentColor" stroke-width="1.1"/><circle cx="18" cy="26" r="1.2" fill="currentColor" opacity=".6"/></svg>`,
-  perception: `<svg width="36" height="36" viewBox="0 0 36 36" fill="none" xmlns="http://www.w3.org/2000/svg"><circle cx="18" cy="18" r="9" stroke="currentColor" stroke-width="1.4"/><circle cx="18" cy="18" r="3.5" stroke="currentColor" stroke-width="1.2"/><path d="M18 4v4M18 28v4M4 18h4M28 18h4" stroke="currentColor" stroke-width="1.4" stroke-linecap="round"/></svg>`,
-};
-const _EMPTY_TITLE = {
-  core:       '暂无核心服务驱动',
-  driver:     '暂无硬件驱动',
-  perception: '暂无感知服务驱动',
-};
-function _emptyStateHTML(category) {
-  return `<div class="drivers-empty-state"><div class="drivers-empty-icon">${_EMPTY_ICONS[category] || _EMPTY_ICONS.driver}</div><div class="drivers-empty-title">${_EMPTY_TITLE[category] || '暂无可用驱动'}</div><div class="drivers-empty-hint">点击右上角「同步镜像」从镜像仓库拉取驱动</div></div>`;
 }
 
 // ── Rendering ─────────────────────────────────────────────────────────────
 
 function _render() {
-  _renderSection('drivers-core',       _catalog.core,       'core');
-  _renderHardwareSection(_catalog.driver);
-  _renderSection('drivers-perception', _catalog.perception, 'perception');
+  if (_activeTab === 'my-services') {
+    _renderMyServices();
+  } else {
+    _renderMarketplace();
+  }
   _syncFooter();
 }
 
-function _renderSection(containerId, items, category) {
-  const container = document.getElementById(containerId);
-  if (!items || items.length === 0) {
-    container.innerHTML = _emptyStateHTML(category);
+// ══════════════════════════════════════════════════════════════════════════
+//  TAB 1: 我的服务
+// ══════════════════════════════════════════════════════════════════════════
+
+function _renderMyServices() {
+  const container = document.getElementById('pane-my-services');
+
+  // Collect all items from catalog that have a status (i.e., deployed)
+  const allItems = [
+    ...(_catalog.core || []).map(it => ({ ...it, _cat: 'core' })),
+    ...(_catalog.driver || []).map(it => ({ ...it, _cat: 'driver' })),
+    ...(_catalog.perception || []).map(it => ({ ...it, _cat: 'perception' })),
+  ];
+
+  // Only show items that have been deployed (have a status entry)
+  const deployed = allItems.filter(item => {
+    const id = _driverIdForItem(item, item._cat);
+    return _statuses[id] !== undefined;
+  });
+
+  if (deployed.length === 0) {
+    container.innerHTML = `<div class="svc-empty">
+      <div class="svc-empty-title">暂无已安装服务</div>
+      <div class="svc-empty-hint">前往「驱动市场」安装驱动</div>
+    </div>`;
     return;
   }
-  container.innerHTML = items.map(item => _cardHTML(item, category)).join('');
-  // Bind version selectors & stop buttons & upgrade buttons
-  container.querySelectorAll('.vsel').forEach(vsel => _bindVsel(vsel));
-  container.querySelectorAll('[data-action="stop"]').forEach(btn => {
-    btn.addEventListener('click', () => _stopDriver(btn.dataset.driverId, btn));
-  });
+
+  // Split into groups: updatable, running, stopped
+  const updatable = [];
+  const running   = [];
+  const stopped   = [];
+
+  for (const item of deployed) {
+    const id = _driverIdForItem(item, item._cat);
+    const s  = _statuses[id] || {};
+    const tags = item.tags || [];
+    const latestTag = tags.length > 0 ? tags[0].tag : null;
+    const currentTag = s.running_image?.includes(':') ? s.running_image.split(':').pop() : null;
+    const hasUpdate = latestTag && currentTag && latestTag !== currentTag;
+
+    const entry = { item, id, s, latestTag, currentTag, hasUpdate };
+
+    if (s.running && hasUpdate) {
+      updatable.push(entry);
+    } else if (s.running) {
+      running.push(entry);
+    } else {
+      stopped.push(entry);
+    }
+  }
+
+  let html = '';
+
+  if (updatable.length) {
+    html += _svcGroupHTML('可更新', updatable.length, 'updatable');
+    html += updatable.map(e => _svcRowHTML(e)).join('');
+    html += '</div>';
+  }
+  if (running.length) {
+    html += _svcGroupHTML('运行中', running.length, 'running');
+    html += running.map(e => _svcRowHTML(e)).join('');
+    html += '</div>';
+  }
+  if (stopped.length) {
+    html += _svcGroupHTML('已停止', stopped.length, 'stopped');
+    html += stopped.map(e => _svcRowHTML(e)).join('');
+    html += '</div>';
+  }
+
+  container.innerHTML = html;
+
+  // Bind actions
   container.querySelectorAll('[data-action="upgrade"]').forEach(btn => {
     btn.addEventListener('click', () => _showUpgradeConfirm(btn.dataset));
   });
+  container.querySelectorAll('[data-action="stop"]').forEach(btn => {
+    btn.addEventListener('click', () => _stopDriver(btn.dataset.driverId, btn));
+  });
+  container.querySelectorAll('[data-action="start"]').forEach(btn => {
+    btn.addEventListener('click', () => _startDriver(btn.dataset.driverId, btn.dataset.image, btn));
+  });
 }
 
-// ── Hardware: provider accordion groups ────────────────────────────────────
+function _svcGroupHTML(title, count, cls) {
+  return `<div class="svc-group ${cls}">
+    <div class="svc-group-header">
+      <span class="svc-group-title">${title}</span>
+      <span class="svc-group-count">${count}</span>
+    </div>`;
+}
 
-function _renderHardwareSection(items) {
-  const container = document.getElementById('drivers-hardware-inner');
-  const q = (document.getElementById('hw-search')?.value || '').trim().toLowerCase();
+function _svcRowHTML({ item, id, s, latestTag, currentTag, hasUpdate }) {
+  const label = item._cat === 'driver' ? (item.model || item.image) : (item.name || item.image);
+  const isRunning = s.running;
+  const statusDot = isRunning ? 'running' : s.status === 'error' ? 'error' : 'stopped';
+  const imageBase = item.full_repo || item.image;
+  const tags = item.tags || [];
 
-  if (!items || items.length === 0) {
-    container.innerHTML = _emptyStateHTML('driver');
-    return;
+  let actions = '';
+  if (hasUpdate) {
+    const latestImage = tags[0]?.imageRef || (imageBase + ':' + latestTag);
+    actions = `<button class="svc-btn svc-btn-upgrade" data-action="upgrade" data-driver-id="${id}" data-current-tag="${currentTag}" data-latest-tag="${latestTag}" data-latest-image="${latestImage}" data-label="${label}">升级到 ${latestTag}</button>`;
+  }
+  if (isRunning) {
+    actions += `<button class="svc-btn svc-btn-stop" data-action="stop" data-driver-id="${id}">停止</button>`;
+  } else {
+    // Stopped: show start
+    const lastImage = s.running_image || s.last_deploy?.image || s.image || '';
+    if (lastImage) {
+      actions += `<button class="svc-btn svc-btn-start" data-action="start" data-driver-id="${id}" data-image="${lastImage}">启动</button>`;
+    }
   }
 
-  // Group by provider
-  const groups = {};
-  for (const item of items) {
-    const prov = item.provider || 'Unknown';
-    (groups[prov] ??= []).push(item);
-  }
+  const versionText = currentTag || (s.running_image?.split(':').pop()) || '—';
 
-  // Filter by search query; within each group, also filter items
-  let entries = Object.entries(groups);
-  let hasQuery = q.length > 0;
-  if (hasQuery) {
-    entries = entries
-      .map(([prov, provItems]) => {
-        const provMatch = prov.toLowerCase().includes(q);
-        const filtered = provMatch
-          ? provItems
-          : provItems.filter(it => (it.model || '').toLowerCase().includes(q));
-        return filtered.length ? [prov, filtered] : null;
-      })
-      .filter(Boolean);
-  }
+  return `
+    <div class="svc-row" id="card-${id}">
+      <div class="svc-row-dot ${statusDot}" id="dot-${id}"></div>
+      <div class="svc-row-info">
+        <span class="svc-row-name">${label}</span>
+        <span class="svc-row-version">${versionText}</span>
+        ${hasUpdate ? `<span class="svc-row-arrow">→</span><span class="svc-row-new-version">${latestTag}</span>` : ''}
+      </div>
+      <div class="svc-row-actions">${actions}</div>
+    </div>
+    <div class="deploy-log hidden" id="log-${id}"></div>`;
+}
 
-  if (entries.length === 0) {
-    container.innerHTML = _emptyStateHTML('driver');
-    return;
-  }
+// ══════════════════════════════════════════════════════════════════════════
+//  TAB 2: 驱动市场
+// ══════════════════════════════════════════════════════════════════════════
 
-  // Render; first group open by default (or all open when searching)
-  container.innerHTML = entries
-    .map(([prov, provItems], idx) => _providerGroupHTML(prov, provItems, hasQuery || idx === 0))
-    .join('');
+function _renderMarketplace() {
+  const q = (document.getElementById('marketplace-search')?.value || '').trim().toLowerCase();
 
-  // Bind accordion toggle
-  container.querySelectorAll('.hw-provider-header').forEach(header => {
-    header.addEventListener('click', () => {
-      header.closest('.hw-provider-group').classList.toggle('open');
+  // Merge all non-core categories for the marketplace
+  const allItems = [
+    ...(_catalog.driver || []).map(it => ({ ...it, _cat: 'driver' })),
+    ...(_catalog.perception || []).map(it => ({ ...it, _cat: 'perception' })),
+    ...(_catalog.core || []).map(it => ({ ...it, _cat: 'core' })),
+  ];
+
+  // Build provider list for filter chips
+  const providers = [...new Set(allItems.map(it => it.provider || it.name || 'Other').filter(Boolean))];
+
+  // Render filter chips
+  const filtersEl = document.getElementById('marketplace-filters');
+  filtersEl.innerHTML = `
+    <button class="mp-chip${_activeFilter === null ? ' active' : ''}" data-filter="">全部</button>
+    ${providers.map(p => `<button class="mp-chip${_activeFilter === p ? ' active' : ''}" data-filter="${p}">${p}</button>`).join('')}
+  `;
+  filtersEl.querySelectorAll('.mp-chip').forEach(chip => {
+    chip.addEventListener('click', () => {
+      _activeFilter = chip.dataset.filter || null;
+      _renderMarketplace();
     });
   });
 
-  // Bind vsel + stop buttons
-  container.querySelectorAll('.vsel').forEach(vsel => _bindVsel(vsel));
-  container.querySelectorAll('[data-action="stop"]').forEach(btn => {
-    btn.addEventListener('click', () => _stopDriver(btn.dataset.driverId, btn));
+  // Filter items
+  let filtered = allItems;
+  if (_activeFilter) {
+    filtered = filtered.filter(it => (it.provider || it.name || 'Other') === _activeFilter);
+  }
+  if (q) {
+    filtered = filtered.filter(it => {
+      const model = (it.model || '').toLowerCase();
+      const provider = (it.provider || '').toLowerCase();
+      const name = (it.name || '').toLowerCase();
+      return model.includes(q) || provider.includes(q) || name.includes(q);
+    });
+  }
+
+  // Render grid
+  const gridEl = document.getElementById('marketplace-grid');
+  if (filtered.length === 0) {
+    gridEl.innerHTML = `<div class="svc-empty">
+      <div class="svc-empty-title">未找到驱动</div>
+      <div class="svc-empty-hint">尝试其他搜索词或切换更新通道</div>
+    </div>`;
+    return;
+  }
+
+  gridEl.innerHTML = filtered.map(item => _mpCardHTML(item)).join('');
+
+  // Bind install buttons
+  gridEl.querySelectorAll('.mp-install-btn').forEach(btn => {
+    btn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      _toggleInstallDropdown(btn);
+    });
   });
-  container.querySelectorAll('[data-action="upgrade"]').forEach(btn => {
-    btn.addEventListener('click', () => _showUpgradeConfirm(btn.dataset));
+
+  // Bind version options
+  gridEl.querySelectorAll('.mp-version-opt').forEach(opt => {
+    opt.addEventListener('click', () => {
+      const driverId = opt.dataset.driverId;
+      const image = opt.dataset.fullImage;
+      const label = opt.dataset.label;
+      const tag = opt.dataset.tag;
+      // Close dropdown
+      opt.closest('.mp-card').querySelector('.mp-versions').classList.add('hidden');
+      // Show confirm and deploy
+      showDeployConfirmModal(
+        [{ label, currentTag: '—', newTag: tag }],
+        () => _executeDeploys([[driverId, { image }]])
+      );
+    });
   });
 }
 
-function _providerGroupHTML(provider, items, open) {
-  const cards = items.map(item => _cardHTML(item, 'driver')).join('');
-  const chevron = `<svg class="hw-provider-chevron" width="14" height="14" viewBox="0 0 14 14" fill="none"><path d="M3 5l4 4 4-4" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>`;
+function _mpCardHTML(item) {
+  const cat = item._cat;
+  const label = cat === 'driver' ? (item.model || item.image) : (item.name || item.image);
+  const provider = item.provider || '';
+  const driverId = _driverIdForItem(item, cat);
+  const s = _statuses[driverId];
+  const isInstalled = s !== undefined;
+  const tags = item.tags || [];
+  const imageBase = item.full_repo || item.image;
+
+  const versionOpts = tags.map(t => {
+    const fullImg = t.imageRef || (imageBase + ':' + t.tag);
+    return `<div class="mp-version-opt" data-driver-id="${driverId}" data-full-image="${fullImg}" data-tag="${t.tag}" data-label="${label}">
+      <span class="mp-version-tag">${t.tag}</span>
+      ${t.created ? `<span class="mp-version-date">${t.created.replace(/\s+\d{2}:\d{2}$/, '')}</span>` : ''}
+    </div>`;
+  }).join('');
+
+  const installBtn = isInstalled
+    ? `<span class="mp-installed-badge">已安装</span>`
+    : tags.length > 0
+      ? `<button class="mp-install-btn">安装 ▾</button>`
+      : `<span class="mp-no-version">暂无版本</span>`;
+
   return `
-  <div class="hw-provider-group${open ? ' open' : ''}">
-    <div class="hw-provider-header">
-      <span class="hw-provider-left">
-        <span>${provider}</span>
-        <span class="hw-provider-count">${items.length}</span>
-      </span>
-      ${chevron}
-    </div>
-    <div class="hw-provider-body">${cards}</div>
-  </div>`;
+    <div class="mp-card" data-driver-id="${driverId}">
+      <div class="mp-card-name">${label}</div>
+      ${provider ? `<div class="mp-card-provider">${provider}</div>` : ''}
+      <div class="mp-card-action">${installBtn}</div>
+      <div class="mp-versions hidden">${versionOpts}</div>
+    </div>`;
 }
 
+function _toggleInstallDropdown(btn) {
+  const card = btn.closest('.mp-card');
+  const dropdown = card.querySelector('.mp-versions');
+  const wasHidden = dropdown.classList.contains('hidden');
 
-function _cardLabel(item, category) {
-  if (category === 'driver') return item.model || item.image;
-  return item.name || item.image;
+  // Close all other dropdowns
+  document.querySelectorAll('.mp-versions').forEach(d => d.classList.add('hidden'));
+
+  if (wasHidden) {
+    dropdown.classList.remove('hidden');
+  }
 }
+
+// Close marketplace dropdowns when clicking outside
+document.addEventListener('click', (e) => {
+  if (!e.target.closest('.mp-card')) {
+    document.querySelectorAll('.mp-versions').forEach(d => d.classList.add('hidden'));
+  }
+});
+
+// ══════════════════════════════════════════════════════════════════════════
+//  SHARED UTILITIES
+// ══════════════════════════════════════════════════════════════════════════
 
 function _driverIdForItem(item, category) {
   if (category === 'driver') return `${item.provider}-${item.model}`;
   return item.image;
 }
 
-function _vselHTML(driverId, imageBase, runningImage, tags, running, latestTag, deployedTag) {
-  const opts = tags.map((t, idx) => {
-    const fullImg   = t.imageRef || (imageBase + ':' + t.tag);
-    const isCurrent = runningImage && runningImage.endsWith(':' + t.tag);
-    // 仅在运行中时，已部署版本不可重新选择
-    const isDisabled = isCurrent && running;
-    const isLatest  = idx === 0;
-    const dateStr   = t.created ? t.created.replace(/\s+\d{2}:\d{2}$/, '') : '';
-    const timeStr   = t.created ? t.created.match(/\d{2}:\d{2}$/)?.[0] ?? '' : '';
-    const dateLabel = dateStr + (timeStr ? ' ' + timeStr : '');
-    return `<div class="vsel-option${isDisabled ? ' disabled' : ''}" data-value="${t.tag}" data-full-image="${fullImg}">
-      <span class="vsel-option-tag">${t.tag}</span>
-      ${dateLabel ? `<span class="vsel-option-date">${dateLabel}</span>` : ''}
-      ${isCurrent ? `<span class="vsel-option-current">已部署</span>` : ''}
-      ${isLatest && !isCurrent ? `<span class="vsel-option-latest">最新</span>` : ''}
-    </div>`;
-  }).join('');
-  // 若有已部署版本，按钮初始显示该版本名
-  const btnLabel = deployedTag ? `${running ? '▶' : '⏹'} ${deployedTag}` : '— 选择版本 —';
-  const hasValue = !!deployedTag;
-  return `<div class="vsel${hasValue ? ' has-value' : ''}" data-driver-id="${driverId}" data-image-base="${imageBase}">
-    <button type="button" class="vsel-btn">
-      <span class="vsel-label">${btnLabel}</span>
-      <svg class="vsel-chevron" width="12" height="12" viewBox="0 0 12 12" fill="none"><path d="M2 4l4 4 4-4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
-    </button>
-    <div class="vsel-dropdown">${opts}</div>
-  </div>`;
-}
-
-function _cardHTML(item, category) {
-  const label    = _cardLabel(item, category);
-  const driverId = _driverIdForItem(item, category);
-  const s        = _statuses[driverId] || {};
-  const running  = s.running || false;
-  const errored  = s.status === 'error';
-  const tags     = item.tags || [];
-  const imageBase = item.full_repo || item.image;
-  const runningImage = s.running_image || '';
-
-  // core: no status dot, no stop button — version selector replaces deployed tag
-  if (category === 'core') {
-    const currentTag = runningImage.includes(':') ? runningImage.split(':').pop() : runningImage;
-    const versionCtrl = tags.length === 0
-      ? `<span style="font-size:11px;color:var(--text-dim)">暂无版本</span>`
-      : _vselHTML(driverId, imageBase, runningImage, tags, false, tags.length > 0 ? tags[0].tag : null, currentTag);
-    return `
-    <div class="driver-card" id="card-${driverId}">
-      <div class="driver-card-info">
-        <div class="driver-card-name">${label}</div>
-        <div class="driver-card-image">${imageBase}</div>
-        <div class="driver-card-vsel">${versionCtrl}</div>
-      </div>
-    </div>
-    <div class="deploy-log hidden" id="log-${driverId}"></div>`;
-  }
-
-  const statusClass = running ? 'running' : errored ? 'error' : 'stopped';
-
-  // Determine currently deployed tag for non-core drivers
-  let deployedTag = '';
-  if (runningImage) {
-    deployedTag = runningImage.includes(':') ? runningImage.split(':').pop() : runningImage;
-  } else if (s.last_deploy?.image) {
-    deployedTag = s.last_deploy.image.includes(':') ? s.last_deploy.image.split(':').pop() : s.last_deploy.image;
-  }
-
-  // 检测是否有新版本（tags[0] 为最新）
-  const latestTag = tags.length > 0 ? tags[0].tag : null;
-  const currentTag = runningImage?.includes(':') ? runningImage.split(':').pop() : null;
-  const hasNewVersion = latestTag && currentTag && latestTag !== currentTag;
-
-  const versionCtrl = tags.length === 0
-    ? `<span style="font-size:11px;color:var(--text-dim)">暂无版本</span>`
-    : _vselHTML(driverId, imageBase, runningImage, tags, running, latestTag, deployedTag);
-
-  const stopBtn = running
-    ? `<button class="btn-deploy-action running" data-action="stop" data-driver-id="${driverId}">停止</button>`
-    : '';
-
-  return `
-    <div class="driver-card" id="card-${driverId}">
-      <div class="driver-status-dot ${statusClass}" id="dot-${driverId}"></div>
-      <div class="driver-card-info">
-        <div class="driver-card-name">${label}${running ? `<span class="driver-running-badge">运行中</span>` : ''}${hasNewVersion ? `<span class="btn-upgrade" data-action="upgrade" data-driver-id="${driverId}" data-current-tag="${currentTag}" data-latest-tag="${latestTag}" data-latest-image="${imageBase}:${latestTag}" data-label="${label}">有新版本</span>` : ''}</div>
-        <div class="driver-card-image">${imageBase}</div>
-        <div class="driver-card-vsel">${versionCtrl}</div>
-      </div>
-      ${stopBtn ? `<div class="driver-card-ctrl">${stopBtn}</div>` : ''}
-    </div>
-    <div class="deploy-log hidden" id="log-${driverId}"></div>`;
-}
-
 function _updateStatusDots() {
   for (const [id, s] of Object.entries(_statuses)) {
     const dot = document.getElementById(`dot-${id}`);
     if (dot) {
-      dot.className = 'driver-status-dot ' + (s.running ? 'running' : s.status === 'error' ? 'error' : 'stopped');
+      dot.className = 'svc-row-dot ' + (s.running ? 'running' : s.status === 'error' ? 'error' : 'stopped');
     }
   }
-}
-
-// ── Version select ─────────────────────────────────────────────────────────
-
-function _bindVsel(vsel) {
-  const btn      = vsel.querySelector('.vsel-btn');
-  const dropdown = vsel.querySelector('.vsel-dropdown');
-
-  btn.addEventListener('click', e => {
-    e.stopPropagation();
-    const isOpen = vsel.classList.contains('open');
-    // Close all others
-    document.querySelectorAll('.vsel.open').forEach(v => v.classList.remove('open'));
-    if (!isOpen) vsel.classList.add('open');
-  });
-
-  dropdown.querySelectorAll('.vsel-option').forEach(opt => {
-    opt.addEventListener('click', () => {
-      if (opt.classList.contains('disabled')) return;
-
-      const tag       = opt.dataset.value;
-      const fullImage = opt.dataset.fullImage;
-      const driverId  = vsel.dataset.driverId;
-
-      // Update label & selected state
-      dropdown.querySelectorAll('.vsel-option').forEach(o => o.classList.remove('selected'));
-      opt.classList.add('selected');
-      vsel.querySelector('.vsel-label').textContent = tag;
-      vsel.classList.add('has-value');
-      vsel.classList.remove('open');
-
-      if (tag) {
-        _pending[driverId] = { image: fullImage };
-      } else {
-        delete _pending[driverId];
-      }
-      _syncFooter();
-    });
-  });
-}
-
-// Close dropdowns when clicking outside
-document.addEventListener('click', () => {
-  document.querySelectorAll('.vsel.open').forEach(v => v.classList.remove('open'));
-});
-
-function _onVersionChange(sel) {
-  const driverId  = sel.dataset.driverId;
-  const tag       = sel.value;
-  const opt       = sel.selectedIndex >= 0 ? sel.options[sel.selectedIndex] : null;
-  // Prefer the full imageRef stored on the option; fall back to building from imageBase
-  const fullImage = (opt && opt.dataset.fullImage) || (sel.dataset.imageBase + ':' + tag);
-
-  if (tag) {
-    _pending[driverId] = { image: fullImage };
-  } else {
-    delete _pending[driverId];
-  }
-  _syncFooter();
 }
 
 function _syncFooter() {
@@ -457,19 +483,16 @@ export function showDeployConfirmModal(items, onConfirm) {
   btnCancel.addEventListener('click', doCancel);
 }
 
-// ── Upgrade confirm (single driver → deploy immediately) ──────────────────
+// ── Upgrade confirm ───────────────────────────────────────────────────────
 
 function _showUpgradeConfirm({ driverId, currentTag, latestTag, latestImage, label }) {
   showDeployConfirmModal(
     [{ label, currentTag, newTag: latestTag }],
-    () => {
-      // Deploy directly
-      _executeDeploys([[driverId, { image: latestImage }]]);
-    }
+    () => _executeDeploys([[driverId, { image: latestImage }]])
   );
 }
 
-// ── Stop ──────────────────────────────────────────────────────────────────
+// ── Stop / Start / Remove ─────────────────────────────────────────────────
 
 async function _stopDriver(driverId, btn) {
   btn.disabled    = true;
@@ -479,7 +502,30 @@ async function _stopDriver(driverId, btn) {
   } catch (e) {
     console.error('[deploy] stop', e);
   }
-  setTimeout(_loadStatuses, 1500);
+  setTimeout(async () => { await _loadStatuses(); _render(); }, 1500);
+}
+
+async function _startDriver(driverId, image, btn) {
+  if (!image) return;
+  btn.disabled    = true;
+  btn.textContent = '启动中…';
+  _showDeployLog(driverId, '正在启动…');
+  try {
+    const res = await fetch(`/api/drivers/${driverId}/deploy`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ image }),
+    });
+    const json = await res.json();
+    if (json.code !== 200) {
+      _appendLog(driverId, `✗ 错误: ${json.message || '未知错误'}`, 'error');
+    } else {
+      _appendLog(driverId, '容器启动中…');
+      _startLogPolling(driverId);
+    }
+  } catch (e) {
+    _appendLog(driverId, `✗ 网络错误: ${e.message}`, 'error');
+  }
 }
 
 // ── Confirm all pending deploys ───────────────────────────────────────────
@@ -488,31 +534,22 @@ async function _confirmAll() {
   const entries = Object.entries(_pending);
   if (!entries.length) return;
 
-  // Build items for the confirm modal
   const items = entries.map(([id, { image }]) => {
     const s = _statuses[id] || {};
     const currentTag = s.running_image?.includes(':') ? s.running_image.split(':').pop() : '—';
     const newTag = image.split(':').pop();
-    let label = id;
-    for (const cat of [_catalog.core, _catalog.driver, _catalog.perception]) {
-      for (const item of (cat || [])) {
-        const cid = _driverIdForItem(item, cat === _catalog.driver ? 'driver' : 'core');
-        if (cid === id) { label = _cardLabel(item, cat === _catalog.driver ? 'driver' : 'core'); break; }
-      }
-    }
-    return { label, currentTag, newTag };
+    return { label: s.name || id, currentTag, newTag };
   });
 
-  showDeployConfirmModal(items, () => {
-    _executeDeploys(entries);
-  });
+  showDeployConfirmModal(items, () => _executeDeploys(entries));
 }
 
 async function _executeDeploys(entries) {
-  document.getElementById('deploy-modal-confirm').disabled = true;
+  const confirmBtn = document.getElementById('deploy-modal-confirm');
+  if (confirmBtn) confirmBtn.disabled = true;
 
   for (const [driverId, { image }] of entries) {
-    const isCoreDriver = _catalog.core.some(item => _driverIdForItem(item, 'core') === driverId);
+    const isCoreDriver = (_catalog.core || []).some(item => _driverIdForItem(item, 'core') === driverId);
 
     if (isCoreDriver) {
       _showDeployLog(driverId, '正在启动升级…');
@@ -535,7 +572,7 @@ async function _executeDeploys(entries) {
     } else {
       _showDeployLog(driverId, '正在请求部署…');
       try {
-        const res  = await fetch(`/api/drivers/${driverId}/deploy`, {
+        const res = await fetch(`/api/drivers/${driverId}/deploy`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ image }),
@@ -555,7 +592,7 @@ async function _executeDeploys(entries) {
 
   _pending = {};
   _syncFooter();
-  document.getElementById('deploy-modal-confirm').disabled = false;
+  if (confirmBtn) confirmBtn.disabled = false;
 }
 
 // ── Deploy log (inline) ───────────────────────────────────────────────────
@@ -607,7 +644,8 @@ function _startLogPolling(driverId) {
           const logEl = document.getElementById(`log-${driverId}`);
           if (logEl) logEl.classList.add('hidden');
         }, 5000);
-        _loadStatuses();
+        await _loadStatuses();
+        _render();
       } else if (status === 'error' || attempts > 30) {
         _stopLogPolling(driverId);
         _appendLog(driverId, `✗ ${status === 'error' ? (data.error || '启动失败') : '部署超时'}`, 'error');
@@ -625,7 +663,7 @@ function _stopLogPolling(driverId) {
   }
 }
 
-// ── Core update polling (uses /api/system/update-status) ─────────────────
+// ── Core update polling ───────────────────────────────────────────────────
 
 function _startCoreUpdatePolling(driverId) {
   if (_logPolls[driverId]) clearInterval(_logPolls[driverId]);
@@ -642,7 +680,6 @@ function _startCoreUpdatePolling(driverId) {
         _stopLogPolling(driverId);
         _appendLog(driverId, `✗ 升级失败：${data.error}`, 'error');
       } else if (data.step) {
-        // 更新进度显示
         const el = document.getElementById(`log-${driverId}`);
         if (el) {
           el.querySelectorAll('.log-output').forEach(e => e.remove());
@@ -658,7 +695,7 @@ function _startCoreUpdatePolling(driverId) {
         _appendLog(driverId, '✗ 升级超时', 'error');
       }
     } catch {
-      // 服务重启中，连接断开是正常的 — 等待重连
+      // 服务重启中，连接断开是正常的
     }
   }, 2000);
 }

--- a/agent-core/web/js/deploy-panel.js
+++ b/agent-core/web/js/deploy-panel.js
@@ -247,8 +247,22 @@ function _renderMyServices() {
       const dd = wrap.querySelector('.svc-ver-dropdown');
       const wasHidden = dd.classList.contains('hidden');
       // Close all others
-      container.querySelectorAll('.svc-ver-dropdown').forEach(d => d.classList.add('hidden'));
-      if (wasHidden) dd.classList.remove('hidden');
+      document.querySelectorAll('.svc-ver-dropdown').forEach(d => d.classList.add('hidden'));
+      if (wasHidden) {
+        // Position fixed relative to button
+        const rect = btn.getBoundingClientRect();
+        dd.classList.remove('hidden');
+        const ddHeight = dd.offsetHeight;
+        // Prefer dropping up if near bottom, else drop down
+        const spaceBelow = window.innerHeight - rect.bottom;
+        if (spaceBelow < ddHeight + 10) {
+          dd.style.top = (rect.top - ddHeight - 4) + 'px';
+        } else {
+          dd.style.top = (rect.bottom + 4) + 'px';
+        }
+        dd.style.right = (window.innerWidth - rect.right) + 'px';
+        dd.style.left = '';
+      }
     });
   });
   container.querySelectorAll('.svc-ver-opt').forEach(opt => {

--- a/agent-core/web/js/deploy-panel.js
+++ b/agent-core/web/js/deploy-panel.js
@@ -245,15 +245,20 @@ function _renderMyServices() {
       e.stopPropagation();
       const wrap = btn.closest('.svc-ver-wrap');
       const dd = wrap.querySelector('.svc-ver-dropdown');
+
+      if (window.innerWidth <= 768) {
+        // Mobile: show bottom action sheet
+        _showVersionSheet(dd.innerHTML, wrap.dataset.driverId || '');
+        return;
+      }
+
+      // Desktop: position fixed dropdown
       const wasHidden = dd.classList.contains('hidden');
-      // Close all others
       document.querySelectorAll('.svc-ver-dropdown').forEach(d => d.classList.add('hidden'));
       if (wasHidden) {
-        // Position fixed relative to button
         const rect = btn.getBoundingClientRect();
         dd.classList.remove('hidden');
         const ddHeight = dd.offsetHeight;
-        // Prefer dropping up if near bottom, else drop down
         const spaceBelow = window.innerHeight - rect.bottom;
         if (spaceBelow < ddHeight + 10) {
           dd.style.top = (rect.top - ddHeight - 4) + 'px';
@@ -490,6 +495,51 @@ document.addEventListener('click', (e) => {
 // ══════════════════════════════════════════════════════════════════════════
 //  SHARED UTILITIES
 // ══════════════════════════════════════════════════════════════════════════
+
+// ── Mobile: bottom action sheet for version selection ─────────────────────
+
+function _showVersionSheet(optionsHTML) {
+  // Remove existing sheet if any
+  document.getElementById('ver-sheet-overlay')?.remove();
+
+  const overlay = document.createElement('div');
+  overlay.id = 'ver-sheet-overlay';
+  overlay.className = 'ver-sheet-overlay';
+  overlay.innerHTML = `
+    <div class="ver-sheet">
+      <div class="ver-sheet-header">
+        <span class="ver-sheet-title">选择版本</span>
+        <button class="ver-sheet-close">✕</button>
+      </div>
+      <div class="ver-sheet-body">${optionsHTML}</div>
+    </div>
+  `;
+  document.body.appendChild(overlay);
+
+  // Animate in
+  requestAnimationFrame(() => overlay.classList.add('active'));
+
+  const close = () => {
+    overlay.classList.remove('active');
+    setTimeout(() => overlay.remove(), 200);
+  };
+
+  overlay.querySelector('.ver-sheet-close').addEventListener('click', close);
+  overlay.addEventListener('click', (e) => { if (e.target === overlay) close(); });
+
+  // Bind version option clicks
+  overlay.querySelectorAll('.svc-ver-opt').forEach(opt => {
+    opt.addEventListener('click', () => {
+      if (opt.classList.contains('current')) return;
+      const { driverId, fullImage, tag, label } = opt.dataset;
+      close();
+      showDeployConfirmModal(
+        [{ label, currentTag: '—', newTag: tag }],
+        () => _executeDeploys([[driverId, { image: fullImage }]])
+      );
+    });
+  });
+}
 
 function _driverIdForItem(item, category) {
   if (category === 'driver') return `${item.provider}-${item.model}`;

--- a/agent-core/web/js/deploy-panel.js
+++ b/agent-core/web/js/deploy-panel.js
@@ -166,10 +166,12 @@ function _renderMyServices() {
     ...(_catalog.perception || []).map(it => ({ ...it, _cat: 'perception' })),
   ];
 
-  // Only show items that have been deployed (have a status entry)
+  // Only show items that have actually been deployed (not just synced from catalog)
   const deployed = allItems.filter(item => {
     const id = _driverIdForItem(item, item._cat);
-    return _statuses[id] !== undefined;
+    const s = _statuses[id];
+    if (!s) return false;
+    return s.running || s.last_deploy || item._cat === 'core';
   });
 
   if (deployed.length === 0) {
@@ -369,7 +371,7 @@ function _mpCardHTML(item) {
   const provider = item.provider || '';
   const driverId = _driverIdForItem(item, cat);
   const s = _statuses[driverId];
-  const isInstalled = s !== undefined;
+  const isInstalled = s && (s.running || s.last_deploy);
   const tags = item.tags || [];
   const imageBase = item.full_repo || item.image;
 

--- a/agent-core/web/js/deploy-panel.js
+++ b/agent-core/web/js/deploy-panel.js
@@ -487,14 +487,70 @@ function _escHTML(s) { return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').rep
 function _toggleInstallDropdown(btn) {
   const card = btn.closest('.mp-card');
   const dropdown = card.querySelector('.mp-versions');
-  const wasHidden = dropdown.classList.contains('hidden');
 
-  // Close all other dropdowns
-  document.querySelectorAll('.mp-versions').forEach(d => d.classList.add('hidden'));
-
-  if (wasHidden) {
-    dropdown.classList.remove('hidden');
+  if (window.innerWidth <= 768) {
+    // Mobile: use bottom action sheet
+    const label = card.querySelector('.mp-card-name')?.textContent || '';
+    _showInstallSheet(dropdown.innerHTML, label);
+    return;
   }
+
+  // Desktop: position fixed dropdown
+  const wasHidden = dropdown.classList.contains('hidden');
+  document.querySelectorAll('.mp-versions').forEach(d => d.classList.add('hidden'));
+  if (wasHidden) {
+    const rect = btn.getBoundingClientRect();
+    dropdown.classList.remove('hidden');
+    dropdown.style.position = 'fixed';
+    dropdown.style.left = '';
+    dropdown.style.transform = '';
+    const ddHeight = dropdown.offsetHeight;
+    const spaceBelow = window.innerHeight - rect.bottom;
+    if (spaceBelow < ddHeight + 10) {
+      dropdown.style.top = (rect.top - ddHeight - 4) + 'px';
+    } else {
+      dropdown.style.top = (rect.bottom + 4) + 'px';
+    }
+    dropdown.style.right = (window.innerWidth - rect.right) + 'px';
+  }
+}
+
+function _showInstallSheet(optionsHTML, title) {
+  document.getElementById('ver-sheet-overlay')?.remove();
+
+  const overlay = document.createElement('div');
+  overlay.id = 'ver-sheet-overlay';
+  overlay.className = 'ver-sheet-overlay';
+  overlay.innerHTML = `
+    <div class="ver-sheet">
+      <div class="ver-sheet-header">
+        <span class="ver-sheet-title">${title || '选择版本'}</span>
+        <button class="ver-sheet-close">✕</button>
+      </div>
+      <div class="ver-sheet-body">${optionsHTML}</div>
+    </div>
+  `;
+  document.body.appendChild(overlay);
+  requestAnimationFrame(() => overlay.classList.add('active'));
+
+  const close = () => {
+    overlay.classList.remove('active');
+    setTimeout(() => overlay.remove(), 200);
+  };
+
+  overlay.querySelector('.ver-sheet-close').addEventListener('click', close);
+  overlay.addEventListener('click', (e) => { if (e.target === overlay) close(); });
+
+  overlay.querySelectorAll('.mp-version-opt').forEach(opt => {
+    opt.addEventListener('click', () => {
+      const { driverId, fullImage, tag, label } = opt.dataset;
+      close();
+      showDeployConfirmModal(
+        [{ label, currentTag: '—', newTag: tag }],
+        () => _executeDeploys([[driverId, { image: fullImage }]])
+      );
+    });
+  });
 }
 
 // Close marketplace dropdowns when clicking outside

--- a/agent-core/web/js/deploy-panel.js
+++ b/agent-core/web/js/deploy-panel.js
@@ -451,7 +451,7 @@ function _mpCardHTML(item) {
 
   const versionOpts = tags.map(t => {
     const fullImg = t.imageRef || (imageBase + ':' + t.tag);
-    const ch = _channelLabel(t.tag);
+    const ch = _channelLabel(t.channel);
     return `<div class="mp-version-opt" data-driver-id="${driverId}" data-full-image="${fullImg}" data-tag="${t.tag}" data-label="${label}">
       <span class="mp-version-tag">${t.tag}</span>
       ${ch ? `<span class="svc-ver-channel">${ch}</span>` : ''}

--- a/agent-core/web/js/mobile.js
+++ b/agent-core/web/js/mobile.js
@@ -97,6 +97,9 @@ function _switchTab(tab) {
   closeSidebarMobile();
   _closeLogDrawer();
 
+  // Close any open modal overlays
+  document.querySelectorAll('.modal-overlay:not(.hidden)').forEach(o => o.classList.add('hidden'));
+
   // Sidebar fab: only in configure
   const sidebarFab = document.getElementById('mobile-sidebar-fab');
   if (sidebarFab) {

--- a/agent-core/web/js/sidebar.js
+++ b/agent-core/web/js/sidebar.js
@@ -63,8 +63,8 @@ export function renderSidebar(mcps, topicStatuses = {}) {
 
   const allMcps = mcps || [];
   const controllers = allMcps.filter(m => m.category === 'controller');
-  const drivers = allMcps.filter(m => m.category === 'driver');
-  const perceptions = allMcps.filter(m => m.category === 'perception');
+  const drivers = allMcps.filter(m => m.category === 'driver' && m.online === true);
+  const perceptions = allMcps.filter(m => m.category === 'perception' && m.online === true);
 
   _scroll.innerHTML = '';
 


### PR DESCRIPTION
## Summary
- Sidebar 只显示在线的 driver/perception，停止的不再占位
- Update banner 只对运行中的服务提示更新，停止的不再弹出
- 部署 Modal 重新设计为双 Tab 布局：
  - **我的服务**：已安装服务按状态分组（可更新/运行中/已停止），紧凑列表，操作按钮直观
  - **驱动市场**：扁平卡片网格 + provider filter chips + 搜索，去掉了 accordion 嵌套

## Test plan
- [ ] 启动 Agent Core，连接 driver 后停止，确认 sidebar 不再显示
- [ ] 停止 driver 后确认 update banner 不再为其弹出
- [ ] 打开部署 modal → 我的服务 tab 显示已安装服务分组
- [ ] 切换到驱动市场 tab → 卡片网格正常显示，filter chips 过滤正确
- [ ] 安装流程：点击安装 → 选版本 → 确认 → 部署成功
- [ ] 升级流程：我的服务 tab 点升级按钮 → 确认 → 升级成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)