### PR TITLE
fix: subagent sessions missing token usage in history

### DIFF
--- a/agent-core/src/subagent/agent.py
+++ b/agent-core/src/subagent/agent.py
@@ -277,6 +277,8 @@ class Subagent:
                     assistant_msg['content'] = content
                 if tool_calls:
                     assistant_msg['tool_calls'] = tool_calls
+                if response.get('_usage'):
+                    assistant_msg['_usage'] = response['_usage']
                 round_messages.append(assistant_msg)
 
                 # Dispatch tool calls


### PR DESCRIPTION
## Summary
- Subagent assistant messages were not preserving `_usage` from LLM responses
- This caused the history modal to show empty dividers (no token usage) for all subagent sessions
- Fix: copy `_usage` field into the assistant message stored in subagent turns

## Test plan
- [x] Deployed to R1, verified container restarted
- [ ] Trigger a subagent run and check history modal shows usage on divider lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)