### PR TITLE
feat: LLM logging, loop optimization, and skill cache fix

### DIFF
--- a/agent-core/src/client/__init__.py
+++ b/agent-core/src/client/__init__.py
@@ -6,6 +6,8 @@ All LLM calls should go through `client.call()` to ensure usage is recorded.
 
 import client.llm
 import perf_log
+import llm_logger as _llm_logger
+from uuid import uuid4
 
 # Raw client instance (for direct access if needed)
 llm = client.llm.Client()
@@ -17,6 +19,7 @@ async def call(
     cancel_event=None,
     model_override: str | None = None,
     trace_id: str = '',
+    caller_info: dict | None = None,
 ) -> dict:
     """Unified LLM call with automatic usage recording.
 
@@ -29,16 +32,31 @@ async def call(
         cancel_event: Optional asyncio.Event to cancel the call
         model_override: Optional model name override
         trace_id: Optional trace ID for usage attribution
+        caller_info: Optional caller metadata {'agent_type': 'main_agent'|'subagent'}
 
     Returns:
         LLM response dict (with _usage field attached)
     """
+    import config
+    request_id = str(uuid4())
+
+    # Resolve model name for logging
+    configs = config.main.get('client', {}).get('llm', [])
+    model_name = model_override or (configs[0]['model'] if configs else 'unknown')
+
+    # Log request
+    logger = _llm_logger.get_logger()
+    await logger.log_request(request_id, trace_id, caller_info, message_list, tool_list, model_name)
+
     response = await llm(
         message_list=message_list,
         tool_list=tool_list,
         cancel_event=cancel_event,
         model_override=model_override,
     )
+
+    # Log response
+    await logger.log_response(request_id, trace_id, caller_info, response)
 
     # Record usage
     usage = response.get('_usage')

--- a/agent-core/src/config.py
+++ b/agent-core/src/config.py
@@ -93,6 +93,14 @@ _DB_DEFAULTS = {
             'api_key': '',
         },
     },
+    'llm_logger': {
+        'enabled': True,
+        'data_dir': './resource/llm_data',
+        'recent_dir': './resource/llm_recent_request',
+        'batch_size': 500,
+        'max_records': 50000,
+        'recent_max_per_dir': 100,
+    },
 }
 
 

--- a/agent-core/src/config.py
+++ b/agent-core/src/config.py
@@ -54,6 +54,8 @@ _DB_DEFAULTS = {
             'trigger_interval_ms': 1000,
             'collector_max_window': 20,
             'history_turns': 30,
+            'max_rounds': 100,                  # 单 turn 触发截断续跑的轮数阈值
+            'truncate_keep_rounds': 50,         # 截断时保留最新消息条数
             'compress_threshold_chars': 80000,  # 约 20K tokens，超过此字符数触发压缩
             'compress_keep_recent': 6,          # 压缩时保留最近 N 轮不动
             'source_ring_size': 50,             # per-source ring buffer 大小（供 raw_input_info 查询）
@@ -71,7 +73,7 @@ _DB_DEFAULTS = {
     'subagent': {
         'max_concurrent': 2,
         'max_total': 10,
-        'default_max_rounds': 10,
+        'default_max_rounds': 50,
         'default_timeout_s': 300,
         'preemption_enabled': True,
         'checkpoint_interval': 5,

--- a/agent-core/src/event/llm.py
+++ b/agent-core/src/event/llm.py
@@ -631,6 +631,7 @@ class Event:
                     tool_list    = all_tool_list,
                     cancel_event = cancel_event,
                     trace_id     = _trace_id,
+                    caller_info  = {'agent_type': 'main_agent'},
                 )
             except TurnCancelled:
                 raise
@@ -660,6 +661,7 @@ class Event:
                             message_list = messages,
                             tool_list    = all_tool_list,
                             trace_id     = _trace_id,
+                            caller_info  = {'agent_type': 'main_agent'},
                         )
                     else:
                         raise

--- a/agent-core/src/event/llm.py
+++ b/agent-core/src/event/llm.py
@@ -570,13 +570,32 @@ class Event:
         frozen_system = prompt_mod.build_system(mcp_client.registry, bound_tool_names)
 
         finish_tool = 'finish'
-        max_rounds  = 20
+        llm_cfg = config.main.get('event', {}).get('llm', {})
+        max_rounds  = llm_cfg.get('max_rounds', 100)
+        truncate_keep = llm_cfg.get('truncate_keep_rounds', 50)
+        absolute_max = max_rounds * 5  # 绝对上限防死循环
         response    = None
         decisions   = []
         turn_messages = self._current_turn  # alias for brevity
         _turn_usage = {'prompt_tokens': 0, 'completion_tokens': 0, 'total_tokens': 0, 'cached_tokens': 0}
 
-        for round_idx in range(max_rounds):
+        round_idx = 0
+        total_rounds = 0
+        while True:
+            # ── 绝对上限检查 ──────────────────────────────────────────────
+            if total_rounds >= absolute_max:
+                print(f'[decision] absolute max {absolute_max} reached, forcing end')
+                break
+
+            # ── 截断续跑：达到 max_rounds 时截断 turn_messages ────────────
+            if round_idx >= max_rounds:
+                if len(turn_messages) > truncate_keep:
+                    turn_messages_new = [turn_messages[0]] + turn_messages[-truncate_keep:]
+                    turn_messages.clear()
+                    turn_messages.extend(turn_messages_new)
+                round_idx = 0
+                print(f'[decision] hit max_rounds={max_rounds}, truncated turn_messages to {len(turn_messages)}, continuing')
+                await push_event({'type': 'turn_truncated', 'payload': {'kept': len(turn_messages), 'total_rounds': total_rounds}})
             # ── 构建分层 prompt ────────────────────────────────────────────
             history = self._build_history()
             # 本轮已产生的消息也要加入历史（多轮工具调用场景）
@@ -795,6 +814,9 @@ class Event:
             if cancel_event and cancel_event.is_set():
                 raise TurnCancelled("Interrupted after tool dispatch")
 
+            round_idx += 1
+            total_rounds += 1
+
         # 检查是否需要压缩（保存由 run_forever 的 finally 统一处理）
         await self._maybe_compress()
 
@@ -809,12 +831,12 @@ class Event:
         ros2_bridge.publish('/decision_core', json.dumps(decision, ensure_ascii=False))
 
         await push_event({'type': 'turn_end', 'payload': {
-            'rounds': round_idx + 1,
+            'rounds': total_rounds + 1,
             'duration_s': round(_time.perf_counter() - _turn_t0, 2),
             'usage': _turn_usage,
         }})
         _turn_elapsed = _time.perf_counter() - _turn_t0
-        print(f'[decision] turn complete: {_turn_elapsed:.2f}s total, {round_idx + 1} rounds')
+        print(f'[decision] turn complete: {_turn_elapsed:.2f}s total, {total_rounds + 1} rounds')
 
         # 性能追踪：提交 spans
         _turn_end_ts = time.time()

--- a/agent-core/src/llm_logger.py
+++ b/agent-core/src/llm_logger.py
@@ -1,0 +1,199 @@
+"""
+llm_logger.py — LLM 请求/回复持久化日志。
+
+功能：
+  - 每次 LLM 调用立即持久化请求和回复（防异常关机丢数据）
+  - 每 500 条自动切分 JSONL 文件（训练数据准备）
+  - 按 agent 类型分目录保存最新记录（快速查阅）
+  - 循环删除管理存储空间
+
+目录结构：
+  resource/llm_data/              → JSONL 打包文件
+  resource/llm_recent_request/    → 最新记录（按 agent_type 分子目录）
+"""
+
+import json
+import os
+import pathlib
+import threading
+import time
+from datetime import datetime, timezone, timedelta
+
+import config
+
+_TZ_CN = timezone(timedelta(hours=8))
+_SEPARATOR = '=' * 64
+
+
+def _get_config() -> dict:
+    defaults = {
+        'enabled': True,
+        'data_dir': './resource/llm_data',
+        'recent_dir': './resource/llm_recent_request',
+        'batch_size': 500,
+        'max_records': 50000,
+        'recent_max_per_dir': 100,
+    }
+    cfg = config.main.get('llm_logger', {})
+    return {**defaults, **cfg}
+
+
+class LLMLogger:
+    def __init__(self):
+        self._cfg = _get_config()
+        self._lock = threading.Lock()
+        self._ensure_dirs()
+        # Current active JSONL files (append mode)
+        self._req_file: pathlib.Path | None = None
+        self._resp_file: pathlib.Path | None = None
+        self._req_count = 0
+        self._resp_count = 0
+        self._resume_current_files()
+
+    def _ensure_dirs(self):
+        pathlib.Path(self._cfg['data_dir']).mkdir(parents=True, exist_ok=True)
+        pathlib.Path(self._cfg['recent_dir']).mkdir(parents=True, exist_ok=True)
+
+    def _resume_current_files(self):
+        """启动时检查是否有未满的 JSONL 文件可以续写。"""
+        data_dir = pathlib.Path(self._cfg['data_dir'])
+        batch_size = self._cfg['batch_size']
+
+        # Find latest request file
+        req_files = sorted(data_dir.glob('llm_request_*.jsonl'))
+        if req_files:
+            last = req_files[-1]
+            count = sum(1 for _ in last.open('r', encoding='utf-8'))
+            if count < batch_size:
+                self._req_file = last
+                self._req_count = count
+
+        # Find latest response file
+        resp_files = sorted(data_dir.glob('llm_response_*.jsonl'))
+        if resp_files:
+            last = resp_files[-1]
+            count = sum(1 for _ in last.open('r', encoding='utf-8'))
+            if count < batch_size:
+                self._resp_file = last
+                self._resp_count = count
+
+    def _new_file(self, prefix: str) -> pathlib.Path:
+        ts = datetime.now(_TZ_CN).strftime('%Y%m%d_%H%M%S')
+        return pathlib.Path(self._cfg['data_dir']) / f'{prefix}{ts}.jsonl'
+
+    # ── Public API ────────────────────────────────────────────────────────────
+
+    async def log_request(self, request_id: str, trace_id: str,
+                          caller_info: dict | None, message_list: list[dict],
+                          tool_list: list[dict], model: str):
+        if not self._cfg.get('enabled'):
+            return
+        record = {
+            'request_id': request_id,
+            'trace_id': trace_id,
+            'agent_type': (caller_info or {}).get('agent_type', 'unknown'),
+            'model': model,
+            'messages': message_list,
+            'tools': tool_list,
+            'ts': time.time(),
+        }
+        line = json.dumps(record, ensure_ascii=False, separators=(',', ':'))
+        self._append_request(line)
+
+        # 暂存到实例，供 log_response 写 recent 文件
+        self._last_request = record
+
+    async def log_response(self, request_id: str, trace_id: str,
+                           caller_info: dict | None, response: dict):
+        if not self._cfg.get('enabled'):
+            return
+        record = {
+            'request_id': request_id,
+            'trace_id': trace_id,
+            'agent_type': (caller_info or {}).get('agent_type', 'unknown'),
+            'role': response.get('role', 'assistant'),
+            'content': response.get('content'),
+            'tool_calls': response.get('tool_calls'),
+            'usage': response.get('_usage'),
+            'ts': time.time(),
+        }
+        line = json.dumps(record, ensure_ascii=False, separators=(',', ':'))
+        self._append_response(line)
+
+        # Write recent file
+        self._write_recent(request_id, caller_info, response)
+
+    # ── Immediate append to JSONL ─────────────────────────────────────────────
+
+    def _append_request(self, line: str):
+        with self._lock:
+            batch_size = self._cfg['batch_size']
+            if self._req_file is None or self._req_count >= batch_size:
+                self._req_file = self._new_file('llm_request_')
+                self._req_count = 0
+                self._rotate_data_files('llm_request_')
+            with self._req_file.open('a', encoding='utf-8') as f:
+                f.write(line + '\n')
+            self._req_count += 1
+
+    def _append_response(self, line: str):
+        with self._lock:
+            batch_size = self._cfg['batch_size']
+            if self._resp_file is None or self._resp_count >= batch_size:
+                self._resp_file = self._new_file('llm_response_')
+                self._resp_count = 0
+                self._rotate_data_files('llm_response_')
+            with self._resp_file.open('a', encoding='utf-8') as f:
+                f.write(line + '\n')
+            self._resp_count += 1
+
+    def _rotate_data_files(self, prefix: str):
+        """文件数 * batch_size > max_records 时删除最早文件。"""
+        data_dir = pathlib.Path(self._cfg['data_dir'])
+        files = sorted(data_dir.glob(f'{prefix}*.jsonl'))
+        max_files = self._cfg['max_records'] // self._cfg['batch_size']
+        while len(files) > max_files:
+            files[0].unlink()
+            files.pop(0)
+
+    # ── Recent Files ──────────────────────────────────────────────────────────
+
+    def _write_recent(self, request_id: str, caller_info: dict | None, response: dict):
+        agent_type = (caller_info or {}).get('agent_type', 'unknown')
+        recent_dir = pathlib.Path(self._cfg['recent_dir']) / agent_type
+        recent_dir.mkdir(parents=True, exist_ok=True)
+
+        ts = datetime.now(_TZ_CN).strftime('%y%m%d_%H%M%S')
+        short_id = request_id[:8]
+        filename = f'{ts}_{short_id}.txt'
+        filepath = recent_dir / filename
+
+        # Build file content: request + separator + response
+        req_data = getattr(self, '_last_request', None)
+        req_json = json.dumps(req_data, ensure_ascii=False, indent=2) if req_data else '{}'
+        resp_json = json.dumps(response, ensure_ascii=False, indent=2, default=str)
+
+        filepath.write_text(f'{req_json}\n{_SEPARATOR}\n{resp_json}\n', encoding='utf-8')
+
+        # Rotate: keep max recent_max_per_dir files
+        self._rotate_recent(recent_dir)
+
+    def _rotate_recent(self, directory: pathlib.Path):
+        """保持目录内最多 N 个文件，删除最早的。"""
+        max_files = self._cfg['recent_max_per_dir']
+        files = sorted(directory.glob('*.txt'))
+        while len(files) > max_files:
+            files[0].unlink()
+            files.pop(0)
+
+
+# ── Module-level singleton ────────────────────────────────────────────────────
+
+_instance: LLMLogger | None = None
+
+
+def get_logger() -> LLMLogger:
+    global _instance
+    if _instance is None:
+        _instance = LLMLogger()
+    return _instance

--- a/agent-core/src/prompt.py
+++ b/agent-core/src/prompt.py
@@ -73,7 +73,7 @@ _l2_static_cache: dict = {'fingerprint': None, 'content': ''}
 
 
 def _registry_fingerprint(mcp_registry: dict, bound_tools: set | None) -> tuple:
-    """计算 registry + bound_tools 的指纹，用于判断是否需要重建。"""
+    """计算 registry + bound_tools + skills 状态的指纹，用于判断是否需要重建。"""
     # 使用 registry 的 key 集合 + 每个设备的 online/tools 状态 + bound_tools
     parts = []
     for mcp_id, info in sorted(mcp_registry.items()):
@@ -83,7 +83,13 @@ def _registry_fingerprint(mcp_registry: dict, bound_tools: set | None) -> tuple:
             tuple(sorted(info.get('tools', []))),
             info.get('name', ''),
         ))
-    return (tuple(parts), frozenset(bound_tools) if bound_tools else None)
+    # 包含 skills 状态（visible + runtime activated）
+    import event.skills as _sk
+    skills_fp = (
+        tuple(s['slug'] for s in _sk.visible_skills()),
+        frozenset(_sk._runtime_activated),
+    )
+    return (tuple(parts), frozenset(bound_tools) if bound_tools else None, skills_fp)
 
 
 def _env_static(mcp_registry: dict, bound_tools: set | None = None) -> str:

--- a/agent-core/src/subagent/agent.py
+++ b/agent-core/src/subagent/agent.py
@@ -254,6 +254,7 @@ class Subagent:
                         cancel_event=self._cancel_event,
                         model_override=self.spec.model,
                         trace_id=_trace_id,
+                        caller_info={'agent_type': 'subagent'},
                     )
                     _spans.append({'span': f'llm_round_{round_idx}', 'component': 'subagent',
                                    'start_ts': _round_start, 'end_ts': time.time()})

--- a/perception/plugins/asr.py
+++ b/perception/plugins/asr.py
@@ -1194,11 +1194,21 @@ class ASRPlugin:
                 self._load_model_async(self._asr_model)
                 return {"status": "loading", "asr_model": self._asr_model,
                         "message": f"Switching to model '{self._asr_model}', downloading..."}
-            # Stop all nodes but keep them in executor (preserves publisher for DDS discovery)
-            # Only stop VAD/subscription internals — node + publisher stay alive
-            for key in list(self._nodes.keys()):
-                node = self._nodes[key]
+            # Hot-reload: stop running nodes, apply new config, restart automatically
+            was_running = [(key, node) for key, node in self._nodes.items() if node.state == "running"]
+            for key, node in was_running:
                 node.stop()
+            # Sync updated config into nodes and restart
+            for key, node in was_running:
+                node._adapter = self._adapter
+                node._language = self._language
+                node._vad_backend = self._vad_backend
+                node._vad_threshold = self._vad_threshold
+                node._vad_silence_ms = self._vad_silence_ms
+                node._kws_cfg = self._kws_cfg
+                node._save_vad_segments = self._save_vad_segments
+                node._max_saved_segments = self._max_saved_segments
+                node.start()
             return {"status": "configured", "asr_model": self._asr_model}
 
         return None


### PR DESCRIPTION
## Summary
- **LLM request/response logging**: Persistent JSONL files for training data + per-agent-type recent files for debugging
- **ASR config hot-reload**: Config changes now hot-reload running ASR nodes instead of leaving them idle
- **Agent loop optimization**: Replace hard-coded 20-round cap with auto-truncate-and-continue mechanism (default 100 rounds, truncate to 50 msgs then reset counter)
- **Skill activate fix**: L2 static cache now invalidates on skill state changes — previously activated skills were invisible to LLM due to stale cache

## Test plan
- [x] Deployed to R1, verified JSONL and recent files generated correctly
- [x] Container restarts cleanly with all changes
- [ ] Run 12-waypoint tour to verify >20 rounds without interruption
- [ ] Activate a skill and verify instruction appears in next LLM call

🤖 Generated with [Claude Code](https://claude.com/claude-code)