### PR TITLE
fix(channel): fix Feishu WS reception + persist reply context

### DIFF
--- a/agent-core/src/api/channel.py
+++ b/agent-core/src/api/channel.py
@@ -93,6 +93,19 @@ async def restart_channel(channel_id: str):
     return {'status': 'ok'}
 
 
+@router.post('/{channel_id}/stop')
+async def stop_channel(channel_id: str):
+    ch = get_channel_config(channel_id)
+    if ch is None:
+        raise fastapi.HTTPException(404, f'Channel not found: {channel_id}')
+    if channel_id in manager._adapters:
+        await manager._adapters[channel_id].stop()
+        del manager._adapters[channel_id]
+    from channel.manager import _update_status
+    _update_status(channel_id, 'stopped')
+    return {'status': 'stopped'}
+
+
 # ── User Management ──────────────────────────────────────────────────────────
 
 @router.get('/users')

--- a/agent-core/src/channel/adapters/feishu.py
+++ b/agent-core/src/channel/adapters/feishu.py
@@ -85,16 +85,27 @@ class FeishuAdapter(ChannelAdapter):
         print(f'[feishu] adapter started (WebSocket mode): {self.channel_id}')
 
     async def _run(self):
-        """Run the lark WebSocket client in a dedicated thread with its own event loop."""
+        """Run the lark WebSocket client in a dedicated thread.
+
+        The SDK's client.start() uses loop.run_until_complete() which has issues
+        in a sub-thread — tasks created during _connect() may not be properly
+        scheduled. Instead, we use asyncio.run() and manually call the internal
+        methods to ensure the event loop stays running continuously.
+        """
         import threading
+        import lark_oapi.ws.client as ws_mod
+
+        async def _run_ws():
+            ws_mod.loop = asyncio.get_event_loop()
+            await self._client._connect()
+            asyncio.create_task(self._client._ping_loop())
+            # Keep event loop alive (mirrors SDK's _select())
+            while self._running:
+                await asyncio.sleep(1)
 
         def _thread_target():
-            new_loop = asyncio.new_event_loop()
-            asyncio.set_event_loop(new_loop)
             try:
-                import lark_oapi.ws.client as ws_mod
-                ws_mod.loop = new_loop
-                self._client.start()
+                asyncio.run(_run_ws())
             except Exception as e:
                 err_msg = str(e)
                 if 'invalid' in err_msg.lower() and ('app_id' in err_msg.lower() or 'secret' in err_msg.lower()):
@@ -103,10 +114,8 @@ class FeishuAdapter(ChannelAdapter):
                 else:
                     print(f'[feishu] WebSocket connection error: {e}')
                 self._running = False
-            finally:
-                new_loop.close()
 
-        self._thread = threading.Thread(target=_thread_target, daemon=True)
+        self._thread = threading.Thread(target=_thread_target, daemon=True, name='feishu-ws')
         self._thread.start()
 
     async def stop(self) -> None:

--- a/agent-core/src/channel/manager.py
+++ b/agent-core/src/channel/manager.py
@@ -96,8 +96,18 @@ class ChannelManager:
         self._adapters: dict[str, ChannelAdapter] = {}  # channel_id → adapter
         self._active_input_channels: set[str] = set()
         self._active_output_channels: set[str] = set()
-        # Last conversation context per channel (auto-updated on inbound)
-        self._last_context: dict[str, dict] = {}  # channel_id → {chat_id, user_id}
+
+    # ── Persistent conversation context ──────────────────────────────────────
+
+    def _get_last_context(self) -> dict:
+        """Get all channel contexts from persistent storage."""
+        return config.main.get('channel_last_context', {})
+
+    def _set_last_context(self, channel_id: str, chat_id: str, user_id: str):
+        """Persist conversation context for a channel."""
+        ctx = config.main.get('channel_last_context', {})
+        ctx[channel_id] = {'chat_id': chat_id, 'user_id': user_id}
+        config.main['channel_last_context'] = ctx
 
     def sync_from_canvas(self):
         """从 canvas layout 读取 channel_msg_input/output 卡片的 instance config，
@@ -242,11 +252,8 @@ class ChannelManager:
         if user['role'] == 'blocked':
             return  # 静默丢弃
 
-        # 4. Store last conversation context for reply routing
-        self._last_context[msg.channel_id] = {
-            'chat_id': msg.chat_id,
-            'user_id': msg.user_id,
-        }
+        # 4. Store last conversation context for reply routing (persisted)
+        self._set_last_context(msg.channel_id, msg.chat_id, msg.user_id)
 
         # 5. Publish to topic for dashboard and canvas data flow
         from api.inspection import publish_to_topic
@@ -305,7 +312,7 @@ class ChannelManager:
     async def send_to_channel(self, channel_id: str, text: str) -> str:
         """Send a message to a channel using the last known chat context.
         Called by channel_reply tool dispatch."""
-        ctx = self._last_context.get(channel_id)
+        ctx = self._get_last_context().get(channel_id)
         if not ctx:
             return (
                 f'Error: No conversation context for channel "{channel_id}". '
@@ -340,10 +347,11 @@ class ChannelManager:
 
     async def send_to_channel_any(self, text: str) -> str:
         """Send to the most recent channel with conversation context."""
-        if not self._last_context:
+        all_ctx = self._get_last_context()
+        if not all_ctx:
             return 'No active conversation. A user must send a message first.'
         # Use the most recently updated channel
-        channel_id = list(self._last_context.keys())[-1]
+        channel_id = list(all_ctx.keys())[-1]
         return await self.send_to_channel(channel_id, text)
 
     # ── Status ───────────────────────────────────────────────────────────────

--- a/agent-core/src/mcp_client.py
+++ b/agent-core/src/mcp_client.py
@@ -434,7 +434,7 @@ async def _dispatch_internal(mcp_id: str, tool_name: str, args: dict) -> str:
             if not text:
                 return 'Error: "text" field is required.'
             from channel.manager import manager as channel_mgr
-            channels_with_context = list(channel_mgr._last_context.keys())
+            channels_with_context = list(channel_mgr._get_last_context().keys())
             if not channels_with_context:
                 return (
                     'Error: No active conversation context. '

--- a/agent-core/src/perf_log.py
+++ b/agent-core/src/perf_log.py
@@ -154,8 +154,9 @@ def aggregate(start: float = 0, end: float = 0) -> dict:
         cnt = row[1]
         avg_ms = int(row[2]) if row[2] else 0
 
-        # P95
-        p95_offset = max(0, int(cnt * 0.95) - 1)
+        # P95: index of the 95th percentile value in ascending order
+        import math
+        p95_offset = min(cnt - 1, math.ceil(cnt * 0.95) - 1)
         p95_row = conn.execute(
             f'SELECT duration_ms FROM perf_spans {where} AND span=? ORDER BY duration_ms ASC LIMIT 1 OFFSET ?',
             params + [span_name, p95_offset],

--- a/agent-core/web/js/channels.js
+++ b/agent-core/web/js/channels.js
@@ -58,6 +58,7 @@ function _renderChannels(channels) {
         <span class="channel-item-status ${ch.status === 'connected' ? 'online' : 'offline'}">${_esc(ch.status)}</span>
       </div>
       <div class="channel-item-actions">
+        <button class="btn-ghost btn-sm" onclick="window._channelStop('${_esc(ch.id)}')">Stop</button>
         <button class="btn-ghost btn-sm" onclick="window._channelRestart('${_esc(ch.id)}')">Restart</button>
         <button class="btn-ghost btn-sm btn-danger" onclick="window._channelDelete('${_esc(ch.id)}')">Delete</button>
       </div>
@@ -190,19 +191,48 @@ async function _submitAdd(formEl) {
 
 // ── Actions ───────────────────────────────────────────────────────────────────
 
-window._channelRestart = async function(id) {
+window._channelStop = async function(id) {
+  const btn = event.target;
+  btn.disabled = true;
+  btn.textContent = 'Stopping…';
   try {
-    await fetch(`/api/channel/${id}/restart`, { method: 'POST' });
-    setTimeout(_loadChannels, 500);
+    const res = await fetch(`/api/channel/${id}/stop`, { method: 'POST' });
+    if (!res.ok) {
+      const j = await res.json().catch(() => ({}));
+      alert(j.detail || `Stop failed (${res.status})`);
+    }
+  } catch (e) {
+    alert('Stop failed: ' + e.message);
+  } finally {
+    setTimeout(_loadChannels, 300);
+  }
+};
+
+window._channelRestart = async function(id) {
+  const btn = event.target;
+  btn.disabled = true;
+  btn.textContent = 'Restarting…';
+  try {
+    const res = await fetch(`/api/channel/${id}/restart`, { method: 'POST' });
+    if (!res.ok) {
+      const j = await res.json().catch(() => ({}));
+      alert(j.detail || `Restart failed (${res.status})`);
+    }
   } catch (e) {
     alert('Restart failed: ' + e.message);
+  } finally {
+    setTimeout(_loadChannels, 500);
   }
 };
 
 window._channelDelete = async function(id) {
   if (!confirm(`Delete channel "${id}"?`)) return;
   try {
-    await fetch(`/api/channel/${id}`, { method: 'DELETE' });
+    const res = await fetch(`/api/channel/${id}`, { method: 'DELETE' });
+    if (!res.ok) {
+      const j = await res.json().catch(() => ({}));
+      alert(j.detail || `Delete failed (${res.status})`);
+    }
     _loadChannels();
   } catch (e) {
     alert('Delete failed: ' + e.message);


### PR DESCRIPTION
## Summary
- Fix Feishu WebSocket adapter not receiving messages when running in a sub-thread (root cause: SDK's `client.start()` event loop scheduling issue)
- Persist `channel_last_context` to SQLite so `channel_reply` survives container restarts
- Add Stop button and loading feedback to channel management UI
- Fix P95 percentile calculation for small sample sizes

## Test plan
- [x] Feishu messages received in agent-core after container restart
- [x] `channel_reply` works after restart without needing a new inbound message
- [x] Stop/Restart buttons show loading state and error feedback
- [x] P95 values are >= average (no longer computing P75 by mistake)

🤖 Generated with [Claude Code](https://claude.com/claude-code)