### PR TITLE
feat(canvas): editor lock for multi-dashboard conflict prevention

### DIFF
--- a/agent-core/src/api/canvas.py
+++ b/agent-core/src/api/canvas.py
@@ -3,13 +3,16 @@ canvas.py — Canvas layout persistence + per-tool config storage.
 
 Stores the orchestration canvas layout (card positions) and per-tool
 configuration in the SQLite config table.
+
+Includes editor lock: only one session can edit at a time.
 """
 
 import asyncio
 import json
+import time
 import fastapi
 from pydantic import BaseModel
-from typing import Any
+from typing import Any, Optional
 
 import config
 
@@ -17,25 +20,102 @@ router = fastapi.APIRouter(prefix='/canvas', tags=['canvas'])
 
 _TOOL_CONFIG_PREFIX = 'tool_config:'
 
+# ── Editor Lock State (in-memory, resets on restart) ─────────────────────────
+
+_editor_session: Optional[str] = None   # session_id of current editor
+_editor_last_seen: float = 0.0          # monotonic timestamp of last activity
+_EDITOR_TIMEOUT = 60.0                  # seconds before auto-release
+
+
+def _check_editor_expired():
+    """Release editor if inactive for too long."""
+    global _editor_session, _editor_last_seen
+    if _editor_session and (time.monotonic() - _editor_last_seen) > _EDITOR_TIMEOUT:
+        _editor_session = None
+        _editor_last_seen = 0.0
+
 
 class CanvasLayout(BaseModel):
     cards:           list  = []
     connections:     list  = []
     execConnections: list  = []
     transform:       dict  = {}
+    session_id:      Optional[str] = None
 
+
+# ── Editor Lock Endpoints ────────────────────────────────────────────────────
+
+@router.post('/claim-edit')
+async def claim_edit(body: dict = fastapi.Body(...)):
+    """Request edit permission. Returns 423 if someone else is editing."""
+    global _editor_session, _editor_last_seen
+    _check_editor_expired()
+
+    session_id = body.get('session_id', '')
+    if not session_id:
+        return fastapi.responses.JSONResponse(
+            status_code=400, content={'code': 400, 'message': 'session_id required'})
+
+    if _editor_session and _editor_session != session_id:
+        return fastapi.responses.JSONResponse(
+            status_code=423, content={'code': 423, 'message': 'Canvas is locked by another editor',
+                                      'editor': _editor_session})
+
+    _editor_session = session_id
+    _editor_last_seen = time.monotonic()
+    return {'code': 200, 'editor': session_id}
+
+
+@router.post('/release-edit')
+async def release_edit(body: dict = fastapi.Body(...)):
+    """Release edit permission."""
+    global _editor_session, _editor_last_seen
+    session_id = body.get('session_id', '')
+    if _editor_session == session_id:
+        _editor_session = None
+        _editor_last_seen = 0.0
+    return {'code': 200}
+
+
+@router.get('/edit-status')
+async def edit_status():
+    """Check who is currently editing."""
+    _check_editor_expired()
+    return {'code': 200, 'editor': _editor_session}
+
+
+# ── Layout Endpoints ─────────────────────────────────────────────────────────
 
 @router.get('/layout')
 async def get_layout():
-    """Return the saved canvas layout."""
+    """Return the saved canvas layout + current editor info."""
+    _check_editor_expired()
     data = config.main.get('canvas_layout', {'cards': []})
-    return {'code': 200, 'data': data}
+    return {'code': 200, 'data': data, 'editor': _editor_session}
 
 
 @router.post('/layout')
 async def save_layout(layout: CanvasLayout):
-    """Persist the canvas layout to the config store."""
-    config.main['canvas_layout'] = layout.dict()
+    """Persist the canvas layout. Only the current editor can save."""
+    global _editor_session, _editor_last_seen
+    _check_editor_expired()
+
+    session_id = layout.session_id
+    if _editor_session and session_id != _editor_session:
+        return fastapi.responses.JSONResponse(
+            status_code=403, content={'code': 403, 'message': 'Not the current editor',
+                                      'editor': _editor_session})
+
+    # Auto-claim if no editor (backward compat: first save becomes editor)
+    if not _editor_session and session_id:
+        _editor_session = session_id
+
+    if session_id == _editor_session:
+        _editor_last_seen = time.monotonic()
+
+    save_data = layout.dict()
+    save_data.pop('session_id', None)
+    config.main['canvas_layout'] = save_data
     return {'code': 200}
 
 

--- a/agent-core/web/js/canvas.js
+++ b/agent-core/web/js/canvas.js
@@ -23,6 +23,15 @@ let _connSvg    = null;
 let _cards      = [];   // [{ id, mcpId, toolName, driverName, x, y, el }]
 let _allMcps    = [];
 
+// ── Editor Lock ──────────────────────────────────────────────────────────────
+let _sessionId = localStorage.getItem('canvas_session_id');
+if (!_sessionId) {
+  _sessionId = 'sess-' + Date.now().toString(36) + Math.random().toString(36).slice(2, 6);
+  localStorage.setItem('canvas_session_id', _sessionId);
+}
+let _isEditor = false;
+let _currentEditor = null;  // session_id of current editor (null = no one)
+
 // Connection state
 let _connections = [];  // [{id, fromCardId, fromPort, toCardId, toPort, format}]
 let _execConnections = []; // [{id, fromCardId, toCardId, toToolName, toMcpId}]
@@ -126,7 +135,14 @@ export async function initCanvas(initialMcps) {
     if (window.innerWidth <= 768 && _cards.length > 0) {
       _fitToViewport();
     }
+
+    // Initialize editor lock state from layout response
+    _currentEditor = layoutJson.editor || null;
+    if (_currentEditor === _sessionId) _isEditor = true;
   } catch { /* start empty */ }
+
+  // Show editor status bar
+  _updateEditorUI();
 
   // Restore project running state from backend
   try {
@@ -1942,6 +1958,7 @@ function _debouncedSave() {
 }
 
 async function _saveLayout() {
+  if (!_isEditor) return;  // Only editor can save
   const cards = _cards.map(c => ({
     id:         c.id,
     mcpId:      c.mcpId,
@@ -1953,11 +1970,17 @@ async function _saveLayout() {
     topicOut:   c.topicOut || [],
   }));
   try {
-    await fetch('/api/canvas/layout', {
+    const resp = await fetch('/api/canvas/layout', {
       method:  'POST',
       headers: { 'Content-Type': 'application/json' },
-      body:    JSON.stringify({ cards, connections: _connections, execConnections: _execConnections, transform: { zoom: _zoom, tx: _tx, ty: _ty } }),
+      body:    JSON.stringify({ cards, connections: _connections, execConnections: _execConnections, transform: { zoom: _zoom, tx: _tx, ty: _ty }, session_id: _sessionId }),
     });
+    if (resp.status === 403) {
+      // Lost edit permission — reload layout from server
+      _isEditor = false;
+      _updateEditorUI();
+      await _reloadLayout();
+    }
   } catch { /* silent */ }
 }
 
@@ -1971,3 +1994,120 @@ function _syncEmptyState() {
 function _esc(s) {
   return String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
 }
+
+// ── Editor Lock UI ───────────────────────────────────────────────────────────
+
+function _createEditorBar() {
+  const bar = document.createElement('div');
+  bar.id = 'canvas-editor-bar';
+  bar.style.cssText = 'position:absolute;top:12px;right:12px;z-index:999;background:var(--bg-card,#fff);border-radius:8px;padding:6px 14px;box-shadow:0 2px 8px rgba(0,0,0,.12);font-size:13px;display:flex;align-items:center;gap:8px;';
+  _canvasEl.appendChild(bar);
+  return bar;
+}
+
+function _updateEditorUI() {
+  let bar = document.getElementById('canvas-editor-bar');
+  if (!bar) bar = _createEditorBar();
+
+  if (_isEditor) {
+    bar.innerHTML = '<span style="color:var(--color-success,#4caf50);">&#9998; 编辑中</span><button id="canvas-release-btn" style="font-size:12px;padding:2px 8px;border-radius:4px;border:1px solid #ccc;cursor:pointer;background:transparent;">释放</button>';
+    bar.querySelector('#canvas-release-btn').onclick = _releaseEdit;
+    _setCanvasReadonly(false);
+  } else if (_currentEditor) {
+    bar.innerHTML = `<span style="color:var(--color-warning,#ff9800);">&#128274; 他人编辑中</span>`;
+    _setCanvasReadonly(true);
+  } else {
+    bar.innerHTML = '<button id="canvas-claim-btn" style="font-size:12px;padding:4px 12px;border-radius:4px;border:1px solid var(--color-primary,#e87040);color:var(--color-primary,#e87040);cursor:pointer;background:transparent;">获取编辑权</button>';
+    bar.querySelector('#canvas-claim-btn').onclick = _claimEdit;
+    _setCanvasReadonly(true);
+  }
+}
+
+function _setCanvasReadonly(readonly) {
+  if (_viewport) {
+    _viewport.style.pointerEvents = readonly ? 'none' : '';
+  }
+  // Also disable sidebar drag if readonly
+  document.querySelectorAll('.sidebar-tool-item').forEach(el => {
+    el.draggable = !readonly;
+  });
+}
+
+async function _claimEdit() {
+  try {
+    const resp = await fetch('/api/canvas/claim-edit', {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ session_id: _sessionId }),
+    });
+    const data = await resp.json();
+    if (resp.ok) {
+      _isEditor = true;
+      _currentEditor = _sessionId;
+    } else {
+      _currentEditor = data.editor || null;
+    }
+  } catch { /* silent */ }
+  _updateEditorUI();
+}
+
+async function _releaseEdit() {
+  try {
+    await fetch('/api/canvas/release-edit', {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ session_id: _sessionId }),
+    });
+  } catch { /* silent */ }
+  _isEditor = false;
+  _currentEditor = null;
+  _updateEditorUI();
+}
+
+async function _checkEditStatus() {
+  try {
+    const resp = await fetch('/api/canvas/edit-status');
+    const data = await resp.json();
+    _currentEditor = data.editor || null;
+    if (_currentEditor === _sessionId) {
+      _isEditor = true;
+    } else if (_currentEditor && _isEditor) {
+      // We lost editor status (timeout?)
+      _isEditor = false;
+    }
+    _updateEditorUI();
+  } catch { /* silent */ }
+}
+
+async function _reloadLayout() {
+  try {
+    const layoutRes = await fetch('/api/canvas/layout');
+    const layoutJson = await layoutRes.json();
+    // Clear current cards
+    for (const c of _cards) c.el.remove();
+    _cards = [];
+    _connections = [];
+    _execConnections = [];
+    // Reload
+    const saved = layoutJson.data?.cards || [];
+    for (const c of saved) _addCard(c, false);
+    const cardIds = new Set(_cards.map(c => c.id));
+    _connections = (layoutJson.data?.connections || []).filter(c => cardIds.has(c.fromCardId) && cardIds.has(c.toCardId));
+    _execConnections = (layoutJson.data?.execConnections || []).filter(c => cardIds.has(c.fromCardId) && cardIds.has(c.toCardId));
+    _resolveAllTopics();
+    _redrawConnections();
+    _syncEmptyState();
+    // Update editor info
+    _currentEditor = layoutJson.editor || null;
+    if (_currentEditor === _sessionId) _isEditor = true;
+    _updateEditorUI();
+  } catch { /* silent */ }
+}
+
+// Release on page close
+window.addEventListener('beforeunload', () => {
+  if (_isEditor) {
+    navigator.sendBeacon('/api/canvas/release-edit', JSON.stringify({ session_id: _sessionId }));
+  }
+});
+
+// Periodically check edit status (piggyback on existing polling interval)
+setInterval(_checkEditStatus, 10000);

--- a/agent-core/web/js/canvas.js
+++ b/agent-core/web/js/canvas.js
@@ -32,6 +32,15 @@ if (!_sessionId) {
 let _isEditor = false;
 let _currentEditor = null;  // session_id of current editor (null = no one)
 
+/** Check if current session can modify. If not, show warning and return false. */
+function _canEdit() {
+  if (!_isEditor) {
+    _logActivity('warn', _currentEditor ? '画布已被其他用户锁定，无法编辑' : '请先获取编辑权');
+    return false;
+  }
+  return true;
+}
+
 // Connection state
 let _connections = [];  // [{id, fromCardId, fromPort, toCardId, toPort, format}]
 let _execConnections = []; // [{id, fromCardId, toCardId, toToolName, toMcpId}]
@@ -452,6 +461,11 @@ function _setupDropZone() {
       return;
     }
 
+    if (!_isEditor) {
+      _showDropReject(e, _currentEditor ? '画布已被其他用户锁定' : '请先获取编辑权');
+      return;
+    }
+
     let data;
     try {
       data = JSON.parse(e.dataTransfer.getData('application/x-cap-card'));
@@ -574,6 +588,7 @@ function _removeCard(id) {
     _logActivity('warn', '请停止智能控制后修改');
     return;
   }
+  if (!_canEdit()) return;
   const idx = _cards.findIndex(c => c.id === id);
   if (idx === -1) return;
   _cards[idx].el.remove();
@@ -1177,6 +1192,7 @@ function _setupPortDrag() {
       _logActivity('warn', '请停止智能控制后修改');
       return;
     }
+    if (!_canEdit()) return;
     e.preventDefault();
     e.stopPropagation();
 
@@ -2066,12 +2082,14 @@ async function _checkEditStatus() {
   try {
     const resp = await fetch('/api/canvas/edit-status');
     const data = await resp.json();
+    const prevEditor = _isEditor;
     _currentEditor = data.editor || null;
     if (_currentEditor === _sessionId) {
       _isEditor = true;
-    } else if (_currentEditor && _isEditor) {
-      // We lost editor status (timeout?)
+    } else if (_isEditor) {
+      // We lost editor status (timeout)
       _isEditor = false;
+      _logActivity('warn', '编辑权已超时释放（60秒无操作）');
     }
     _updateEditorUI();
   } catch { /* silent */ }


### PR DESCRIPTION
## Summary
- Add editor/viewer mode to canvas: only one session can edit at a time
- Backend: `claim-edit`/`release-edit`/`edit-status` endpoints with 60s inactivity auto-expire
- Frontend: floating status bar showing lock state, readonly mode for non-editors
- All modification actions check lock before proceeding, show warning if locked

## Test plan
- [ ] Open 2 browsers, first one claims edit → can modify canvas
- [ ] Second browser sees "他人编辑中" → canvas readonly, modifications blocked with toast
- [ ] First browser does nothing for 60s → lock auto-releases, gets notified
- [ ] Second browser can then claim edit

🤖 Generated with [Claude Code](https://claude.com/claude-code)