### PR TITLE
fix: update banner and overlap issues

### DIFF
--- a/agent-core/web/css/style.css
+++ b/agent-core/web/css/style.css
@@ -1827,7 +1827,8 @@ html, body {
 .svc-row {
   display: flex;
   align-items: center;
-  gap: 12px;
+  flex-wrap: wrap;
+  gap: 10px;
   padding: 10px 14px;
   background: var(--bg-card);
   border: 1px solid var(--border);
@@ -1865,7 +1866,10 @@ html, body {
   font-size: 11px;
   font-family: var(--font-mono);
   color: var(--text-muted);
-  flex-shrink: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
 }
 .svc-row-arrow {
   font-size: 12px;

--- a/agent-core/web/js/deploy-panel.js
+++ b/agent-core/web/js/deploy-panel.js
@@ -691,7 +691,8 @@ function _updateStatusDots() {
   for (const [id, s] of Object.entries(_statuses)) {
     const dot = document.getElementById(`dot-${id}`);
     if (dot) {
-      dot.className = 'svc-row-dot ' + (s.running ? 'running' : s.status === 'error' ? 'error' : 'stopped');
+      const isRunning = s.running || s.category === 'core';
+      dot.className = 'svc-row-dot ' + (isRunning ? 'running' : s.status === 'error' ? 'error' : 'stopped');
     }
   }
 }


### PR DESCRIPTION
## Summary
- Restore update banner for core + fix upgrade button overlap
- Core dot stays green after polling + row wraps to prevent overlap

## Test plan
- [ ] Verify update banner shows correctly when new version available
- [ ] Check that upgrade button doesn't overlap other elements
- [ ] Confirm core status dot remains green after polling

🤖 Generated with [Claude Code](https://claude.com/claude-code)