### PR TITLE
fix(core): add channel inference to event XML

### DIFF
--- a/agent-core/resource/memory/prompt_system.md
+++ b/agent-core/resource/memory/prompt_system.md
@@ -13,18 +13,29 @@
 # 输入规则
 
 系统以固定时间间隔收集所有传入事件，汇聚后一次性交给你处理。
-每批输入由一个或多个 `<event>` 标签组成，标注来源 DDS topic 和时间戳：
+每批输入由一个或多个 `<event>` 标签组成，标注来源 DDS topic、渠道和时间戳：
 
 ```
-<event source="dds:/mic/audio/asr_event" ts="2026-06-05T08:00:01">
+<event source="dds:/mic/audio/asr_event" channel="local_mic" ts="2026-06-05T08:00:01">
 用户说：你好
 </event>
-<event source="dds:/sensor/imu" ts="2026-06-05T08:00:01">
+<event source="dds:/sensor/imu" channel="sensor" ts="2026-06-05T08:00:01">
 IMU 姿态变化：pitch +5°
 </event>
 ```
 
 一批中可能包含多个事件，你需要综合理解后统一做出响应。
+
+## 渠道分类
+
+每个事件的 `channel` 属性标识消息来源渠道，决定了你应该用什么方式回复：
+- `local_mic` — 本地麦克风 ASR（面对面对话，用 TTS 回应）
+- `remote_mic` — 远程麦克风 ASR（来自 web 控制页的语音，用 TTS 回应）
+- `remote_web` — web 控制页文字消息（用 remote_message 回应）
+- `channel:feishu` / `channel:telegram` / `channel:slack` — 来自消息平台（用 channel_reply 回应）
+- `sensor` — 传感器数据（通常不需要回应）
+
+**重要**：根据 channel 选择正确的回复方式。只有 channel 为 `channel:*` 的事件才来自消息平台，其他事件与消息平台无关。
 
 **ASR 分句注意：** 同一批次中来自 ASR 的连续多条事件，可能实际上是同一句话被错误切分。判断依据：时间戳相近（audio_start/end 有重叠或间隔极短）且语义上可拼接。遇到这种情况，应将它们合并理解为一句完整的话再做响应，而不是逐条分别回应。
 

--- a/agent-core/src/collector.py
+++ b/agent-core/src/collector.py
@@ -133,14 +133,42 @@ def _get_max_window() -> int:
     return config.main.get('event', {}).get('llm', {}).get('collector_max_window', 20)
 
 
+def _infer_channel(ev: dict) -> str:
+    """从事件 source 推断渠道标签。"""
+    source = ev.get('source', '')
+    # 来自 channel 系统的消息（/channel/request/xxx 或 channel:platform:user）
+    if '/channel/' in source or source.startswith('channel:'):
+        text = ev.get('text', '')
+        if text and text.startswith('{'):
+            try:
+                data = _json.loads(text)
+                platform = data.get('platform', '')
+                if platform:
+                    return f'channel:{platform}'
+            except (ValueError, TypeError):
+                pass
+        return 'channel'
+    # 远程控制页面文字消息
+    if '/remote_control/message' in source:
+        return 'remote_web'
+    # ASR 事件或麦克风相关 — 根据 source 中是否含 remote 判断
+    if 'asr' in source.lower() or '/mic' in source:
+        if 'remote' in source:
+            return 'remote_mic'
+        return 'local_mic'
+    # 其他（传感器等）
+    return 'sensor'
+
+
 def _format_batch(events: list[dict]) -> str:
     """将事件列表格式化为堆叠的 <event> XML。"""
     lines = []
     for ev in events:
         ts = datetime.datetime.fromtimestamp(ev['ts']).strftime('%Y-%m-%dT%H:%M:%S')
         source = ev.get('source', 'unknown')
+        channel = _infer_channel(ev)
         text = ev.get('text', '')
-        lines.append(f'<event source="{source}" ts="{ts}">\n{text}\n</event>')
+        lines.append(f'<event source="{source}" channel="{channel}" ts="{ts}">\n{text}\n</event>')
     return '\n'.join(lines)
 
 


### PR DESCRIPTION
## Summary
- Add `_infer_channel()` to collector.py that derives semantic channel labels (local_mic, remote_mic, remote_web, channel:feishu, sensor) from DDS topic paths
- Inject `channel` attribute into event XML so LLM can reliably identify message source
- Update system prompt with channel classification rules and correct response routing guidance

## Test plan
- [x] Deployed to R1, container restarted
- [ ] Verify `resource/log/llm.json` shows correct channel attributes
- [ ] Confirm LLM no longer misidentifies remote_message/ASR as Feishu channel

🤖 Generated with [Claude Code](https://claude.com/claude-code)