### PR TITLE
fix(ui): correct activity badge and ASR tag rendering

### DIFF
--- a/agent-core/web/css/style.css
+++ b/agent-core/web/css/style.css
@@ -2856,6 +2856,12 @@ html, body {
   background: var(--accent-dim);
   border-radius: 0 var(--radius-xs) var(--radius-xs) 0;
 }
+.asr-tag {
+  display: inline-block; font-size: 10px; font-weight: 600;
+  padding: 1px 5px; margin-right: 6px;
+  border-radius: 3px;
+  background: #D1FAF0; color: #0D6B55;
+}
 
 /* Live table (joints / array-of-objects state data) */
 .live-table-wrap {

--- a/agent-core/web/js/renderers/activity.js
+++ b/agent-core/web/js/renderers/activity.js
@@ -27,7 +27,10 @@ export const ActivityRenderer = {
       const msg = obj.text
         ? `<span style="color:var(--text-primary)">${obj.text}</span>`
         : `<span style="color:var(--text-muted)">${_truncate(text, 120)}</span>`;
-      row.innerHTML = `<span class="log-time">${t}</span><span class="log-type asr_result">asr</span><span class="log-msg">${msg}</span>`;
+      // Determine badge type from data content
+      const badgeType = obj.platform ? obj.platform : (obj.asr_complete_ts ? 'asr_result' : 'msg');
+      const badgeLabel = obj.platform || (obj.asr_complete_ts ? 'ASR' : 'msg');
+      row.innerHTML = `<span class="log-time">${t}</span><span class="log-type ${badgeType}">${badgeLabel}</span><span class="log-msg">${msg}</span>`;
       this._el.appendChild(row);
       this._el.scrollTop = this._el.scrollHeight;
     } catch {

--- a/agent-core/web/js/renderers/text.js
+++ b/agent-core/web/js/renderers/text.js
@@ -25,7 +25,13 @@ export const TextRenderer = {
       if (json.text) {
         const p = document.createElement('p');
         p.className = 'asr-line';
-        p.textContent = json.text;
+        if (json.asr_complete_ts) {
+          const tag = document.createElement('span');
+          tag.className = 'asr-tag';
+          tag.textContent = 'ASR';
+          p.appendChild(tag);
+        }
+        p.appendChild(document.createTextNode(json.text));
         this._textEl.appendChild(p);
         this._textEl.scrollTop = this._textEl.scrollHeight;
         while (this._textEl.children.length > 50) this._textEl.removeChild(this._textEl.firstChild);


### PR DESCRIPTION
## Summary
- Fix hardcoded "ASR" badge on all text messages in activity log view
- Show correct badge based on data content: `feishu`/`telegram` for channel, `ASR` for speech recognition, `msg` for others
- Add ASR tag in "最新" (latest) text view only for actual ASR results

## Test plan
- [x] Feishu messages no longer show "ASR" badge
- [x] ASR results show green "ASR" tag in text renderer
- [x] Channel messages show platform name as badge in log view

🤖 Generated with [Claude Code](https://claude.com/claude-code)