### PR TITLE
feat(perf): propagate trace_id to perception spans

### DIFF
--- a/agent-core/src/api/inspection.py
+++ b/agent-core/src/api/inspection.py
@@ -77,16 +77,23 @@ def _push_factory(topic: str):
                 text = data.decode('utf-8') if isinstance(data, bytes) else data
                 span_data = json.loads(text)
                 if span_data.get('type') == 'perf_span':
-                    # 找到 tool:tts span start_ts 最接近此 span start_ts 的 turn
-                    span_start = span_data.get('start_ts', 0)
-                    conn = config._get_conn()
-                    row = conn.execute(
-                        '''SELECT trace_id FROM perf_spans
-                           WHERE span LIKE 'tool:tts%' AND start_ts <= ?
-                           ORDER BY start_ts DESC LIMIT 1''',
-                        (span_start,)
-                    ).fetchone()
-                    conn.close()
+                    trace_id = span_data.pop('trace_id', None)
+                    if trace_id:
+                        # 直接归属（trace_id 由 agent-core 透传）
+                        perf_log.commit_spans(trace_id, [span_data], source='perception')
+                    else:
+                        # 兼容旧版本 perception: fallback 到时间窗口匹配
+                        span_start = span_data.get('start_ts', 0)
+                        conn = config._get_conn()
+                        row = conn.execute(
+                            '''SELECT trace_id FROM perf_spans
+                               WHERE span LIKE 'tool:tts%' AND start_ts <= ? AND start_ts >= ? - 30
+                               ORDER BY start_ts DESC LIMIT 1''',
+                            (span_start, span_start)
+                        ).fetchone()
+                        conn.close()
+                        if row:
+                            perf_log.commit_spans(row[0], [span_data], source='perception')
                     if row:
                         perf_log.commit_spans(row[0], [span_data], source='perception')
             except Exception:

--- a/agent-core/src/event/llm.py
+++ b/agent-core/src/event/llm.py
@@ -521,6 +521,7 @@ class Event:
                 if name in self._sys_tools:
                     result = await self._sys_tools[name]['object'](**args)
                 elif name.startswith('mcp__'):
+                    args['_trace_id'] = _trace_id
                     result = await mcp_client.call_tool(name, args)
                 else:
                     result = f'未知工具: {name}'

--- a/perception/plugins/tts.py
+++ b/perception/plugins/tts.py
@@ -195,10 +195,10 @@ class _TTSNode(Node):
         self.state = "idle"
         return {"state": "idle"}
 
-    def enqueue(self, text: str):
+    def enqueue(self, text: str, trace_id: str = ''):
         if self.state != "running":
             raise RuntimeError("TTS not running; call start first")
-        self._text_queue.put(text)
+        self._text_queue.put((text, trace_id))
 
     def _text_cb(self, msg: String):
         if self.state != "running": return
@@ -208,7 +208,7 @@ class _TTSNode(Node):
             text = msg.data.strip()
         if text:
             log.info(f"[tts] received text from topic: {text[:50]}...")
-            self._text_queue.put(text)
+            self._text_queue.put((text, ''))
 
     def _worker(self):
         from audio_msgs.msg import AudioChunk
@@ -220,9 +220,14 @@ class _TTSNode(Node):
 
         while not self._stop_event.is_set():
             try:
-                text = self._text_queue.get(timeout=1)
+                item = self._text_queue.get(timeout=1)
             except queue.Empty:
                 continue
+            # Unpack queue item: (text, trace_id) or plain text for backward compat
+            if isinstance(item, tuple):
+                text, _trace_id = item
+            else:
+                text, _trace_id = item, ''
             try:
                 import time as _time
                 t_start = _time.monotonic()
@@ -302,16 +307,19 @@ class _TTSNode(Node):
                     import json as _json
                     t_end_wall = _time.time()
                     spans = []
+                    _span_base = {"type": "perf_span", "component": "perception"}
+                    if _trace_id:
+                        _span_base["trace_id"] = _trace_id
                     if t0_wall:
-                        spans.append({"type": "perf_span", "span": "tts_generate", "component": "perception",
+                        spans.append({**_span_base, "span": "tts_generate",
                                       "start_ts": t_start_wall, "end_ts": t0_wall,
                                       "meta": {"chars": len(text)}})
-                        spans.append({"type": "perf_span", "span": "tts_playback", "component": "perception",
+                        spans.append({**_span_base, "span": "tts_playback",
                                       "start_ts": t0_wall, "end_ts": t_end_wall,
                                       "meta": {"frames": frames_sent}})
                     else:
                         # 没有 prebuf（极短文本），合并为一个 span
-                        spans.append({"type": "perf_span", "span": "tts_generate", "component": "perception",
+                        spans.append({**_span_base, "span": "tts_generate",
                                       "start_ts": t_start_wall, "end_ts": t_end_wall,
                                       "meta": {"chars": len(text), "frames": frames_sent}})
                     for sp in spans:
@@ -489,7 +497,7 @@ class TTSPlugin:
                     node = self._nodes[node_key]
                 if node.state != "running":
                     node.start()
-            node.enqueue(text)
+            node.enqueue(text, trace_id=args.get('_trace_id', ''))
             return {"status": "queued", "text": text}
 
         elif action == "config":


### PR DESCRIPTION
## Summary
- Pass `_trace_id` through MCP tool call args to perception TTS
- Perception tags perf spans with trace_id before publishing to DDS
- Agent-core uses trace_id directly for span attribution (fallback to time-window for backward compat)
- Eliminates incorrect span attribution causing phantom 100s gaps in performance timeline

## Test plan
- [x] Deployed to container, Feishu messages received and processed
- [ ] Trigger TTS to verify trace_id appears in perception spans
- [x] P95 fix from previous PR also included in inspection.py

🤖 Generated with [Claude Code](https://claude.com/claude-code)