### PR TITLE
feat: skill marketplace upgrade + misc fixes

### DIFF
--- a/agent-core/resource/memory/defaults/prompt_system.md
+++ b/agent-core/resource/memory/defaults/prompt_system.md
@@ -82,6 +82,7 @@ IMU 姿态变化：pitch +5°
 
 **关键原则：**
 - 根据事件的 channel 选择对应的回复方式（见"渠道与响应"部分），绝不跨渠道回复。
+- **耗时操作前先告知用户**：当你需要调用可能耗时的工具（如 WebSearch、WebFetch、subagent_spawn、Bash 执行远程命令等）时，**必须先用 TTS/speaker 告知用户**你正在做什么（如"我帮你查一下"、"让我搜索一下相关信息"、"稍等，我查阅一下资料"），然后再调用耗时工具。不要让用户在无反馈的沉默中等待。
 - 注意调用顺序和时机。工具按你给出的顺序依次执行——先写的先执行。根据场景决定说话和动作的先后：执行动作前告知用户意图（"我来站起来"→站立），或动作完成后报告结果（站立→"好了，我站起来了"）。
 - 仅传感器查询类工具（type=sensor）如果相邻会自动并行。其余工具严格按序执行。如果需要 A 的结果才能做 B，请分多轮调用。
 - content 字段（文字输出）仅用于内部思考记录，不会被用户感知到。与用户沟通必须通过工具。
@@ -89,37 +90,17 @@ IMU 姿态变化：pitch +5°
 
 ---
 
-# 可用工具
+# 工具使用
 
-当前可用的工具由 **L2 环境快照** 列出（每轮实时更新）。
+可用工具由 API 实时提供，分三类：
+1. **系统工具** — finish, update_memory, task_*, subagent_*, activate/deactivate_skill
+2. **通用能力工具** — Read, Write, Edit, Glob, Grep, Bash, PythonExec, WebFetch, WebSearch
+3. **MCP 设备工具** — 命名格式 `mcp__<设备id>__<工具名>`
 
-系统内置工具（始终可用）：
-- `finish` — 结束本轮任务，回到等待事件状态。
-- `update_memory` — 更新长期记忆（永久写入）。
-- `task_create(goal, check_cron?)` — 创建长时间任务并追踪。check_cron 设置自动检查间隔（如 `*/2 * * * *` 每2分钟）。
-- `task_update(id, progress?)` — 更新任务进展描述。
-- `task_done(id, summary?)` — 标记任务完成，停止定时检查。
-- `task_fail(id, reason?)` — 标记任务失败，停止定时检查。
-- `task_list()` — 查看所有活跃任务。
-- `task_force_clear()` — 强制清除所有活跃任务及其定时检查。
-- `subagent_spawn(goal, priority?, tools?, model?, max_rounds?, context?)` — 创建子代理异步执行任务。子代理在独立上下文中运行，不影响当前对话。
-- `subagent_spawn_sync(goal, ...)` — 创建子代理并等待结果返回。适合需要立即获得结果的查询。
-- `subagent_status(id?)` — 查看子代理状态（留空列出全部）。
-- `subagent_cancel(id, reason?)` — 取消子代理。
-- `subagent_message(id, text)` — 向运行中的子代理发送指令。
-- `subagent_result(id)` — 获取已完成子代理的结果。
-- `activate_skill(slug)` — 激活已安装技能，获取完整指令。
-- `deactivate_skill(slug)` — 停用技能，释放上下文空间。
+## 行为原则
 
-**通用能力工具（始终可用）：**
-- `Read(file_path, offset?, limit?)` — 读取文件内容（带行号）。查看文件时始终使用此工具，不要用 Bash cat。
-- `Write(file_path, content)` — 创建或覆写文件。
-- `Edit(file_path, old_string, new_string)` — 精确替换文件中的一段文本。修改文件时优先使用此工具而非 Write 整体覆写。
-- `Glob(pattern, path?)` — 按文件名模式搜索。查找文件时使用此工具，不要用 Bash find/ls。
-- `Grep(pattern, path?, include?)` — 按内容正则搜索。搜索代码/配置内容时使用此工具，不要用 Bash grep。
-- `Bash(command, timeout?, cwd?)` — 执行 Shell 命令。用于系统监控、包管理、进程操作等上述专用工具无法完成的任务。
-- `PythonExec(code, timeout?)` — 执行 Python 代码（沙盒）。用于计算、数据处理、JSON 操作。同一轮内变量持久。
-- `WebFetch(url, prompt?, timeout?)` — 抓取 URL 内容（HTML 自动转 Markdown）。
+- **耗时操作前先告知用户**：调用 WebSearch、WebFetch、subagent_spawn 等耗时工具前，先用 TTS 告知用户（如"我帮你查一下"），不要让用户沉默等待。
+- **任务追踪**：预计超过 30 秒的动作用 `task_create` 追踪。收到 `task:<id>` 来源的检查事件时，查询实际状态并用 `task_update` 记录进展。任务完成/失败后及时调用 `task_done` / `task_fail`。
 
 **通用工具使用原则：**
 - 读取文件用 `Read`，不要用 `Bash("cat ...")`。
@@ -130,19 +111,13 @@ IMU 姿态变化：pitch +5°
 - `PythonExec` 用于需要计算或数据处理的场景，比 Bash 更适合复杂逻辑。
 - 这些工具操作的文件限制在 /work 和 /tmp 目录内。
 
-**任务工具使用原则：**
-- 发起预计超过 30 秒的动作（导航、巡逻、等待等）时，用 `task_create` 追踪。
-- 收到 `task:<id>` 来源的检查事件时，查询实际状态并用 `task_update` 记录进展。
-- 被打断问话时，参考 L2 中 `<active_tasks>` 回答进度问题。
-- 任务完成/失败后及时调用 `task_done` / `task_fail`，可选择性告知用户。
-
 **子代理使用原则：**
 - 优先级为 0 的事件（传感器等）已由框架自动交给 background agent 处理，无需手动 spawn。
 - **当任务需要多步搜索、调研、或信息收集时，应使用 `subagent_spawn` 异步执行。** Main agent 告知用户需要一些时间，spawn 子代理后 finish，不必等待结果。
 - 简单的单次查询（如抓取一个已知 URL、查一条新闻标题）可在 main agent 内直接完成。
 - 子代理完成后会通过 subagent_report 事件通知你，届时用合适的方式（TTS/channel_reply 等，视来源渠道而定）将结果告知用户。
 - 子代理不能创建子代理，不能修改记忆，不能管理任务——它们只执行具体操作并返回结果。
-- 如需查看传感器的历史数据，使用 `raw_input_info(source, limit)` 工具按需查询。传感器数据不会主动出现在你的输入中，但你随时可以主动查询。
+- 如需查看传感器的历史数据，使用 `raw_input_info(source, limit)` 工具按需查询。
 
 MCP 工具命名格式：`mcp__<设备id>__<工具名>`
 

--- a/agent-core/resource/memory/prompt_system.md
+++ b/agent-core/resource/memory/prompt_system.md
@@ -82,6 +82,7 @@ IMU 姿态变化：pitch +5°
 
 **关键原则：**
 - 根据事件的 channel 选择对应的回复方式（见"渠道与响应"部分），绝不跨渠道回复。
+- **耗时操作前先告知用户**：当你需要调用可能耗时的工具（如 WebSearch、WebFetch、subagent_spawn、Bash 执行远程命令等）时，**必须先用 TTS/speaker 告知用户**你正在做什么（如"我帮你查一下"、"让我搜索一下相关信息"、"稍等，我查阅一下资料"），然后再调用耗时工具。不要让用户在无反馈的沉默中等待。
 - 注意调用顺序和时机。工具按你给出的顺序依次执行——先写的先执行。根据场景决定说话和动作的先后：执行动作前告知用户意图（"我来站起来"→站立），或动作完成后报告结果（站立→"好了，我站起来了"）。
 - 仅传感器查询类工具（type=sensor）如果相邻会自动并行。其余工具严格按序执行。如果需要 A 的结果才能做 B，请分多轮调用。
 - content 字段（文字输出）仅用于内部思考记录，不会被用户感知到。与用户沟通必须通过工具。
@@ -89,37 +90,17 @@ IMU 姿态变化：pitch +5°
 
 ---
 
-# 可用工具
+# 工具使用
 
-当前可用的工具由 **L2 环境快照** 列出（每轮实时更新）。
+可用工具由 API 实时提供，分三类：
+1. **系统工具** — finish, update_memory, task_*, subagent_*, activate/deactivate_skill
+2. **通用能力工具** — Read, Write, Edit, Glob, Grep, Bash, PythonExec, WebFetch, WebSearch
+3. **MCP 设备工具** — 命名格式 `mcp__<设备id>__<工具名>`
 
-系统内置工具（始终可用）：
-- `finish` — 结束本轮任务，回到等待事件状态。
-- `update_memory` — 更新长期记忆（永久写入）。
-- `task_create(goal, check_cron?)` — 创建长时间任务并追踪。check_cron 设置自动检查间隔（如 `*/2 * * * *` 每2分钟）。
-- `task_update(id, progress?)` — 更新任务进展描述。
-- `task_done(id, summary?)` — 标记任务完成，停止定时检查。
-- `task_fail(id, reason?)` — 标记任务失败，停止定时检查。
-- `task_list()` — 查看所有活跃任务。
-- `task_force_clear()` — 强制清除所有活跃任务及其定时检查。
-- `subagent_spawn(goal, priority?, tools?, model?, max_rounds?, context?)` — 创建子代理异步执行任务。子代理在独立上下文中运行，不影响当前对话。
-- `subagent_spawn_sync(goal, ...)` — 创建子代理并等待结果返回。适合需要立即获得结果的查询。
-- `subagent_status(id?)` — 查看子代理状态（留空列出全部）。
-- `subagent_cancel(id, reason?)` — 取消子代理。
-- `subagent_message(id, text)` — 向运行中的子代理发送指令。
-- `subagent_result(id)` — 获取已完成子代理的结果。
-- `activate_skill(slug)` — 激活已安装技能，获取完整指令。
-- `deactivate_skill(slug)` — 停用技能，释放上下文空间。
+## 行为原则
 
-**通用能力工具（始终可用）：**
-- `Read(file_path, offset?, limit?)` — 读取文件内容（带行号）。查看文件时始终使用此工具，不要用 Bash cat。
-- `Write(file_path, content)` — 创建或覆写文件。
-- `Edit(file_path, old_string, new_string)` — 精确替换文件中的一段文本。修改文件时优先使用此工具而非 Write 整体覆写。
-- `Glob(pattern, path?)` — 按文件名模式搜索。查找文件时使用此工具，不要用 Bash find/ls。
-- `Grep(pattern, path?, include?)` — 按内容正则搜索。搜索代码/配置内容时使用此工具，不要用 Bash grep。
-- `Bash(command, timeout?, cwd?)` — 执行 Shell 命令。用于系统监控、包管理、进程操作等上述专用工具无法完成的任务。
-- `PythonExec(code, timeout?)` — 执行 Python 代码（沙盒）。用于计算、数据处理、JSON 操作。同一轮内变量持久。
-- `WebFetch(url, prompt?, timeout?)` — 抓取 URL 内容（HTML 自动转 Markdown）。
+- **耗时操作前先告知用户**：调用 WebSearch、WebFetch、subagent_spawn 等耗时工具前，先用 TTS 告知用户（如"我帮你查一下"），不要让用户沉默等待。
+- **任务追踪**：预计超过 30 秒的动作用 `task_create` 追踪。收到 `task:<id>` 来源的检查事件时，查询实际状态并用 `task_update` 记录进展。任务完成/失败后及时调用 `task_done` / `task_fail`。
 
 **通用工具使用原则：**
 - 读取文件用 `Read`，不要用 `Bash("cat ...")`。
@@ -130,19 +111,13 @@ IMU 姿态变化：pitch +5°
 - `PythonExec` 用于需要计算或数据处理的场景，比 Bash 更适合复杂逻辑。
 - 这些工具操作的文件限制在 /work 和 /tmp 目录内。
 
-**任务工具使用原则：**
-- 发起预计超过 30 秒的动作（导航、巡逻、等待等）时，用 `task_create` 追踪。
-- 收到 `task:<id>` 来源的检查事件时，查询实际状态并用 `task_update` 记录进展。
-- 被打断问话时，参考 L2 中 `<active_tasks>` 回答进度问题。
-- 任务完成/失败后及时调用 `task_done` / `task_fail`，可选择性告知用户。
-
 **子代理使用原则：**
 - 优先级为 0 的事件（传感器等）已由框架自动交给 background agent 处理，无需手动 spawn。
 - **当任务需要多步搜索、调研、或信息收集时，应使用 `subagent_spawn` 异步执行。** Main agent 告知用户需要一些时间，spawn 子代理后 finish，不必等待结果。
 - 简单的单次查询（如抓取一个已知 URL、查一条新闻标题）可在 main agent 内直接完成。
 - 子代理完成后会通过 subagent_report 事件通知你，届时用合适的方式（TTS/channel_reply 等，视来源渠道而定）将结果告知用户。
 - 子代理不能创建子代理，不能修改记忆，不能管理任务——它们只执行具体操作并返回结果。
-- 如需查看传感器的历史数据，使用 `raw_input_info(source, limit)` 工具按需查询。传感器数据不会主动出现在你的输入中，但你随时可以主动查询。
+- 如需查看传感器的历史数据，使用 `raw_input_info(source, limit)` 工具按需查询。
 
 MCP 工具命名格式：`mcp__<设备id>__<工具名>`
 

--- a/agent-core/src/api/config.py
+++ b/agent-core/src/api/config.py
@@ -825,14 +825,29 @@ async def reset_config(req: ResetRequest):
                     others.append(name)
 
         # Restart others first, then self last
-        if others:
-            subprocess.Popen(
-                ['docker', 'restart'] + others,
+        # Spawn a detached sidecar container to do the restart — child processes
+        # inside this container get killed when it restarts, so we need an external actor.
+        targets = others + ([self_name] if restart_self else [])
+        if targets:
+            restart_script = 'sleep 2; ' + '; '.join(f'docker restart {name}' for name in targets)
+            # Reuse our own image (guaranteed available locally) as the restart helper
+            own_image_result = subprocess.run(
+                ['docker', 'inspect', self_name, '--format', '{{.Config.Image}}'],
+                capture_output=True, text=True
+            )
+            helper_image = own_image_result.stdout.strip() or 'alpine'
+            # Remove stale helper if exists
+            subprocess.run(
+                ['docker', 'rm', '-f', 'phanthy-restart-helper'],
                 stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
             )
-        if restart_self:
             subprocess.Popen(
-                ['sh', '-c', f'sleep 3 && docker restart {self_name}'],
+                ['docker', 'run', '--rm', '-d',
+                 '--name', 'phanthy-restart-helper',
+                 '--entrypoint', 'sh',
+                 '-v', '/var/run/docker.sock:/var/run/docker.sock',
+                 helper_image,
+                 '-c', restart_script],
                 stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
             )
 

--- a/agent-core/src/api/skills.py
+++ b/agent-core/src/api/skills.py
@@ -247,3 +247,149 @@ async def deactivate(body: dict = fastapi.Body(...)):
     slug = body.get('slug', '').strip()
     _skills_mod.active_skills.discard(slug)
     return {'code': 200, 'data': {'slug': slug, 'active': False}}
+
+
+# ── Resource Center proxy endpoints ─────────────────────────────────────────
+
+def _get_rc_token(request: fastapi.Request) -> str | None:
+    """从请求头 X-RC-Token 中获取 RC bearer token。"""
+    return request.headers.get('x-rc-token')
+
+
+@router.post('/rc/login')
+async def rc_login(body: dict = fastapi.Body(...)):
+    """代理登录 Resource Center，返回 bearer token。"""
+    rc_url = _get_rc_url()
+    identifier = body.get('identifier', '').strip()
+    password = body.get('password', '')
+    if not identifier or not password:
+        return {'code': 422, 'error': '请输入账号和密码'}
+
+    try:
+        import httpx
+        async with httpx.AsyncClient(timeout=10) as http:
+            resp = await http.post(f'{rc_url}/api/auth/login', json={
+                'identifier': identifier, 'password': password
+            })
+            data = resp.json()
+            if resp.status_code == 200 and data.get('ok'):
+                return {'code': 200, 'data': {
+                    'token': data['token'],
+                    'userId': data.get('userId'),
+                    'role': data.get('role'),
+                }}
+            return {'code': resp.status_code, 'error': data.get('error', '登录失败')}
+    except Exception as e:
+        return {'code': 502, 'error': f'无法连接 Resource Center: {e}'}
+
+
+@router.get('/rc/mine')
+async def rc_my_skills(request: fastapi.Request):
+    """代理获取用户在 RC 上的技能列表。"""
+    token = _get_rc_token(request)
+    if not token:
+        return {'code': 401, 'error': '未登录 Resource Center'}
+
+    rc_url = _get_rc_url()
+    try:
+        import httpx
+        async with httpx.AsyncClient(timeout=10) as http:
+            resp = await http.get(f'{rc_url}/api/skills/mine', headers={
+                'Authorization': f'Bearer {token}'
+            })
+            data = resp.json()
+            if resp.status_code == 200:
+                return {'code': 200, 'data': data.get('data', [])}
+            return {'code': resp.status_code, 'error': data.get('error', '获取失败')}
+    except Exception as e:
+        return {'code': 502, 'error': f'无法连接 Resource Center: {e}'}
+
+
+@router.post('/rc/mine')
+async def rc_create_skill(request: fastapi.Request, body: dict = fastapi.Body(...)):
+    """代理在 RC 上创建/更新技能。"""
+    token = _get_rc_token(request)
+    if not token:
+        return {'code': 401, 'error': '未登录 Resource Center'}
+
+    rc_url = _get_rc_url()
+    try:
+        import httpx
+        async with httpx.AsyncClient(timeout=15) as http:
+            resp = await http.post(f'{rc_url}/api/skills/mine', json=body, headers={
+                'Authorization': f'Bearer {token}',
+                'Content-Type': 'application/json',
+            })
+            data = resp.json()
+            if resp.status_code == 200 and data.get('ok'):
+                return {'code': 200, 'data': data.get('data')}
+            return {'code': resp.status_code, 'error': data.get('error', '操作失败')}
+    except Exception as e:
+        return {'code': 502, 'error': f'无法连接 Resource Center: {e}'}
+
+
+@router.put('/rc/mine/{skill_id}')
+async def rc_update_skill(skill_id: str, request: fastapi.Request, body: dict = fastapi.Body(...)):
+    """代理更新 RC 上的技能。"""
+    token = _get_rc_token(request)
+    if not token:
+        return {'code': 401, 'error': '未登录 Resource Center'}
+
+    rc_url = _get_rc_url()
+    try:
+        import httpx
+        async with httpx.AsyncClient(timeout=15) as http:
+            resp = await http.put(f'{rc_url}/api/skills/mine/{skill_id}', json=body, headers={
+                'Authorization': f'Bearer {token}',
+                'Content-Type': 'application/json',
+            })
+            data = resp.json()
+            if resp.status_code == 200 and data.get('ok'):
+                return {'code': 200, 'data': data.get('data')}
+            return {'code': resp.status_code, 'error': data.get('error', '更新失败')}
+    except Exception as e:
+        return {'code': 502, 'error': f'无法连接 Resource Center: {e}'}
+
+
+@router.delete('/rc/mine/{skill_id}')
+async def rc_delete_skill(skill_id: str, request: fastapi.Request):
+    """代理删除 RC 上的技能。"""
+    token = _get_rc_token(request)
+    if not token:
+        return {'code': 401, 'error': '未登录 Resource Center'}
+
+    rc_url = _get_rc_url()
+    try:
+        import httpx
+        async with httpx.AsyncClient(timeout=10) as http:
+            resp = await http.delete(f'{rc_url}/api/skills/mine/{skill_id}', headers={
+                'Authorization': f'Bearer {token}'
+            })
+            data = resp.json()
+            if resp.status_code == 200 and data.get('ok'):
+                return {'code': 200, 'data': {'id': skill_id}}
+            return {'code': resp.status_code, 'error': data.get('error', '删除失败')}
+    except Exception as e:
+        return {'code': 502, 'error': f'无法连接 Resource Center: {e}'}
+
+
+@router.post('/rc/mine/{skill_id}/submit')
+async def rc_submit_skill(skill_id: str, request: fastapi.Request):
+    """代理提交技能送审。"""
+    token = _get_rc_token(request)
+    if not token:
+        return {'code': 401, 'error': '未登录 Resource Center'}
+
+    rc_url = _get_rc_url()
+    try:
+        import httpx
+        async with httpx.AsyncClient(timeout=10) as http:
+            resp = await http.post(f'{rc_url}/api/skills/mine/{skill_id}/submit', headers={
+                'Authorization': f'Bearer {token}'
+            })
+            data = resp.json()
+            if resp.status_code == 200 and data.get('ok'):
+                return {'code': 200, 'data': data.get('data')}
+            return {'code': resp.status_code, 'error': data.get('error', '提交失败')}
+    except Exception as e:
+        return {'code': 502, 'error': f'无法连接 Resource Center: {e}'}

--- a/agent-core/src/event/llm.py
+++ b/agent-core/src/event/llm.py
@@ -253,6 +253,46 @@ def get_recent_context(max_turns: int = 5) -> str:
     return '\n'.join(lines[-10:])  # 最多 10 行
 
 
+def get_recent_context_rich(max_turns: int = 20, max_chars: int = 6000) -> str:
+    """返回 main agent 最近对话的原始片段，供 subagent 理解完整上下文。
+
+    策略：20 轮内，纯字符串提取，不额外调 LLM。包含用户消息、
+    assistant 决策文本、tool 结果（含 subagent_result 返回值）。
+    """
+    if not _event_instance or not _event_instance._turns:
+        return ''
+    recent = _event_instance._turns[-max_turns:]
+    parts = []
+    total = 0
+    truncated = False
+    for turn in recent:
+        if truncated:
+            break
+        for msg in turn:
+            role = msg.get('role', '')
+            content = msg.get('content', '')
+            if not content:
+                continue
+            # 跳过 <status 开头的环境快照（噪音大）
+            if role == 'user' and content.startswith('<status'):
+                continue
+            if role == 'user':
+                line = f'[用户] {content[:500]}'
+            elif role == 'assistant':
+                line = f'[助手] {content[:500]}'
+            elif role == 'tool':
+                line = f'[工具结果] {content[:800]}'
+            else:
+                continue
+            if total + len(line) > max_chars:
+                parts.append('...(更早历史已截断)')
+                truncated = True
+                break
+            parts.append(line)
+            total += len(line)
+    return '\n'.join(parts)
+
+
 class Event:
     def __init__(self):
         self._turns: list[list[dict]] = []  # 每轮对话的消息列表

--- a/agent-core/src/start.py
+++ b/agent-core/src/start.py
@@ -1,5 +1,6 @@
 import contextlib
 import asyncio
+import logging
 import pathlib
 import shutil
 import subprocess
@@ -612,6 +613,15 @@ def _ensure_ssl_certs(cert_dir: str = "./resource/certs") -> tuple[str, str]:
 
 # ========== 启动服务 ==========
 if __name__ == '__main__':
+    # Suppress noisy "SSL connection is closed" from uvicorn/asyncio
+    class _SSLCloseFilter(logging.Filter):
+        def filter(self, record):
+            return 'SSL connection is closed' not in record.getMessage()
+
+    logging.getLogger('uvicorn.error').addFilter(_SSLCloseFilter())
+    logging.getLogger('asyncio').addFilter(_SSLCloseFilter())
+
     cert_file, key_file = _ensure_ssl_certs()
     uvicorn.run(app, host='0.0.0.0', port=15678, ws_ping_interval=None,
-                ssl_certfile=cert_file, ssl_keyfile=key_file)
+                ssl_certfile=cert_file, ssl_keyfile=key_file,
+                timeout_keep_alive=65)

--- a/agent-core/src/subagent/tools.py
+++ b/agent-core/src/subagent/tools.py
@@ -20,6 +20,44 @@ class SubagentTools:
     def __init__(self, manager: SubagentManager):
         self._mgr = manager
 
+    def _build_context_with_history(self, explicit_context: str, goal: str) -> str:
+        """自动注入 main agent 对话历史 + 已完成 subagent 结果，减少重复劳动。
+
+        无论 LLM 是否传了 context，都会注入系统提取的历史信息。
+        纯字符串提取，零额外 LLM 调用。
+        """
+        sections = []
+
+        # 1. Main agent 近期对话（20轮内）
+        try:
+            from event.llm import get_recent_context_rich
+            recent = get_recent_context_rich(max_turns=20, max_chars=6000)
+            if recent:
+                sections.append(f'[主代理近期对话]\n{recent}')
+        except (ImportError, AttributeError):
+            pass
+
+        # 2. 已完成的 subagent 结果（非 bg，最近3个）
+        recent_results = []
+        for agent_id, result in self._mgr._completed.items():
+            if result.status != 'completed' or not result.output:
+                continue
+            # Skip background monitoring results
+            if result.output.startswith('电池') or result.output.startswith('后台监控'):
+                continue
+            output_summary = result.output[:1500]
+            if len(result.output) > 1500:
+                output_summary += '...'
+            recent_results.append(f'[子代理 {agent_id[:8]} 结果] {output_summary}')
+        if recent_results:
+            sections.append('\n\n'.join(recent_results[-3:]))
+
+        # 3. LLM 显式传入的 context（合并，不丢弃）
+        if explicit_context:
+            sections.append(f'[额外上下文]\n{explicit_context}')
+
+        return '\n\n'.join(sections) if sections else ''
+
     async def subagent_spawn(
         self,
         goal: Annotated[str, "子代理的任务目标描述"],
@@ -30,6 +68,7 @@ class SubagentTools:
         context: Annotated[str, "传递给子代理的初始上下文信息"] = '',
     ) -> str:
         """创建子代理异步执行任务。返回 agent_id 用于后续查询。适合不需要立即结果的后台任务。"""
+        context_seed = self._build_context_with_history(context, goal)
         tool_filter = None if tools == '*' else [t.strip() for t in tools.split(',')]
         spec = SubagentSpec(
             goal=goal,
@@ -37,7 +76,7 @@ class SubagentTools:
             model=model or None,
             tool_filter=tool_filter,
             max_rounds=max_rounds,
-            context_seed=context,
+            context_seed=context_seed,
         )
         agent_id = await self._mgr.spawn(spec)
         return f'子代理已创建: id={agent_id}, priority={spec.priority}, 任务: {goal[:80]}'
@@ -53,6 +92,7 @@ class SubagentTools:
         timeout: Annotated[int, "等待超时秒数"] = 120,
     ) -> str:
         """创建子代理并等待结果返回。适合需要立即获得结果的查询类任务。会阻塞当前轮直到完成。"""
+        context_seed = self._build_context_with_history(context, goal)
         tool_filter = None if tools == '*' else [t.strip() for t in tools.split(',')]
         spec = SubagentSpec(
             goal=goal,
@@ -60,7 +100,7 @@ class SubagentTools:
             model=model or None,
             tool_filter=tool_filter,
             max_rounds=max_rounds,
-            context_seed=context,
+            context_seed=context_seed,
         )
         result = await self._mgr.spawn_and_wait(spec, timeout=float(timeout))
         if result.status == 'completed':

--- a/agent-core/web/css/style.css
+++ b/agent-core/web/css/style.css
@@ -4372,6 +4372,202 @@ html, body {
   color: var(--red);
 }
 
+/* ── RC Login & My Skills ─────────────────────────────────────────────── */
+
+.skill-rc-login-status {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-left: auto;
+  margin-right: 8px;
+  font-size: 11px;
+}
+.rc-logged-in {
+  color: var(--green, #22c55e);
+  font-weight: 500;
+}
+.rc-logout-btn {
+  font-size: 10px;
+  padding: 2px 8px;
+  border-radius: 4px;
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+}
+.rc-logout-btn:hover { background: var(--red-bg); color: var(--red); border-color: var(--red); }
+
+.skill-rc-login {
+  padding: 24px 16px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+}
+.skill-rc-login-hint {
+  font-size: 12px;
+  color: var(--text-muted);
+  margin: 0;
+}
+.skill-rc-login form {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  justify-content: center;
+  width: 100%;
+  max-width: 360px;
+}
+.skill-rc-login input {
+  flex: 1;
+  min-width: 120px;
+  height: 32px;
+  padding: 0 10px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--bg);
+  font-size: 12px;
+  color: var(--text);
+}
+.skill-rc-login input:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+.skill-rc-login-error {
+  font-size: 11px;
+  color: var(--red, #ef4444);
+  margin: 0;
+}
+
+.skill-mine-toolbar {
+  display: flex;
+  justify-content: flex-end;
+  padding: 8px 0;
+  margin-bottom: 4px;
+}
+
+.skill-mine-actions {
+  display: flex;
+  gap: 6px;
+  margin-top: 8px;
+  padding-top: 8px;
+  border-top: 1px solid var(--border);
+}
+
+.skill-mine-status {
+  font-size: 10px;
+  font-weight: 500;
+  padding: 2px 8px;
+  border-radius: 10px;
+  white-space: nowrap;
+}
+.skill-mine-status.status-draft { background: rgba(107,114,128,.12); color: #6b7280; }
+.skill-mine-status.status-pending { background: rgba(217,119,6,.12); color: #d97706; }
+.skill-mine-status.status-published { background: rgba(34,197,94,.12); color: #22c55e; }
+.skill-mine-status.status-rejected { background: rgba(239,68,68,.12); color: #ef4444; }
+
+/* ── Skill buttons ─────────────────────────────────────────────────────── */
+
+.skill-btn {
+  font-size: 11px;
+  font-family: var(--font-ui);
+  padding: 5px 12px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: all .15s;
+}
+.skill-btn:hover { background: var(--bg-hover, rgba(0,0,0,.03)); }
+.skill-btn-primary {
+  background: var(--accent);
+  color: #fff;
+  border-color: var(--accent);
+}
+.skill-btn-primary:hover { opacity: .85; background: var(--accent); }
+.skill-btn-sm { padding: 3px 10px; font-size: 10px; }
+.skill-btn-warn { background: rgba(217,119,6,.1); color: #d97706; border-color: rgba(217,119,6,.3); }
+.skill-btn-warn:hover { background: rgba(217,119,6,.2); }
+.skill-btn-danger { color: var(--red, #ef4444); border-color: rgba(239,68,68,.3); }
+.skill-btn-danger:hover { background: var(--red-bg, rgba(239,68,68,.08)); }
+
+/* ── Skill Create/Edit Form Modal ──────────────────────────────────────── */
+
+.skill-form-modal {
+  width: min(560px, 92vw);
+  max-height: 88vh;
+  display: flex;
+  flex-direction: column;
+}
+.skill-form-body {
+  overflow-y: auto;
+  padding: 16px 20px;
+  scrollbar-width: thin;
+}
+.skill-form-body form {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.skill-form-row {
+  display: flex;
+  gap: 10px;
+}
+.skill-form-field {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.skill-form-field-sm { flex: 0 0 70px; }
+.skill-form-field label {
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--text-muted);
+}
+.skill-form-field label .required { color: var(--accent); }
+.skill-form-field input,
+.skill-form-field textarea,
+.skill-form-field select {
+  width: 100%;
+  height: 32px;
+  padding: 0 10px;
+  font-size: 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--bg);
+  color: var(--text);
+}
+.skill-form-field input:focus,
+.skill-form-field textarea:focus,
+.skill-form-field select:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+.skill-form-field textarea {
+  height: auto;
+  padding: 8px 10px;
+  resize: vertical;
+  line-height: 1.5;
+}
+.skill-form-field textarea.mono,
+.skill-form-field input.mono {
+  font-family: var(--font-mono);
+  font-size: 11px;
+}
+.skill-form-error {
+  font-size: 11px;
+  color: var(--red, #ef4444);
+  margin: 0;
+}
+.skill-form-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  padding-top: 12px;
+  border-top: 1px solid var(--border);
+}
+
 /* ═══════════════════════════════════════════════════════════════════════════
    History Modal
    ═══════════════════════════════════════════════════════════════════════════ */

--- a/agent-core/web/css/style.css
+++ b/agent-core/web/css/style.css
@@ -4398,39 +4398,54 @@ html, body {
 .rc-logout-btn:hover { background: var(--red-bg); color: var(--red); border-color: var(--red); }
 
 .skill-rc-login {
-  padding: 24px 16px;
+  padding: 20px 24px;
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 12px;
+  gap: 14px;
 }
 .skill-rc-login-hint {
-  font-size: 12px;
+  font-size: 13px;
   color: var(--text-muted);
   margin: 0;
+  text-align: center;
+  line-height: 1.5;
 }
 .skill-rc-login form {
   display: flex;
   gap: 8px;
-  flex-wrap: wrap;
-  justify-content: center;
+  align-items: center;
   width: 100%;
-  max-width: 360px;
+  max-width: 380px;
 }
 .skill-rc-login input {
   flex: 1;
-  min-width: 120px;
-  height: 32px;
-  padding: 0 10px;
+  min-width: 0;
+  height: 34px;
+  padding: 0 12px;
   border: 1px solid var(--border);
-  border-radius: var(--radius-sm);
-  background: var(--bg);
+  border-radius: 8px;
+  background: rgba(255,255,255,0.7);
   font-size: 12px;
   color: var(--text);
+  transition: border-color .15s, box-shadow .15s;
 }
 .skill-rc-login input:focus {
   outline: none;
   border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-dim);
+  background: #fff;
+}
+.skill-rc-login input::placeholder {
+  color: #b8b0a4;
+}
+.skill-rc-login .skill-btn-primary {
+  height: 34px;
+  border-radius: 8px;
+  font-size: 12px;
+  font-weight: 500;
+  padding: 0 16px;
+  white-space: nowrap;
 }
 .skill-rc-login-error {
   font-size: 11px;
@@ -4441,24 +4456,25 @@ html, body {
 .skill-mine-toolbar {
   display: flex;
   justify-content: flex-end;
-  padding: 8px 0;
-  margin-bottom: 4px;
+  padding: 12px 0;
+  margin-bottom: 8px;
 }
 
 .skill-mine-actions {
   display: flex;
   gap: 6px;
-  margin-top: 8px;
-  padding-top: 8px;
+  margin-top: 10px;
+  padding-top: 10px;
   border-top: 1px solid var(--border);
 }
 
 .skill-mine-status {
   font-size: 10px;
-  font-weight: 500;
-  padding: 2px 8px;
+  font-weight: 600;
+  padding: 3px 9px;
   border-radius: 10px;
   white-space: nowrap;
+  letter-spacing: 0.02em;
 }
 .skill-mine-status.status-draft { background: rgba(107,114,128,.12); color: #6b7280; }
 .skill-mine-status.status-pending { background: rgba(217,119,6,.12); color: #d97706; }

--- a/agent-core/web/css/style.css
+++ b/agent-core/web/css/style.css
@@ -4824,8 +4824,8 @@ html, body {
 }
 
 /* ── Usage Modal ──────────────────────────────────────────────────────────── */
-.usage-modal { max-width: 520px; }
-.usage-body { padding: 20px; }
+.usage-modal { max-width: 520px; max-height: 88vh; display: flex; flex-direction: column; }
+.usage-body { padding: 20px; overflow-y: auto; flex: 1; min-height: 0; scrollbar-width: thin; }
 .usage-loading { text-align: center; color: var(--text-dim); padding: 40px 0; }
 
 /* Summary cards */
@@ -4922,9 +4922,36 @@ html, body {
   gap: 3px;
   height: 110px;
   padding: 0;
+  padding-bottom: 20px;
+  position: relative;
+}
+.usage-chart-wrap {
+  position: relative;
   margin-bottom: 24px;
   border-bottom: 1px solid var(--border);
-  padding-bottom: 20px;
+}
+.usage-y-lines {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 20px; /* match chart padding-bottom */
+  pointer-events: none;
+}
+.usage-y-line {
+  position: absolute;
+  left: 0;
+  right: 0;
+  border-top: 1px dashed rgba(0,0,0,0.08);
+}
+.usage-y-label {
+  position: absolute;
+  right: 0;
+  top: -14px;
+  font-size: 0.55rem;
+  color: var(--text-dim);
+  opacity: 0.7;
+  font-family: 'JetBrains Mono', monospace;
 }
 .usage-bar {
   flex: 1;

--- a/agent-core/web/index.html
+++ b/agent-core/web/index.html
@@ -394,16 +394,38 @@
   <div class="modal skill-modal">
     <div class="modal-header">
       <span class="modal-title">技能管理</span>
+      <div class="skill-rc-login-status" id="skill-rc-login-status"></div>
       <button class="btn-icon" id="skill-close">✕</button>
     </div>
     <div class="skill-tabs">
       <button class="skill-tab active" data-tab="installed">已安装</button>
+      <button class="skill-tab" data-tab="mine">我的技能</button>
       <button class="skill-tab" data-tab="browse">技能广场</button>
     </div>
     <div class="modal-body skill-modal-body">
       <div class="skill-panel active" data-panel="installed" id="skill-installed-panel">
         <div class="skill-empty" id="skill-installed-empty">暂无已安装技能</div>
         <div class="skill-list" id="skill-installed-list"></div>
+      </div>
+      <div class="skill-panel" data-panel="mine" id="skill-mine-panel">
+        <!-- Login form (shown when not logged in) -->
+        <div id="skill-rc-login-form" class="skill-rc-login">
+          <p class="skill-rc-login-hint">登录 Resource Center 以管理您的技能</p>
+          <form id="skill-rc-login-form-el">
+            <input type="email" id="skill-rc-email" placeholder="邮箱" required autocomplete="email">
+            <input type="password" id="skill-rc-password" placeholder="密码" required autocomplete="current-password">
+            <button type="submit" class="skill-btn skill-btn-primary">登录</button>
+          </form>
+          <p class="skill-rc-login-error hidden" id="skill-rc-login-error"></p>
+        </div>
+        <!-- My skills list (shown when logged in) -->
+        <div id="skill-mine-content" class="hidden">
+          <div class="skill-mine-toolbar">
+            <button class="skill-btn skill-btn-primary" id="skill-mine-create-btn">+ 创建技能</button>
+          </div>
+          <div class="skill-list" id="skill-mine-list"></div>
+          <div class="skill-empty hidden" id="skill-mine-empty">暂无技能，点击上方创建</div>
+        </div>
       </div>
       <div class="skill-panel" data-panel="browse" id="skill-browse-panel">
         <div class="skill-search-bar">
@@ -412,6 +434,75 @@
         <div class="skill-list" id="skill-browse-list"></div>
         <div class="skill-empty hidden" id="skill-browse-empty">未找到技能</div>
       </div>
+    </div>
+  </div>
+</div>
+
+<!-- Skill Create/Edit Form Modal -->
+<div class="modal-overlay hidden" id="skill-form-overlay">
+  <div class="modal skill-form-modal">
+    <div class="modal-header">
+      <span class="modal-title" id="skill-form-title">创建技能</span>
+      <button class="btn-icon" id="skill-form-close">✕</button>
+    </div>
+    <div class="modal-body skill-form-body">
+      <form id="skill-form-el">
+        <div class="skill-form-row">
+          <div class="skill-form-field">
+            <label>名称 <span class="required">*</span></label>
+            <input type="text" id="sf-name" required>
+          </div>
+          <div class="skill-form-field">
+            <label>Slug <span class="required">*</span></label>
+            <input type="text" id="sf-slug" required pattern="[a-z0-9-]+">
+          </div>
+        </div>
+        <div class="skill-form-row">
+          <div class="skill-form-field">
+            <label>分类</label>
+            <select id="sf-category">
+              <option value="navigation">navigation</option>
+              <option value="perception">perception</option>
+              <option value="manipulation">manipulation</option>
+              <option value="social">social</option>
+              <option value="utility" selected>utility</option>
+            </select>
+          </div>
+          <div class="skill-form-field skill-form-field-sm">
+            <label>图标</label>
+            <input type="text" id="sf-icon" placeholder="🤖">
+          </div>
+          <div class="skill-form-field">
+            <label>版本 <span class="required">*</span></label>
+            <input type="text" id="sf-version" required value="1.0.0">
+          </div>
+        </div>
+        <div class="skill-form-field">
+          <label>一句话描述 <span class="required">*</span></label>
+          <input type="text" id="sf-oneliner" required maxlength="80">
+        </div>
+        <div class="skill-form-field">
+          <label>详细描述 <span class="required">*</span></label>
+          <textarea id="sf-description" rows="2" required></textarea>
+        </div>
+        <div class="skill-form-field">
+          <label>指令 <span class="required">*</span></label>
+          <textarea id="sf-instruction" rows="8" required class="mono"></textarea>
+        </div>
+        <div class="skill-form-field">
+          <label>依赖工具（逗号分隔）</label>
+          <input type="text" id="sf-tools" placeholder="mic_start, speaker_play">
+        </div>
+        <div class="skill-form-field">
+          <label>配置模式 (JSON Schema)</label>
+          <textarea id="sf-configschema" rows="3" class="mono" placeholder='{"type":"object","properties":{}}'></textarea>
+        </div>
+        <p class="skill-form-error hidden" id="skill-form-error"></p>
+        <div class="skill-form-footer">
+          <button type="button" class="skill-btn" id="skill-form-cancel">取消</button>
+          <button type="submit" class="skill-btn skill-btn-primary" id="skill-form-submit-btn">保存</button>
+        </div>
+      </form>
     </div>
   </div>
 </div>

--- a/agent-core/web/index.html
+++ b/agent-core/web/index.html
@@ -412,7 +412,7 @@
         <div id="skill-rc-login-form" class="skill-rc-login">
           <p class="skill-rc-login-hint">登录 Resource Center 以管理您的技能</p>
           <form id="skill-rc-login-form-el">
-            <input type="email" id="skill-rc-email" placeholder="邮箱" required autocomplete="email">
+            <input type="text" id="skill-rc-email" placeholder="账号" required autocomplete="username">
             <input type="password" id="skill-rc-password" placeholder="密码" required autocomplete="current-password">
             <button type="submit" class="skill-btn skill-btn-primary">登录</button>
           </form>

--- a/agent-core/web/js/skills.js
+++ b/agent-core/web/js/skills.js
@@ -1,9 +1,32 @@
 /**
- * skills.js — 技能管理 modal（安装/卸载/浏览/详情/编辑/发布）
+ * skills.js — 技能管理 modal（安装/卸载/浏览/详情/编辑/发布/我的技能/RC登录）
  */
 
 let _overlay, _closeBtn, _tabs, _panels;
 let _installedList, _installedEmpty, _browseList, _browseEmpty, _searchInput;
+let _mineList, _mineEmpty, _mineContent, _loginForm;
+
+// ── RC Auth State ────────────────────────────────────────────────────────────
+
+function _getRcToken() { return localStorage.getItem('rc_token'); }
+function _setRcToken(token, role) {
+  localStorage.setItem('rc_token', token);
+  if (role) localStorage.setItem('rc_role', role);
+}
+function _clearRcToken() {
+  localStorage.removeItem('rc_token');
+  localStorage.removeItem('rc_role');
+}
+function _isRcLoggedIn() { return !!_getRcToken(); }
+
+function _rcHeaders() {
+  const h = { 'Content-Type': 'application/json' };
+  const token = _getRcToken();
+  if (token) h['X-RC-Token'] = token;
+  return h;
+}
+
+// ── Init ─────────────────────────────────────────────────────────────────────
 
 export function initSkills() {
   _overlay        = document.getElementById('skill-overlay');
@@ -15,6 +38,10 @@ export function initSkills() {
   _browseList     = document.getElementById('skill-browse-list');
   _browseEmpty    = document.getElementById('skill-browse-empty');
   _searchInput    = document.getElementById('skill-search');
+  _mineList       = document.getElementById('skill-mine-list');
+  _mineEmpty      = document.getElementById('skill-mine-empty');
+  _mineContent    = document.getElementById('skill-mine-content');
+  _loginForm      = document.getElementById('skill-rc-login-form');
 
   // Open / close
   document.getElementById('btn-skills').addEventListener('click', show);
@@ -28,6 +55,7 @@ export function initSkills() {
       _tabs.forEach(t => t.classList.toggle('active', t === tab));
       _panels.forEach(p => p.classList.toggle('active', p.dataset.panel === target));
       if (target === 'browse') _loadBrowse();
+      if (target === 'mine') _loadMine();
     });
   });
 
@@ -37,6 +65,23 @@ export function initSkills() {
     clearTimeout(_searchTimer);
     _searchTimer = setTimeout(_loadBrowse, 300);
   });
+
+  // RC Login form
+  document.getElementById('skill-rc-login-form-el').addEventListener('submit', _handleRcLogin);
+
+  // My Skills create button
+  document.getElementById('skill-mine-create-btn').addEventListener('click', () => _openSkillForm(null));
+
+  // Skill form modal
+  document.getElementById('skill-form-close').addEventListener('click', _closeSkillForm);
+  document.getElementById('skill-form-cancel').addEventListener('click', _closeSkillForm);
+  document.getElementById('skill-form-overlay').addEventListener('click', (e) => {
+    if (e.target.id === 'skill-form-overlay') _closeSkillForm();
+  });
+  document.getElementById('skill-form-el').addEventListener('submit', _handleSkillFormSubmit);
+
+  // Update login status display
+  _updateLoginStatus();
 }
 
 export function show() {
@@ -47,6 +92,52 @@ export function show() {
 
 export function hide() {
   _overlay.classList.add('hidden');
+}
+
+// ── RC Login ─────────────────────────────────────────────────────────────────
+
+function _updateLoginStatus() {
+  const el = document.getElementById('skill-rc-login-status');
+  if (_isRcLoggedIn()) {
+    el.innerHTML = `<span class="rc-logged-in">RC 已登录</span> <button class="rc-logout-btn" id="rc-logout-btn">退出</button>`;
+    el.querySelector('#rc-logout-btn').addEventListener('click', _handleRcLogout);
+  } else {
+    el.innerHTML = '';
+  }
+}
+
+async function _handleRcLogin(e) {
+  e.preventDefault();
+  const email = document.getElementById('skill-rc-email').value.trim();
+  const password = document.getElementById('skill-rc-password').value;
+  const errorEl = document.getElementById('skill-rc-login-error');
+  errorEl.classList.add('hidden');
+
+  try {
+    const res = await fetch('/api/skills/rc/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ identifier: email, password }),
+    });
+    const data = await res.json();
+    if (data.code === 200 && data.data?.token) {
+      _setRcToken(data.data.token, data.data.role);
+      _updateLoginStatus();
+      _loadMine();
+    } else {
+      errorEl.textContent = data.error || '登录失败';
+      errorEl.classList.remove('hidden');
+    }
+  } catch (err) {
+    errorEl.textContent = '网络错误: ' + err.message;
+    errorEl.classList.remove('hidden');
+  }
+}
+
+function _handleRcLogout() {
+  _clearRcToken();
+  _updateLoginStatus();
+  _loadMine();
 }
 
 // ── Installed tab ─────────────────────────────────────────────────────────
@@ -86,7 +177,6 @@ function _renderInstalled(skills) {
   // Bind click handlers (card body → detail)
   _installedList.querySelectorAll('.skill-card').forEach(card => {
     card.addEventListener('click', (e) => {
-      // Don't navigate if clicking action buttons
       if (e.target.closest('.skill-card-actions')) return;
       _showSkillDetail(card.dataset.slug);
     });
@@ -124,6 +214,210 @@ function _renderInstalled(skills) {
       else alert(data.error || '卸载失败');
     });
   });
+}
+
+// ── My Skills tab ─────────────────────────────────────────────────────────
+
+async function _loadMine() {
+  if (!_isRcLoggedIn()) {
+    _loginForm.classList.remove('hidden');
+    _mineContent.classList.add('hidden');
+    return;
+  }
+  _loginForm.classList.add('hidden');
+  _mineContent.classList.remove('hidden');
+
+  try {
+    const res = await fetch('/api/skills/rc/mine', { headers: _rcHeaders() });
+    const json = await res.json();
+    if (json.code === 401) {
+      _clearRcToken();
+      _updateLoginStatus();
+      _loadMine();
+      return;
+    }
+    const skills = json.data || [];
+    _renderMine(skills);
+  } catch { _renderMine([]); }
+}
+
+const STATUS_LABELS = {
+  draft: { label: '草稿', cls: 'status-draft' },
+  pending: { label: '待审核', cls: 'status-pending' },
+  published: { label: '已发布', cls: 'status-published' },
+  rejected: { label: '已拒绝', cls: 'status-rejected' },
+};
+
+function _renderMine(skills) {
+  _mineEmpty.classList.toggle('hidden', skills.length > 0);
+  if (!skills.length) {
+    _mineList.innerHTML = '';
+    return;
+  }
+  _mineList.innerHTML = skills.map(s => {
+    const st = STATUS_LABELS[s.status] || STATUS_LABELS.draft;
+    const canSubmit = ['draft', 'rejected'].includes(s.status);
+    return `
+    <div class="skill-card" data-id="${_esc(s.id)}">
+      <div class="skill-card-header">
+        <span class="skill-card-icon">${s.icon || '◆'}</span>
+        <div class="skill-card-info">
+          <span class="skill-card-name">${_esc(s.name)}</span>
+          <span class="skill-card-meta">${_esc(s.slug)} · v${_esc(s.version)}</span>
+        </div>
+        <div class="skill-card-actions">
+          <span class="skill-mine-status ${st.cls}">${st.label}</span>
+        </div>
+      </div>
+      <p class="skill-card-desc">${_esc(s.oneLiner)}</p>
+      <div class="skill-mine-actions">
+        <button class="skill-btn skill-btn-sm" data-action="edit" data-id="${_esc(s.id)}">编辑</button>
+        ${canSubmit ? `<button class="skill-btn skill-btn-sm skill-btn-warn" data-action="submit" data-id="${_esc(s.id)}">提交审核</button>` : ''}
+        <button class="skill-btn skill-btn-sm skill-btn-danger" data-action="delete" data-id="${_esc(s.id)}">删除</button>
+      </div>
+    </div>`;
+  }).join('');
+
+  // Bind actions
+  _mineList.querySelectorAll('[data-action="edit"]').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const skill = skills.find(s => s.id === btn.dataset.id);
+      if (skill) _openSkillForm(skill);
+    });
+  });
+  _mineList.querySelectorAll('[data-action="submit"]').forEach(btn => {
+    btn.addEventListener('click', () => _submitForReview(btn.dataset.id));
+  });
+  _mineList.querySelectorAll('[data-action="delete"]').forEach(btn => {
+    btn.addEventListener('click', () => _deleteMineSkill(btn.dataset.id));
+  });
+}
+
+async function _submitForReview(id) {
+  if (!confirm('确定提交审核？')) return;
+  try {
+    const res = await fetch(`/api/skills/rc/mine/${id}/submit`, {
+      method: 'POST',
+      headers: _rcHeaders(),
+    });
+    const data = await res.json();
+    if (data.code === 200) _loadMine();
+    else alert(data.error || '提交失败');
+  } catch (e) { alert('提交失败: ' + e.message); }
+}
+
+async function _deleteMineSkill(id) {
+  if (!confirm('确定删除此技能？')) return;
+  try {
+    const res = await fetch(`/api/skills/rc/mine/${id}`, {
+      method: 'DELETE',
+      headers: _rcHeaders(),
+    });
+    const data = await res.json();
+    if (data.code === 200) _loadMine();
+    else alert(data.error || '删除失败');
+  } catch (e) { alert('删除失败: ' + e.message); }
+}
+
+// ── Skill Create/Edit Form ───────────────────────────────────────────────────
+
+let _editingSkill = null;
+
+function _openSkillForm(skill) {
+  _editingSkill = skill;
+  const title = document.getElementById('skill-form-title');
+  title.textContent = skill ? '编辑技能' : '创建技能';
+
+  // Fill form
+  document.getElementById('sf-name').value = skill?.name || '';
+  document.getElementById('sf-slug').value = skill?.slug || '';
+  document.getElementById('sf-slug').disabled = !!skill;
+  document.getElementById('sf-category').value = skill?.category || 'utility';
+  document.getElementById('sf-icon').value = skill?.icon || '';
+  document.getElementById('sf-version').value = skill?.version || '1.0.0';
+  document.getElementById('sf-oneliner').value = skill?.oneLiner || '';
+  document.getElementById('sf-description').value = skill?.description || '';
+  document.getElementById('sf-instruction').value = skill?.instruction || '';
+  document.getElementById('sf-tools').value = (skill?.requiredTools || []).join(', ');
+  document.getElementById('sf-configschema').value = skill?.configSchema ? JSON.stringify(skill.configSchema, null, 2) : '';
+
+  // If editing a published skill, auto-increment version
+  if (skill?.status === 'published') {
+    const parts = (skill.version || '1.0.0').split('.');
+    parts[parts.length - 1] = String(Number(parts[parts.length - 1]) + 1);
+    document.getElementById('sf-version').value = parts.join('.');
+  }
+
+  document.getElementById('skill-form-error').classList.add('hidden');
+  document.getElementById('skill-form-overlay').classList.remove('hidden');
+}
+
+function _closeSkillForm() {
+  document.getElementById('skill-form-overlay').classList.add('hidden');
+  _editingSkill = null;
+}
+
+async function _handleSkillFormSubmit(e) {
+  e.preventDefault();
+  const errorEl = document.getElementById('skill-form-error');
+  errorEl.classList.add('hidden');
+
+  const body = {
+    name: document.getElementById('sf-name').value.trim(),
+    slug: document.getElementById('sf-slug').value.trim(),
+    category: document.getElementById('sf-category').value,
+    icon: document.getElementById('sf-icon').value.trim() || null,
+    version: document.getElementById('sf-version').value.trim(),
+    oneLiner: document.getElementById('sf-oneliner').value.trim(),
+    description: document.getElementById('sf-description').value.trim(),
+    instruction: document.getElementById('sf-instruction').value.trim(),
+    requiredTools: document.getElementById('sf-tools').value
+      ? document.getElementById('sf-tools').value.split(',').map(s => s.trim()).filter(Boolean)
+      : [],
+    configSchema: null,
+  };
+
+  // Parse config schema
+  const schemaStr = document.getElementById('sf-configschema').value.trim();
+  if (schemaStr) {
+    try { body.configSchema = JSON.parse(schemaStr); }
+    catch { errorEl.textContent = '配置模式 JSON 格式错误'; errorEl.classList.remove('hidden'); return; }
+  }
+
+  const submitBtn = document.getElementById('skill-form-submit-btn');
+  submitBtn.disabled = true;
+  submitBtn.textContent = '保存中…';
+
+  try {
+    let url, method;
+    if (_editingSkill) {
+      url = `/api/skills/rc/mine/${_editingSkill.id}`;
+      method = 'PUT';
+    } else {
+      url = '/api/skills/rc/mine';
+      method = 'POST';
+    }
+
+    const res = await fetch(url, {
+      method,
+      headers: _rcHeaders(),
+      body: JSON.stringify(body),
+    });
+    const data = await res.json();
+    if (data.code === 200) {
+      _closeSkillForm();
+      _loadMine();
+    } else {
+      errorEl.textContent = data.error || '保存失败';
+      errorEl.classList.remove('hidden');
+    }
+  } catch (err) {
+    errorEl.textContent = '网络错误: ' + err.message;
+    errorEl.classList.remove('hidden');
+  } finally {
+    submitBtn.disabled = false;
+    submitBtn.textContent = '保存';
+  }
 }
 
 // ── Browse tab (from Resource Center) ─────────────────────────────────────

--- a/agent-core/web/js/usage.js
+++ b/agent-core/web/js/usage.js
@@ -91,6 +91,9 @@ function _renderChart(el, breakdown, granularity) {
   const days = [...breakdown].reverse();
   const maxVal = Math.max(...days.map(d => d.prompt_tokens + d.completion_tokens), 1);
 
+  // Generate Y-axis reference lines (3-4 lines)
+  const yLines = _calcYLines(maxVal);
+
   const bars = days.map(d => {
     const total = d.prompt_tokens + d.completion_tokens;
     const h = Math.max((total / maxVal) * 100, 3);
@@ -119,6 +122,11 @@ function _renderChart(el, breakdown, granularity) {
       </div>`;
   }).join('');
 
+  const yLinesHtml = yLines.map(line => `
+    <div class="usage-y-line" style="bottom:${(line.value / maxVal) * 100}%">
+      <span class="usage-y-label">${line.label}</span>
+    </div>`).join('');
+
   const titleText = granularity === 'hourly' ? '每小时用量' : '每日用量';
   el.innerHTML = `
     <div class="usage-chart-header">
@@ -129,7 +137,29 @@ function _renderChart(el, breakdown, granularity) {
         <span class="usage-legend-item"><i style="background:#10b981"></i>输出</span>
       </div>
     </div>
-    <div class="usage-chart">${bars}</div>`;
+    <div class="usage-chart-wrap">
+      <div class="usage-y-lines">${yLinesHtml}</div>
+      <div class="usage-chart">${bars}</div>
+    </div>`;
+}
+
+/** Calculate nice Y-axis reference values. */
+function _calcYLines(maxVal) {
+  if (maxVal <= 0) return [];
+  // Find a nice step (1, 2, 5 × 10^n)
+  const rough = maxVal / 4;
+  const mag = Math.pow(10, Math.floor(Math.log10(rough)));
+  let step;
+  if (rough / mag < 1.5) step = mag;
+  else if (rough / mag < 3.5) step = mag * 2;
+  else if (rough / mag < 7.5) step = mag * 5;
+  else step = mag * 10;
+
+  const lines = [];
+  for (let v = step; v < maxVal; v += step) {
+    lines.push({ value: v, label: _fmt(v) });
+  }
+  return lines;
 }
 
 function _renderTable(el, breakdown, granularity) {


### PR DESCRIPTION
## Summary

- Add RC login, "My Skills" tab, and skill CRUD in agent-core web UI (proxy endpoints for cross-origin auth)
- Suppress SSL close log noise and enable HTTP keep-alive (timeout_keep_alive=65s)
- Fix service restart via sidecar container (child process was killed on self-restart)
- Fix usage modal scrolling + add Y-axis reference lines to chart
- Clean up prompt_system.md (remove redundant tool signatures, add behavioral rules)
- Improve skills login UI spacing and allow non-email accounts

## Test plan

- [ ] Open agent-core dashboard → Skills → "My Skills" tab → login with RC account
- [ ] Create/edit/submit skill for review
- [ ] Verify SSL close messages no longer flood logs
- [ ] Dashboard "restart services" successfully restarts all containers
- [ ] Usage modal scrollable, Y-axis lines visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)