### PR TITLE
feat(canvas): editor lock for multi-dashboard conflict prevention

### DIFF
--- a/agent-core/web/css/style.css
+++ b/agent-core/web/css/style.css
@@ -2,10 +2,10 @@
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
 @keyframes canvas-toast-in {
-  0% { opacity: 0; transform: translateY(8px); }
-  12% { opacity: 1; transform: translateY(0); }
-  80% { opacity: 1; }
-  100% { opacity: 0; }
+  0% { opacity: 0; transform: translateX(-50%) translateY(8px); }
+  12% { opacity: 1; transform: translateX(-50%) translateY(0); }
+  80% { opacity: 1; transform: translateX(-50%) translateY(0); }
+  100% { opacity: 0; transform: translateX(-50%) translateY(0); }
 }
 
 :root {

--- a/agent-core/web/css/style.css
+++ b/agent-core/web/css/style.css
@@ -1,6 +1,13 @@
 /* ── Reset & Base ─────────────────────────────────────────────────────────── */
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
+@keyframes toast-fade {
+  0% { opacity: 0; transform: translate(-50%, -50%) scale(0.9); }
+  10% { opacity: 1; transform: translate(-50%, -50%) scale(1); }
+  80% { opacity: 1; }
+  100% { opacity: 0; }
+}
+
 :root {
   /* ── Warm parchment palette (Claude Code light inspired) ── */
   --bg:          #F5F0E8;

--- a/agent-core/web/css/style.css
+++ b/agent-core/web/css/style.css
@@ -1,9 +1,9 @@
 /* ── Reset & Base ─────────────────────────────────────────────────────────── */
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
-@keyframes toast-fade {
-  0% { opacity: 0; transform: translate(-50%, -50%) scale(0.9); }
-  10% { opacity: 1; transform: translate(-50%, -50%) scale(1); }
+@keyframes canvas-toast-in {
+  0% { opacity: 0; transform: translateY(8px); }
+  12% { opacity: 1; transform: translateY(0); }
   80% { opacity: 1; }
   100% { opacity: 0; }
 }
@@ -6037,6 +6037,9 @@ html, body {
     padding: 4px 8px;
     font-size: 11px;
     gap: 5px;
+  }
+  #canvas-toast {
+    bottom: calc(56px + env(safe-area-inset-bottom, 0px) + 16px) !important;
   }
 }
 

--- a/agent-core/web/js/canvas.js
+++ b/agent-core/web/js/canvas.js
@@ -51,6 +51,7 @@ let _projectRunning = false;
 
 export function isProjectRunning() { return _projectRunning; }
 export function redrawCanvas() { _redrawConnections(); }
+export function canEdit() { return _canEdit(); }
 
 /**
  * Programmatically add a card to the canvas (used by mobile tap-to-add).

--- a/agent-core/web/js/canvas.js
+++ b/agent-core/web/js/canvas.js
@@ -1323,6 +1323,7 @@ function _redrawConnections() {
         _logActivity('warn', '请停止智能控制后修改');
         return;
       }
+      if (!_canEdit()) return;
       _connections = _connections.filter(c => c.id !== conn.id);
       _resolveAllTopics();
       _autoStopOnDisconnect(conn.toCardId, conn.toPortIdx, conn.fromTopic);
@@ -1398,6 +1399,7 @@ function _redrawConnections() {
     delBtn.addEventListener('mouseleave', () => delBtn.classList.remove('visible'));
 
     const removeExec = () => {
+      if (!_canEdit()) return;
       _execConnections = _execConnections.filter(c => c.id !== conn.id);
       _logActivity('executor', `解绑执行器: ${conn.toToolName || conn.toCardId}`);
       _redrawConnections();
@@ -2057,10 +2059,8 @@ function _updateEditorUI() {
 }
 
 function _setCanvasReadonly(readonly) {
-  if (_viewport) {
-    _viewport.style.pointerEvents = readonly ? 'none' : '';
-  }
-  // Also disable sidebar drag if readonly
+  // Don't use pointer-events: none — it blocks all interaction including toast triggers.
+  // Instead, each action handler checks _canEdit() individually.
   document.querySelectorAll('.sidebar-tool-item').forEach(el => {
     el.draggable = !readonly;
   });

--- a/agent-core/web/js/canvas.js
+++ b/agent-core/web/js/canvas.js
@@ -35,10 +35,23 @@ let _currentEditor = null;  // session_id of current editor (null = no one)
 /** Check if current session can modify. If not, show warning and return false. */
 function _canEdit() {
   if (!_isEditor) {
-    _logActivity('warn', _currentEditor ? '画布已被其他用户锁定，无法编辑' : '请先获取编辑权');
+    const msg = _currentEditor ? '画布已被其他用户锁定，无法编辑' : '请先点击「编辑」进入编辑状态';
+    _showToast(msg);
     return false;
   }
   return true;
+}
+
+function _showToast(msg) {
+  // Remove existing toast
+  const old = document.getElementById('canvas-toast');
+  if (old) old.remove();
+  const toast = document.createElement('div');
+  toast.id = 'canvas-toast';
+  toast.textContent = msg;
+  toast.style.cssText = 'position:fixed;top:50%;left:50%;transform:translate(-50%,-50%);background:rgba(0,0,0,.8);color:#fff;padding:12px 24px;border-radius:8px;font-size:14px;z-index:9999;pointer-events:none;animation:toast-fade 2.5s forwards;';
+  document.body.appendChild(toast);
+  setTimeout(() => toast.remove(), 2500);
 }
 
 // Connection state

--- a/agent-core/web/js/canvas.js
+++ b/agent-core/web/js/canvas.js
@@ -43,15 +43,14 @@ function _canEdit() {
 }
 
 function _showToast(msg) {
-  // Remove existing toast
   const old = document.getElementById('canvas-toast');
   if (old) old.remove();
   const toast = document.createElement('div');
   toast.id = 'canvas-toast';
   toast.textContent = msg;
-  toast.style.cssText = 'position:fixed;top:50%;left:50%;transform:translate(-50%,-50%);background:rgba(0,0,0,.8);color:#fff;padding:12px 24px;border-radius:8px;font-size:14px;z-index:9999;pointer-events:none;animation:toast-fade 2.5s forwards;';
+  toast.style.cssText = 'position:fixed;bottom:80px;left:0;right:0;margin:auto;width:fit-content;max-width:80vw;background:rgba(28,25,23,.85);color:#fff;padding:10px 20px;border-radius:20px;font-size:13px;z-index:9999;pointer-events:none;opacity:0;animation:canvas-toast-in 2.5s ease forwards;';
   document.body.appendChild(toast);
-  setTimeout(() => toast.remove(), 2500);
+  setTimeout(() => toast.remove(), 2600);
 }
 
 // Connection state

--- a/agent-core/web/js/canvas.js
+++ b/agent-core/web/js/canvas.js
@@ -48,8 +48,8 @@ function _showToast(msg) {
   const toast = document.createElement('div');
   toast.id = 'canvas-toast';
   toast.textContent = msg;
-  toast.style.cssText = 'position:fixed;bottom:80px;left:0;right:0;margin:auto;width:fit-content;max-width:80vw;background:rgba(28,25,23,.85);color:#fff;padding:10px 20px;border-radius:20px;font-size:13px;z-index:9999;pointer-events:none;opacity:0;animation:canvas-toast-in 2.5s ease forwards;';
-  document.body.appendChild(toast);
+  toast.style.cssText = 'position:absolute;bottom:80px;left:50%;transform:translateX(-50%);width:fit-content;max-width:80%;background:rgba(28,25,23,.85);color:#fff;padding:10px 20px;border-radius:20px;font-size:13px;z-index:9999;pointer-events:none;opacity:0;animation:canvas-toast-in 2.5s ease forwards;';
+  _canvasEl.appendChild(toast);
   setTimeout(() => toast.remove(), 2600);
 }
 

--- a/agent-core/web/js/sidebar.js
+++ b/agent-core/web/js/sidebar.js
@@ -4,7 +4,7 @@
  * Tools with configSchema show config status and config button.
  */
 
-import { isProjectRunning, addCardFromSidebar } from './canvas.js';
+import { isProjectRunning, addCardFromSidebar, canEdit } from './canvas.js';
 import { isMobile, closeSidebarMobile } from './mobile.js';
 
 let _scroll = null;
@@ -281,6 +281,7 @@ function _buildChip(mcp, tool) {
   });
 
   chip.addEventListener('dragstart', (e) => {
+    if (!canEdit()) { e.preventDefault(); return; }
     chip.classList.add('dragging-source');
     e.dataTransfer.effectAllowed = 'copy';
     e.dataTransfer.setData('application/x-cap-card', JSON.stringify({
@@ -409,6 +410,7 @@ function _buildToolCard(mcp, tool) {
 
   // Drag (for canvas drop)
   card.addEventListener('dragstart', (e) => {
+    if (!canEdit()) { e.preventDefault(); return; }
     card.classList.add('dragging-source');
     e.dataTransfer.effectAllowed = 'copy';
     e.dataTransfer.setData('application/x-cap-card', JSON.stringify({
@@ -651,6 +653,7 @@ function _openToolConfigModal(mcpId, toolName, configSchema) {
   // Handlers
   const close = () => { overlay.classList.add('hidden'); };
   const save = async () => {
+    if (!canEdit()) return;
     const values = {};
     bodyEl.querySelectorAll('[data-key]').forEach(input => {
       const v = input.value.trim();
@@ -936,6 +939,7 @@ export function openInstanceConfigModal(mcpId, toolName, instanceId, configSchem
 
   const close = () => { overlay.classList.add('hidden'); };
   const save = async () => {
+    if (!canEdit()) return;
     const values = {};
     bodyEl.querySelectorAll('[data-key]').forEach(input => {
       const v = input.value.trim();

--- a/agent-core/web/js/sidebar.js
+++ b/agent-core/web/js/sidebar.js
@@ -448,6 +448,7 @@ function _openToolConfigModal(mcpId, toolName, configSchema) {
     alert('Stop agent before modifying');
     return;
   }
+  if (!canEdit()) return;
   const overlay = document.getElementById('tool-config-overlay');
   const titleEl = document.getElementById('tool-config-title');
   const bodyEl  = document.getElementById('tool-config-body');
@@ -774,6 +775,7 @@ export function openInstanceConfigModal(mcpId, toolName, instanceId, configSchem
     alert('Stop agent before modifying');
     return;
   }
+  if (!canEdit()) return;
   const overlay = document.getElementById('tool-config-overlay');
   const titleEl = document.getElementById('tool-config-title');
   const bodyEl  = document.getElementById('tool-config-body');


### PR DESCRIPTION
## Summary
- Add editor/viewer mode: only one session can edit canvas at a time
- SVG pen/lock icons, positioned top-left (desktop) / bottom-left (mobile)
- 60s inactivity auto-expire, toast notifications for blocked actions
- All edit actions (sidebar config, card delete, connection delete, drag) check lock
- Fixes multi-dashboard layout overwrite causing topic mismatches during start-project

## Test plan
- [x] Non-edit mode: click any edit button → toast "请先点击编辑进入编辑状态"
- [x] Claim edit → can modify canvas normally
- [x] 60s no save → lock auto-releases
- [x] Toast appears centered in canvas area with slide-up animation

🤖 Generated with [Claude Code](https://claude.com/claude-code)