### PR TITLE
fix: recreate stale DDS subscriptions after driver restart

### DIFF
--- a/agent-core/src/api/inspection.py
+++ b/agent-core/src/api/inspection.py
@@ -102,12 +102,22 @@ def _push_factory(topic: str):
 
 
 def _ensure_primary_sub(topic: str, fmt: str, loop: asyncio.AbstractEventLoop):
-    """Start primary ROS2 subscription only if not already active. Once started, stays forever."""
-    if topic in _active_primary_subs:
-        return  # already subscribed, no DDS discovery delay
-    _active_primary_subs.add(topic)  # mark immediately to prevent race
-
+    """Start primary ROS2 subscription only if not already active. Recreate if stale."""
     key = f'__primary__#{topic}'
+
+    if topic in _active_primary_subs:
+        # Health check: if subscription hasn't received data for >10s
+        # but topic is still advertised in DDS, the sub is likely stale
+        # (common after driver container restart with fastrtps VOLATILE QoS)
+        last = ros2_bridge.get_last_seen(topic)
+        if last > 0 and (time.time() - last) > 10 and topic in ros2_bridge.get_dds_topics():
+            print(f'[inspection] primary sub stale, recreating: {topic}')
+            ros2_bridge.unsubscribe(key)
+            _active_primary_subs.discard(topic)
+        else:
+            return  # healthy or never received yet
+
+    _active_primary_subs.add(topic)  # mark immediately to prevent race
     ros2_bridge.subscribe(key, topic, fmt, loop, _push_factory(topic))
     print(f'[inspection] started primary sub: {topic}')
 
@@ -115,19 +125,18 @@ def _ensure_primary_sub(topic: str, fmt: str, loop: asyncio.AbstractEventLoop):
 # ── Internal API (called by mcp_manage directly) ───────────────────────────────
 
 async def register_topic_internal(topic: str, fmt: str, mcp_id: str) -> None:
-    """Register a topic in the registry; if consumers exist, start primary sub immediately."""
+    """Register a topic in the registry; always check primary sub health."""
     if not topic:
         return
     existing = _topic_registry.get(topic)
-    if existing and existing.get('format') == fmt and existing.get('mcp_id') == mcp_id:
-        return  # already registered with same params, skip
-    _topic_registry[topic] = {
-        'format':        fmt,
-        'mcp_id':        mcp_id,
-        'registered_at': time.time(),
-    }
-    print(f'[inspection] registered topic={topic} format={fmt} mcp_id={mcp_id}')
-    # Start primary sub immediately on registration (stays forever)
+    if not (existing and existing.get('format') == fmt and existing.get('mcp_id') == mcp_id):
+        _topic_registry[topic] = {
+            'format':        fmt,
+            'mcp_id':        mcp_id,
+            'registered_at': time.time(),
+        }
+        print(f'[inspection] registered topic={topic} format={fmt} mcp_id={mcp_id}')
+    # Always check health of primary sub (even on duplicate registration)
     loop = asyncio.get_event_loop()
     _ensure_primary_sub(topic, fmt, loop)
 


### PR DESCRIPTION
## Summary
- Driver 容器重启后，fastrtps VOLATILE QoS subscription 变 stale，dashboard 声波/数据流静默
- 在 `_ensure_primary_sub` 中增加健康检查：>10s 无数据且 topic 仍在 DDS 网络中则自动重建
- 移除 `register_topic_internal` 的 early-return，确保每次 MCP discovery 都触发健康检查

## Test plan
- [x] 重启 G1 agent-core 后 mic 声波恢复
- [ ] 部署此修改后，重启 driver 容器验证 subscription 自动重建（日志出现 `primary sub stale, recreating`）

🤖 Generated with [Claude Code](https://claude.com/claude-code)