### PR TITLE
feat: add desktop agent tools + WebSearch + routing fixes

### DIFF
--- a/agent-core/pyproject.toml
+++ b/agent-core/pyproject.toml
@@ -7,6 +7,7 @@ dependencies = [
     "aiohttp>=3.13.5",
     "docker>=7.1.0",
     "fastapi[all]>=0.135.3",
+    "html2text>=2024.2.26",
     "jsonschema>=4.0",
     "numpy>=1.24",
     "openai>=2.31.0",

--- a/agent-core/resource/memory/defaults/prompt_system.md
+++ b/agent-core/resource/memory/defaults/prompt_system.md
@@ -36,16 +36,15 @@ IMU 姿态变化：pitch +5°
 
 一批中可能包含多个事件，你需要综合理解后统一做出响应。
 
-## 渠道分类
+## 渠道与响应
 
-每个事件的 `channel` 属性标识消息来源渠道，决定了你应该用什么方式回复：
-- `local_mic` — 本地麦克风 ASR（面对面对话，用 TTS 回应）
-- `remote_mic` — 远程麦克风 ASR（来自 web 控制页的语音，用 TTS 回应）
-- `remote_web` — web 控制页文字消息（用 remote_message 回应）
-- `channel:feishu` / `channel:telegram` / `channel:slack` — 来自消息平台（用 channel_reply 回应）
-- `sensor` — 传感器数据（通常不需要回应）
+每个事件的 `channel` 属性标识消息来源渠道。回复方式的总体原则：
 
-**重要**：根据 channel 选择正确的回复方式。只有 channel 为 `channel:*` 的事件才来自消息平台，其他事件与消息平台无关。
+- **本体交互**（用户在机器人身边或通过 web 控制页操作）→ 通过机器人本体回应（TTS/speaker/动作）
+- **远程消息平台**（用户在飞书/Telegram/Slack 等消息 App 中）→ 通过对应平台回复
+- **传感器事件** → 大多数情况无需主动回应
+
+具体使用哪个工具回复，参考各工具的 description 中的使用场景说明。不同渠道的回复方式绝不混用——不要把一个渠道的消息发到另一个渠道。
 
 **ASR 分句注意：** 同一批次中来自 ASR 的连续多条事件，可能实际上是同一句话被错误切分。判断依据：时间戳相近（audio_start/end 有重叠或间隔极短）且语义上可拼接。遇到这种情况，应将它们合并理解为一句完整的话再做响应，而不是逐条分别回应。
 
@@ -82,7 +81,7 @@ IMU 姿态变化：pitch +5°
 所有与外界的交互都必须通过调用工具完成，包括说话（tts/speak）、显示内容（screen/led）、肢体动作（loco/arm）、发送消息（remote_message）等。
 
 **关键原则：**
-- 根据当前场景选择正确的沟通方式。面对面对话用 tts；远程通信用 remote_message；需要视觉反馈用 led 或 screen。
+- 根据事件的 channel 选择对应的回复方式（见"渠道与响应"部分），绝不跨渠道回复。
 - 注意调用顺序和时机。工具按你给出的顺序依次执行——先写的先执行。根据场景决定说话和动作的先后：执行动作前告知用户意图（"我来站起来"→站立），或动作完成后报告结果（站立→"好了，我站起来了"）。
 - 仅传感器查询类工具（type=sensor）如果相邻会自动并行。其余工具严格按序执行。如果需要 A 的结果才能做 B，请分多轮调用。
 - content 字段（文字输出）仅用于内部思考记录，不会被用户感知到。与用户沟通必须通过工具。
@@ -102,14 +101,48 @@ IMU 姿态变化：pitch +5°
 - `task_done(id, summary?)` — 标记任务完成，停止定时检查。
 - `task_fail(id, reason?)` — 标记任务失败，停止定时检查。
 - `task_list()` — 查看所有活跃任务。
+- `task_force_clear()` — 强制清除所有活跃任务及其定时检查。
+- `subagent_spawn(goal, priority?, tools?, model?, max_rounds?, context?)` — 创建子代理异步执行任务。子代理在独立上下文中运行，不影响当前对话。
+- `subagent_spawn_sync(goal, ...)` — 创建子代理并等待结果返回。适合需要立即获得结果的查询。
+- `subagent_status(id?)` — 查看子代理状态（留空列出全部）。
+- `subagent_cancel(id, reason?)` — 取消子代理。
+- `subagent_message(id, text)` — 向运行中的子代理发送指令。
+- `subagent_result(id)` — 获取已完成子代理的结果。
 - `activate_skill(slug)` — 激活已安装技能，获取完整指令。
 - `deactivate_skill(slug)` — 停用技能，释放上下文空间。
+
+**通用能力工具（始终可用）：**
+- `Read(file_path, offset?, limit?)` — 读取文件内容（带行号）。查看文件时始终使用此工具，不要用 Bash cat。
+- `Write(file_path, content)` — 创建或覆写文件。
+- `Edit(file_path, old_string, new_string)` — 精确替换文件中的一段文本。修改文件时优先使用此工具而非 Write 整体覆写。
+- `Glob(pattern, path?)` — 按文件名模式搜索。查找文件时使用此工具，不要用 Bash find/ls。
+- `Grep(pattern, path?, include?)` — 按内容正则搜索。搜索代码/配置内容时使用此工具，不要用 Bash grep。
+- `Bash(command, timeout?, cwd?)` — 执行 Shell 命令。用于系统监控、包管理、进程操作等上述专用工具无法完成的任务。
+- `PythonExec(code, timeout?)` — 执行 Python 代码（沙盒）。用于计算、数据处理、JSON 操作。同一轮内变量持久。
+- `WebFetch(url, prompt?, timeout?)` — 抓取 URL 内容（HTML 自动转 Markdown）。
+
+**通用工具使用原则：**
+- 读取文件用 `Read`，不要用 `Bash("cat ...")`。
+- 查找文件用 `Glob`，不要用 `Bash("find ...")`。
+- 搜索文件内容用 `Grep`，不要用 `Bash("grep ...")`。
+- 修改文件的局部内容用 `Edit`；只有创建新文件或需要完全重写时才用 `Write`。
+- `Bash` 仅用于无专用工具覆盖的系统操作（如 apt、pip、systemctl、top、df、docker 等）。
+- `PythonExec` 用于需要计算或数据处理的场景，比 Bash 更适合复杂逻辑。
+- 这些工具操作的文件限制在 /work 和 /tmp 目录内。
 
 **任务工具使用原则：**
 - 发起预计超过 30 秒的动作（导航、巡逻、等待等）时，用 `task_create` 追踪。
 - 收到 `task:<id>` 来源的检查事件时，查询实际状态并用 `task_update` 记录进展。
 - 被打断问话时，参考 L2 中 `<active_tasks>` 回答进度问题。
 - 任务完成/失败后及时调用 `task_done` / `task_fail`，可选择性告知用户。
+
+**子代理使用原则：**
+- 优先级为 0 的事件（传感器等）已由框架自动交给 background agent 处理，无需手动 spawn。
+- **当任务需要多步搜索、调研、或信息收集时，应使用 `subagent_spawn` 异步执行。** Main agent 告知用户需要一些时间，spawn 子代理后 finish，不必等待结果。
+- 简单的单次查询（如抓取一个已知 URL、查一条新闻标题）可在 main agent 内直接完成。
+- 子代理完成后会通过 subagent_report 事件通知你，届时用合适的方式（TTS/channel_reply 等，视来源渠道而定）将结果告知用户。
+- 子代理不能创建子代理，不能修改记忆，不能管理任务——它们只执行具体操作并返回结果。
+- 如需查看传感器的历史数据，使用 `raw_input_info(source, limit)` 工具按需查询。传感器数据不会主动出现在你的输入中，但你随时可以主动查询。
 
 MCP 工具命名格式：`mcp__<设备id>__<工具名>`
 

--- a/agent-core/resource/memory/prompt_system.md
+++ b/agent-core/resource/memory/prompt_system.md
@@ -36,16 +36,15 @@ IMU 姿态变化：pitch +5°
 
 一批中可能包含多个事件，你需要综合理解后统一做出响应。
 
-## 渠道分类
+## 渠道与响应
 
-每个事件的 `channel` 属性标识消息来源渠道，决定了你应该用什么方式回复：
-- `local_mic` — 本地麦克风 ASR（面对面对话，用 TTS 回应）
-- `remote_mic` — 远程麦克风 ASR（来自 web 控制页的语音，用 TTS 回应）
-- `remote_web` — web 控制页文字消息（用 remote_message 回应）
-- `channel:feishu` / `channel:telegram` / `channel:slack` — 来自消息平台（用 channel_reply 回应）
-- `sensor` — 传感器数据（通常不需要回应）
+每个事件的 `channel` 属性标识消息来源渠道。回复方式的总体原则：
 
-**重要**：根据 channel 选择正确的回复方式。只有 channel 为 `channel:*` 的事件才来自消息平台，其他事件与消息平台无关。
+- **本体交互**（用户在机器人身边或通过 web 控制页操作）→ 通过机器人本体回应（TTS/speaker/动作）
+- **远程消息平台**（用户在飞书/Telegram/Slack 等消息 App 中）→ 通过对应平台回复
+- **传感器事件** → 大多数情况无需主动回应
+
+具体使用哪个工具回复，参考各工具的 description 中的使用场景说明。不同渠道的回复方式绝不混用——不要把一个渠道的消息发到另一个渠道。
 
 **ASR 分句注意：** 同一批次中来自 ASR 的连续多条事件，可能实际上是同一句话被错误切分。判断依据：时间戳相近（audio_start/end 有重叠或间隔极短）且语义上可拼接。遇到这种情况，应将它们合并理解为一句完整的话再做响应，而不是逐条分别回应。
 
@@ -82,7 +81,7 @@ IMU 姿态变化：pitch +5°
 所有与外界的交互都必须通过调用工具完成，包括说话（tts/speak）、显示内容（screen/led）、肢体动作（loco/arm）、发送消息（remote_message）等。
 
 **关键原则：**
-- 根据当前场景选择正确的沟通方式。面对面对话用 tts；远程通信用 remote_message；需要视觉反馈用 led 或 screen。
+- 根据事件的 channel 选择对应的回复方式（见"渠道与响应"部分），绝不跨渠道回复。
 - 注意调用顺序和时机。工具按你给出的顺序依次执行——先写的先执行。根据场景决定说话和动作的先后：执行动作前告知用户意图（"我来站起来"→站立），或动作完成后报告结果（站立→"好了，我站起来了"）。
 - 仅传感器查询类工具（type=sensor）如果相邻会自动并行。其余工具严格按序执行。如果需要 A 的结果才能做 B，请分多轮调用。
 - content 字段（文字输出）仅用于内部思考记录，不会被用户感知到。与用户沟通必须通过工具。
@@ -112,6 +111,25 @@ IMU 姿态变化：pitch +5°
 - `activate_skill(slug)` — 激活已安装技能，获取完整指令。
 - `deactivate_skill(slug)` — 停用技能，释放上下文空间。
 
+**通用能力工具（始终可用）：**
+- `Read(file_path, offset?, limit?)` — 读取文件内容（带行号）。查看文件时始终使用此工具，不要用 Bash cat。
+- `Write(file_path, content)` — 创建或覆写文件。
+- `Edit(file_path, old_string, new_string)` — 精确替换文件中的一段文本。修改文件时优先使用此工具而非 Write 整体覆写。
+- `Glob(pattern, path?)` — 按文件名模式搜索。查找文件时使用此工具，不要用 Bash find/ls。
+- `Grep(pattern, path?, include?)` — 按内容正则搜索。搜索代码/配置内容时使用此工具，不要用 Bash grep。
+- `Bash(command, timeout?, cwd?)` — 执行 Shell 命令。用于系统监控、包管理、进程操作等上述专用工具无法完成的任务。
+- `PythonExec(code, timeout?)` — 执行 Python 代码（沙盒）。用于计算、数据处理、JSON 操作。同一轮内变量持久。
+- `WebFetch(url, prompt?, timeout?)` — 抓取 URL 内容（HTML 自动转 Markdown）。
+
+**通用工具使用原则：**
+- 读取文件用 `Read`，不要用 `Bash("cat ...")`。
+- 查找文件用 `Glob`，不要用 `Bash("find ...")`。
+- 搜索文件内容用 `Grep`，不要用 `Bash("grep ...")`。
+- 修改文件的局部内容用 `Edit`；只有创建新文件或需要完全重写时才用 `Write`。
+- `Bash` 仅用于无专用工具覆盖的系统操作（如 apt、pip、systemctl、top、df、docker 等）。
+- `PythonExec` 用于需要计算或数据处理的场景，比 Bash 更适合复杂逻辑。
+- 这些工具操作的文件限制在 /work 和 /tmp 目录内。
+
 **任务工具使用原则：**
 - 发起预计超过 30 秒的动作（导航、巡逻、等待等）时，用 `task_create` 追踪。
 - 收到 `task:<id>` 来源的检查事件时，查询实际状态并用 `task_update` 记录进展。
@@ -120,8 +138,9 @@ IMU 姿态变化：pitch +5°
 
 **子代理使用原则：**
 - 优先级为 0 的事件（传感器等）已由框架自动交给 background agent 处理，无需手动 spawn。
-- 当用户要求一个需要多步探测/查询的复杂任务时，可 spawn 子代理异步执行，同时保持与用户的对话响应。
-- 需要快速获取某个信息（如查电量、查状态）时，用 `subagent_spawn_sync` 同步获取结果后直接回复用户。
+- **当任务需要多步搜索、调研、或信息收集时，应使用 `subagent_spawn` 异步执行。** Main agent 告知用户需要一些时间，spawn 子代理后 finish，不必等待结果。
+- 简单的单次查询（如抓取一个已知 URL、查一条新闻标题）可在 main agent 内直接完成。
+- 子代理完成后会通过 subagent_report 事件通知你，届时用合适的方式（TTS/channel_reply 等，视来源渠道而定）将结果告知用户。
 - 子代理不能创建子代理，不能修改记忆，不能管理任务——它们只执行具体操作并返回结果。
 - 如需查看传感器的历史数据，使用 `raw_input_info(source, limit)` 工具按需查询。传感器数据不会主动出现在你的输入中，但你随时可以主动查询。
 

--- a/agent-core/src/api/config.py
+++ b/agent-core/src/api/config.py
@@ -46,12 +46,19 @@ class InspectorConfig(BaseModel):
     url: str = ''
 
 
+class SearchConfig(BaseModel):
+    type:     str = 'none'   # 'none' | 'baidu_search'
+    base_url: str = ''
+    api_key:  str = ''
+
+
 class ServicesConfig(BaseModel):
     llm:       LLMConfig       = LLMConfig()
     tts:       TTSConfig       = TTSConfig()
     vad:       VADConfig       = VADConfig()
     asr:       ASRConfig       = ASRConfig()
     inspector: InspectorConfig = InspectorConfig()
+    search:    SearchConfig    = SearchConfig()
 
 
 class MCPEntry(BaseModel):
@@ -342,6 +349,12 @@ async def config_get():
     if tts.get('api_key'):
         tts['api_key'] = '****'
 
+    # Search config (from desktop_tools)
+    dt = config.main.get('desktop_tools', {})
+    search = dict(dt.get('search', {}))
+    if search.get('api_key'):
+        search['api_key'] = '****'
+
     return {
         'code': 200,
         'data': {
@@ -351,6 +364,7 @@ async def config_get():
                 'vad':       dict(services.get('vad', {})),
                 'asr':       asr,
                 'inspector': inspector,
+                'search':    search,
             },
             'mcp_list': mcp_list,
         }
@@ -433,6 +447,18 @@ async def config_save(req: ConfigSaveRequest):
         services['inspector'] = {'url': req.services.inspector.url}
 
     config.main['services'] = services
+
+    # Search config → desktop_tools section
+    dt = config.main.get('desktop_tools', {})
+    existing_search = dt.get('search', {})
+    existing_search_key = existing_search.get('api_key', '')
+    new_search_key = req.services.search.api_key if (req.services.search.api_key and req.services.search.api_key != '****') else existing_search_key
+    dt['search'] = {
+        'type':     req.services.search.type,
+        'base_url': req.services.search.base_url,
+        'api_key':  new_search_key,
+    }
+    config.main['desktop_tools'] = dt
 
     # Mark configured
     core = config.main.get('core', {})

--- a/agent-core/src/api/mcp_manage.py
+++ b/agent-core/src/api/mcp_manage.py
@@ -707,6 +707,20 @@ async def _handle_agentcore_call(req: MCPCallRequest):
             llm_cfg['trigger_interval_ms'] = int(trigger_interval)
             event_cfg['llm'] = llm_cfg
             config.main['event'] = event_cfg
+        # Save search config to desktop_tools.search
+        search_type = req.arguments.get('search_type')
+        if search_type is not None:
+            dt = config.main.get('desktop_tools', {})
+            search_cfg = dt.get('search', {})
+            search_cfg['type'] = search_type
+            search_base = req.arguments.get('search_base_url', '')
+            search_key = req.arguments.get('search_api_key', '')
+            if search_base and search_base != '****':
+                search_cfg['base_url'] = search_base
+            if search_key and search_key != '****':
+                search_cfg['api_key'] = search_key
+            dt['search'] = search_cfg
+            config.main['desktop_tools'] = dt
         return {'code': 200, 'data': 'config saved'}
 
     return {'code': 200, 'data': None}

--- a/agent-core/src/collector.py
+++ b/agent-core/src/collector.py
@@ -34,7 +34,7 @@ _current_turn_priority: int = 0
 _source_ring: dict[str, deque] = {}  # per-source ring buffer（所有事件）
 
 # 优先级判定规则
-_PRIORITY_SOURCES = {'asr', 'message', 'channel'}
+_PRIORITY_SOURCES = {'asr', 'message', 'channel', 'subagent'}
 
 
 def _extract_priority(ev: dict) -> int:

--- a/agent-core/src/config.py
+++ b/agent-core/src/config.py
@@ -80,6 +80,19 @@ _DB_DEFAULTS = {
         'bg_route_enabled': True,
         'bg_model': None,  # None = use main model; or specify e.g. 'qwen-turbo'
     },
+    'desktop_tools': {
+        'enabled': True,
+        'allowed_dirs': ['/work', '/tmp'],
+        'bash_blocked_patterns': ['rm -rf /', 'rm -rf /*', 'mkfs', 'reboot', 'shutdown', 'poweroff'],
+        'python_allowed_modules': ['math', 'json', 're', 'datetime', 'collections', 'itertools',
+                                   'struct', 'pathlib', 'numpy', 'hashlib', 'base64', 'urllib.parse'],
+        'max_output_bytes': 51200,
+        'search': {
+            'type': 'none',       # 'none' | 'baidu_search'
+            'base_url': '',
+            'api_key': '',
+        },
+    },
 }
 
 

--- a/agent-core/src/event/desktop.py
+++ b/agent-core/src/event/desktop.py
@@ -1,0 +1,601 @@
+"""
+event/desktop.py — 通用桌面 Agent 工具。
+
+提供文件操作、Shell 执行、Python 沙盒、内容搜索、URL 抓取等基础能力，
+工具命名与 Claude Code 保持一致以最大化 LLM 调用准确率。
+"""
+
+import asyncio
+import fnmatch
+import io
+import os
+import pathlib
+import re
+import sys
+import typing
+
+import log
+import config
+
+# ── 安全配置 ─────────────────────────────────────────────────────────────────────
+
+_MAX_OUTPUT = 51200  # 50 KB output cap
+
+_ALLOWED_DIRS = ['/work', '/tmp']
+
+_BASH_BLOCKED = [
+    'rm -rf /', 'rm -rf /*', 'mkfs', 'reboot', 'shutdown', 'poweroff',
+    'dd if=', 'dd of=/dev',
+]
+
+_PYTHON_ALLOWED_MODULES = {
+    'math', 'json', 're', 'datetime', 'collections', 'itertools',
+    'struct', 'pathlib', 'numpy', 'hashlib', 'base64', 'urllib.parse',
+    'string', 'textwrap', 'functools', 'operator', 'copy', 'time',
+    'random', 'statistics', 'fractions', 'decimal', 'enum', 'typing',
+    'dataclasses', 'csv', 'io', 'os.path',
+}
+
+
+def _resolve_path(path: str) -> pathlib.Path:
+    """Resolve path, default relative to /work."""
+    p = pathlib.Path(path)
+    if not p.is_absolute():
+        p = pathlib.Path('/work') / p
+    return p.resolve()
+
+
+def _check_path_allowed(p: pathlib.Path, dirs: list[str] | None = None) -> str | None:
+    """Return error message if path is not within allowed dirs, else None."""
+    allowed = dirs or _ALLOWED_DIRS
+    s = str(p)
+    for d in allowed:
+        if s == d or s.startswith(d + '/'):
+            return None
+    return f'Access denied: {p} is outside allowed directories {allowed}'
+
+
+def _truncate(text: str, max_bytes: int = _MAX_OUTPUT) -> str:
+    """Truncate output to max bytes."""
+    if len(text.encode('utf-8', errors='replace')) <= max_bytes:
+        return text
+    # Truncate by characters (approximate)
+    encoded = text.encode('utf-8', errors='replace')[:max_bytes]
+    truncated = encoded.decode('utf-8', errors='ignore')
+    return truncated + f'\n\n... [output truncated at {max_bytes} bytes]'
+
+
+# ── Tools class ──────────────────────────────────────────────────────────────────
+
+class DesktopTools:
+    """General-purpose desktop agent tools."""
+
+    def __init__(self):
+        self._python_namespace: dict = {}  # persists within turn
+
+    def reset_python_namespace(self):
+        """Reset Python namespace between turns."""
+        self._python_namespace = {}
+
+    # ── 1. Bash ──────────────────────────────────────────────────────────────
+
+    @log.function_(call=True)
+    async def Bash(self,
+        command: typing.Annotated[str, 'The shell command to execute'],
+        timeout: typing.Annotated[int, 'Timeout in seconds (default 30, max 120)'] = 30,
+        cwd: typing.Annotated[str, 'Working directory (default /work)'] = '/work',
+    ) -> str:
+        """Execute a shell command and return stdout+stderr. Use for system monitoring (top/df/ps), package management, process control, network debugging. For file operations prefer Read/Write/Edit; for file search prefer Glob/Grep."""
+        # Security: check blocked patterns
+        cmd_lower = command.lower().strip()
+        for blocked in _BASH_BLOCKED:
+            if blocked in cmd_lower:
+                return f'Error: command blocked for safety — contains "{blocked}"'
+
+        if 'sudo ' in cmd_lower:
+            return 'Error: sudo is not allowed'
+
+        timeout = max(1, min(timeout, 120))
+
+        # Resolve cwd
+        cwd_path = pathlib.Path(cwd)
+        if not cwd_path.exists():
+            cwd_path = pathlib.Path('/work')
+
+        try:
+            proc = await asyncio.create_subprocess_shell(
+                command,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.STDOUT,
+                cwd=str(cwd_path),
+                env={**os.environ, 'TERM': 'dumb'},
+            )
+            try:
+                stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+            except asyncio.TimeoutError:
+                proc.kill()
+                await proc.wait()
+                return f'Error: command timed out after {timeout}s and was killed'
+
+            output = stdout.decode('utf-8', errors='replace')
+            result = _truncate(output)
+            if proc.returncode != 0:
+                result = f'[exit code {proc.returncode}]\n{result}'
+            return result or '(no output)'
+
+        except Exception as e:
+            return f'Error: {e}'
+
+    # ── 2. PythonExec ────────────────────────────────────────────────────────
+
+    @log.function_(call=True)
+    async def PythonExec(self,
+        code: typing.Annotated[str, 'Python code to execute'],
+        timeout: typing.Annotated[int, 'Timeout in seconds (default 30)'] = 30,
+    ) -> str:
+        """Execute Python code in a sandboxed environment. Useful for calculations, data processing, JSON manipulation. Variables persist across calls within the same turn. Available: math, json, re, datetime, collections, itertools, struct, pathlib, numpy, hashlib, base64."""
+        timeout = max(1, min(timeout, 60))
+
+        # Build restricted builtins
+        import builtins as _builtins
+        safe_builtins = {k: getattr(_builtins, k) for k in dir(_builtins)
+                        if not k.startswith('_') and k not in ('exec', 'eval', 'compile', 'exit', 'quit')}
+
+        original_import = __builtins__.__import__ if hasattr(__builtins__, '__import__') else __import__
+
+        def _restricted_import(name, *args, **kwargs):
+            top = name.split('.')[0]
+            if top not in _PYTHON_ALLOWED_MODULES and name not in _PYTHON_ALLOWED_MODULES:
+                raise ImportError(f"Module '{name}' is not allowed. Allowed: {sorted(_PYTHON_ALLOWED_MODULES)}")
+            return original_import(name, *args, **kwargs)
+
+        safe_builtins['__import__'] = _restricted_import
+        safe_builtins['__builtins__'] = safe_builtins
+
+        if not self._python_namespace:
+            self._python_namespace = {'__builtins__': safe_builtins}
+        else:
+            self._python_namespace['__builtins__'] = safe_builtins
+
+        # Capture stdout
+        captured = io.StringIO()
+
+        def _exec_code():
+            old_stdout = sys.stdout
+            sys.stdout = captured
+            try:
+                # Try as expression first (to capture result)
+                try:
+                    result = eval(compile(code, '<agent>', 'eval'), self._python_namespace)
+                    if result is not None:
+                        print(repr(result))
+                except SyntaxError:
+                    exec(compile(code, '<agent>', 'exec'), self._python_namespace)
+            finally:
+                sys.stdout = old_stdout
+
+        try:
+            # Run in thread pool with timeout
+            loop = asyncio.get_event_loop()
+            await asyncio.wait_for(
+                loop.run_in_executor(None, _exec_code),
+                timeout=timeout,
+            )
+        except asyncio.TimeoutError:
+            return f'Error: execution timed out after {timeout}s'
+        except Exception as e:
+            output = captured.getvalue()
+            err_msg = f'{type(e).__name__}: {e}'
+            return _truncate(f'{output}\n{err_msg}' if output else err_msg)
+
+        output = captured.getvalue()
+        return _truncate(output) if output else '(no output)'
+
+    # ── 3. Read ──────────────────────────────────────────────────────────────
+
+    @log.function_(call=True)
+    async def Read(self,
+        file_path: typing.Annotated[str, 'Absolute file path to read'],
+        offset: typing.Annotated[int, 'Line number to start reading from (1-indexed)'] = 1,
+        limit: typing.Annotated[int, 'Maximum number of lines to return (default 200)'] = 200,
+    ) -> str:
+        """Read file contents with line numbers. Supports reading specific line ranges for large files."""
+        p = _resolve_path(file_path)
+
+        err = _check_path_allowed(p)
+        if err:
+            return err
+
+        if not p.exists():
+            return f'Error: file not found: {p}'
+        if not p.is_file():
+            return f'Error: not a file: {p}'
+
+        # Check if binary
+        try:
+            raw = p.read_bytes()
+            if b'\x00' in raw[:8192]:
+                hex_preview = raw[:256].hex(' ')
+                return f'[Binary file, {len(raw)} bytes]\nHex preview (first 256 bytes):\n{hex_preview}'
+            text = raw.decode('utf-8', errors='replace')
+        except Exception as e:
+            return f'Error reading file: {e}'
+
+        lines = text.splitlines(keepends=True)
+        total_lines = len(lines)
+        file_size = len(raw)
+
+        # Apply offset/limit
+        offset = max(1, offset)
+        limit = max(1, min(limit, 1000))
+        selected = lines[offset - 1: offset - 1 + limit]
+
+        # Format with line numbers
+        header = f'[{p} | {file_size} bytes | {total_lines} lines | showing {offset}-{offset + len(selected) - 1}]\n'
+        numbered = ''.join(f'{offset + i:>4}| {line}' for i, line in enumerate(selected))
+
+        return _truncate(header + numbered)
+
+    # ── 4. Write ─────────────────────────────────────────────────────────────
+
+    @log.function_(call=True)
+    async def Write(self,
+        file_path: typing.Annotated[str, 'Absolute file path to write'],
+        content: typing.Annotated[str, 'The content to write to the file'],
+    ) -> str:
+        """Create a new file or overwrite an existing file. Creates parent directories automatically. For modifying existing files, prefer Edit for surgical changes."""
+        p = _resolve_path(file_path)
+
+        err = _check_path_allowed(p)
+        if err:
+            return err
+
+        # Size check (1 MB max)
+        if len(content.encode('utf-8')) > 1_048_576:
+            return 'Error: content exceeds 1 MB limit'
+
+        try:
+            p.parent.mkdir(parents=True, exist_ok=True)
+
+            # Backup existing file > 1KB
+            if p.exists() and p.stat().st_size > 1024:
+                bak = p.with_suffix(p.suffix + '.bak')
+                bak.write_bytes(p.read_bytes())
+
+            p.write_text(content, encoding='utf-8')
+            return f'Written {len(content)} bytes to {p}'
+        except Exception as e:
+            return f'Error: {e}'
+
+    # ── 5. Edit ──────────────────────────────────────────────────────────────
+
+    @log.function_(call=True)
+    async def Edit(self,
+        file_path: typing.Annotated[str, 'Absolute file path to modify'],
+        old_string: typing.Annotated[str, 'The exact text to find and replace (must be unique in file)'],
+        new_string: typing.Annotated[str, 'The replacement text'],
+    ) -> str:
+        """Replace a unique string in a file. The old_string must appear exactly once in the file. Use for surgical modifications to code and config files."""
+        p = _resolve_path(file_path)
+
+        err = _check_path_allowed(p)
+        if err:
+            return err
+
+        if not p.exists():
+            return f'Error: file not found: {p}'
+
+        try:
+            text = p.read_text(encoding='utf-8')
+        except Exception as e:
+            return f'Error reading file: {e}'
+
+        count = text.count(old_string)
+        if count == 0:
+            return f'Error: old_string not found in {p}'
+        if count > 1:
+            return f'Error: old_string found {count} times (must be unique). Provide more context to make it unique.'
+
+        new_text = text.replace(old_string, new_string, 1)
+
+        # Backup
+        if p.stat().st_size > 1024:
+            bak = p.with_suffix(p.suffix + '.bak')
+            bak.write_text(text, encoding='utf-8')
+
+        p.write_text(new_text, encoding='utf-8')
+        return f'Edited {p}: replaced {len(old_string)} chars with {len(new_string)} chars'
+
+    # ── 6. Glob ──────────────────────────────────────────────────────────────
+
+    @log.function_(call=True)
+    async def Glob(self,
+        pattern: typing.Annotated[str, 'Glob pattern (e.g. "**/*.py", "src/**/*.ts")'],
+        path: typing.Annotated[str, 'Root directory to search in'] = '/work',
+    ) -> str:
+        """Find files matching a glob pattern. Returns sorted file paths, most recently modified first."""
+        root = _resolve_path(path)
+
+        err = _check_path_allowed(root)
+        if err:
+            return err
+
+        if not root.exists() or not root.is_dir():
+            return f'Error: directory not found: {root}'
+
+        try:
+            matches = sorted(root.glob(pattern), key=lambda p: p.stat().st_mtime, reverse=True)
+        except Exception as e:
+            return f'Error: {e}'
+
+        if not matches:
+            return f'No files matching "{pattern}" in {root}'
+
+        limit = 200
+        lines = [str(m) for m in matches[:limit]]
+        result = '\n'.join(lines)
+        if len(matches) > limit:
+            result += f'\n\n... ({len(matches) - limit} more files not shown)'
+        return result
+
+    # ── 7. Grep ──────────────────────────────────────────────────────────────
+
+    @log.function_(call=True)
+    async def Grep(self,
+        pattern: typing.Annotated[str, 'Regex pattern to search for'],
+        path: typing.Annotated[str, 'File or directory to search in'] = '/work',
+        include: typing.Annotated[str, 'File glob filter (e.g. "*.py")'] = '',
+    ) -> str:
+        """Search file contents using regex. Returns matching lines with file path and line number. Use for finding function definitions, config values, error messages."""
+        root = _resolve_path(path)
+
+        err = _check_path_allowed(root)
+        if err:
+            return err
+
+        # Try using grep/rg subprocess for speed
+        cmd_parts = []
+        if os.path.exists('/usr/bin/grep') or os.path.exists('/bin/grep'):
+            cmd_parts = ['grep', '-rn', '--color=never', '-E']
+            if include:
+                cmd_parts.extend(['--include', include])
+            cmd_parts.extend([pattern, str(root)])
+        else:
+            # Fallback: pure Python
+            return await self._grep_python(pattern, root, include)
+
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *cmd_parts,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=30)
+            output = stdout.decode('utf-8', errors='replace')
+        except asyncio.TimeoutError:
+            return 'Error: grep timed out after 30s'
+        except Exception as e:
+            return await self._grep_python(pattern, root, include)
+
+        if not output.strip():
+            return f'No matches for pattern "{pattern}" in {root}'
+
+        # Limit output
+        lines = output.splitlines()
+        if len(lines) > 50:
+            result = '\n'.join(lines[:50])
+            result += f'\n\n... ({len(lines) - 50} more matches not shown)'
+            return _truncate(result)
+        return _truncate(output)
+
+    async def _grep_python(self, pattern: str, root: pathlib.Path, include: str) -> str:
+        """Pure Python grep fallback."""
+        try:
+            regex = re.compile(pattern)
+        except re.error as e:
+            return f'Error: invalid regex — {e}'
+
+        results = []
+        max_results = 50
+
+        def _search_file(fp: pathlib.Path):
+            try:
+                text = fp.read_text(encoding='utf-8', errors='ignore')
+                for i, line in enumerate(text.splitlines(), 1):
+                    if regex.search(line):
+                        results.append(f'{fp}:{i}: {line.rstrip()}')
+                        if len(results) >= max_results:
+                            return
+            except (OSError, UnicodeDecodeError):
+                pass
+
+        if root.is_file():
+            _search_file(root)
+        else:
+            for fp in root.rglob('*'):
+                if len(results) >= max_results:
+                    break
+                if not fp.is_file():
+                    continue
+                if include and not fnmatch.fnmatch(fp.name, include):
+                    continue
+                _search_file(fp)
+
+        if not results:
+            return f'No matches for pattern "{pattern}" in {root}'
+        return _truncate('\n'.join(results))
+
+    # ── 8. WebFetch ──────────────────────────────────────────────────────────
+
+    @log.function_(call=True)
+    async def WebFetch(self,
+        url: typing.Annotated[str, 'URL to fetch'],
+        prompt: typing.Annotated[str, 'What information to extract from the page (optional)'] = '',
+        timeout: typing.Annotated[int, 'Timeout in seconds (default 30)'] = 30,
+    ) -> str:
+        """Fetch URL content. HTML is automatically converted to Markdown for readability. Optionally specify a prompt to describe what information you want to extract."""
+        timeout = max(5, min(timeout, 60))
+
+        try:
+            import aiohttp
+        except ImportError:
+            return 'Error: aiohttp not installed. Run: pip install aiohttp'
+
+        try:
+            import html2text
+            h2t = html2text.HTML2Text()
+            h2t.ignore_links = False
+            h2t.ignore_images = True
+            h2t.body_width = 0
+        except ImportError:
+            h2t = None
+
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.get(url, timeout=aiohttp.ClientTimeout(total=timeout),
+                                       headers={'User-Agent': 'Mozilla/5.0 (compatible; AgentBot/1.0)'},
+                                       ssl=False) as resp:
+                    if resp.status >= 400:
+                        return f'Error: HTTP {resp.status} {resp.reason}'
+                    content_type = resp.headers.get('content-type', '')
+                    raw = await resp.read()
+
+                    # Limit to 500KB raw
+                    if len(raw) > 512_000:
+                        raw = raw[:512_000]
+
+                    text = raw.decode('utf-8', errors='replace')
+
+                    # Convert HTML to markdown
+                    if 'html' in content_type and h2t:
+                        text = h2t.handle(text)
+
+        except asyncio.TimeoutError:
+            return f'Error: request timed out after {timeout}s'
+        except Exception as e:
+            return f'Error fetching URL: {e}'
+
+        result = _truncate(text, max_bytes=_MAX_OUTPUT)
+
+        if prompt:
+            result = f'[Extracted from {url} — user asked: "{prompt}"]\n\n{result}'
+        else:
+            result = f'[Content from {url}]\n\n{result}'
+
+        return result
+
+    # ── 9. WebSearch ─────────────────────────────────────────────────────────
+
+    @log.function_(call=True)
+    async def WebSearch(self,
+        query: typing.Annotated[str, 'Search query keywords'],
+        search_type: typing.Annotated[str, 'Type of search: web, image, or video (default web)'] = 'web',
+        top_k: typing.Annotated[int, 'Maximum number of results (default 10)'] = 10,
+        time_range: typing.Annotated[str, 'Time filter: day/week/month/year, empty for no limit'] = '',
+    ) -> str:
+        """Search the web for current information. Returns structured results with titles, URLs, and content summaries. Use for finding news, documentation, research, or any information that may have changed recently."""
+        import json as _json
+
+        # Load search config (prefer desktop_tools.search, fallback to tool_config)
+        dt_config = config.main.get('desktop_tools', {})
+        search_cfg = dt_config.get('search', {})
+        search_provider = search_cfg.get('type', 'none')
+
+        if search_provider == 'none' or not search_provider:
+            return 'Error: Web search is not configured. Ask the administrator to configure search in Settings.'
+
+        base_url = search_cfg.get('base_url', '').rstrip('/')
+        api_key = search_cfg.get('api_key', '')
+
+        if not base_url:
+            return 'Error: Search base_url is not configured.'
+
+        # Ensure base_url ends with /v1
+        if not base_url.endswith('/v1'):
+            base_url = base_url + '/v1'
+
+        # Build request payload
+        search_params = {
+            'search_type': search_type if search_type in ('web', 'image', 'video') else 'web',
+            'top_k': max(1, min(top_k, 20)),
+        }
+        if time_range and time_range in ('day', 'week', 'month', 'year'):
+            search_params['time_range'] = time_range
+
+        payload = {
+            'model': 'baidu-search',
+            'messages': [{'role': 'user', 'content': query}],
+            'stream': False,
+            'search_parameters': search_params,
+        }
+
+        try:
+            import aiohttp
+        except ImportError:
+            return 'Error: aiohttp not installed'
+
+        try:
+            headers = {'Content-Type': 'application/json'}
+            if api_key:
+                headers['Authorization'] = f'Bearer {api_key}'
+
+            async with aiohttp.ClientSession() as session:
+                async with session.post(
+                    f'{base_url}/chat/completions',
+                    json=payload,
+                    headers=headers,
+                    timeout=aiohttp.ClientTimeout(total=30),
+                    ssl=False,
+                ) as resp:
+                    if resp.status == 401:
+                        return 'Error: Search API key is invalid (401 Unauthorized)'
+                    if resp.status == 422:
+                        body = await resp.text()
+                        return f'Error: Invalid search parameters (422): {body[:200]}'
+                    if resp.status >= 400:
+                        body = await resp.text()
+                        return f'Error: Search API returned HTTP {resp.status}: {body[:200]}'
+
+                    data = await resp.json()
+
+        except asyncio.TimeoutError:
+            return 'Error: Search request timed out after 30s'
+        except Exception as e:
+            return f'Error: Search request failed: {e}'
+
+        # Parse response
+        try:
+            content_str = data['choices'][0]['message']['content']
+            results_data = _json.loads(content_str)
+            results = results_data.get('results', [])
+        except (KeyError, IndexError, _json.JSONDecodeError) as e:
+            return f'Error: Failed to parse search results: {e}\nRaw: {str(data)[:500]}'
+
+        if not results:
+            return f'No results found for "{query}"'
+
+        # Format results for LLM consumption
+        lines = [f'Search results for "{query}" ({len(results)} results):']
+        lines.append('')
+        for r in results:
+            title = r.get('title', 'Untitled')
+            url = r.get('url', '')
+            content = r.get('content', '')
+            website = r.get('website', '')
+            date = r.get('date', '')
+
+            lines.append(f'### {title}')
+            if url:
+                lines.append(f'URL: {url}')
+            meta_parts = []
+            if website:
+                meta_parts.append(website)
+            if date:
+                meta_parts.append(date)
+            if meta_parts:
+                lines.append(f'Source: {" | ".join(meta_parts)}')
+            if content:
+                lines.append(content[:500])
+            lines.append('')
+
+        return _truncate('\n'.join(lines))

--- a/agent-core/src/event/llm.py
+++ b/agent-core/src/event/llm.py
@@ -273,7 +273,11 @@ class Event:
         _set_manager(self._subagent_mgr)
         _sa_tools = SubagentTools(self._subagent_mgr)
 
-        # 注册系统工具（finish / memory / task / detailed_info / subagent）
+        # 注册桌面工具（文件操作 / Shell / Python / 搜索 / Web）
+        from event.desktop import DesktopTools
+        self._desktop_tools = DesktopTools()
+
+        # 注册系统工具（finish / memory / task / detailed_info / subagent / desktop）
         self._sys_tools = _build_system_tools([
             ('finish', event.finish.__call__),
             ('update_memory', event.memory.update),
@@ -293,6 +297,16 @@ class Event:
             ('subagent_cancel', _sa_tools.subagent_cancel),
             ('subagent_message', _sa_tools.subagent_message),
             ('subagent_result', _sa_tools.subagent_result),
+            # Desktop tools (Claude Code 风格)
+            ('Bash', self._desktop_tools.Bash),
+            ('PythonExec', self._desktop_tools.PythonExec),
+            ('Read', self._desktop_tools.Read),
+            ('Write', self._desktop_tools.Write),
+            ('Edit', self._desktop_tools.Edit),
+            ('Glob', self._desktop_tools.Glob),
+            ('Grep', self._desktop_tools.Grep),
+            ('WebFetch', self._desktop_tools.WebFetch),
+            ('WebSearch', self._desktop_tools.WebSearch),
         ])
         # 连接并注册所有 MCP 工具
         await mcp_client.init_all()
@@ -463,6 +477,9 @@ class Event:
         import time as _time
         from uuid import uuid4
         _turn_t0 = _time.perf_counter()
+
+        # Reset Python sandbox namespace for this turn
+        self._desktop_tools.reset_python_namespace()
 
         # 性能追踪（开放 span 式）
         _trace_id = str(uuid4())

--- a/agent-core/src/start.py
+++ b/agent-core/src/start.py
@@ -112,6 +112,9 @@ def _register_core_mcp(silent=False):
                         'llm_model': {'type': 'string', 'description': 'LLM 模型名称'},
                         'trigger_interval_ms': {'type': 'integer', 'description': '采集触发间隔（毫秒）', 'default': 1000},
                         'think_mode': {'type': 'boolean', 'description': 'Think mode (enables deep reasoning, disable for faster response)', 'default': False},
+                        'search_type': {'type': 'string', 'description': '搜索引擎', 'enum': ['none', 'baidu_search'], 'default': 'none'},
+                        'search_base_url': {'type': 'string', 'description': '搜索服务 URL (带 /v1)', 'x-show-when': {'search_type': 'baidu_search'}},
+                        'search_api_key': {'type': 'string', 'description': '搜索服务 API Key', 'format': 'password', 'x-show-when': {'search_type': 'baidu_search'}},
                     },
                     'required': ['llm_url', 'llm_key']
                 },
@@ -202,7 +205,7 @@ def _register_core_mcp(silent=False):
             {
                 'name': 'channel_reply',
                 'type': 'actuator',
-                'description': 'Send a reply message to a messaging channel (Feishu/Telegram/Slack)',
+                'description': 'Reply to a message from a messaging platform (Feishu/Telegram/Slack). ONLY use this tool when the triggering event has channel="channel:*". Never use for local_mic/remote_mic/remote_web events — those should be answered via TTS/speaker on the robot body.',
                 'inputSchema': {
                     'type': 'object',
                     'properties': {

--- a/agent-core/src/subagent/agent.py
+++ b/agent-core/src/subagent/agent.py
@@ -97,6 +97,9 @@ class Subagent:
         # Get all bound tools from canvas (same as main agent sees)
         all_schemas = self._get_all_mcp_schemas()
 
+        # Also include desktop tools (system tools available to subagents)
+        all_schemas.extend(self._get_desktop_tool_schemas())
+
         # Apply whitelist filter
         if self.spec.tool_filter is not None:
             filtered = []
@@ -135,6 +138,18 @@ class Subagent:
             for name, schema in info.get('schemas', {}).items():
                 schemas.append(schema)
         return schemas
+
+    def _get_desktop_tool_schemas(self) -> list[dict]:
+        """Get desktop tool schemas from the main event loop's sys_tools."""
+        from event.llm import _event_instance
+        if not _event_instance:
+            return []
+        _DESKTOP_TOOLS = {'Bash', 'PythonExec', 'Read', 'Write', 'Edit', 'Glob', 'Grep', 'WebFetch', 'WebSearch'}
+        return [
+            info['schema']
+            for name, info in _event_instance._sys_tools.items()
+            if name in _DESKTOP_TOOLS and name not in _DENIED_TOOLS
+        ]
 
     def _build_subagent_sys_tools(self) -> list[dict]:
         """Build the 3 subagent-specific system tools."""
@@ -431,6 +446,16 @@ class Subagent:
                 if isinstance(result, dict):
                     return json.dumps(result, ensure_ascii=False)
                 return str(result)
+            except Exception as e:
+                return f'[tool error] {type(e).__name__}: {e}'
+
+        # Desktop tool call (system tools from main agent)
+        from event.llm import _event_instance
+        if _event_instance and name in _event_instance._sys_tools:
+            try:
+                fn = _event_instance._sys_tools[name]['object']
+                result = await fn(**args)
+                return str(result) if result else '(no output)'
             except Exception as e:
                 return f'[tool error] {type(e).__name__}: {e}'
 

--- a/agent-core/web/js/sidebar.js
+++ b/agent-core/web/js/sidebar.js
@@ -655,6 +655,9 @@ function _openToolConfigModal(mcpId, toolName, configSchema) {
     bodyEl.querySelectorAll('[data-key]').forEach(input => {
       const v = input.value.trim();
       if (!v) return;
+      // Skip fields hidden by x-show-when (their parent .tool-config-field has display:none)
+      const fieldWrapper = input.closest('.tool-config-field');
+      if (fieldWrapper && fieldWrapper.style.display === 'none') return;
       const fieldDef = props[input.dataset.key];
       if (fieldDef?.type === 'integer') values[input.dataset.key] = parseInt(v, 10);
       else if (fieldDef?.type === 'number') values[input.dataset.key] = parseFloat(v);
@@ -937,6 +940,9 @@ export function openInstanceConfigModal(mcpId, toolName, instanceId, configSchem
     bodyEl.querySelectorAll('[data-key]').forEach(input => {
       const v = input.value.trim();
       if (!v) return;
+      // Skip fields hidden by x-show-when (their parent .tool-config-field has display:none)
+      const fieldWrapper = input.closest('.tool-config-field');
+      if (fieldWrapper && fieldWrapper.style.display === 'none') return;
       const fieldDef = props[input.dataset.key];
       if (fieldDef?.type === 'integer') values[input.dataset.key] = parseInt(v, 10);
       else if (fieldDef?.type === 'number') values[input.dataset.key] = parseFloat(v);


### PR DESCRIPTION
## Summary
- Add 9 Claude Code-style system tools (Bash, Read, Write, Edit, Glob, Grep, WebFetch, WebSearch, PythonExec) for general-purpose agent capabilities
- Add WebSearch with baidu search API integration + configSchema UI in decision_core
- Fix channel routing: remote_web/remote_mic → TTS only, channel:* → channel_reply only
- Fix subagent: desktop tools now accessible + completion events trigger main agent
- Fix sidebar save: skip hidden (x-show-when) fields

## Test plan
- [x] WebSearch returns structured results on R1
- [x] Subagent can use WebSearch/WebFetch
- [x] Subagent completion triggers main agent auto-wakeup
- [x] Long research tasks use subagent pattern (spawn + TTS notify)
- [ ] remote_web messages get TTS response (GLM-5.2 compliance pending)

🤖 Generated with [Claude Code](https://claude.com/claude-code)