### PR TITLE
feat: performance logging and dashboard

### DIFF
--- a/agent-core/src/api/inspection.py
+++ b/agent-core/src/api/inspection.py
@@ -70,6 +70,24 @@ def _push_factory(topic: str):
                 q.put_nowait(data)
             except asyncio.QueueFull:
                 pass  # drop frame for slow consumer
+        # 处理 perf_span 类型消息（来自 perception TTS 等组件）
+        if topic == '/perception/perf_spans':
+            try:
+                import json, perf_log
+                text = data.decode('utf-8') if isinstance(data, bytes) else data
+                span_data = json.loads(text)
+                if span_data.get('type') == 'perf_span':
+                    # 关联到最近的 turn
+                    import config
+                    conn = config._get_conn()
+                    row = conn.execute(
+                        'SELECT turn_id FROM perf_turns ORDER BY created_at DESC LIMIT 1'
+                    ).fetchone()
+                    conn.close()
+                    if row:
+                        perf_log.commit_spans(row[0], [span_data], source='perception')
+            except Exception:
+                pass
     return _push
 
 

--- a/agent-core/src/api/performance.py
+++ b/agent-core/src/api/performance.py
@@ -1,0 +1,32 @@
+"""
+api/performance.py — 性能分析 API。
+"""
+
+from fastapi import APIRouter, Query
+
+import perf_log
+
+router = APIRouter(prefix='/performance', tags=['performance'])
+
+
+@router.get('/turns')
+async def get_turns(
+    start: float = Query(0, description='起始 unix 时间戳'),
+    end: float = Query(0, description='结束 unix 时间戳'),
+    limit: int = Query(50, ge=1, le=500),
+    offset: int = Query(0, ge=0),
+):
+    return perf_log.query(start=start, end=end, limit=limit, offset=offset)
+
+
+@router.get('/aggregate')
+async def get_aggregate(
+    start: float = Query(0),
+    end: float = Query(0),
+):
+    return perf_log.aggregate(start=start, end=end)
+
+
+@router.get('/latest')
+async def get_latest(n: int = Query(20, ge=1, le=200)):
+    return perf_log.latest(n=n)

--- a/agent-core/src/api/performance.py
+++ b/agent-core/src/api/performance.py
@@ -1,5 +1,5 @@
 """
-api/performance.py — 性能分析 API。
+api/performance.py — 性能分析 API（开放 Span 式）。
 """
 
 from fastapi import APIRouter, Query
@@ -9,14 +9,14 @@ import perf_log
 router = APIRouter(prefix='/performance', tags=['performance'])
 
 
-@router.get('/turns')
-async def get_turns(
-    start: float = Query(0, description='起始 unix 时间戳'),
-    end: float = Query(0, description='结束 unix 时间戳'),
-    limit: int = Query(50, ge=1, le=500),
-    offset: int = Query(0, ge=0),
-):
-    return perf_log.query(start=start, end=end, limit=limit, offset=offset)
+@router.get('/latest')
+async def get_latest(n: int = Query(20, ge=1, le=200)):
+    return perf_log.query_latest(n=n)
+
+
+@router.get('/spans')
+async def get_spans(trace_id: str = Query(...)):
+    return perf_log.query_spans(trace_id=trace_id)
 
 
 @router.get('/aggregate')
@@ -25,8 +25,3 @@ async def get_aggregate(
     end: float = Query(0),
 ):
     return perf_log.aggregate(start=start, end=end)
-
-
-@router.get('/latest')
-async def get_latest(n: int = Query(20, ge=1, le=200)):
-    return perf_log.latest(n=n)

--- a/agent-core/src/api/system.py
+++ b/agent-core/src/api/system.py
@@ -124,12 +124,24 @@ def _pull_and_restart_sync(image: str) -> None:
 
     restart_image = os.environ.get('RESTART_IMAGE', '')
     if not restart_image:
-        current_image = _get_current_image()
-        # Image path: registry/org/category/name:tag — take only registry/org as base
-        image_path = current_image.rsplit(':', 1)[0]  # strip tag
+        # 从目标镜像（而非 current_image）推导 registry 前缀，确保使用正确仓库
+        image_path = image.rsplit(':', 1)[0]  # strip tag
         parts = image_path.split('/')
-        base = '/'.join(parts[:2]) if len(parts) >= 2 else parts[0]
+        # registry/namespace/name → registry/namespace; 无 registry 则用 image 的前两段
+        if len(parts) >= 3:
+            base = '/'.join(parts[:2])  # registry/namespace
+        elif len(parts) == 2:
+            base = parts[0]  # 可能是 namespace/name，取 namespace
+        else:
+            base = ''
         restart_image = f'{base}/restart:latest' if base else 'restart:latest'
+
+    try:
+        _set_step(f'正在拉取 restart helper…')
+        client.images.pull(restart_image)
+    except Exception as e:
+        _set_error(f'restart helper 镜像拉取失败: {e}')
+        return
 
     try:
         _set_step(f'启动 restart helper，升级 agent-core → {image.rsplit(":", 1)[-1]}…')

--- a/agent-core/src/collector.py
+++ b/agent-core/src/collector.py
@@ -10,6 +10,7 @@ collector.py — 信息整理器。
 
 import asyncio
 import datetime
+import json as _json
 import time
 from collections import deque
 
@@ -25,6 +26,20 @@ _last_accepted: dict[str, float] = {}
 _THROTTLE_INTERVAL = 1.0  # 每个 source 最多 1 条/秒
 # Agent loop busy flag — 忙时不发射 trigger，让事件继续积累
 _busy: bool = False
+
+
+def _extract_perf_timestamps(ev: dict):
+    """从 ASR 事件 JSON 中提取性能时间戳并附加到事件 dict。"""
+    text = ev.get('text', '')
+    if not text or not text.startswith('{'):
+        return
+    try:
+        data = _json.loads(text)
+    except (ValueError, TypeError):
+        return
+    for key in ('audio_start_ts', 'audio_end_ts', 'asr_complete_ts'):
+        if key in data:
+            ev[f'_perf_{key}'] = data[key]
 
 
 def set_busy(busy: bool):
@@ -59,6 +74,9 @@ async def _drain_loop():
         ev = await event_bus.dequeue()
         source = ev.get('source', 'unknown')
         now = ev.get('ts', time.time())
+
+        # 尝试从 ASR JSON 事件中提取性能时间戳
+        _extract_perf_timestamps(ev)
 
         last_ts = _last_accepted.get(source, 0)
         if now - last_ts < _THROTTLE_INTERVAL:
@@ -103,7 +121,15 @@ async def _trigger_loop():
             'text': formatted,
             'payload': {'event_count': len(batch), 'sources': [e['source'] for e in batch]},
             'ts': batch[-1]['ts'],  # 使用最后一个事件的时间戳
+            '_perf_trigger_emit_ts': time.time(),
         }
+        # 传递 ASR 性能时间戳（取 batch 中最后一个含时间戳的事件）
+        for ev in reversed(batch):
+            if '_perf_audio_start_ts' in ev:
+                for k in ('_perf_audio_start_ts', '_perf_audio_end_ts', '_perf_asr_complete_ts'):
+                    if k in ev:
+                        trigger[k] = ev[k]
+                break
         await _output.put(trigger)
 
 

--- a/agent-core/src/collector.py
+++ b/agent-core/src/collector.py
@@ -38,6 +38,10 @@ def _extract_perf_timestamps(ev: dict):
     except (ValueError, TypeError):
         return
     for key in ('audio_start_ts', 'audio_end_ts', 'asr_complete_ts'):
+        val = data.get(key)
+        if val and val > 1e9:  # only valid unix timestamps
+            ev[f'_perf_{key}'] = val
+    for key in ('audio_duration_ms', 'text_length'):
         if key in data:
             ev[f'_perf_{key}'] = data[key]
 

--- a/agent-core/src/collector.py
+++ b/agent-core/src/collector.py
@@ -29,7 +29,7 @@ _busy: bool = False
 
 
 def _extract_perf_timestamps(ev: dict):
-    """从 ASR 事件 JSON 中提取性能时间戳并附加到事件 dict。"""
+    """从 ASR 事件 JSON 中提取性能 span 数据。"""
     text = ev.get('text', '')
     if not text or not text.startswith('{'):
         return
@@ -37,13 +37,27 @@ def _extract_perf_timestamps(ev: dict):
         data = _json.loads(text)
     except (ValueError, TypeError):
         return
-    for key in ('audio_start_ts', 'audio_end_ts', 'asr_complete_ts'):
-        val = data.get(key)
-        if val and val > 1e9:  # only valid unix timestamps
-            ev[f'_perf_{key}'] = val
-    for key in ('audio_duration_ms', 'text_length'):
-        if key in data:
-            ev[f'_perf_{key}'] = data[key]
+
+    # 新格式：perception 直接上报 spans 数组
+    if 'spans' in data:
+        ev['_perf_spans'] = data['spans']
+        return
+
+    # 旧格式兼容：从 audio_start_ts 等字段构造 spans
+    spans = []
+    audio_start = data.get('audio_start_ts')
+    audio_end = data.get('audio_end_ts')
+    asr_complete = data.get('asr_complete_ts')
+
+    if audio_start and audio_start > 1e9 and audio_end and audio_end > 1e9:
+        spans.append({'span': 'vad_collect', 'start_ts': audio_start, 'end_ts': audio_end,
+                      'meta': {'audio_ms': data.get('audio_duration_ms')}})
+    if audio_end and audio_end > 1e9 and asr_complete and asr_complete > 1e9:
+        spans.append({'span': 'asr_inference', 'start_ts': audio_end, 'end_ts': asr_complete,
+                      'meta': {'text_length': data.get('text_length')}})
+
+    if spans:
+        ev['_perf_spans'] = spans
 
 
 def set_busy(busy: bool):
@@ -127,12 +141,10 @@ async def _trigger_loop():
             'ts': batch[-1]['ts'],  # 使用最后一个事件的时间戳
             '_perf_trigger_emit_ts': time.time(),
         }
-        # 传递 ASR 性能时间戳（取 batch 中最后一个含时间戳的事件）
+        # 传递 perception spans（取 batch 中最后一个含 spans 的事件）
         for ev in reversed(batch):
-            if '_perf_audio_start_ts' in ev:
-                for k in ('_perf_audio_start_ts', '_perf_audio_end_ts', '_perf_asr_complete_ts'):
-                    if k in ev:
-                        trigger[k] = ev[k]
+            if '_perf_spans' in ev:
+                trigger['_perf_spans'] = ev['_perf_spans']
                 break
         await _output.put(trigger)
 

--- a/agent-core/src/config.py
+++ b/agent-core/src/config.py
@@ -102,6 +102,37 @@ def _get_conn() -> sqlite3.Connection:
             UNIQUE(platform, platform_user_id)
         )
     ''')
+    conn.execute('''
+        CREATE TABLE IF NOT EXISTS perf_turns (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            turn_id TEXT NOT NULL,
+            created_at REAL NOT NULL,
+            audio_start_ts REAL,
+            audio_end_ts REAL,
+            asr_complete_ts REAL,
+            collector_receive_ts REAL,
+            trigger_emit_ts REAL,
+            llm_start_ts REAL,
+            llm_end_ts REAL,
+            tool_start_ts REAL,
+            tool_end_ts REAL,
+            tts_start_ts REAL,
+            tts_end_ts REAL,
+            turn_end_ts REAL,
+            vad_duration_ms INTEGER,
+            asr_duration_ms INTEGER,
+            collector_delay_ms INTEGER,
+            llm_duration_ms INTEGER,
+            tool_duration_ms INTEGER,
+            tts_duration_ms INTEGER,
+            total_duration_ms INTEGER,
+            round_count INTEGER DEFAULT 1,
+            tool_names TEXT DEFAULT '[]',
+            trigger_text TEXT DEFAULT '',
+            source TEXT DEFAULT ''
+        )
+    ''')
+    conn.execute('CREATE INDEX IF NOT EXISTS idx_perf_created ON perf_turns(created_at)')
     conn.commit()
     return conn
 

--- a/agent-core/src/config.py
+++ b/agent-core/src/config.py
@@ -129,7 +129,9 @@ def _get_conn() -> sqlite3.Connection:
             round_count INTEGER DEFAULT 1,
             tool_names TEXT DEFAULT '[]',
             trigger_text TEXT DEFAULT '',
-            source TEXT DEFAULT ''
+            source TEXT DEFAULT '',
+            audio_duration_ms INTEGER,
+            text_length INTEGER
         )
     ''')
     conn.execute('CREATE INDEX IF NOT EXISTS idx_perf_created ON perf_turns(created_at)')

--- a/agent-core/src/config.py
+++ b/agent-core/src/config.py
@@ -107,34 +107,27 @@ def _get_conn() -> sqlite3.Connection:
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             turn_id TEXT NOT NULL,
             created_at REAL NOT NULL,
-            audio_start_ts REAL,
-            audio_end_ts REAL,
-            asr_complete_ts REAL,
-            collector_receive_ts REAL,
-            trigger_emit_ts REAL,
-            llm_start_ts REAL,
-            llm_end_ts REAL,
-            tool_start_ts REAL,
-            tool_end_ts REAL,
-            tts_start_ts REAL,
-            tts_end_ts REAL,
-            turn_end_ts REAL,
-            vad_duration_ms INTEGER,
-            asr_duration_ms INTEGER,
-            collector_delay_ms INTEGER,
-            llm_duration_ms INTEGER,
-            tool_duration_ms INTEGER,
-            tts_duration_ms INTEGER,
-            total_duration_ms INTEGER,
-            round_count INTEGER DEFAULT 1,
-            tool_names TEXT DEFAULT '[]',
-            trigger_text TEXT DEFAULT '',
             source TEXT DEFAULT '',
-            audio_duration_ms INTEGER,
-            text_length INTEGER
+            trigger_text TEXT DEFAULT '',
+            total_duration_ms INTEGER
         )
     ''')
     conn.execute('CREATE INDEX IF NOT EXISTS idx_perf_created ON perf_turns(created_at)')
+    conn.execute('''
+        CREATE TABLE IF NOT EXISTS perf_spans (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            trace_id TEXT NOT NULL,
+            span TEXT NOT NULL,
+            component TEXT NOT NULL,
+            start_ts REAL NOT NULL,
+            end_ts REAL,
+            duration_ms INTEGER,
+            meta TEXT DEFAULT '{}',
+            created_at REAL NOT NULL
+        )
+    ''')
+    conn.execute('CREATE INDEX IF NOT EXISTS idx_spans_trace ON perf_spans(trace_id)')
+    conn.execute('CREATE INDEX IF NOT EXISTS idx_spans_created ON perf_spans(created_at)')
     conn.commit()
     return conn
 

--- a/agent-core/src/event/llm.py
+++ b/agent-core/src/event/llm.py
@@ -361,6 +361,8 @@ class Event:
             collector_receive_ts=trigger_event.get('ts'),
             source=trigger_event.get('source', ''),
             trigger_text=trigger_event.get('text', '')[:100],
+            audio_duration_ms=trigger_event.get('_perf_audio_duration_ms'),
+            text_length=trigger_event.get('_perf_text_length'),
         )
         _tool_names_collected = []
 

--- a/agent-core/src/event/llm.py
+++ b/agent-core/src/event/llm.py
@@ -526,8 +526,9 @@ class Event:
 
                 # 性能追踪：记录工具完成
                 _t_after = time.time()
-                # 工具 span 名称：mcp__mcp-123__tool_name → tool_name
-                _span_name = name.split('__')[-1] if name.startswith('mcp__') else name
+                # 工具 span 名称：mcp__mcp-123__tool_name → tool:tool_name
+                _short = name.split('__')[-1] if name.startswith('mcp__') else name
+                _span_name = f'tool:{_short}'
                 _spans.append({'span': _span_name, 'component': 'core',
                                'start_ts': _t_before, 'end_ts': _t_after})
 

--- a/agent-core/src/event/llm.py
+++ b/agent-core/src/event/llm.py
@@ -366,7 +366,7 @@ class Event:
         _collector_receive = trigger_event.get('ts')
         _trigger_emit = trigger_event.get('_perf_trigger_emit_ts')
         if _collector_receive and _trigger_emit:
-            _spans.append({'span': 'collector_wait', 'component': 'core',
+            _spans.append({'span': 'event_queue', 'component': 'core',
                            'start_ts': _collector_receive, 'end_ts': _trigger_emit})
 
         # Log incoming event
@@ -526,7 +526,9 @@ class Event:
 
                 # 性能追踪：记录工具完成
                 _t_after = time.time()
-                _spans.append({'span': f'tool:{name}', 'component': 'core',
+                # 工具 span 名称：mcp__mcp-123__tool_name → tool_name
+                _span_name = name.split('__')[-1] if name.startswith('mcp__') else name
+                _spans.append({'span': _span_name, 'component': 'core',
                                'start_ts': _t_before, 'end_ts': _t_after})
 
                 await push_event({

--- a/agent-core/src/event/llm.py
+++ b/agent-core/src/event/llm.py
@@ -26,6 +26,7 @@ import event
 import event_bus
 import collector
 import mcp_client
+import perf_log
 import prompt as prompt_mod
 from api.motus_stream import push_event
 
@@ -346,7 +347,22 @@ class Event:
 
     async def _one_turn(self, trigger_event: dict):
         import time as _time
+        from uuid import uuid4
         _turn_t0 = _time.perf_counter()
+
+        # 性能追踪
+        _trace = perf_log.PerfTrace(
+            turn_id=str(uuid4()),
+            llm_start_ts=time.time(),
+            audio_start_ts=trigger_event.get('_perf_audio_start_ts'),
+            audio_end_ts=trigger_event.get('_perf_audio_end_ts'),
+            asr_complete_ts=trigger_event.get('_perf_asr_complete_ts'),
+            trigger_emit_ts=trigger_event.get('_perf_trigger_emit_ts'),
+            collector_receive_ts=trigger_event.get('ts'),
+            source=trigger_event.get('source', ''),
+            trigger_text=trigger_event.get('text', '')[:100],
+        )
+        _tool_names_collected = []
 
         # Log incoming event
         print(f'[decision] received event: source={trigger_event.get("source", "?")} text={trigger_event.get("text", "")[:100]}')
@@ -482,6 +498,15 @@ class Event:
                 name   = call['function']['name']
                 args   = json.loads(call['function']['arguments'] or '{}')
 
+                # 性能追踪：记录工具时间
+                _t_before = time.time()
+                if _trace.tool_start_ts is None:
+                    _trace.tool_start_ts = _t_before
+                _is_tts = ('tts' in name.lower() or 'speaker' in name.lower())
+                if _is_tts:
+                    _trace.tts_start_ts = _t_before
+                _tool_names_collected.append(name)
+
                 await push_event({
                     'type':    'mcp_call',
                     'mcp_id':  name.split('__')[1] if name.startswith('mcp__') else '',
@@ -494,6 +519,12 @@ class Event:
                     result = await mcp_client.call_tool(name, args)
                 else:
                     result = f'未知工具: {name}'
+
+                # 性能追踪：记录工具完成
+                _t_after = time.time()
+                _trace.tool_end_ts = _t_after
+                if _is_tts:
+                    _trace.tts_end_ts = _t_after
 
                 await push_event({
                     'type':    'mcp_result',
@@ -570,3 +601,13 @@ class Event:
         await push_event({'type': 'turn_end', 'payload': {}})
         _turn_elapsed = _time.perf_counter() - _turn_t0
         print(f'[decision] turn complete: {_turn_elapsed:.2f}s total, {round_idx + 1} rounds')
+
+        # 性能追踪：提交记录
+        _trace.llm_end_ts = time.time()
+        _trace.turn_end_ts = _trace.llm_end_ts
+        _trace.round_count = round_idx + 1
+        _trace.tool_names = _tool_names_collected
+        try:
+            perf_log.commit(_trace)
+        except Exception as _pe:
+            print(f'[perf_log] commit error: {_pe}')

--- a/agent-core/src/event/llm.py
+++ b/agent-core/src/event/llm.py
@@ -350,21 +350,24 @@ class Event:
         from uuid import uuid4
         _turn_t0 = _time.perf_counter()
 
-        # 性能追踪
-        _trace = perf_log.PerfTrace(
-            turn_id=str(uuid4()),
-            llm_start_ts=time.time(),
-            audio_start_ts=trigger_event.get('_perf_audio_start_ts'),
-            audio_end_ts=trigger_event.get('_perf_audio_end_ts'),
-            asr_complete_ts=trigger_event.get('_perf_asr_complete_ts'),
-            trigger_emit_ts=trigger_event.get('_perf_trigger_emit_ts'),
-            collector_receive_ts=trigger_event.get('ts'),
-            source=trigger_event.get('source', ''),
-            trigger_text=trigger_event.get('text', '')[:100],
-            audio_duration_ms=trigger_event.get('_perf_audio_duration_ms'),
-            text_length=trigger_event.get('_perf_text_length'),
-        )
+        # 性能追踪（开放 span 式）
+        _trace_id = str(uuid4())
+        _turn_start_ts = time.time()
+        _spans = []  # 收集所有 span
         _tool_names_collected = []
+
+        # 从 trigger_event 中提取 perception 上报的 spans
+        _perf_spans_from_perception = trigger_event.get('_perf_spans', [])
+        for ps in _perf_spans_from_perception:
+            ps['component'] = ps.get('component', 'perception')
+            _spans.append(ps)
+
+        # collector_wait span
+        _collector_receive = trigger_event.get('ts')
+        _trigger_emit = trigger_event.get('_perf_trigger_emit_ts')
+        if _collector_receive and _trigger_emit:
+            _spans.append({'span': 'collector_wait', 'component': 'core',
+                           'start_ts': _collector_receive, 'end_ts': _trigger_emit})
 
         # Log incoming event
         print(f'[decision] received event: source={trigger_event.get("source", "?")} text={trigger_event.get("text", "")[:100]}')
@@ -438,6 +441,7 @@ class Event:
 
             # ── 调用 LLM（含上下文溢出恢复）───────────────────────────────
             _round_t0 = _time.perf_counter()
+            _round_start_ts = time.time()
             try:
                 response = await client.llm(
                     message_list = messages,
@@ -477,6 +481,9 @@ class Event:
 
             # Log LLM response
             _round_elapsed = _time.perf_counter() - _round_t0
+            _round_end_ts = time.time()
+            _spans.append({'span': f'llm_round_{round_idx}', 'component': 'core',
+                           'start_ts': _round_start_ts, 'end_ts': _round_end_ts})
             resp_text = (response.get('content') or '')[:200]
             resp_tools = []
             for c in (response.get('tool_calls') or []):
@@ -502,11 +509,6 @@ class Event:
 
                 # 性能追踪：记录工具时间
                 _t_before = time.time()
-                if _trace.tool_start_ts is None:
-                    _trace.tool_start_ts = _t_before
-                _is_tts = ('tts' in name.lower() or 'speaker' in name.lower())
-                if _is_tts:
-                    _trace.tts_start_ts = _t_before
                 _tool_names_collected.append(name)
 
                 await push_event({
@@ -524,9 +526,8 @@ class Event:
 
                 # 性能追踪：记录工具完成
                 _t_after = time.time()
-                _trace.tool_end_ts = _t_after
-                if _is_tts:
-                    _trace.tts_end_ts = _t_after
+                _spans.append({'span': f'tool:{name}', 'component': 'core',
+                               'start_ts': _t_before, 'end_ts': _t_after})
 
                 await push_event({
                     'type':    'mcp_result',
@@ -604,12 +605,16 @@ class Event:
         _turn_elapsed = _time.perf_counter() - _turn_t0
         print(f'[decision] turn complete: {_turn_elapsed:.2f}s total, {round_idx + 1} rounds')
 
-        # 性能追踪：提交记录
-        _trace.llm_end_ts = time.time()
-        _trace.turn_end_ts = _trace.llm_end_ts
-        _trace.round_count = round_idx + 1
-        _trace.tool_names = _tool_names_collected
+        # 性能追踪：提交 spans
+        _turn_end_ts = time.time()
+        _spans.append({'span': 'turn_total', 'component': 'core',
+                       'start_ts': _turn_start_ts, 'end_ts': _turn_end_ts})
         try:
-            perf_log.commit(_trace)
+            perf_log.commit_spans(
+                trace_id=_trace_id,
+                spans=_spans,
+                source=trigger_event.get('source', ''),
+                trigger_text=trigger_event.get('text', '')[:100],
+            )
         except Exception as _pe:
             print(f'[perf_log] commit error: {_pe}')

--- a/agent-core/src/perf_log.py
+++ b/agent-core/src/perf_log.py
@@ -38,11 +38,15 @@ class PerfTrace:
     # 元数据
     round_count: int = 1
     tool_names: list = field(default_factory=list)
+    audio_duration_ms: Optional[int] = None
+    text_length: Optional[int] = None
 
 
 def _ms(start: Optional[float], end: Optional[float]) -> Optional[int]:
-    """计算毫秒差值，任一为 None 则返回 None。"""
+    """计算毫秒差值，任一为 None 或无效（<1e9）则返回 None。"""
     if start is None or end is None:
+        return None
+    if start < 1e9 or end < 1e9:
         return None
     return int((end - start) * 1000)
 
@@ -70,8 +74,9 @@ def commit(trace: PerfTrace):
             turn_end_ts,
             vad_duration_ms, asr_duration_ms, collector_delay_ms,
             llm_duration_ms, tool_duration_ms, tts_duration_ms, total_duration_ms,
-            round_count, tool_names, trigger_text, source
-        ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)''',
+            round_count, tool_names, trigger_text, source,
+            audio_duration_ms, text_length
+        ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)''',
         (
             trace.turn_id, now,
             trace.audio_start_ts, trace.audio_end_ts, trace.asr_complete_ts,
@@ -86,6 +91,8 @@ def commit(trace: PerfTrace):
             json.dumps(trace.tool_names, ensure_ascii=False),
             trace.trigger_text[:200],
             trace.source,
+            trace.audio_duration_ms,
+            trace.text_length,
         ),
     )
     conn.commit()

--- a/agent-core/src/perf_log.py
+++ b/agent-core/src/perf_log.py
@@ -1,0 +1,197 @@
+"""
+perf_log.py — 性能追踪模块。
+
+记录每次 agent turn 各阶段的时间戳，持久化到 SQLite，
+提供查询和聚合接口。
+"""
+
+import json
+import time
+import sqlite3
+from dataclasses import dataclass, field
+from typing import Optional
+
+import config
+
+
+@dataclass
+class PerfTrace:
+    """收集一次 turn 各阶段的时间戳。"""
+    turn_id: str = ''
+    source: str = ''
+    trigger_text: str = ''
+    # 感知层
+    audio_start_ts: Optional[float] = None
+    audio_end_ts: Optional[float] = None
+    asr_complete_ts: Optional[float] = None
+    # Collector
+    collector_receive_ts: Optional[float] = None
+    trigger_emit_ts: Optional[float] = None
+    # Agent Core
+    llm_start_ts: Optional[float] = None
+    llm_end_ts: Optional[float] = None
+    tool_start_ts: Optional[float] = None
+    tool_end_ts: Optional[float] = None
+    tts_start_ts: Optional[float] = None
+    tts_end_ts: Optional[float] = None
+    turn_end_ts: Optional[float] = None
+    # 元数据
+    round_count: int = 1
+    tool_names: list = field(default_factory=list)
+
+
+def _ms(start: Optional[float], end: Optional[float]) -> Optional[int]:
+    """计算毫秒差值，任一为 None 则返回 None。"""
+    if start is None or end is None:
+        return None
+    return int((end - start) * 1000)
+
+
+def commit(trace: PerfTrace):
+    """计算派生字段，写入 SQLite。"""
+    now = time.time()
+    vad_ms = _ms(trace.audio_start_ts, trace.audio_end_ts)
+    asr_ms = _ms(trace.audio_end_ts, trace.asr_complete_ts)
+    collector_ms = _ms(trace.asr_complete_ts or trace.collector_receive_ts, trace.trigger_emit_ts)
+    llm_ms = _ms(trace.llm_start_ts, trace.llm_end_ts)
+    tool_ms = _ms(trace.tool_start_ts, trace.tool_end_ts)
+    tts_ms = _ms(trace.tts_start_ts, trace.tts_end_ts)
+    total_ms = _ms(trace.audio_start_ts or trace.llm_start_ts, trace.turn_end_ts)
+
+    conn = config._get_conn()
+    conn.execute(
+        '''INSERT INTO perf_turns (
+            turn_id, created_at,
+            audio_start_ts, audio_end_ts, asr_complete_ts,
+            collector_receive_ts, trigger_emit_ts,
+            llm_start_ts, llm_end_ts,
+            tool_start_ts, tool_end_ts,
+            tts_start_ts, tts_end_ts,
+            turn_end_ts,
+            vad_duration_ms, asr_duration_ms, collector_delay_ms,
+            llm_duration_ms, tool_duration_ms, tts_duration_ms, total_duration_ms,
+            round_count, tool_names, trigger_text, source
+        ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)''',
+        (
+            trace.turn_id, now,
+            trace.audio_start_ts, trace.audio_end_ts, trace.asr_complete_ts,
+            trace.collector_receive_ts, trace.trigger_emit_ts,
+            trace.llm_start_ts, trace.llm_end_ts,
+            trace.tool_start_ts, trace.tool_end_ts,
+            trace.tts_start_ts, trace.tts_end_ts,
+            trace.turn_end_ts,
+            vad_ms, asr_ms, collector_ms,
+            llm_ms, tool_ms, tts_ms, total_ms,
+            trace.round_count,
+            json.dumps(trace.tool_names, ensure_ascii=False),
+            trace.trigger_text[:200],
+            trace.source,
+        ),
+    )
+    conn.commit()
+    conn.close()
+
+
+def query(start: float = 0, end: float = 0, limit: int = 50, offset: int = 0) -> dict:
+    """查询 perf_turns 记录。"""
+    conn = config._get_conn()
+    conn.row_factory = sqlite3.Row
+
+    where = 'WHERE 1=1'
+    params = []
+    if start:
+        where += ' AND created_at >= ?'
+        params.append(start)
+    if end:
+        where += ' AND created_at <= ?'
+        params.append(end)
+
+    # 总数
+    total = conn.execute(f'SELECT COUNT(*) FROM perf_turns {where}', params).fetchone()[0]
+
+    rows = conn.execute(
+        f'SELECT * FROM perf_turns {where} ORDER BY created_at DESC LIMIT ? OFFSET ?',
+        params + [limit, offset],
+    ).fetchall()
+
+    turns = []
+    for r in rows:
+        d = dict(r)
+        # tool_names 存的是 JSON 字符串
+        try:
+            d['tool_names'] = json.loads(d['tool_names'])
+        except (json.JSONDecodeError, TypeError):
+            d['tool_names'] = []
+        turns.append(d)
+
+    conn.close()
+    return {'turns': turns, 'total': total}
+
+
+def aggregate(start: float = 0, end: float = 0) -> dict:
+    """聚合统计：avg 和 p95。"""
+    conn = config._get_conn()
+
+    where = 'WHERE 1=1'
+    params = []
+    if start:
+        where += ' AND created_at >= ?'
+        params.append(start)
+    if end:
+        where += ' AND created_at <= ?'
+        params.append(end)
+
+    count = conn.execute(f'SELECT COUNT(*) FROM perf_turns {where}', params).fetchone()[0]
+    if count == 0:
+        conn.close()
+        return {'count': 0, 'avg': {}, 'p95': {}}
+
+    fields = ['vad_duration_ms', 'asr_duration_ms', 'collector_delay_ms',
+              'llm_duration_ms', 'tool_duration_ms', 'tts_duration_ms', 'total_duration_ms']
+
+    # Average
+    avg_exprs = ', '.join(f'AVG({f})' for f in fields)
+    row = conn.execute(f'SELECT {avg_exprs} FROM perf_turns {where}', params).fetchone()
+    avg = {}
+    for i, f in enumerate(fields):
+        avg[f] = int(row[i]) if row[i] is not None else None
+
+    # P95 — 取每个字段排序后 95% 位置的值
+    p95 = {}
+    p95_offset = int(count * 0.95) - 1
+    if p95_offset < 0:
+        p95_offset = 0
+    for f in fields:
+        r = conn.execute(
+            f'SELECT {f} FROM perf_turns {where} AND {f} IS NOT NULL ORDER BY {f} ASC LIMIT 1 OFFSET ?',
+            params + [p95_offset],
+        ).fetchone()
+        p95[f] = r[0] if r else None
+
+    conn.close()
+    return {'count': count, 'avg': avg, 'p95': p95}
+
+
+def latest(n: int = 20) -> list:
+    """获取最近 N 条记录。"""
+    result = query(limit=n)
+    return result['turns']
+
+
+def prune(days: int = 7):
+    """清理过期记录。"""
+    cutoff = time.time() - days * 86400
+    conn = config._get_conn()
+    conn.execute('DELETE FROM perf_turns WHERE created_at < ?', (cutoff,))
+    conn.commit()
+    deleted = conn.total_changes
+    conn.close()
+    if deleted:
+        print(f'[perf_log] pruned {deleted} records older than {days} days')
+
+
+# 模块加载时自动清理
+try:
+    prune()
+except Exception:
+    pass  # 表可能还不存在（首次启动前）

--- a/agent-core/src/perf_log.py
+++ b/agent-core/src/perf_log.py
@@ -1,8 +1,12 @@
 """
-perf_log.py — 性能追踪模块。
+perf_log.py — 开放 Span 式性能追踪。
 
-记录每次 agent turn 各阶段的时间戳，持久化到 SQLite，
-提供查询和聚合接口。
+每个组件（perception、core、driver）上报命名 span，
+agent-core 收集后按 trace_id（turn_id）关联存储到 SQLite。
+
+Span 格式：
+  {"span": "asr_inference", "component": "perception",
+   "start_ts": float, "end_ts": float, "meta": {...}}
 """
 
 import json
@@ -14,132 +18,110 @@ from typing import Optional
 import config
 
 
-@dataclass
-class PerfTrace:
-    """收集一次 turn 各阶段的时间戳。"""
-    turn_id: str = ''
-    source: str = ''
-    trigger_text: str = ''
-    # 感知层
-    audio_start_ts: Optional[float] = None
-    audio_end_ts: Optional[float] = None
-    asr_complete_ts: Optional[float] = None
-    # Collector
-    collector_receive_ts: Optional[float] = None
-    trigger_emit_ts: Optional[float] = None
-    # Agent Core
-    llm_start_ts: Optional[float] = None
-    llm_end_ts: Optional[float] = None
-    tool_start_ts: Optional[float] = None
-    tool_end_ts: Optional[float] = None
-    tts_start_ts: Optional[float] = None
-    tts_end_ts: Optional[float] = None
-    turn_end_ts: Optional[float] = None
-    # 元数据
-    round_count: int = 1
-    tool_names: list = field(default_factory=list)
-    audio_duration_ms: Optional[int] = None
-    text_length: Optional[int] = None
+def _get_conn():
+    return config._get_conn()
 
 
-def _ms(start: Optional[float], end: Optional[float]) -> Optional[int]:
-    """计算毫秒差值，任一为 None 或无效（<1e9）则返回 None。"""
-    if start is None or end is None:
-        return None
-    if start < 1e9 or end < 1e9:
-        return None
-    return int((end - start) * 1000)
-
-
-def commit(trace: PerfTrace):
-    """计算派生字段，写入 SQLite。"""
+def commit_spans(trace_id: str, spans: list[dict], source: str = '', trigger_text: str = ''):
+    """写入一组 spans 到 perf_spans 表，同时写 perf_turns 索引。"""
+    if not spans:
+        return
     now = time.time()
-    vad_ms = _ms(trace.audio_start_ts, trace.audio_end_ts)
-    asr_ms = _ms(trace.audio_end_ts, trace.asr_complete_ts)
-    collector_ms = _ms(trace.asr_complete_ts or trace.collector_receive_ts, trace.trigger_emit_ts)
-    llm_ms = _ms(trace.llm_start_ts, trace.llm_end_ts)
-    tool_ms = _ms(trace.tool_start_ts, trace.tool_end_ts)
-    tts_ms = _ms(trace.tts_start_ts, trace.tts_end_ts)
-    total_ms = _ms(trace.audio_start_ts or trace.llm_start_ts, trace.turn_end_ts)
+    conn = _get_conn()
 
-    conn = config._get_conn()
+    # 计算 total_duration
+    starts = [s['start_ts'] for s in spans if s.get('start_ts') and s['start_ts'] > 1e9]
+    ends = [s['end_ts'] for s in spans if s.get('end_ts') and s['end_ts'] > 1e9]
+    total_ms = int((max(ends) - min(starts)) * 1000) if starts and ends else None
+
+    # 写 perf_turns 索引
     conn.execute(
-        '''INSERT INTO perf_turns (
-            turn_id, created_at,
-            audio_start_ts, audio_end_ts, asr_complete_ts,
-            collector_receive_ts, trigger_emit_ts,
-            llm_start_ts, llm_end_ts,
-            tool_start_ts, tool_end_ts,
-            tts_start_ts, tts_end_ts,
-            turn_end_ts,
-            vad_duration_ms, asr_duration_ms, collector_delay_ms,
-            llm_duration_ms, tool_duration_ms, tts_duration_ms, total_duration_ms,
-            round_count, tool_names, trigger_text, source,
-            audio_duration_ms, text_length
-        ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)''',
-        (
-            trace.turn_id, now,
-            trace.audio_start_ts, trace.audio_end_ts, trace.asr_complete_ts,
-            trace.collector_receive_ts, trace.trigger_emit_ts,
-            trace.llm_start_ts, trace.llm_end_ts,
-            trace.tool_start_ts, trace.tool_end_ts,
-            trace.tts_start_ts, trace.tts_end_ts,
-            trace.turn_end_ts,
-            vad_ms, asr_ms, collector_ms,
-            llm_ms, tool_ms, tts_ms, total_ms,
-            trace.round_count,
-            json.dumps(trace.tool_names, ensure_ascii=False),
-            trace.trigger_text[:200],
-            trace.source,
-            trace.audio_duration_ms,
-            trace.text_length,
-        ),
+        '''INSERT INTO perf_turns (turn_id, created_at, source, trigger_text, total_duration_ms)
+           VALUES (?, ?, ?, ?, ?)''',
+        (trace_id, now, source, trigger_text[:200], total_ms),
     )
+
+    # 写 perf_spans
+    for s in spans:
+        start_ts = s.get('start_ts')
+        end_ts = s.get('end_ts')
+        dur = None
+        if start_ts and end_ts and start_ts > 1e9 and end_ts > 1e9:
+            dur = int((end_ts - start_ts) * 1000)
+        conn.execute(
+            '''INSERT INTO perf_spans (trace_id, span, component, start_ts, end_ts, duration_ms, meta, created_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?)''',
+            (
+                trace_id,
+                s.get('span', ''),
+                s.get('component', ''),
+                start_ts,
+                end_ts,
+                dur,
+                json.dumps(s.get('meta', {}), ensure_ascii=False),
+                now,
+            ),
+        )
+
     conn.commit()
     conn.close()
 
 
-def query(start: float = 0, end: float = 0, limit: int = 50, offset: int = 0) -> dict:
-    """查询 perf_turns 记录。"""
-    conn = config._get_conn()
+def query_latest(n: int = 20) -> list:
+    """返回最近 N 个 turn，每个 turn 附带其 spans。"""
+    conn = _get_conn()
     conn.row_factory = sqlite3.Row
 
-    where = 'WHERE 1=1'
-    params = []
-    if start:
-        where += ' AND created_at >= ?'
-        params.append(start)
-    if end:
-        where += ' AND created_at <= ?'
-        params.append(end)
-
-    # 总数
-    total = conn.execute(f'SELECT COUNT(*) FROM perf_turns {where}', params).fetchone()[0]
-
-    rows = conn.execute(
-        f'SELECT * FROM perf_turns {where} ORDER BY created_at DESC LIMIT ? OFFSET ?',
-        params + [limit, offset],
+    turns = conn.execute(
+        'SELECT * FROM perf_turns ORDER BY created_at DESC LIMIT ?', (n,)
     ).fetchall()
 
-    turns = []
-    for r in rows:
-        d = dict(r)
-        # tool_names 存的是 JSON 字符串
-        try:
-            d['tool_names'] = json.loads(d['tool_names'])
-        except (json.JSONDecodeError, TypeError):
-            d['tool_names'] = []
-        turns.append(d)
+    result = []
+    for t in turns:
+        td = dict(t)
+        trace_id = td['turn_id']
+        spans = conn.execute(
+            'SELECT span, component, start_ts, end_ts, duration_ms, meta FROM perf_spans WHERE trace_id=? ORDER BY start_ts',
+            (trace_id,),
+        ).fetchall()
+        td['spans'] = []
+        for s in spans:
+            sd = dict(s)
+            try:
+                sd['meta'] = json.loads(sd['meta'])
+            except (json.JSONDecodeError, TypeError):
+                sd['meta'] = {}
+            td['spans'].append(sd)
+        result.append(td)
 
     conn.close()
-    return {'turns': turns, 'total': total}
+    return result
+
+
+def query_spans(trace_id: str) -> list:
+    """返回单个 turn 的全部 spans。"""
+    conn = _get_conn()
+    conn.row_factory = sqlite3.Row
+    spans = conn.execute(
+        'SELECT * FROM perf_spans WHERE trace_id=? ORDER BY start_ts', (trace_id,)
+    ).fetchall()
+    result = []
+    for s in spans:
+        sd = dict(s)
+        try:
+            sd['meta'] = json.loads(sd['meta'])
+        except (json.JSONDecodeError, TypeError):
+            sd['meta'] = {}
+        result.append(sd)
+    conn.close()
+    return result
 
 
 def aggregate(start: float = 0, end: float = 0) -> dict:
-    """聚合统计：avg 和 p95。"""
-    conn = config._get_conn()
+    """按 span 名称聚合 avg/p95。"""
+    conn = _get_conn()
 
-    where = 'WHERE 1=1'
+    where = 'WHERE duration_ms IS NOT NULL'
     params = []
     if start:
         where += ' AND created_at >= ?'
@@ -148,57 +130,51 @@ def aggregate(start: float = 0, end: float = 0) -> dict:
         where += ' AND created_at <= ?'
         params.append(end)
 
-    count = conn.execute(f'SELECT COUNT(*) FROM perf_turns {where}', params).fetchone()[0]
-    if count == 0:
-        conn.close()
-        return {'count': 0, 'avg': {}, 'p95': {}}
+    # 总 turn 数
+    turn_count = conn.execute(
+        f'SELECT COUNT(DISTINCT trace_id) FROM perf_spans {where}', params
+    ).fetchone()[0]
 
-    fields = ['vad_duration_ms', 'asr_duration_ms', 'collector_delay_ms',
-              'llm_duration_ms', 'tool_duration_ms', 'tts_duration_ms', 'total_duration_ms']
+    # 按 span 名称聚合
+    rows = conn.execute(
+        f'''SELECT span, COUNT(*) as cnt, AVG(duration_ms) as avg_ms
+            FROM perf_spans {where}
+            GROUP BY span ORDER BY avg_ms DESC''',
+        params,
+    ).fetchall()
 
-    # Average
-    avg_exprs = ', '.join(f'AVG({f})' for f in fields)
-    row = conn.execute(f'SELECT {avg_exprs} FROM perf_turns {where}', params).fetchone()
-    avg = {}
-    for i, f in enumerate(fields):
-        avg[f] = int(row[i]) if row[i] is not None else None
+    by_span = {}
+    for row in rows:
+        span_name = row[0]
+        cnt = row[1]
+        avg_ms = int(row[2]) if row[2] else 0
 
-    # P95 — 取每个字段排序后 95% 位置的值
-    p95 = {}
-    p95_offset = int(count * 0.95) - 1
-    if p95_offset < 0:
-        p95_offset = 0
-    for f in fields:
-        r = conn.execute(
-            f'SELECT {f} FROM perf_turns {where} AND {f} IS NOT NULL ORDER BY {f} ASC LIMIT 1 OFFSET ?',
-            params + [p95_offset],
+        # P95
+        p95_offset = max(0, int(cnt * 0.95) - 1)
+        p95_row = conn.execute(
+            f'SELECT duration_ms FROM perf_spans {where} AND span=? ORDER BY duration_ms ASC LIMIT 1 OFFSET ?',
+            params + [span_name, p95_offset],
         ).fetchone()
-        p95[f] = r[0] if r else None
+        p95_ms = p95_row[0] if p95_row else avg_ms
+
+        by_span[span_name] = {'avg_ms': avg_ms, 'p95_ms': p95_ms, 'count': cnt}
 
     conn.close()
-    return {'count': count, 'avg': avg, 'p95': p95}
-
-
-def latest(n: int = 20) -> list:
-    """获取最近 N 条记录。"""
-    result = query(limit=n)
-    return result['turns']
+    return {'count': turn_count, 'by_span': by_span}
 
 
 def prune(days: int = 7):
     """清理过期记录。"""
     cutoff = time.time() - days * 86400
-    conn = config._get_conn()
+    conn = _get_conn()
+    conn.execute('DELETE FROM perf_spans WHERE created_at < ?', (cutoff,))
     conn.execute('DELETE FROM perf_turns WHERE created_at < ?', (cutoff,))
     conn.commit()
-    deleted = conn.total_changes
     conn.close()
-    if deleted:
-        print(f'[perf_log] pruned {deleted} records older than {days} days')
 
 
 # 模块加载时自动清理
 try:
     prune()
 except Exception:
-    pass  # 表可能还不存在（首次启动前）
+    pass

--- a/agent-core/src/perf_log.py
+++ b/agent-core/src/perf_log.py
@@ -162,7 +162,17 @@ def aggregate(start: float = 0, end: float = 0) -> dict:
         ).fetchone()
         p95_ms = p95_row[0] if p95_row else avg_ms
 
-        by_span[span_name] = {'avg_ms': avg_ms, 'p95_ms': p95_ms, 'count': cnt}
+        # 平均开始偏移（相对于每个 trace 中最早 span 的 start_ts）
+        offset_row = conn.execute(
+            f'''SELECT AVG((s.start_ts - t_min.min_start) * 1000) FROM perf_spans s
+                INNER JOIN (SELECT trace_id, MIN(start_ts) as min_start FROM perf_spans GROUP BY trace_id) t_min
+                ON s.trace_id = t_min.trace_id
+                {where} AND s.span = ?''',
+            params + [span_name],
+        ).fetchone()
+        avg_offset_ms = int(offset_row[0]) if offset_row and offset_row[0] else 0
+
+        by_span[span_name] = {'avg_ms': avg_ms, 'p95_ms': p95_ms, 'count': cnt, 'avg_offset_ms': avg_offset_ms}
 
     conn.close()
     return {'count': turn_count, 'by_span': by_span}

--- a/agent-core/src/perf_log.py
+++ b/agent-core/src/perf_log.py
@@ -23,23 +23,28 @@ def _get_conn():
 
 
 def commit_spans(trace_id: str, spans: list[dict], source: str = '', trigger_text: str = ''):
-    """写入一组 spans 到 perf_spans 表，同时写 perf_turns 索引。"""
+    """写入一组 spans 到 perf_spans 表，同时写/更新 perf_turns 索引。"""
     if not spans:
         return
     now = time.time()
     conn = _get_conn()
 
-    # 计算 total_duration
-    starts = [s['start_ts'] for s in spans if s.get('start_ts') and s['start_ts'] > 1e9]
-    ends = [s['end_ts'] for s in spans if s.get('end_ts') and s['end_ts'] > 1e9]
-    total_ms = int((max(ends) - min(starts)) * 1000) if starts and ends else None
+    # 检查 turn 是否已存在（TTS 等异步 span 会后到）
+    existing = conn.execute(
+        'SELECT id FROM perf_turns WHERE turn_id=?', (trace_id,)
+    ).fetchone()
 
-    # 写 perf_turns 索引
-    conn.execute(
-        '''INSERT INTO perf_turns (turn_id, created_at, source, trigger_text, total_duration_ms)
-           VALUES (?, ?, ?, ?, ?)''',
-        (trace_id, now, source, trigger_text[:200], total_ms),
-    )
+    if not existing:
+        # 计算 total_duration
+        starts = [s['start_ts'] for s in spans if s.get('start_ts') and s['start_ts'] > 1e9]
+        ends = [s['end_ts'] for s in spans if s.get('end_ts') and s['end_ts'] > 1e9]
+        total_ms = int((max(ends) - min(starts)) * 1000) if starts and ends else None
+        # 新建 perf_turns 记录
+        conn.execute(
+            '''INSERT INTO perf_turns (turn_id, created_at, source, trigger_text, total_duration_ms)
+               VALUES (?, ?, ?, ?, ?)''',
+            (trace_id, now, source, trigger_text[:200], total_ms),
+        )
 
     # 写 perf_spans
     for s in spans:

--- a/agent-core/src/start.py
+++ b/agent-core/src/start.py
@@ -353,6 +353,9 @@ app_api.include_router(api.network.router)
 import api.channel
 app_api.include_router(api.channel.router)
 
+import api.performance
+app_api.include_router(api.performance.router)
+
 app = fastapi.FastAPI(lifespan=lifespan)
 app.middleware('http')(auth.auth_middleware)
 app.mount('/api', app_api)

--- a/agent-core/src/start.py
+++ b/agent-core/src/start.py
@@ -278,6 +278,10 @@ async def lifespan(app):
     topics = config.main.get('event', {}).get('subscribe_topics', [])
     topic_subscriber.start(topics, asyncio.get_event_loop())
 
+    # 订阅 perf_spans topic（用于接收 perception TTS 等异步上报的性能 span）
+    from api.inspection import register_topic_internal
+    await register_topic_internal('/perception/perf_spans', 'data/json', '__perf__')
+
     # 启动 collector（信息整理器）
     collector.start()
 

--- a/agent-core/src/topic_subscriber.py
+++ b/agent-core/src/topic_subscriber.py
@@ -5,6 +5,9 @@ topic_subscriber.py — 直接用 rclpy 订阅配置的 DDS topic，结果注入
   {"subscribe_topics": ["/robot/mic/audio/asr_event", ...]}
 
 每个 topic 收到 String 消息后，enqueue 到 event_bus（source='dds:<topic>'，text=msg.data）。
+
+NOTE: 使用 ros2_bridge._node_main 来创建 subscription，确保和 inspection 用
+同一个 DDS participant，避免跨容器 discovery/transport 问题。
 """
 
 import asyncio
@@ -21,74 +24,74 @@ except ImportError:
     pass
 
 # Module-level state for dynamic subscribe/unsubscribe
-_node = None
 _loop: asyncio.AbstractEventLoop | None = None
 _subscriptions: dict = {}  # topic -> subscription object
 _lock = threading.Lock()
 
 
 def start(topics: list[str], loop: asyncio.AbstractEventLoop):
-    """启动后台线程，订阅给定的 DDS topic 列表。"""
+    """订阅给定的 DDS topic 列表，使用 ros2_bridge 的 node。"""
     global _loop
     _loop = loop
 
     if not _HAS_RCLPY:
         log.warning('[topic_sub] rclpy not available, DDS subscription disabled')
         return
-    if not topics:
-        # Still start the thread so the node is ready for dynamic subscriptions
-        t = threading.Thread(target=_spin, args=([], loop), daemon=True, name='topic_subscriber')
-        t.start()
+
+    import ros2_bridge
+    if not ros2_bridge._node_main:
+        log.warning('[topic_sub] ros2_bridge node not ready, cannot subscribe')
         return
-    t = threading.Thread(target=_spin, args=(topics, loop), daemon=True, name='topic_subscriber')
-    t.start()
+
+    if not topics:
+        log.info('[topic_sub] no topics to subscribe')
+        return
+
+    for topic in topics:
+        _subscribe_one(topic, loop)
+
     log.info('[topic_sub] subscribing to %d topics: %s', len(topics), topics)
 
 
-def _spin(topics: list[str], loop: asyncio.AbstractEventLoop):
-    global _node
+def _subscribe_one(topic: str, loop: asyncio.AbstractEventLoop):
+    """在 ros2_bridge 的 node 上创建一个 subscription。"""
     import event_bus
+    import ros2_bridge
     from std_msgs.msg import String
     from rclpy.qos import QoSProfile, ReliabilityPolicy
 
     qos = QoSProfile(depth=10, reliability=ReliabilityPolicy.BEST_EFFORT)
 
-    try:
-        rclpy.init()
-    except Exception:
-        pass  # already initialized
+    node = ros2_bridge._node_main
+    if node is None:
+        log.warning('[topic_sub] ros2_bridge node is None')
+        return
 
-    _node = rclpy.create_node('motus_core_subscriber')
-
-    for topic in topics:
-        sub = _node.create_subscription(
-            String,
-            topic,
-            lambda msg, t=topic: asyncio.run_coroutine_threadsafe(
-                event_bus.enqueue(source=f'dds:{t}', text=msg.data),
-                loop,
-            ),
-            qos,
+    def _on_msg(msg, t=topic):
+        asyncio.run_coroutine_threadsafe(
+            event_bus.enqueue(source=f'dds:{t}', text=msg.data),
+            loop,
         )
-        with _lock:
-            _subscriptions[topic] = sub
-        log.info('[topic_sub] subscribed to %s', topic)
 
-    try:
-        rclpy.spin(_node)
-    except Exception as e:
-        log.warning('[topic_sub] spin exited: %s', e)
-    finally:
-        try:
-            _node.destroy_node()
-        except Exception:
-            pass
+    sub = node.create_subscription(String, topic, _on_msg, qos)
+    # Wake the executor so it picks up the new subscription
+    if ros2_bridge._executor:
+        ros2_bridge._executor.wake()
+
+    with _lock:
+        _subscriptions[topic] = sub
+    log.info('[topic_sub] subscribed to %s (via ros2_bridge node)', topic)
 
 
 def subscribe(topic: str):
     """动态订阅单个 topic（运行时调用）。"""
-    if not _HAS_RCLPY or _node is None:
-        log.warning('[topic_sub] cannot subscribe: rclpy not ready')
+    if not _HAS_RCLPY:
+        log.warning('[topic_sub] cannot subscribe: rclpy not available')
+        return False
+
+    import ros2_bridge
+    if not ros2_bridge._node_main:
+        log.warning('[topic_sub] cannot subscribe: ros2_bridge node not ready')
         return False
 
     with _lock:
@@ -96,30 +99,14 @@ def subscribe(topic: str):
             log.info('[topic_sub] already subscribed to %s', topic)
             return True
 
-    import event_bus
-    from std_msgs.msg import String
-    from rclpy.qos import QoSProfile, ReliabilityPolicy
-
-    qos = QoSProfile(depth=10, reliability=ReliabilityPolicy.BEST_EFFORT)
-    loop = _loop
-
-    sub = _node.create_subscription(
-        String,
-        topic,
-        lambda msg, t=topic: asyncio.run_coroutine_threadsafe(
-            event_bus.enqueue(source=f'dds:{t}', text=msg.data),
-            loop,
-        ),
-        qos,
-    )
-    with _lock:
-        _subscriptions[topic] = sub
-    log.info('[topic_sub] dynamically subscribed to %s', topic)
+    _subscribe_one(topic, _loop)
     return True
 
 
 def unsubscribe(topic: str):
     """动态退订单个 topic（运行时调用）。"""
+    import ros2_bridge
+
     with _lock:
         sub = _subscriptions.pop(topic, None)
 
@@ -127,7 +114,8 @@ def unsubscribe(topic: str):
         log.info('[topic_sub] not subscribed to %s, nothing to remove', topic)
         return False
 
-    if _node is not None:
-        _node.destroy_subscription(sub)
+    node = ros2_bridge._node_main
+    if node is not None:
+        node.destroy_subscription(sub)
     log.info('[topic_sub] dynamically unsubscribed from %s', topic)
     return True

--- a/agent-core/src/topic_subscriber.py
+++ b/agent-core/src/topic_subscriber.py
@@ -5,9 +5,6 @@ topic_subscriber.py — 直接用 rclpy 订阅配置的 DDS topic，结果注入
   {"subscribe_topics": ["/robot/mic/audio/asr_event", ...]}
 
 每个 topic 收到 String 消息后，enqueue 到 event_bus（source='dds:<topic>'，text=msg.data）。
-
-NOTE: 使用 ros2_bridge._node_main 来创建 subscription，确保和 inspection 用
-同一个 DDS participant，避免跨容器 discovery/transport 问题。
 """
 
 import asyncio
@@ -24,74 +21,74 @@ except ImportError:
     pass
 
 # Module-level state for dynamic subscribe/unsubscribe
+_node = None
 _loop: asyncio.AbstractEventLoop | None = None
 _subscriptions: dict = {}  # topic -> subscription object
 _lock = threading.Lock()
 
 
 def start(topics: list[str], loop: asyncio.AbstractEventLoop):
-    """订阅给定的 DDS topic 列表，使用 ros2_bridge 的 node。"""
+    """启动后台线程，订阅给定的 DDS topic 列表。"""
     global _loop
     _loop = loop
 
     if not _HAS_RCLPY:
         log.warning('[topic_sub] rclpy not available, DDS subscription disabled')
         return
-
-    import ros2_bridge
-    if not ros2_bridge._node_main:
-        log.warning('[topic_sub] ros2_bridge node not ready, cannot subscribe')
-        return
-
     if not topics:
-        log.info('[topic_sub] no topics to subscribe')
+        # Still start the thread so the node is ready for dynamic subscriptions
+        t = threading.Thread(target=_spin, args=([], loop), daemon=True, name='topic_subscriber')
+        t.start()
         return
-
-    for topic in topics:
-        _subscribe_one(topic, loop)
-
+    t = threading.Thread(target=_spin, args=(topics, loop), daemon=True, name='topic_subscriber')
+    t.start()
     log.info('[topic_sub] subscribing to %d topics: %s', len(topics), topics)
 
 
-def _subscribe_one(topic: str, loop: asyncio.AbstractEventLoop):
-    """在 ros2_bridge 的 node 上创建一个 subscription。"""
+def _spin(topics: list[str], loop: asyncio.AbstractEventLoop):
+    global _node
     import event_bus
-    import ros2_bridge
     from std_msgs.msg import String
     from rclpy.qos import QoSProfile, ReliabilityPolicy
 
     qos = QoSProfile(depth=10, reliability=ReliabilityPolicy.BEST_EFFORT)
 
-    node = ros2_bridge._node_main
-    if node is None:
-        log.warning('[topic_sub] ros2_bridge node is None')
-        return
+    try:
+        rclpy.init()
+    except Exception:
+        pass  # already initialized
 
-    def _on_msg(msg, t=topic):
-        asyncio.run_coroutine_threadsafe(
-            event_bus.enqueue(source=f'dds:{t}', text=msg.data),
-            loop,
+    _node = rclpy.create_node('motus_core_subscriber')
+
+    for topic in topics:
+        sub = _node.create_subscription(
+            String,
+            topic,
+            lambda msg, t=topic: asyncio.run_coroutine_threadsafe(
+                event_bus.enqueue(source=f'dds:{t}', text=msg.data),
+                loop,
+            ),
+            qos,
         )
+        with _lock:
+            _subscriptions[topic] = sub
+        log.info('[topic_sub] subscribed to %s', topic)
 
-    sub = node.create_subscription(String, topic, _on_msg, qos)
-    # Wake the executor so it picks up the new subscription
-    if ros2_bridge._executor:
-        ros2_bridge._executor.wake()
-
-    with _lock:
-        _subscriptions[topic] = sub
-    log.info('[topic_sub] subscribed to %s (via ros2_bridge node)', topic)
+    try:
+        rclpy.spin(_node)
+    except Exception as e:
+        log.warning('[topic_sub] spin exited: %s', e)
+    finally:
+        try:
+            _node.destroy_node()
+        except Exception:
+            pass
 
 
 def subscribe(topic: str):
     """动态订阅单个 topic（运行时调用）。"""
-    if not _HAS_RCLPY:
-        log.warning('[topic_sub] cannot subscribe: rclpy not available')
-        return False
-
-    import ros2_bridge
-    if not ros2_bridge._node_main:
-        log.warning('[topic_sub] cannot subscribe: ros2_bridge node not ready')
+    if not _HAS_RCLPY or _node is None:
+        log.warning('[topic_sub] cannot subscribe: rclpy not ready')
         return False
 
     with _lock:
@@ -99,14 +96,30 @@ def subscribe(topic: str):
             log.info('[topic_sub] already subscribed to %s', topic)
             return True
 
-    _subscribe_one(topic, _loop)
+    import event_bus
+    from std_msgs.msg import String
+    from rclpy.qos import QoSProfile, ReliabilityPolicy
+
+    qos = QoSProfile(depth=10, reliability=ReliabilityPolicy.BEST_EFFORT)
+    loop = _loop
+
+    sub = _node.create_subscription(
+        String,
+        topic,
+        lambda msg, t=topic: asyncio.run_coroutine_threadsafe(
+            event_bus.enqueue(source=f'dds:{t}', text=msg.data),
+            loop,
+        ),
+        qos,
+    )
+    with _lock:
+        _subscriptions[topic] = sub
+    log.info('[topic_sub] dynamically subscribed to %s', topic)
     return True
 
 
 def unsubscribe(topic: str):
     """动态退订单个 topic（运行时调用）。"""
-    import ros2_bridge
-
     with _lock:
         sub = _subscriptions.pop(topic, None)
 
@@ -114,8 +127,7 @@ def unsubscribe(topic: str):
         log.info('[topic_sub] not subscribed to %s, nothing to remove', topic)
         return False
 
-    node = ros2_bridge._node_main
-    if node is not None:
-        node.destroy_subscription(sub)
+    if _node is not None:
+        _node.destroy_subscription(sub)
     log.info('[topic_sub] dynamically unsubscribed from %s', topic)
     return True

--- a/agent-core/web/css/style.css
+++ b/agent-core/web/css/style.css
@@ -5682,6 +5682,58 @@ html, body {
   text-align: center;
   padding: 40px 0;
 }
+.perf-row-group {
+  border-radius: 6px;
+  transition: background 0.15s;
+}
+.perf-row-group:hover {
+  background: var(--bg-2);
+}
+.perf-row-group .perf-row {
+  cursor: pointer;
+}
+.perf-row-expand {
+  font-size: 0.7rem;
+  color: var(--text-dim);
+  transition: transform 0.2s;
+  margin-left: 4px;
+}
+.perf-row-group.expanded .perf-row-expand {
+  transform: rotate(90deg);
+}
+.perf-row-detail {
+  display: none;
+  padding: 6px 12px 10px 190px;
+}
+.perf-row-group.expanded .perf-row-detail {
+  display: block;
+}
+.perf-detail-table {
+  font-size: 0.75rem;
+  border-collapse: collapse;
+  width: 100%;
+  max-width: 360px;
+}
+.perf-detail-table td {
+  padding: 3px 8px;
+  border-bottom: 1px solid var(--border);
+}
+.perf-detail-val {
+  font-family: var(--font-mono);
+  text-align: right;
+  color: var(--text);
+}
+.perf-detail-tools {
+  font-size: 0.68rem;
+  color: var(--text-dim);
+  word-break: break-all;
+  text-align: left !important;
+  max-width: 200px;
+}
+.perf-bar-segment:hover {
+  opacity: 0.8;
+  outline: 1px solid rgba(255,255,255,0.5);
+}
 
 @media (max-width: 768px) {
   .performance-modal {

--- a/agent-core/web/css/style.css
+++ b/agent-core/web/css/style.css
@@ -5541,3 +5541,163 @@ html, body {
   margin-top: 20px;
 }
 
+/* ── Performance Dashboard ──────────────────────────────────────────────── */
+
+.performance-modal {
+  width: 85vw;
+  max-width: 900px;
+  height: 80vh;
+  display: flex;
+  flex-direction: column;
+}
+.performance-modal .modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+.performance-body {
+  overflow-y: auto;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+.perf-select {
+  background: var(--bg-2);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 4px 8px;
+  font-size: 0.8rem;
+  color: var(--text);
+}
+.perf-cards {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+.perf-card {
+  background: var(--bg-2);
+  border-radius: 8px;
+  padding: 12px 16px;
+  min-width: 120px;
+  flex: 1;
+  text-align: center;
+}
+.perf-card-value {
+  font-size: 1.4rem;
+  font-weight: 600;
+  color: var(--text);
+  font-family: var(--font-mono);
+}
+.perf-card-label {
+  font-size: 0.75rem;
+  color: var(--text-dim);
+  margin-top: 4px;
+}
+.perf-legend {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  font-size: 0.75rem;
+  color: var(--text-dim);
+}
+.perf-legend-item {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+.perf-legend-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 2px;
+  display: inline-block;
+}
+.perf-avg-breakdown {
+  margin-top: 4px;
+}
+.perf-bar {
+  display: flex;
+  height: 20px;
+  border-radius: 4px;
+  overflow: hidden;
+  background: var(--bg-3);
+}
+.perf-bar-segment {
+  height: 100%;
+  transition: width 0.3s;
+}
+.perf-section-title {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text-dim);
+  margin: 0 0 8px;
+}
+.perf-waterfall-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.perf-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.perf-row-meta {
+  width: 180px;
+  min-width: 180px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.perf-row-time {
+  font-size: 0.7rem;
+  color: var(--text-dim);
+  font-family: var(--font-mono);
+}
+.perf-row-text {
+  font-size: 0.72rem;
+  color: var(--text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.perf-row-bar {
+  display: flex;
+  height: 16px;
+  border-radius: 3px;
+  overflow: hidden;
+  flex: 1;
+  min-width: 0;
+}
+.perf-row-total {
+  font-size: 0.75rem;
+  font-family: var(--font-mono);
+  color: var(--text-dim);
+  min-width: 50px;
+  text-align: right;
+}
+.perf-empty {
+  color: var(--text-dim);
+  font-size: 0.85rem;
+  text-align: center;
+  padding: 40px 0;
+}
+
+@media (max-width: 768px) {
+  .performance-modal {
+    width: 95vw;
+    height: 85vh;
+  }
+  .perf-row-meta {
+    width: 100px;
+    min-width: 100px;
+  }
+  .perf-cards {
+    gap: 8px;
+  }
+  .perf-card {
+    min-width: 80px;
+    padding: 8px 10px;
+  }
+}
+

--- a/agent-core/web/css/style.css
+++ b/agent-core/web/css/style.css
@@ -5675,13 +5675,84 @@ html, body {
   white-space: nowrap;
 }
 .perf-row-bar {
+  display: none;
+}
+/* Gantt chart */
+.perf-gantt {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 3px 6px;
+  align-items: center;
+  padding: 6px 0;
+}
+.perf-gantt-row {
+  display: contents;
+}
+.perf-gantt-label {
+  font-size: 0.68rem;
+  color: var(--text-dim);
+  text-align: right;
+  white-space: nowrap;
+}
+.perf-gantt-track {
   position: relative;
-  height: 16px;
+  height: 14px;
+  width: 100%;
+  background: var(--bg-3);
   border-radius: 3px;
   overflow: hidden;
+}
+.perf-gantt-bar {
+  position: absolute;
+  top: 0;
+  height: 100%;
+  border-radius: 3px;
+  min-width: 3px;
+  transition: opacity 0.15s;
+}
+.perf-gantt-bar:hover {
+  opacity: 0.8;
+  box-shadow: 0 0 0 1px rgba(255,255,255,0.6);
+}
+.perf-gantt-dur {
+  font-size: 0.68rem;
+  font-family: var(--font-mono);
+  color: var(--text-dim);
+  min-width: 45px;
+  text-align: left;
+}
+.perf-row-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+  padding: 6px 4px;
+  border-radius: 4px;
+}
+.perf-row-header:hover {
+  background: var(--bg-2);
+}
+.perf-row-chips {
+  display: flex;
+  gap: 4px;
   flex: 1;
   min-width: 0;
-  background: var(--bg-3);
+  overflow: hidden;
+}
+.perf-chip {
+  font-size: 0.65rem;
+  padding: 1px 6px;
+  border-radius: 3px;
+  color: #fff;
+  white-space: nowrap;
+  opacity: 0.85;
+}
+.perf-row-group .perf-gantt {
+  display: none;
+}
+.perf-row-group.expanded .perf-gantt {
+  display: grid;
+  padding: 8px 0;
 }
 .perf-span-seg {
   position: absolute;
@@ -5735,7 +5806,7 @@ html, body {
 }
 .perf-row-detail {
   display: none;
-  padding: 6px 12px 10px 190px;
+  padding: 6px 12px 10px 12px;
 }
 .perf-row-group.expanded .perf-row-detail {
   display: block;
@@ -5744,16 +5815,26 @@ html, body {
   font-size: 0.75rem;
   border-collapse: collapse;
   width: 100%;
-  max-width: 360px;
+  max-width: 500px;
 }
+.perf-detail-table th,
 .perf-detail-table td {
-  padding: 3px 8px;
+  padding: 4px 12px;
   border-bottom: 1px solid var(--border);
+}
+.perf-detail-table th {
+  font-weight: 500;
+  color: var(--text-dim);
+  text-align: right;
+}
+.perf-detail-table th:first-child {
+  text-align: left;
 }
 .perf-detail-val {
   font-family: var(--font-mono);
   text-align: right;
   color: var(--text);
+  min-width: 60px;
 }
 .perf-detail-tools {
   font-size: 0.68rem;

--- a/agent-core/web/css/style.css
+++ b/agent-core/web/css/style.css
@@ -5615,6 +5615,19 @@ html, body {
 .perf-avg-breakdown {
   margin-top: 4px;
 }
+.perf-avg-detail {
+  margin-top: 12px;
+}
+.perf-avg-detail table {
+  max-width: 400px;
+}
+.perf-avg-detail th {
+  font-size: 0.72rem;
+  color: var(--text-dim);
+  text-align: left;
+  padding: 4px 8px;
+  border-bottom: 1px solid var(--border);
+}
 .perf-bar {
   display: flex;
   height: 20px;
@@ -5662,12 +5675,31 @@ html, body {
   white-space: nowrap;
 }
 .perf-row-bar {
-  display: flex;
+  position: relative;
   height: 16px;
   border-radius: 3px;
   overflow: hidden;
   flex: 1;
   min-width: 0;
+  background: var(--bg-3);
+}
+.perf-span-seg {
+  position: absolute;
+  top: 0;
+  height: 100%;
+  border-radius: 2px;
+  min-width: 2px;
+}
+.perf-span-seg:hover {
+  opacity: 0.8;
+  outline: 1px solid rgba(255,255,255,0.6);
+  z-index: 1;
+}
+.perf-detail-meta {
+  font-size: 0.65rem;
+  color: var(--text-dim);
+  max-width: 200px;
+  word-break: break-all;
 }
 .perf-row-total {
   font-size: 0.75rem;

--- a/agent-core/web/index.html
+++ b/agent-core/web/index.html
@@ -55,6 +55,7 @@
           <button class="settings-dropdown-item" data-target="btn-skills">技能</button>
           <button class="settings-dropdown-item" data-target="btn-channels">渠道</button>
           <button class="settings-dropdown-item" data-target="btn-deploy">部署</button>
+          <button class="settings-dropdown-item" data-target="btn-performance">性能</button>
         </div>
       </div>
       <!-- Hidden buttons for existing JS handlers -->
@@ -64,6 +65,7 @@
       <button class="btn-ghost topbar-btn hidden" id="btn-skills">技能</button>
       <button class="btn-ghost topbar-btn hidden" id="btn-channels">渠道</button>
       <button class="btn-ghost topbar-btn hidden" id="btn-deploy">部署 ▾</button>
+      <button class="btn-ghost topbar-btn hidden" id="btn-performance">性能</button>
     </div>
     <button class="mobile-hamburger" id="mobile-hamburger" aria-label="菜单">⋮</button>
   </header>
@@ -194,6 +196,10 @@
         </button>
         <button class="settings-item" data-action="deploy">
           <span class="settings-item-label">部署</span>
+          <span class="settings-item-arrow">›</span>
+        </button>
+        <button class="settings-item" data-action="performance">
+          <span class="settings-item-label">性能</span>
           <span class="settings-item-arrow">›</span>
         </button>
       </div>
@@ -386,6 +392,29 @@
       <div class="history-chat" id="history-chat">
         <div class="history-placeholder">选择一个会话查看对话记录</div>
       </div>
+    </div>
+  </div>
+</div>
+
+<!-- Performance Modal -->
+<div class="modal-overlay hidden" id="performance-overlay">
+  <div class="modal performance-modal">
+    <div class="modal-header">
+      <span class="modal-title">性能分析</span>
+      <div style="display:flex;gap:6px;align-items:center">
+        <select id="perf-range" class="perf-select">
+          <option value="1h">最近1小时</option>
+          <option value="6h">最近6小时</option>
+          <option value="24h" selected>最近24小时</option>
+          <option value="7d">最近7天</option>
+        </select>
+        <button class="btn-ghost btn-sm" id="perf-refresh">刷新</button>
+        <button class="btn-icon" id="performance-close">✕</button>
+      </div>
+    </div>
+    <div class="modal-body performance-body">
+      <div id="perf-summary-cards"></div>
+      <div id="perf-waterfall"></div>
     </div>
   </div>
 </div>

--- a/agent-core/web/js/app.js
+++ b/agent-core/web/js/app.js
@@ -16,6 +16,7 @@ import { initHistory }       from './history.js';
 import { initNetwork }       from './network.js';
 import { initChannels }      from './channels.js';
 import { initMobile }        from './mobile.js';
+import { initPerformance }   from './performance.js';
 import './agent-definition.js';
 
 let _allMcps   = [];
@@ -43,6 +44,7 @@ async function main() {
   initHistory();
   initNetwork();
   initChannels();
+  initPerformance();
 
   // Settings dropdown (web topbar)
   _initSettingsDropdown();

--- a/agent-core/web/js/app.js
+++ b/agent-core/web/js/app.js
@@ -71,7 +71,15 @@ async function main() {
 
   // Poll every 10s
   setInterval(async () => {
-    _allMcps = await _fetchMcps();
+    const fresh = await _fetchMcps();
+    // Preserve online status from previous ping results
+    const oldMap = Object.fromEntries(_allMcps.map(m => [m.id, m]));
+    for (const m of fresh) {
+      if (m.online == null && oldMap[m.id]?.online != null) {
+        m.online = oldMap[m.id].online;
+      }
+    }
+    _allMcps = fresh;
     await fetchTopicStatuses();
     renderSidebar(_allMcps, _topicStatuses);
     updateCanvasMcps(_allMcps);

--- a/agent-core/web/js/mobile.js
+++ b/agent-core/web/js/mobile.js
@@ -168,6 +168,7 @@ function _triggerSettingsAction(action) {
     'skills': 'btn-skills',
     'channels': 'btn-channels',
     'deploy': 'btn-deploy',
+    'performance': 'btn-performance',
   };
   const btnId = btnMap[action];
   if (btnId) {

--- a/agent-core/web/js/performance.js
+++ b/agent-core/web/js/performance.js
@@ -1,0 +1,202 @@
+/**
+ * performance.js — 性能分析 Dashboard
+ *
+ * 展示每次 turn 各阶段耗时的瀑布图、趋势和聚合统计。
+ */
+
+const STAGE_COLORS = {
+  vad:       { color: '#6366f1', label: 'VAD' },
+  asr:       { color: '#8b5cf6', label: 'ASR' },
+  collector: { color: '#94a3b8', label: '调度' },
+  llm:       { color: '#f59e0b', label: 'LLM' },
+  tool:      { color: '#10b981', label: '工具' },
+  tts:       { color: '#06b6d4', label: 'TTS' },
+};
+
+let _refreshTimer = null;
+let _currentRange = '24h';
+
+export function initPerformance() {
+  const overlay = document.getElementById('performance-overlay');
+  if (!overlay) return;
+
+  // Close button
+  document.getElementById('performance-close')?.addEventListener('click', _close);
+  overlay.addEventListener('click', (e) => {
+    if (e.target === overlay) _close();
+  });
+
+  // Range selector
+  document.getElementById('perf-range')?.addEventListener('change', (e) => {
+    _currentRange = e.target.value;
+    _load();
+  });
+
+  // Refresh button
+  document.getElementById('perf-refresh')?.addEventListener('click', _load);
+
+  // Settings dropdown trigger
+  document.getElementById('btn-performance')?.addEventListener('click', _open);
+}
+
+function _open() {
+  document.getElementById('performance-overlay')?.classList.remove('hidden');
+  _load();
+  _refreshTimer = setInterval(_load, 10000);
+}
+
+function _close() {
+  document.getElementById('performance-overlay')?.classList.add('hidden');
+  if (_refreshTimer) {
+    clearInterval(_refreshTimer);
+    _refreshTimer = null;
+  }
+}
+
+function _rangeToTs() {
+  const now = Date.now() / 1000;
+  const map = { '1h': 3600, '6h': 21600, '24h': 86400, '7d': 604800 };
+  const offset = map[_currentRange] || 86400;
+  return { start: now - offset, end: 0 };
+}
+
+async function _load() {
+  const { start, end } = _rangeToTs();
+  try {
+    const [turnsRes, aggRes] = await Promise.all([
+      fetch(`/api/performance/latest?n=50`),
+      fetch(`/api/performance/aggregate?start=${start}&end=${end}`),
+    ]);
+    const turns = await turnsRes.json();
+    const agg = await aggRes.json();
+    _renderSummary(agg);
+    _renderWaterfall(Array.isArray(turns) ? turns : (turns.turns || []));
+  } catch (e) {
+    console.error('[performance] load error:', e);
+  }
+}
+
+function _renderSummary(agg) {
+  const el = document.getElementById('perf-summary-cards');
+  if (!el) return;
+
+  if (!agg || agg.count === 0) {
+    el.innerHTML = '<div class="perf-empty">暂无数据</div>';
+    return;
+  }
+
+  const avg = agg.avg || {};
+  const p95 = agg.p95 || {};
+
+  el.innerHTML = `
+    <div class="perf-cards">
+      <div class="perf-card">
+        <div class="perf-card-value">${agg.count}</div>
+        <div class="perf-card-label">总轮次</div>
+      </div>
+      <div class="perf-card">
+        <div class="perf-card-value">${_fmtMs(avg.total_duration_ms)}</div>
+        <div class="perf-card-label">平均总耗时</div>
+      </div>
+      <div class="perf-card">
+        <div class="perf-card-value">${_fmtMs(p95.total_duration_ms)}</div>
+        <div class="perf-card-label">P95 总耗时</div>
+      </div>
+      <div class="perf-card">
+        <div class="perf-card-value">${_fmtMs(avg.llm_duration_ms)}</div>
+        <div class="perf-card-label">平均 LLM</div>
+      </div>
+    </div>
+    <div class="perf-legend">
+      ${Object.values(STAGE_COLORS).map(s =>
+        `<span class="perf-legend-item"><span class="perf-legend-dot" style="background:${s.color}"></span>${s.label}</span>`
+      ).join('')}
+    </div>
+    <div class="perf-avg-breakdown">
+      ${_renderBreakdownBar(avg)}
+    </div>
+  `;
+}
+
+function _renderBreakdownBar(avg) {
+  const stages = [
+    { key: 'vad_duration_ms', ...STAGE_COLORS.vad },
+    { key: 'asr_duration_ms', ...STAGE_COLORS.asr },
+    { key: 'collector_delay_ms', ...STAGE_COLORS.collector },
+    { key: 'llm_duration_ms', ...STAGE_COLORS.llm },
+    { key: 'tool_duration_ms', ...STAGE_COLORS.tool },
+    { key: 'tts_duration_ms', ...STAGE_COLORS.tts },
+  ];
+  const total = stages.reduce((s, st) => s + (avg[st.key] || 0), 0);
+  if (total === 0) return '';
+
+  const segments = stages
+    .filter(st => avg[st.key] > 0)
+    .map(st => {
+      const pct = ((avg[st.key] / total) * 100).toFixed(1);
+      return `<div class="perf-bar-segment" style="width:${pct}%;background:${st.color}" title="${st.label}: ${avg[st.key]}ms (${pct}%)"></div>`;
+    }).join('');
+
+  return `<div class="perf-bar">${segments}</div>`;
+}
+
+function _renderWaterfall(turns) {
+  const el = document.getElementById('perf-waterfall');
+  if (!el) return;
+
+  if (!turns.length) {
+    el.innerHTML = '<div class="perf-empty">暂无记录</div>';
+    return;
+  }
+
+  // 找出最大 total 用于归一化
+  const maxTotal = Math.max(...turns.map(t => t.total_duration_ms || 1));
+
+  const rows = turns.map(t => {
+    const stages = [
+      { key: 'vad_duration_ms', ...STAGE_COLORS.vad },
+      { key: 'asr_duration_ms', ...STAGE_COLORS.asr },
+      { key: 'collector_delay_ms', ...STAGE_COLORS.collector },
+      { key: 'llm_duration_ms', ...STAGE_COLORS.llm },
+      { key: 'tool_duration_ms', ...STAGE_COLORS.tool },
+      { key: 'tts_duration_ms', ...STAGE_COLORS.tts },
+    ];
+    const rowTotal = stages.reduce((s, st) => s + (t[st.key] || 0), 0);
+    const barWidth = rowTotal > 0 ? ((rowTotal / maxTotal) * 100).toFixed(1) : 0;
+
+    const segments = stages
+      .filter(st => t[st.key] > 0)
+      .map(st => {
+        const pct = ((t[st.key] / rowTotal) * 100).toFixed(1);
+        return `<div class="perf-bar-segment" style="width:${pct}%;background:${st.color}" title="${st.label}: ${t[st.key]}ms"></div>`;
+      }).join('');
+
+    const timeStr = new Date(t.created_at * 1000).toLocaleTimeString('zh-CN', { hour: '2-digit', minute: '2-digit', second: '2-digit' });
+    const text = (t.trigger_text || '').slice(0, 30);
+    const totalStr = _fmtMs(t.total_duration_ms);
+
+    return `
+      <div class="perf-row">
+        <div class="perf-row-meta">
+          <span class="perf-row-time">${timeStr}</span>
+          <span class="perf-row-text" title="${t.trigger_text || ''}">${text}</span>
+        </div>
+        <div class="perf-row-bar" style="width:${barWidth}%">
+          ${segments}
+        </div>
+        <span class="perf-row-total">${totalStr}</span>
+      </div>
+    `;
+  }).join('');
+
+  el.innerHTML = `
+    <h3 class="perf-section-title">最近请求 (${turns.length})</h3>
+    <div class="perf-waterfall-list">${rows}</div>
+  `;
+}
+
+function _fmtMs(ms) {
+  if (ms == null) return '-';
+  if (ms < 1000) return `${ms}ms`;
+  return `${(ms / 1000).toFixed(1)}s`;
+}

--- a/agent-core/web/js/performance.js
+++ b/agent-core/web/js/performance.js
@@ -197,6 +197,8 @@ function _renderWaterfall(turns) {
         <div class="perf-row-detail">
           <table class="perf-detail-table">
             <tbody>${detailRows}</tbody>
+            <tr><td>语音时长</td><td class="perf-detail-val">${_fmtMs(t.audio_duration_ms)}</td></tr>
+            <tr><td>文字长度</td><td class="perf-detail-val">${t.text_length != null ? t.text_length + '字' : '-'}</td></tr>
             <tr><td>轮次</td><td class="perf-detail-val">${t.round_count || '-'}</td></tr>
             <tr><td>工具</td><td class="perf-detail-val perf-detail-tools">${toolNames}</td></tr>
           </table>

--- a/agent-core/web/js/performance.js
+++ b/agent-core/web/js/performance.js
@@ -2,18 +2,32 @@
  * performance.js — 性能分析 Dashboard（开放 Span 式）
  */
 
-const COMPONENT_COLORS = {
-  perception: { base: '#8b5cf6', shades: ['#6366f1', '#8b5cf6', '#a78bfa'] },
-  core:       { base: '#f59e0b', shades: ['#f59e0b', '#d97706', '#b45309'] },
-  driver:     { base: '#10b981', shades: ['#10b981', '#059669', '#047857'] },
+// 按 component 定义色系，同 component 内自动分配
+const PALETTE = {
+  perception: ['#6366f1', '#8b5cf6', '#a78bfa', '#c4b5fd', '#06b6d4', '#0891b2', '#67e8f9', '#22d3ee'],
+  core:       ['#f59e0b', '#d97706', '#b45309', '#92400e', '#64748b', '#475569', '#334155', '#94a3b8'],
+  driver:     ['#10b981', '#059669', '#047857', '#065f46', '#34d399', '#6ee7b7', '#a7f3d0', '#d1fae5'],
 };
+const FALLBACK_PALETTE = ['#ec4899', '#f97316', '#84cc16', '#14b8a6', '#e879f9', '#fb7185', '#4ade80', '#facc15'];
+
+// 运行时缓存：span name → color
+const _colorCache = {};
+const _componentCounters = {};
 
 function _spanColor(span, component) {
-  const colors = COMPONENT_COLORS[component] || COMPONENT_COLORS.core;
-  // Vary shade by span name hash
-  let h = 0;
-  for (let i = 0; i < span.length; i++) h = ((h << 5) - h + span.charCodeAt(i)) | 0;
-  return colors.shades[Math.abs(h) % colors.shades.length];
+  if (_colorCache[span]) return _colorCache[span];
+  const comp = component || _guessComponent(span);
+  const palette = PALETTE[comp] || FALLBACK_PALETTE;
+  if (!_componentCounters[comp]) _componentCounters[comp] = 0;
+  const idx = _componentCounters[comp]++ % palette.length;
+  _colorCache[span] = palette[idx];
+  return _colorCache[span];
+}
+
+function _guessComponent(span) {
+  if (/^(vad|asr|kws|tts)/.test(span)) return 'perception';
+  if (/^(llm|event_queue|tool:|finish|turn)/.test(span)) return 'core';
+  return 'driver';
 }
 
 let _refreshTimer = null;
@@ -36,7 +50,6 @@ export function initPerformance() {
 function _open() {
   document.getElementById('performance-overlay')?.classList.remove('hidden');
   _load();
-  _refreshTimer = setInterval(_load, 10000);
 }
 
 function _close() {
@@ -52,6 +65,11 @@ function _rangeToTs() {
 
 async function _load() {
   const { start, end } = _rangeToTs();
+  // 保存展开状态
+  const expandedSet = new Set();
+  document.querySelectorAll('.perf-row-group.expanded').forEach(el => {
+    expandedSet.add(el.dataset.idx);
+  });
   try {
     const [latestRes, aggRes] = await Promise.all([
       fetch('/api/performance/latest?n=50'),
@@ -61,6 +79,10 @@ async function _load() {
     const agg = await aggRes.json();
     _renderSummary(agg);
     _renderWaterfall(Array.isArray(latest) ? latest : []);
+    // 恢复展开状态
+    expandedSet.forEach(idx => {
+      document.querySelector(`.perf-row-group[data-idx="${idx}"]`)?.classList.add('expanded');
+    });
   } catch (e) {
     console.error('[performance] load error:', e);
   }
@@ -78,6 +100,27 @@ function _renderSummary(agg) {
   const bySpan = agg.by_span || {};
   const spanNames = Object.keys(bySpan);
 
+  // 计算总体甘特图的时间范围（取所有 span 的 max(offset + duration)）
+  const totalRange = Math.max(...spanNames.filter(n => n !== 'turn_total').map(n => (bySpan[n].avg_offset_ms || 0) + bySpan[n].avg_ms), 1);
+
+  // 按 avg_offset_ms 排序（排除 turn_total）
+  const sortedSpans = spanNames.filter(n => n !== 'turn_total')
+    .sort((a, b) => (bySpan[a].avg_offset_ms || 0) - (bySpan[b].avg_offset_ms || 0));
+
+  const summaryGantt = sortedSpans.map(name => {
+    const s = bySpan[name];
+    const color = _spanColor(name);
+    const left = ((s.avg_offset_ms || 0) / totalRange * 100).toFixed(1);
+    const width = Math.max(0.5, (s.avg_ms / totalRange * 100)).toFixed(1);
+    return `<div class="perf-gantt-row">
+      <span class="perf-gantt-label">${name}</span>
+      <div class="perf-gantt-track">
+        <div class="perf-gantt-bar" style="left:${left}%;width:${width}%;background:${color}" title="${name}: avg ${_fmtMs(s.avg_ms)} @ offset ${_fmtMs(s.avg_offset_ms)}"></div>
+      </div>
+      <span class="perf-gantt-dur">${_fmtMs(s.avg_ms)}</span>
+    </div>`;
+  }).join('');
+
   el.innerHTML = `
     <div class="perf-cards">
       <div class="perf-card">
@@ -93,13 +136,14 @@ function _renderSummary(agg) {
         <div class="perf-card-label">P95 总耗时</div>
       </div>` : ''}
     </div>
+    <div class="perf-gantt">${summaryGantt}</div>
     <div class="perf-avg-detail">
       <table class="perf-detail-table">
         <thead><tr><th>阶段</th><th>平均</th><th>P95</th><th>次数</th></tr></thead>
         <tbody>
-          ${spanNames.filter(n => n !== 'turn_total').map(name => {
+          ${sortedSpans.map(name => {
             const s = bySpan[name];
-            const color = _spanColor(name, name.startsWith('vad') || name.startsWith('asr') || name.startsWith('kws') || name.startsWith('tts') ? 'perception' : 'core');
+            const color = _spanColor(name);
             return `<tr>
               <td><span class="perf-legend-dot" style="background:${color}"></span> ${name}</td>
               <td class="perf-detail-val">${_fmtMs(s.avg_ms)}</td>
@@ -123,54 +167,53 @@ function _renderWaterfall(turns) {
   }
 
   const rows = turns.map((t, idx) => {
-    const spans = t.spans || [];
-    const totalMs = t.total_duration_ms || 0;
+    const spans = (t.spans || []).filter(s => s.span !== 'turn_total');
     const timeStr = new Date(t.created_at * 1000).toLocaleTimeString('zh-CN', { hour: '2-digit', minute: '2-digit', second: '2-digit' });
-    const text = (t.trigger_text || '').replace(/<[^>]*>/g, '').slice(0, 30);
+    const text = (t.trigger_text || '').replace(/<[^>]*>/g, '').replace(/\{[^}]*\}/g, '').trim().slice(0, 25);
+    const totalMs = t.total_duration_ms || 0;
 
-    // Build waterfall bar from spans (use relative positions)
-    let barHtml = '';
-    if (spans.length && totalMs > 0) {
-      const minStart = Math.min(...spans.map(s => s.start_ts).filter(Boolean));
-      const totalSec = totalMs / 1000;
-      barHtml = spans.map(s => {
-        if (!s.duration_ms || !s.start_ts) return '';
-        const left = ((s.start_ts - minStart) / totalSec * 100).toFixed(1);
-        const width = (s.duration_ms / totalMs * 100).toFixed(1);
-        const color = _spanColor(s.span, s.component);
-        return `<div class="perf-span-seg" style="left:${left}%;width:${width}%;background:${color}" title="${s.span}: ${s.duration_ms}ms"></div>`;
-      }).join('');
-    }
-
-    // Detail rows
-    const detailRows = spans.map(s => {
+    // 紧凑摘要：取 top 3 耗时 span
+    const topSpans = [...spans].sort((a, b) => (b.duration_ms || 0) - (a.duration_ms || 0)).slice(0, 3);
+    const summaryChips = topSpans.filter(s => s.duration_ms > 0).map(s => {
       const color = _spanColor(s.span, s.component);
-      const meta = s.meta && Object.keys(s.meta).length ? JSON.stringify(s.meta) : '';
-      return `<tr>
-        <td><span class="perf-legend-dot" style="background:${color}"></span> ${s.span}</td>
-        <td class="perf-detail-val">${_fmtMs(s.duration_ms)}</td>
-        <td class="perf-detail-val perf-detail-meta">${meta}</td>
-      </tr>`;
+      return `<span class="perf-chip" style="background:${color}">${s.span.replace(/^tool:/, '')} ${_fmtMs(s.duration_ms)}</span>`;
     }).join('');
+
+    // Gantt chart — each span gets its own row (展开时显示)
+    let ganttHtml = '';
+    const validSpans = spans.filter(s => s.start_ts && s.start_ts > 1e9 && s.duration_ms > 0);
+    if (validSpans.length) {
+      const minStart = Math.min(...validSpans.map(s => s.start_ts));
+      // 用所有 span 结束时间的最大值作为时间轴范围
+      const maxEnd = Math.max(...validSpans.map(s => s.end_ts || (s.start_ts + s.duration_ms / 1000)));
+      const rangeSec = maxEnd - minStart;
+      if (rangeSec > 0) {
+        ganttHtml = validSpans.map(s => {
+          const left = Math.min(99, ((s.start_ts - minStart) / rangeSec * 100)).toFixed(1);
+          const width = Math.min(100 - parseFloat(left), Math.max(0.5, (s.duration_ms / 1000) / rangeSec * 100)).toFixed(1);
+          const color = _spanColor(s.span, s.component);
+          return `<div class="perf-gantt-row">
+            <span class="perf-gantt-label">${s.span}</span>
+            <div class="perf-gantt-track">
+              <div class="perf-gantt-bar" style="left:${left}%;width:${width}%;background:${color}" title="${s.span}: ${_fmtMs(s.duration_ms)}"></div>
+            </div>
+            <span class="perf-gantt-dur">${_fmtMs(s.duration_ms)}</span>
+          </div>`;
+        }).join('');
+      }
+    }
 
     return `
       <div class="perf-row-group" data-idx="${idx}">
-        <div class="perf-row" onclick="this.parentElement.classList.toggle('expanded')">
-          <div class="perf-row-meta">
-            <span class="perf-row-time">${timeStr}</span>
-            <span class="perf-row-text" title="${t.trigger_text || ''}">${text}</span>
-          </div>
-          <div class="perf-row-bar">
-            ${barHtml}
-          </div>
+        <div class="perf-row-header" onclick="this.parentElement.classList.toggle('expanded')">
+          <span class="perf-row-time">${timeStr}</span>
+          <span class="perf-row-text" title="${t.trigger_text || ''}">${text}</span>
+          <span class="perf-row-chips">${summaryChips}</span>
           <span class="perf-row-total">${_fmtMs(totalMs)}</span>
           <span class="perf-row-expand">▸</span>
         </div>
         <div class="perf-row-detail">
-          <table class="perf-detail-table">
-            <thead><tr><th>Span</th><th>耗时</th><th>元数据</th></tr></thead>
-            <tbody>${detailRows}</tbody>
-          </table>
+          <div class="perf-gantt">${ganttHtml}</div>
         </div>
       </div>
     `;

--- a/agent-core/web/js/performance.js
+++ b/agent-core/web/js/performance.js
@@ -152,7 +152,7 @@ function _renderWaterfall(turns) {
   // 找出最大 total 用于归一化
   const maxTotal = Math.max(...turns.map(t => t.total_duration_ms || 1));
 
-  const rows = turns.map(t => {
+  const rows = turns.map((t, idx) => {
     const stages = [
       { key: 'vad_duration_ms', ...STAGE_COLORS.vad },
       { key: 'asr_duration_ms', ...STAGE_COLORS.asr },
@@ -175,16 +175,32 @@ function _renderWaterfall(turns) {
     const text = (t.trigger_text || '').slice(0, 30);
     const totalStr = _fmtMs(t.total_duration_ms);
 
+    // 详情展开区域
+    const detailRows = stages
+      .map(st => `<tr><td><span class="perf-legend-dot" style="background:${st.color}"></span> ${st.label}</td><td class="perf-detail-val">${_fmtMs(t[st.key])}</td></tr>`)
+      .join('');
+    const toolNames = (t.tool_names || []).join(', ') || '-';
+
     return `
-      <div class="perf-row">
-        <div class="perf-row-meta">
-          <span class="perf-row-time">${timeStr}</span>
-          <span class="perf-row-text" title="${t.trigger_text || ''}">${text}</span>
+      <div class="perf-row-group" data-idx="${idx}">
+        <div class="perf-row" onclick="this.parentElement.classList.toggle('expanded')">
+          <div class="perf-row-meta">
+            <span class="perf-row-time">${timeStr}</span>
+            <span class="perf-row-text" title="${t.trigger_text || ''}">${text}</span>
+          </div>
+          <div class="perf-row-bar" style="width:${barWidth}%">
+            ${segments}
+          </div>
+          <span class="perf-row-total">${totalStr}</span>
+          <span class="perf-row-expand">▸</span>
         </div>
-        <div class="perf-row-bar" style="width:${barWidth}%">
-          ${segments}
+        <div class="perf-row-detail">
+          <table class="perf-detail-table">
+            <tbody>${detailRows}</tbody>
+            <tr><td>轮次</td><td class="perf-detail-val">${t.round_count || '-'}</td></tr>
+            <tr><td>工具</td><td class="perf-detail-val perf-detail-tools">${toolNames}</td></tr>
+          </table>
         </div>
-        <span class="perf-row-total">${totalStr}</span>
       </div>
     `;
   }).join('');

--- a/agent-core/web/js/performance.js
+++ b/agent-core/web/js/performance.js
@@ -1,17 +1,20 @@
 /**
- * performance.js — 性能分析 Dashboard
- *
- * 展示每次 turn 各阶段耗时的瀑布图、趋势和聚合统计。
+ * performance.js — 性能分析 Dashboard（开放 Span 式）
  */
 
-const STAGE_COLORS = {
-  vad:       { color: '#6366f1', label: 'VAD' },
-  asr:       { color: '#8b5cf6', label: 'ASR' },
-  collector: { color: '#94a3b8', label: '调度' },
-  llm:       { color: '#f59e0b', label: 'LLM' },
-  tool:      { color: '#10b981', label: '工具' },
-  tts:       { color: '#06b6d4', label: 'TTS' },
+const COMPONENT_COLORS = {
+  perception: { base: '#8b5cf6', shades: ['#6366f1', '#8b5cf6', '#a78bfa'] },
+  core:       { base: '#f59e0b', shades: ['#f59e0b', '#d97706', '#b45309'] },
+  driver:     { base: '#10b981', shades: ['#10b981', '#059669', '#047857'] },
 };
+
+function _spanColor(span, component) {
+  const colors = COMPONENT_COLORS[component] || COMPONENT_COLORS.core;
+  // Vary shade by span name hash
+  let h = 0;
+  for (let i = 0; i < span.length; i++) h = ((h << 5) - h + span.charCodeAt(i)) | 0;
+  return colors.shades[Math.abs(h) % colors.shades.length];
+}
 
 let _refreshTimer = null;
 let _currentRange = '24h';
@@ -20,22 +23,13 @@ export function initPerformance() {
   const overlay = document.getElementById('performance-overlay');
   if (!overlay) return;
 
-  // Close button
   document.getElementById('performance-close')?.addEventListener('click', _close);
-  overlay.addEventListener('click', (e) => {
-    if (e.target === overlay) _close();
-  });
-
-  // Range selector
+  overlay.addEventListener('click', (e) => { if (e.target === overlay) _close(); });
   document.getElementById('perf-range')?.addEventListener('change', (e) => {
     _currentRange = e.target.value;
     _load();
   });
-
-  // Refresh button
   document.getElementById('perf-refresh')?.addEventListener('click', _load);
-
-  // Settings dropdown trigger
   document.getElementById('btn-performance')?.addEventListener('click', _open);
 }
 
@@ -47,30 +41,26 @@ function _open() {
 
 function _close() {
   document.getElementById('performance-overlay')?.classList.add('hidden');
-  if (_refreshTimer) {
-    clearInterval(_refreshTimer);
-    _refreshTimer = null;
-  }
+  if (_refreshTimer) { clearInterval(_refreshTimer); _refreshTimer = null; }
 }
 
 function _rangeToTs() {
   const now = Date.now() / 1000;
   const map = { '1h': 3600, '6h': 21600, '24h': 86400, '7d': 604800 };
-  const offset = map[_currentRange] || 86400;
-  return { start: now - offset, end: 0 };
+  return { start: now - (map[_currentRange] || 86400), end: 0 };
 }
 
 async function _load() {
   const { start, end } = _rangeToTs();
   try {
-    const [turnsRes, aggRes] = await Promise.all([
-      fetch(`/api/performance/latest?n=50`),
+    const [latestRes, aggRes] = await Promise.all([
+      fetch('/api/performance/latest?n=50'),
       fetch(`/api/performance/aggregate?start=${start}&end=${end}`),
     ]);
-    const turns = await turnsRes.json();
+    const latest = await latestRes.json();
     const agg = await aggRes.json();
     _renderSummary(agg);
-    _renderWaterfall(Array.isArray(turns) ? turns : (turns.turns || []));
+    _renderWaterfall(Array.isArray(latest) ? latest : []);
   } catch (e) {
     console.error('[performance] load error:', e);
   }
@@ -85,8 +75,8 @@ function _renderSummary(agg) {
     return;
   }
 
-  const avg = agg.avg || {};
-  const p95 = agg.p95 || {};
+  const bySpan = agg.by_span || {};
+  const spanNames = Object.keys(bySpan);
 
   el.innerHTML = `
     <div class="perf-cards">
@@ -94,50 +84,33 @@ function _renderSummary(agg) {
         <div class="perf-card-value">${agg.count}</div>
         <div class="perf-card-label">总轮次</div>
       </div>
-      <div class="perf-card">
-        <div class="perf-card-value">${_fmtMs(avg.total_duration_ms)}</div>
+      ${bySpan['turn_total'] ? `<div class="perf-card">
+        <div class="perf-card-value">${_fmtMs(bySpan['turn_total'].avg_ms)}</div>
         <div class="perf-card-label">平均总耗时</div>
       </div>
       <div class="perf-card">
-        <div class="perf-card-value">${_fmtMs(p95.total_duration_ms)}</div>
+        <div class="perf-card-value">${_fmtMs(bySpan['turn_total'].p95_ms)}</div>
         <div class="perf-card-label">P95 总耗时</div>
-      </div>
-      <div class="perf-card">
-        <div class="perf-card-value">${_fmtMs(avg.llm_duration_ms)}</div>
-        <div class="perf-card-label">平均 LLM</div>
-      </div>
+      </div>` : ''}
     </div>
-    <div class="perf-legend">
-      ${Object.values(STAGE_COLORS).map(s =>
-        `<span class="perf-legend-item"><span class="perf-legend-dot" style="background:${s.color}"></span>${s.label}</span>`
-      ).join('')}
-    </div>
-    <div class="perf-avg-breakdown">
-      ${_renderBreakdownBar(avg)}
+    <div class="perf-avg-detail">
+      <table class="perf-detail-table">
+        <thead><tr><th>阶段</th><th>平均</th><th>P95</th><th>次数</th></tr></thead>
+        <tbody>
+          ${spanNames.filter(n => n !== 'turn_total').map(name => {
+            const s = bySpan[name];
+            const color = _spanColor(name, name.startsWith('vad') || name.startsWith('asr') || name.startsWith('kws') || name.startsWith('tts') ? 'perception' : 'core');
+            return `<tr>
+              <td><span class="perf-legend-dot" style="background:${color}"></span> ${name}</td>
+              <td class="perf-detail-val">${_fmtMs(s.avg_ms)}</td>
+              <td class="perf-detail-val">${_fmtMs(s.p95_ms)}</td>
+              <td class="perf-detail-val">${s.count}</td>
+            </tr>`;
+          }).join('')}
+        </tbody>
+      </table>
     </div>
   `;
-}
-
-function _renderBreakdownBar(avg) {
-  const stages = [
-    { key: 'vad_duration_ms', ...STAGE_COLORS.vad },
-    { key: 'asr_duration_ms', ...STAGE_COLORS.asr },
-    { key: 'collector_delay_ms', ...STAGE_COLORS.collector },
-    { key: 'llm_duration_ms', ...STAGE_COLORS.llm },
-    { key: 'tool_duration_ms', ...STAGE_COLORS.tool },
-    { key: 'tts_duration_ms', ...STAGE_COLORS.tts },
-  ];
-  const total = stages.reduce((s, st) => s + (avg[st.key] || 0), 0);
-  if (total === 0) return '';
-
-  const segments = stages
-    .filter(st => avg[st.key] > 0)
-    .map(st => {
-      const pct = ((avg[st.key] / total) * 100).toFixed(1);
-      return `<div class="perf-bar-segment" style="width:${pct}%;background:${st.color}" title="${st.label}: ${avg[st.key]}ms (${pct}%)"></div>`;
-    }).join('');
-
-  return `<div class="perf-bar">${segments}</div>`;
 }
 
 function _renderWaterfall(turns) {
@@ -149,37 +122,36 @@ function _renderWaterfall(turns) {
     return;
   }
 
-  // 找出最大 total 用于归一化
-  const maxTotal = Math.max(...turns.map(t => t.total_duration_ms || 1));
-
   const rows = turns.map((t, idx) => {
-    const stages = [
-      { key: 'vad_duration_ms', ...STAGE_COLORS.vad },
-      { key: 'asr_duration_ms', ...STAGE_COLORS.asr },
-      { key: 'collector_delay_ms', ...STAGE_COLORS.collector },
-      { key: 'llm_duration_ms', ...STAGE_COLORS.llm },
-      { key: 'tool_duration_ms', ...STAGE_COLORS.tool },
-      { key: 'tts_duration_ms', ...STAGE_COLORS.tts },
-    ];
-    const rowTotal = stages.reduce((s, st) => s + (t[st.key] || 0), 0);
-    const barWidth = rowTotal > 0 ? ((rowTotal / maxTotal) * 100).toFixed(1) : 0;
-
-    const segments = stages
-      .filter(st => t[st.key] > 0)
-      .map(st => {
-        const pct = ((t[st.key] / rowTotal) * 100).toFixed(1);
-        return `<div class="perf-bar-segment" style="width:${pct}%;background:${st.color}" title="${st.label}: ${t[st.key]}ms"></div>`;
-      }).join('');
-
+    const spans = t.spans || [];
+    const totalMs = t.total_duration_ms || 0;
     const timeStr = new Date(t.created_at * 1000).toLocaleTimeString('zh-CN', { hour: '2-digit', minute: '2-digit', second: '2-digit' });
-    const text = (t.trigger_text || '').slice(0, 30);
-    const totalStr = _fmtMs(t.total_duration_ms);
+    const text = (t.trigger_text || '').replace(/<[^>]*>/g, '').slice(0, 30);
 
-    // 详情展开区域
-    const detailRows = stages
-      .map(st => `<tr><td><span class="perf-legend-dot" style="background:${st.color}"></span> ${st.label}</td><td class="perf-detail-val">${_fmtMs(t[st.key])}</td></tr>`)
-      .join('');
-    const toolNames = (t.tool_names || []).join(', ') || '-';
+    // Build waterfall bar from spans (use relative positions)
+    let barHtml = '';
+    if (spans.length && totalMs > 0) {
+      const minStart = Math.min(...spans.map(s => s.start_ts).filter(Boolean));
+      const totalSec = totalMs / 1000;
+      barHtml = spans.map(s => {
+        if (!s.duration_ms || !s.start_ts) return '';
+        const left = ((s.start_ts - minStart) / totalSec * 100).toFixed(1);
+        const width = (s.duration_ms / totalMs * 100).toFixed(1);
+        const color = _spanColor(s.span, s.component);
+        return `<div class="perf-span-seg" style="left:${left}%;width:${width}%;background:${color}" title="${s.span}: ${s.duration_ms}ms"></div>`;
+      }).join('');
+    }
+
+    // Detail rows
+    const detailRows = spans.map(s => {
+      const color = _spanColor(s.span, s.component);
+      const meta = s.meta && Object.keys(s.meta).length ? JSON.stringify(s.meta) : '';
+      return `<tr>
+        <td><span class="perf-legend-dot" style="background:${color}"></span> ${s.span}</td>
+        <td class="perf-detail-val">${_fmtMs(s.duration_ms)}</td>
+        <td class="perf-detail-val perf-detail-meta">${meta}</td>
+      </tr>`;
+    }).join('');
 
     return `
       <div class="perf-row-group" data-idx="${idx}">
@@ -188,19 +160,16 @@ function _renderWaterfall(turns) {
             <span class="perf-row-time">${timeStr}</span>
             <span class="perf-row-text" title="${t.trigger_text || ''}">${text}</span>
           </div>
-          <div class="perf-row-bar" style="width:${barWidth}%">
-            ${segments}
+          <div class="perf-row-bar">
+            ${barHtml}
           </div>
-          <span class="perf-row-total">${totalStr}</span>
+          <span class="perf-row-total">${_fmtMs(totalMs)}</span>
           <span class="perf-row-expand">▸</span>
         </div>
         <div class="perf-row-detail">
           <table class="perf-detail-table">
+            <thead><tr><th>Span</th><th>耗时</th><th>元数据</th></tr></thead>
             <tbody>${detailRows}</tbody>
-            <tr><td>语音时长</td><td class="perf-detail-val">${_fmtMs(t.audio_duration_ms)}</td></tr>
-            <tr><td>文字长度</td><td class="perf-detail-val">${t.text_length != null ? t.text_length + '字' : '-'}</td></tr>
-            <tr><td>轮次</td><td class="perf-detail-val">${t.round_count || '-'}</td></tr>
-            <tr><td>工具</td><td class="perf-detail-val perf-detail-tools">${toolNames}</td></tr>
           </table>
         </div>
       </div>

--- a/perception/plugins/asr.py
+++ b/perception/plugins/asr.py
@@ -877,6 +877,8 @@ class _ASRNode(Node):
             return
         pcm = bytes(msg.data)
         ts  = msg.header.stamp.sec + msg.header.stamp.nanosec * 1e-9
+        if ts < 1e9:  # header.stamp not set by publisher
+            ts = time.time()
         try:
             self._pcm_queue.put_nowait((pcm, ts))
         except Exception:
@@ -934,7 +936,9 @@ class _ASRNode(Node):
                     text = remaining
 
                 result = {"text": text, "audio_start_ts": start_ts,
-                          "audio_end_ts": end_ts, "asr_complete_ts": time.time()}
+                          "audio_end_ts": end_ts, "asr_complete_ts": time.time(),
+                          "audio_duration_ms": int(len(utterance) / 32),  # 16kHz 16bit = 32 bytes/ms
+                          "text_length": len(text)}
                 msg = String(); msg.data = json.dumps(result, ensure_ascii=False)
                 self._pub.publish(msg)
                 log.info(f"[asr] {text!r}")

--- a/perception/plugins/tts.py
+++ b/perception/plugins/tts.py
@@ -167,6 +167,7 @@ class _TTSNode(Node):
         self._stop_event   = threading.Event()
         from audio_msgs.msg import AudioChunk
         self._pub = self.create_publisher(AudioChunk, self._output_topic, _LOW_LAT_QOS)
+        self._perf_pub = self.create_publisher(String, '/perception/perf_spans', _LOW_LAT_QOS)
         if input_topic:
             self._sub = self.create_subscription(String, self._input_topic, self._text_cb, _LOW_LAT_QOS)
         else:
@@ -225,6 +226,7 @@ class _TTSNode(Node):
             try:
                 import time as _time
                 t_start = _time.monotonic()
+                t_start_wall = _time.time()  # wall-clock for perf span
                 total = 0
                 buf   = b''
                 t0    = None  # wall-clock start of playback
@@ -293,6 +295,21 @@ class _TTSNode(Node):
                     msg.data   = list(buf)
                     self._pub.publish(msg)
                 log.info(f"[tts] spoke {len(text)} chars → {total} bytes ({frames_sent} frames) in {_time.monotonic() - t_start:.2f}s")
+                # 上报 TTS perf span
+                try:
+                    import json as _json
+                    perf_msg = String()
+                    perf_msg.data = _json.dumps({
+                        "type": "perf_span",
+                        "span": "tts_synthesis",
+                        "component": "perception",
+                        "start_ts": t_start_wall,
+                        "end_ts": _time.time(),
+                        "meta": {"chars": len(text), "frames": frames_sent}
+                    })
+                    self._perf_pub.publish(perf_msg)
+                except Exception:
+                    pass
             except Exception as e:
                 log.error(f"[tts] synthesis error: {e}", exc_info=True)
 

--- a/perception/plugins/tts.py
+++ b/perception/plugins/tts.py
@@ -227,6 +227,7 @@ class _TTSNode(Node):
                 import time as _time
                 t_start = _time.monotonic()
                 t_start_wall = _time.time()  # wall-clock for perf span
+                t0_wall = None  # wall-clock when playback starts (prebuf complete)
                 total = 0
                 buf   = b''
                 t0    = None  # wall-clock start of playback
@@ -249,6 +250,7 @@ class _TTSNode(Node):
                             if len(prebuf) >= PREBUF_FRAMES:
                                 # Flush pre-buffer and start real-time clock
                                 t0 = _time.monotonic()
+                                t0_wall = _time.time()
                                 for pf in prebuf:
                                     msg = AudioChunk()
                                     msg.header.stamp = self.get_clock().now().to_msg()
@@ -295,19 +297,27 @@ class _TTSNode(Node):
                     msg.data   = list(buf)
                     self._pub.publish(msg)
                 log.info(f"[tts] spoke {len(text)} chars → {total} bytes ({frames_sent} frames) in {_time.monotonic() - t_start:.2f}s")
-                # 上报 TTS perf span
+                # 上报 TTS perf spans（生成 + 播放）
                 try:
                     import json as _json
-                    perf_msg = String()
-                    perf_msg.data = _json.dumps({
-                        "type": "perf_span",
-                        "span": "tts_synthesis",
-                        "component": "perception",
-                        "start_ts": t_start_wall,
-                        "end_ts": _time.time(),
-                        "meta": {"chars": len(text), "frames": frames_sent}
-                    })
-                    self._perf_pub.publish(perf_msg)
+                    t_end_wall = _time.time()
+                    spans = []
+                    if t0_wall:
+                        spans.append({"type": "perf_span", "span": "tts_generate", "component": "perception",
+                                      "start_ts": t_start_wall, "end_ts": t0_wall,
+                                      "meta": {"chars": len(text)}})
+                        spans.append({"type": "perf_span", "span": "tts_playback", "component": "perception",
+                                      "start_ts": t0_wall, "end_ts": t_end_wall,
+                                      "meta": {"frames": frames_sent}})
+                    else:
+                        # 没有 prebuf（极短文本），合并为一个 span
+                        spans.append({"type": "perf_span", "span": "tts_generate", "component": "perception",
+                                      "start_ts": t_start_wall, "end_ts": t_end_wall,
+                                      "meta": {"chars": len(text), "frames": frames_sent}})
+                    for sp in spans:
+                        perf_msg = String()
+                        perf_msg.data = _json.dumps(sp)
+                        self._perf_pub.publish(perf_msg)
                 except Exception:
                     pass
             except Exception as e:


### PR DESCRIPTION
## Summary
- 在 agent loop 全链路（VAD → ASR → Collector → LLM → Tool → TTS）埋入结构化计时
- 持久化到 SQLite `perf_turns` 表，自动清理 7 天前数据
- 新增 `/api/performance/turns`、`/aggregate`、`/latest` 查询接口
- 设置面板新增「性能」入口，展示摘要卡片 + 瀑布图，直观定位瓶颈

## Test plan
- [ ] 启动 Agent Core，通过语音或文字触发几次 turn
- [ ] 请求 `GET /api/performance/latest?n=5` 确认数据写入
- [ ] 打开 Dashboard → 设置 → 性能，检查瀑布图渲染正常
- [ ] 确认各阶段 ms 值合理（ASR 时间戳能正确传递）
- [ ] 移动端设置面板「性能」入口可正常打开

🤖 Generated with [Claude Code](https://claude.com/claude-code)