### PR TITLE
fix: restore update banner + fix upgrade button overlap

### DIFF
--- a/agent-core/web/css/style.css
+++ b/agent-core/web/css/style.css
@@ -1885,6 +1885,7 @@ html, body {
   align-items: center;
   gap: 6px;
   flex-shrink: 0;
+  flex-wrap: wrap;
 }
 
 .svc-btn {

--- a/agent-core/web/js/app.js
+++ b/agent-core/web/js/app.js
@@ -108,7 +108,7 @@ async function checkForUpdate() {
 
     // Find services that have a newer image available vs what's running
     const updatable = json.data.filter(d => {
-      if (!d.running) return false;  // 只提示正在运行的服务
+      if (!d.running && d.category !== 'core') return false;  // core is always running if responding
       if (!d.image || !d.running_image) return false;
       const latestTag  = _tagFromImage(d.image);
       const runningTag = _tagFromImage(d.running_image);

--- a/agent-core/web/js/deploy-panel.js
+++ b/agent-core/web/js/deploy-panel.js
@@ -318,7 +318,7 @@ function _svcRowHTML({ item, id, s, latestTag, currentTag, hasUpdate }) {
   }
   if (hasUpdate) {
     const latestImage = tags[0]?.imageRef || (imageBase + ':' + latestTag);
-    actions += `<button class="svc-btn svc-btn-upgrade" data-action="upgrade" data-driver-id="${id}" data-current-tag="${currentTag}" data-latest-tag="${latestTag}" data-latest-image="${latestImage}" data-label="${label}">升级到 ${latestTag}</button>`;
+    actions += `<button class="svc-btn svc-btn-upgrade" data-action="upgrade" data-driver-id="${id}" data-current-tag="${currentTag}" data-latest-tag="${latestTag}" data-latest-image="${latestImage}" data-label="${label}">升级</button>`;
   }
   if (item._cat === 'core') {
     // Core cannot stop itself — no stop button


### PR DESCRIPTION
## Summary
- Fix topbar update banner not showing for Agent Core (backend doesn't return `running` for core)
- Fix mobile red dot not appearing (syncs from desktop banner)
- Fix "升级到 release.xxx" button text overflowing — shortened to "升级"
- Add flex-wrap to action buttons to prevent layout overlap

## Test plan
- [ ] Update available for core → topbar banner shows
- [ ] Mobile settings tab red dot appears
- [ ] "可更新" row in deploy modal doesn't overflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)