### PR TITLE
feat(perception): add on-device OCR plugin (PP-OCRv6 TensorRT)

### DIFF
--- a/perception/Dockerfile.jetson
+++ b/perception/Dockerfile.jetson
@@ -1,35 +1,50 @@
 # ── Jetson GPU variant ──────────────────────────────────────────────
-# Base: jetson-base:jp511-torch (torch 2.0 + torchvision 0.15 with CUDA)
 #
 # Build context: repo root (phanthy-motus/) so we can access both
 # src/perception_stack/ and deploy/ros-base/audio_msgs/
 #
 # Usage:
+#   docker build -f perception/Dockerfile.jetson --network=host \
+#     --build-arg JP_VERSION=61 \
+#     -t phanthymotus-perception-ocr:jp61 .
+#
 #   ./deploy/build_perception.sh --variant jetson --mirror tuna
 # ────────────────────────────────────────────────────────────────────
 
 ARG PYPI_MIRROR=https://pypi.tuna.tsinghua.edu.cn/simple/
 ARG APT_MIRROR=mirrors.tuna.tsinghua.edu.cn
 ARG JP_VERSION=511
+FROM bj-warehouse.tencentcloudcr.com/phanthy-motus/jetson-base:jp61-torch AS jp61-compat
 FROM bj-warehouse.tencentcloudcr.com/phanthy-motus/jetson-base:jp${JP_VERSION}-torch
-ARG PYPI_MIRROR APT_MIRROR
+ARG PYPI_MIRROR APT_MIRROR JP_VERSION
+
+ENV PIP_INDEX_URL=${PYPI_MIRROR} \
+    PIP_EXTRA_INDEX_URL= \
+    PIP_TRUSTED_HOST="mirrors.tuna.tsinghua.edu.cn pypi.tuna.tsinghua.edu.cn pypi.org files.pythonhosted.org" \
+    OMP_NUM_THREADS=1 \
+    OPENBLAS_NUM_THREADS=1 \
+    MKL_NUM_THREADS=1 \
+    NUMEXPR_NUM_THREADS=1 \
+    OPENCV_FOR_THREADS_NUM=1 \
+    VIPS_CONCURRENCY=1 \
+    MALLOC_ARENA_MAX=2
 
 # ── APT mirror (conditional) ─────────────────────────────────────
 RUN if [ -n "${APT_MIRROR}" ]; then \
         sed -i "s/archive.ubuntu.com/${APT_MIRROR}/g; s/ports.ubuntu.com/${APT_MIRROR}/g" /etc/apt/sources.list; \
     fi
 
-# ── Switch ROS2 to TUNA mirror + skip expired key (if sources exist) ──
-RUN if ls /etc/apt/sources.list.d/*.list 1>/dev/null 2>&1; then \
-        sed -i 's|http://packages.ros.org/ros2/ubuntu|https://mirrors.tuna.tsinghua.edu.cn/ros2/ubuntu|g' /etc/apt/sources.list.d/*.list && \
-        sed -i 's|deb \[|deb [trusted=yes |g; s|deb http|deb [trusted=yes] http|g' /etc/apt/sources.list.d/ros2*.list; \
-    fi
-
 # ── System deps ────────────────────────────────────────────────────
+# (build-essential + python3-dev: webrtcvad has no aarch64 wheel, builds from source)
 RUN rm -f /etc/apt/sources.list.d/* && rm -rf /var/cache/apt/archives/* /var/lib/apt/lists/* && \
-    apt-get -o Acquire::AllowInsecureRepositories=true update && \
-    apt-get install -y --no-install-recommends --allow-unauthenticated ffmpeg && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+      ffmpeg build-essential python3-dev libvips42 curl && \
     apt-get clean && rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
+
+# JP511/Focal lacks libffi.so.8, which is required when the NVIDIA runtime
+# exposes the OpenCV/CUDA dependency chain. The JP61 donor contains Ubuntu's
+# ABI-compatible 39 KiB libffi8 package; copying it is harmless on JP61.
 
 RUN pip3 install --no-cache-dir -i ${PYPI_MIRROR} colcon-common-extensions && \
     pip3 install --no-cache-dir -i ${PYPI_MIRROR} "empy<4"
@@ -50,7 +65,7 @@ RUN pip3 install --no-cache-dir -i ${PYPI_MIRROR} \
     kiss-icp scipy
 
 # ── VOP deps (YOLOv8-World object detection) ─────────────────────
-# Fix broken system cv2 __init__.py (mat_wrapper circular import on Jetson)
+# Fix the legacy JP5.1.1 cv2 package when needed; JP6 passes the import probe.
 RUN python3 -c "import cv2" 2>/dev/null || { \
     echo 'import importlib.util, sys, os' > /usr/lib/python3.8/dist-packages/cv2/__init__.py && \
     echo '_so = os.path.join(os.path.dirname(__file__), "python-3.8", "cv2.cpython-38-aarch64-linux-gnu.so")' >> /usr/lib/python3.8/dist-packages/cv2/__init__.py && \
@@ -79,10 +94,78 @@ ENV YOLO_CONFIG_DIR=/work
 # ── sherpa-onnx (on-device ASR/TTS/KWS) ──────────────────────────
 RUN pip3 install --no-cache-dir -i ${PYPI_MIRROR} sherpa-onnx
 
+# TensorRT is supplied by the selected JetPack base.
+RUN python3 -c "from importlib.metadata import version; value = version('tensorrt'); minimum = 10 if '${JP_VERSION}' == '61' else 8; assert int(value.split('.')[0]) >= minimum, value"
+
+# ── RapidOCR post-processing utilities ────────────────────────────
+RUN if [ "${JP_VERSION}" = "61" ]; then \
+      NUMPY_VERSION=1.26.4; \
+    else \
+      NUMPY_VERSION=1.24.4; \
+    fi; \
+    pip3 install --no-cache-dir -i ${PYPI_MIRROR} \
+      "numpy==${NUMPY_VERSION}" pyclipper==1.3.0.post3 six Shapely==2.0.5 Pillow \
+      omegaconf==2.3.0 colorlog && \
+    pip3 install --no-cache-dir --no-deps -i ${PYPI_MIRROR} \
+      rapidocr==3.9.1 && \
+    pip3 install --no-cache-dir -i ${PYPI_MIRROR} "pyvips==3.1.0" && \
+    RAPIDOCR_MODELS="$(python3 -c 'from pathlib import Path; import rapidocr; print(Path(rapidocr.__file__).resolve().parent / "models")')" && \
+    find "${RAPIDOCR_MODELS}" -type f -name '*.onnx' -delete
+
+# ── OCR model (kept outside Git) ──────────────────────────────────
+ARG OCR_MODEL_BASE_URL=https://www.modelscope.cn/models/Flame4pd/ppocrv6-small-edge-ocr/resolve
+ARG OCR_MODEL_REVISION=0301e9299b3abe09c6a60796d7bed74c23fcc525
+RUN if [ "${JP_VERSION}" = "61" ]; then \
+      OCR_TRT_MODEL_BUNDLE=tensorrt-jp6-trt10.4-orin-batch8-cls8; \
+      DET_SIZE=11194324; \
+      DET_SHA256=3b36aae43b2cc4a1b1e2d74d846a1319b4b6f42fbc6d97747d8d72e12c74a1ef; \
+      REC_SIZE=23303292; \
+      REC_SHA256=8149fa68d5418f2c0763b8c4e5088987cb679a407317c7510f88ab6de38dd641; \
+      CLS_SIZE=1046484; \
+      CLS_SHA256=148a6895260d3b6b6f86e0c5787121fc1bba316f3427397f654421196c13cb77; \
+    else \
+      OCR_TRT_MODEL_BUNDLE=tensorrt-jp511-trt8.5-orin-batch8-cls8; \
+      DET_SIZE=12334256; \
+      DET_SHA256=1bb32a027e93b06d5319ac61e38bb3e447137b01465eacefa7a652f58130ebdf; \
+      REC_SIZE=19915466; \
+      REC_SHA256=1e204f0469beba33d8590b29c06419cf1073d98d41243b5ee316d2f877340b61; \
+      CLS_SIZE=1038858; \
+      CLS_SHA256=02c722e56e621b56a36678cc8aa124a31b41e9e3c9ca350b11e4de0d5bbd0a35; \
+    fi && \
+    OCR_TRT_MODEL_BASE_URL="${OCR_MODEL_BASE_URL}/${OCR_MODEL_REVISION}/${OCR_TRT_MODEL_BUNDLE}" && \
+    OCR_TRT_MODEL_DIR=/opt/phanthy-motus/model-seed/ocr/ppocrv6-small-trt && \
+    mkdir -p "${OCR_TRT_MODEL_DIR}" && \
+    for MODEL_SPEC in \
+      "det.engine:${DET_SIZE}:${DET_SHA256}" \
+      "rec.engine:${REC_SIZE}:${REC_SHA256}" \
+      "cls.engine:${CLS_SIZE}:${CLS_SHA256}" \
+      "keys.txt:74947:b5f2bfe2bdd9448429e3e82b51c789775d9b42f2403d082b00662eb77e401c5d"; do \
+      MODEL_FILE="${MODEL_SPEC%%:*}"; \
+      MODEL_METADATA="${MODEL_SPEC#*:}"; \
+      MODEL_SIZE="${MODEL_METADATA%%:*}"; \
+      MODEL_SHA256="${MODEL_METADATA#*:}"; \
+      MODEL_TEMP="$(mktemp "${OCR_TRT_MODEL_DIR}/.${MODEL_FILE}.XXXXXX")"; \
+      curl --fail --location --silent --show-error --retry 3 \
+        --retry-connrefused --connect-timeout 20 --max-time 120 \
+        "${OCR_TRT_MODEL_BASE_URL}/${MODEL_FILE}" \
+        --output "${MODEL_TEMP}"; \
+      ACTUAL_SIZE="$(stat -c '%s' "${MODEL_TEMP}")"; \
+      [ "${ACTUAL_SIZE}" = "${MODEL_SIZE}" ] || { \
+        echo "size mismatch for ${MODEL_FILE}: expected ${MODEL_SIZE}, got ${ACTUAL_SIZE}" >&2; \
+        exit 1; \
+      }; \
+      echo "${MODEL_SHA256}  ${MODEL_TEMP}" | sha256sum -c -; \
+      chmod 0644 "${MODEL_TEMP}"; \
+      mv -f "${MODEL_TEMP}" "${OCR_TRT_MODEL_DIR}/${MODEL_FILE}"; \
+    done
 # ── phonemizer (multilingual IPA via espeak-ng for asr_kws mode) ──
 RUN apt-get update && apt-get install -y --no-install-recommends espeak-ng && \
     rm -rf /var/lib/apt/lists/*
 RUN pip3 install --no-cache-dir -i ${PYPI_MIRROR} phonemizer
+
+# Keep the JP511 image self-contained instead of requiring a host bind mount.
+COPY --from=jp61-compat /usr/lib/aarch64-linux-gnu/libffi.so.8.1.0 /usr/lib/aarch64-linux-gnu/libffi.so.8.1.0
+RUN ln -sfn libffi.so.8.1.0 /usr/lib/aarch64-linux-gnu/libffi.so.8
 
 # ── Application code ───────────────────────────────────────────────
 WORKDIR /work
@@ -90,6 +173,9 @@ COPY perception/main.py    /work/main.py
 COPY perception/plugins/   /work/plugins/
 COPY perception/utils/     /work/utils/
 COPY perception/config.yaml /work/config.yaml
+COPY perception/config/fastdds_large_message.xml /opt/phanthy-motus/config/fastdds_large_message.xml
+COPY perception/deploy/seed_ocr_models.sh /deploy/seed_ocr_models.sh
+RUN chmod 0755 /deploy/seed_ocr_models.sh
 
 EXPOSE 15720
 EXPOSE 15721
@@ -104,6 +190,7 @@ ENV AMENT_PREFIX_PATH="/ros_ws/install/audio_msgs:/opt/ros/humble/install"
 
 CMD ["/bin/bash", "-c", \
     "export LD_PRELOAD=/usr/lib/aarch64-linux-gnu/libgomp.so.1 && \
+     /deploy/seed_ocr_models.sh && \
      source /opt/ros/humble/install/setup.bash && \
      source /ros_ws/install/setup.bash && \
      python3 /work/main.py"]

--- a/perception/config.yaml
+++ b/perception/config.yaml
@@ -45,3 +45,27 @@ plugins:
     confidence: 0.3
     classes: []         # empty = default broad set
     fps: 5
+
+  ocr:
+    enabled: false
+    provider: rapidocr
+    model_dir: /models/ocr/ppocrv6-small-trt
+    device_id: 0
+    language: zh
+    use_angle_cls: true
+    max_side_len: 1600
+    det_unclip_ratio: 0.7
+    det_thresh: 0.3
+    det_box_thresh: 0.5
+    rec_min_score: 0.9
+    crop_refinement:
+      enabled: true
+      min_score: 0.9
+      min_gain: 0.12
+      min_text_length: 2
+      profiles: [prefix_65, upper_center, upper_tight]
+    empty_result_retry:
+      enabled: true
+      det_thresh: 0.1
+      det_box_thresh: 0.1
+    min_interval_ms: 0

--- a/perception/config/fastdds_large_message.xml
+++ b/perception/config/fastdds_large_message.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<profiles xmlns="http://www.eprosima.com/XMLSchemas/fastRTPS_Profiles">
+    <transport_descriptors>
+        <transport_descriptor>
+            <transport_id>CustomUDPTransport</transport_id>
+            <type>UDPv4</type>
+            <maxMessageSize>65000</maxMessageSize>
+            <sendBufferSize>8388608</sendBufferSize>
+            <receiveBufferSize>8388608</receiveBufferSize>
+        </transport_descriptor>
+    </transport_descriptors>
+
+    <participant profile_name="large_message_profile" is_default_profile="true">
+        <rtps>
+            <userTransports>
+                <transport_id>CustomUDPTransport</transport_id>
+            </userTransports>
+            <useBuiltinTransports>true</useBuiltinTransports>
+        </rtps>
+    </participant>
+</profiles>

--- a/perception/deploy/seed_ocr_models.sh
+++ b/perception/deploy/seed_ocr_models.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+seed_root="/opt/phanthy-motus/model-seed/ocr"
+target_root="/models/ocr"
+
+if [ ! -d "${seed_root}" ]; then
+    exit 0
+fi
+
+mkdir -p "${target_root}"
+for source_bundle in "${seed_root}"/*; do
+    [ -d "${source_bundle}" ] || continue
+    bundle_name="${source_bundle##*/}"
+    target_bundle="${target_root}/${bundle_name}"
+    mkdir -p "${target_bundle}"
+    for source_file in "${source_bundle}"/*; do
+        [ -f "${source_file}" ] || continue
+        filename="${source_file##*/}"
+        target_file="${target_bundle}/${filename}"
+        if [ ! -f "${target_file}" ] || ! cmp -s "${source_file}" "${target_file}"; then
+            temporary_file="$(mktemp "${target_bundle}/.${filename}.XXXXXX")"
+            cp "${source_file}" "${temporary_file}"
+            chmod 0644 "${temporary_file}"
+            mv -f "${temporary_file}" "${target_file}"
+        fi
+    done
+done

--- a/perception/deploy/service.yml
+++ b/perception/deploy/service.yml
@@ -1,6 +1,7 @@
 perception:
   image: __IMAGE__
   container_name: embodied-perception
+  runtime: nvidia
   network_mode: host
   ipc: host
   pid: host
@@ -11,7 +12,7 @@ perception:
   environment:
     - ROS_DOMAIN_ID=42
     - RMW_IMPLEMENTATION=rmw_fastrtps_cpp
-    - FASTDDS_BUILTIN_TRANSPORTS=DEFAULT
+    - FASTRTPS_DEFAULT_PROFILES_FILE=/opt/phanthy-motus/config/fastdds_large_message.xml
   logging:
     driver: local
     options:

--- a/perception/main.py
+++ b/perception/main.py
@@ -108,6 +108,11 @@ class PerceptionBundle:
             self._plugins.append(plugin)
             log.info("VideoObjectPerceptionPlugin loaded (namespace=%s)", namespace)
 
+        if plugins_cfg.get("ocr", {}).get("enabled", False):
+            from plugins.ocr import OCRPlugin
+            self._plugins.append(OCRPlugin(plugins_cfg["ocr"], executor))
+            log.info("OCRPlugin loaded")
+
     def get_all_tools(self) -> list:
         tools = []
         for p in self._plugins:
@@ -129,6 +134,20 @@ class PerceptionBundle:
             if getattr(p, 'PREFIX', None) == 'tts':
                 return p.synthesize_raw(text)
         raise RuntimeError("TTS plugin not loaded or not enabled")
+
+    def run_lifecycle_hook(self, name: str) -> None:
+        for plugin in self._plugins:
+            hook = getattr(plugin, name, None)
+            if hook is None:
+                continue
+            try:
+                hook()
+            except Exception:
+                log.exception(
+                    "plugin %s failed: %s",
+                    name,
+                    getattr(plugin, "PREFIX", type(plugin).__name__),
+                )
 
 
 # ── MCP HTTP server ───────────────────────────────────────────────────────────
@@ -434,8 +453,8 @@ def main():
     global _bundle
 
     cfg      = _load_config()
-    mcp_port = int(cfg.get("mcp_port", 15720))
-    ws_port  = int(cfg.get("ws_port",  15721))
+    mcp_port = int(os.environ.get("MCP_PORT") or cfg.get("mcp_port", 15720))
+    ws_port  = int(os.environ.get("WS_PORT") or cfg.get("ws_port", 15721))
 
     log.info(f"perception bundle starting, mcp_port={mcp_port}, ws_port={ws_port}")
     log.info(f"config: plugins.asr.enabled={cfg.get('plugins',{}).get('asr',{}).get('enabled')}, "
@@ -477,7 +496,9 @@ def main():
     try:
         server.serve_forever()
     finally:
+        _bundle.run_lifecycle_hook("prepare_shutdown")
         executor.shutdown()
+        _bundle.run_lifecycle_hook("destroy_nodes")
         rclpy.shutdown()
 
 

--- a/perception/plugins/ocr.py
+++ b/perception/plugins/ocr.py
@@ -1,0 +1,583 @@
+#!/usr/bin/env python3
+"""
+plugins/ocr.py — OCRPlugin: OCR 文字识别封装。
+
+订阅 image/jpeg topic，持续进行 OCR 识别并发布结果到 ROS2 topic。
+参考 asr.py 架构设计。
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import queue
+import threading
+import time
+
+from rclpy.node import Node
+from rclpy.qos import QoSProfile, ReliabilityPolicy, HistoryPolicy, DurabilityPolicy
+from sensor_msgs.msg import CompressedImage
+from std_msgs.msg import String
+
+from plugins.ocr_runtime import (
+    DEFAULT_CROP_REFINEMENT_ENABLED,
+    DEFAULT_CROP_REFINEMENT_MIN_GAIN,
+    DEFAULT_CROP_REFINEMENT_MIN_SCORE,
+    DEFAULT_CROP_REFINEMENT_PROFILES,
+    DEFAULT_DET_BOX_THRESH,
+    DEFAULT_DET_THRESH,
+    DEFAULT_DET_UNCLIP_RATIO,
+    DEFAULT_EMPTY_RESULT_RETRY_DET_BOX_THRESH,
+    DEFAULT_EMPTY_RESULT_RETRY_DET_THRESH,
+    DEFAULT_EMPTY_RESULT_RETRY_ENABLED,
+    DEFAULT_MAX_SIDE_LEN,
+    DEFAULT_REC_MIN_SCORE,
+    RapidOCRAdapter,
+    recognize_to_payload,
+)
+
+log = logging.getLogger(__name__)
+
+DEFAULT_OCR_MODEL_DIR = "/models/ocr/ppocrv6-small-trt"
+_ERROR_LOG_INTERVAL_SECONDS = 10.0
+
+_CAMERA_QOS = QoSProfile(
+    reliability=ReliabilityPolicy.RELIABLE,
+    history=HistoryPolicy.KEEP_LAST,
+    depth=1,
+    durability=DurabilityPolicy.VOLATILE,
+)
+
+_RESULT_QOS = QoSProfile(
+    reliability=ReliabilityPolicy.RELIABLE,
+    history=HistoryPolicy.KEEP_LAST,
+    depth=1,
+    durability=DurabilityPolicy.VOLATILE,
+)
+
+TOOLS = [
+    {
+        "name": "ocr",
+        "type": "processor",
+        "multiInstance": True,
+        "description": "OCR — recognize text in camera feed via image topic subscription",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": ["start", "stop", "info", "config"],
+                    "description": "Action to perform"
+                },
+                "input_topic": {
+                    "type": "string",
+                    "description": "ROS2 image topic to subscribe (e.g. /hostname/camera/rgb, required for action=start)"
+                },
+            },
+            "required": ["action"]
+        },
+        "configSchema": {
+            "type": "object",
+            "properties": {
+                "model_dir": {"type": "string", "description": "OCR 模型或 TensorRT engine 目录", "scope": "shared"},
+                "device_id": {"type": "integer", "minimum": 0, "default": 0, "scope": "shared"},
+                "use_angle_cls": {"type": "boolean", "default": True, "description": "启用 0/180 度文字方向分类", "scope": "shared"},
+                "provider": {"type": "string", "enum": ["rapidocr"], "description": "OCR 运行时", "scope": "shared"},
+                "language": {"type": "string", "description": "默认语言", "default": "zh", "scope": "instance"},
+                "max_side_len": {"type": "integer", "minimum": 32, "default": DEFAULT_MAX_SIDE_LEN, "description": "检测输入最长边", "scope": "shared"},
+                "det_thresh": {"type": "number", "minimum": 0, "maximum": 1, "default": DEFAULT_DET_THRESH, "description": "DB 文本像素阈值", "scope": "shared"},
+                "det_box_thresh": {"type": "number", "minimum": 0, "maximum": 1, "default": DEFAULT_DET_BOX_THRESH, "description": "DB 文本框阈值", "scope": "shared"},
+                "det_unclip_ratio": {"type": "number", "exclusiveMinimum": 0, "default": DEFAULT_DET_UNCLIP_RATIO, "description": "DB 文本框扩张比例", "scope": "shared"},
+                "rec_min_score": {"type": "number", "minimum": 0, "maximum": 1, "default": DEFAULT_REC_MIN_SCORE, "description": "识别结果最低置信度", "scope": "shared"},
+                "enable_preprocess": {"type": "boolean", "default": True, "description": "启用 OCR 图像预处理", "scope": "shared"},
+                "crop_refinement": {
+                    "type": "object",
+                    "description": "TensorRT 低置信文本框二次裁剪识别",
+                    "scope": "shared",
+                    "default": {
+                        "enabled": DEFAULT_CROP_REFINEMENT_ENABLED,
+                        "min_score": DEFAULT_CROP_REFINEMENT_MIN_SCORE,
+                        "min_gain": DEFAULT_CROP_REFINEMENT_MIN_GAIN,
+                        "min_text_length": 2,
+                        "profiles": list(DEFAULT_CROP_REFINEMENT_PROFILES),
+                    },
+                    "properties": {
+                        "enabled": {"type": "boolean"},
+                        "min_score": {"type": "number", "minimum": 0, "maximum": 1},
+                        "min_gain": {"type": "number", "minimum": 0},
+                        "min_text_length": {"type": "integer", "minimum": 1},
+                        "profiles": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "enum": ["prefix_65", "upper_center", "upper_tight"],
+                            },
+                        },
+                    },
+                },
+                "empty_result_retry": {
+                    "type": "object",
+                    "description": "TensorRT 主流程空输出时复用检测图进行低阈值后处理",
+                    "scope": "shared",
+                    "default": {
+                        "enabled": DEFAULT_EMPTY_RESULT_RETRY_ENABLED,
+                        "det_thresh": DEFAULT_EMPTY_RESULT_RETRY_DET_THRESH,
+                        "det_box_thresh": DEFAULT_EMPTY_RESULT_RETRY_DET_BOX_THRESH,
+                    },
+                    "properties": {
+                        "enabled": {"type": "boolean"},
+                        "det_thresh": {"type": "number", "minimum": 0, "maximum": 1},
+                        "det_box_thresh": {"type": "number", "minimum": 0, "maximum": 1},
+                    },
+                },
+                "min_interval_ms": {"type": "integer", "minimum": 0, "default": 0, "description": "帧处理最小间隔(ms)，限制 GPU 占用，0=不限", "scope": "instance"},
+            },
+            "required": ["provider"]
+        },
+        "topic_in":  [{"format": "image/jpeg", "desc": "camera image input"}],
+        "topic_out": [{"format": "data/json",  "desc": "OCR result with text boxes"}],
+    }
+]
+
+
+# ── OCR Adapters ──────────────────────────────────────────────────────────────
+
+def _ocr_output_topic(input_topic: str) -> str:
+    return f"{input_topic}/ocr"
+
+
+def _adapter_options(cfg: dict) -> dict:
+    return {
+        "model_dir": str(cfg.get("model_dir", DEFAULT_OCR_MODEL_DIR)),
+        "device_id": int(cfg.get("device_id", 0)),
+        "use_angle_cls": bool(cfg.get("use_angle_cls", True)),
+        "max_side_len": int(cfg.get("max_side_len", DEFAULT_MAX_SIDE_LEN)),
+        "rec_min_score": float(
+            cfg.get("rec_min_score", DEFAULT_REC_MIN_SCORE)
+        ),
+        "enable_preprocess": bool(cfg.get("enable_preprocess", True)),
+        "det_thresh": float(cfg.get("det_thresh", DEFAULT_DET_THRESH)),
+        "det_box_thresh": float(
+            cfg.get("det_box_thresh", DEFAULT_DET_BOX_THRESH)
+        ),
+        "det_unclip_ratio": float(
+            cfg.get("det_unclip_ratio", DEFAULT_DET_UNCLIP_RATIO)
+        ),
+        "crop_refinement": dict(cfg.get("crop_refinement") or {}),
+        "empty_result_retry": dict(cfg.get("empty_result_retry") or {}),
+    }
+
+
+def _adapter_signature(cfg: dict) -> tuple:
+    provider = cfg.get('provider', 'rapidocr')
+    return provider, _adapter_options(cfg)
+
+
+def _build_ocr_adapter(cfg: dict) -> RapidOCRAdapter:
+    """根据配置创建 OCR 适配器"""
+    provider = cfg.get('provider', 'rapidocr')
+    if provider != 'rapidocr':
+        raise ValueError(f"unsupported OCR provider: {provider}")
+    return RapidOCRAdapter(**_adapter_options(cfg))
+
+
+# ── ROS2 Node (订阅模式) ───────────────────────────────────────────────────────
+
+class _OCRNode(Node):
+    """订阅 image/jpeg topic，持续进行 OCR 识别"""
+
+    def __init__(self, input_topic: str, adapter: RapidOCRAdapter, language: str = "zh",
+                 node_suffix: str = '', min_interval: float = 0.0):
+        node_name = f"ocr_{node_suffix}" if node_suffix else "ocr"
+        super().__init__(node_name)
+
+        self._input_topic = input_topic
+        self._output_topic = _ocr_output_topic(input_topic)
+        self._adapter = adapter
+        self._language = language
+        # 帧处理最小间隔（秒）：限制 GPU 占用，0 = 不限
+        self._min_interval = max(0.0, float(min_interval))
+        self.state = "idle"
+
+        self._sub = None
+        self._pub = self.create_publisher(String, self._output_topic, _RESULT_QOS)
+
+        self._frame_queue: queue.Queue = queue.Queue(maxsize=1)
+        self._worker_thread: threading.Thread | None = None
+        self._stop_event = threading.Event()
+        self._stop_event.set()
+        self._generation = 0
+        self._worker_threads: list[threading.Thread] = []
+        self._last_error_log_at: float | None = None
+        log.info(f"[ocr] node created: subscribing={self._input_topic}, publishing={self._output_topic}")
+
+    def start(self) -> dict:
+        if self.state == "running":
+            return self._status_dict()
+
+        if not self._adapter:
+            raise RuntimeError("OCR adapter not configured")
+
+        self._generation += 1
+        generation = self._generation
+        stop_event = threading.Event()
+        frame_queue: queue.Queue = queue.Queue(maxsize=1)
+        self._stop_event = stop_event
+        self._frame_queue = frame_queue
+        if self._sub is None:
+            self._sub = self.create_subscription(
+                CompressedImage, self._input_topic, self._image_cb, _CAMERA_QOS
+            )
+        self.state = "running"
+        self._worker_threads = [
+            thread for thread in self._worker_threads if thread.is_alive()
+        ]
+        self._worker_thread = threading.Thread(
+            target=self._worker,
+            args=(generation, stop_event, frame_queue),
+            daemon=True,
+        )
+        self._worker_threads.append(self._worker_thread)
+        self._worker_thread.start()
+
+        log.info(f"[ocr] started: {self._input_topic} → {self._output_topic}")
+        return self._status_dict()
+
+    def stop(self) -> dict:
+        self.state = "idle"
+        self._stop_event.set()
+        while True:
+            try:
+                self._frame_queue.get_nowait()
+            except queue.Empty:
+                break
+        deadline = time.monotonic() + 3.0
+        for thread in self._worker_threads:
+            if thread.is_alive():
+                thread.join(timeout=max(0.0, deadline - time.monotonic()))
+        self._worker_threads = [
+            thread for thread in self._worker_threads if thread.is_alive()
+        ]
+        if self._worker_threads:
+            log.warning(
+                "[ocr] %d worker(s) still stopping after timeout: %s",
+                len(self._worker_threads),
+                self._input_topic,
+            )
+
+        log.info(f"[ocr] stopped: {self._input_topic}")
+        return {"state": "idle"}
+
+    @property
+    def worker_alive(self) -> bool:
+        return any(thread.is_alive() for thread in self._worker_threads)
+
+    def _image_cb(self, msg: CompressedImage):
+        """接收图片帧，放入队列"""
+        stop_event = self._stop_event
+        frame_queue = self._frame_queue
+        if self.state != "running" or stop_event.is_set():
+            return
+        image_data = bytes(msg.data)
+        try:
+            frame_queue.put_nowait((image_data, time.time()))
+        except queue.Full:
+            log.debug("[ocr] frame queue full, dropping old frame")
+            try:
+                frame_queue.get_nowait()
+            except queue.Empty:
+                pass
+            try:
+                frame_queue.put_nowait((image_data, time.time()))
+            except queue.Full:
+                pass
+
+    def _is_generation_active(
+        self, generation: int, stop_event: threading.Event
+    ) -> bool:
+        return (
+            self.state == "running"
+            and self._generation == generation
+            and self._stop_event is stop_event
+            and not stop_event.is_set()
+        )
+
+    def _worker(
+        self,
+        generation: int,
+        stop_event: threading.Event,
+        frame_queue: queue.Queue,
+    ):
+        """后台工作线程：从队列取图片进行 OCR"""
+        while not stop_event.is_set():
+            try:
+                image_bytes, ts = frame_queue.get(timeout=1)
+            except queue.Empty:
+                continue
+
+            t_start = time.time()
+            payload = recognize_to_payload(
+                self._adapter, image_bytes, self._language, ts
+            )
+            if not self._is_generation_active(generation, stop_event):
+                continue
+            msg = String()
+            msg.data = json.dumps(payload, ensure_ascii=False)
+            self._pub.publish(msg)
+            if "error" in payload:
+                now = time.monotonic()
+                if (
+                    self._last_error_log_at is None
+                    or now - self._last_error_log_at >= _ERROR_LOG_INTERVAL_SECONDS
+                ):
+                    log.error("[ocr] recognition error: %s", payload["error"])
+                    self._last_error_log_at = now
+                else:
+                    log.debug("[ocr] recognition error: %s", payload["error"])
+            else:
+                log.debug(
+                    "[ocr] published result to %s: %d items",
+                    self._output_topic,
+                    len(payload["items"]),
+                )
+
+            # 限帧：距上一帧开始不足 min_interval 则等待（降低 GPU 占用）
+            if self._min_interval > 0:
+                remaining = self._min_interval - (time.time() - t_start)
+                if remaining > 0:
+                    stop_event.wait(remaining)
+
+    def _status_dict(self) -> dict:
+        return {
+            "state": self.state,
+            "topic_in": [{"topic": self._input_topic, "format": "image/jpeg", "desc": "image input"}],
+            "topic_out": [{"topic": self._output_topic, "format": "data/json", "desc": "OCR result"}],
+        }
+
+
+# ── Plugin ────────────────────────────────────────────────────────────────────
+
+class OCRPlugin:
+    PREFIX = "ocr"
+
+    def __init__(self, plugin_cfg: dict, executor):
+        self._plugin_cfg = dict(plugin_cfg)
+        self._language = plugin_cfg.get('language', 'zh')
+        self._nodes: dict[str, _OCRNode] = {}
+        self._instance_configs: dict[str, dict] = {}
+        self._retired_nodes: list[_OCRNode] = []
+        self._executor = executor
+        self._lifecycle_lock = threading.RLock()
+
+        self._adapter: RapidOCRAdapter | None = None
+        log.info(
+            f"[ocr] plugin init: provider={plugin_cfg.get('provider')}, "
+            f"language={self._language}"
+        )
+
+    def get_tools(self) -> list:
+        return TOOLS
+
+    def _ensure_adapter(self) -> RapidOCRAdapter:
+        if self._adapter is None:
+            self._adapter = _build_ocr_adapter(self._plugin_cfg)
+        return self._adapter
+
+    def _retire_node(self, node_key: str) -> dict:
+        node = self._nodes.pop(node_key)
+        result = node.stop()
+        self._executor.remove_node(node)
+        if node not in self._retired_nodes:
+            self._retired_nodes.append(node)
+        log.info(
+            f"[ocr] node retired: {node_key} | nodes={len(self._nodes)} "
+            f"retired={len(self._retired_nodes)}"
+        )
+        return result
+
+    def _configure_node(self, node: _OCRNode, instance_id: str) -> None:
+        cfg = {**self._plugin_cfg, **self._instance_configs.get(instance_id, {})}
+        node._adapter = self._adapter
+        node._language = cfg.get("language", self._language)
+        node._min_interval = max(
+            0.0, float(cfg.get("min_interval_ms", 0)) / 1000.0
+        )
+
+    @staticmethod
+    def _unique_objects(values) -> list:
+        unique = []
+        seen = set()
+        for value in values:
+            if value is None:
+                continue
+            identity = id(value)
+            if identity not in seen:
+                seen.add(identity)
+                unique.append(value)
+        return unique
+
+    def prepare_shutdown(self) -> None:
+        with self._lifecycle_lock:
+            nodes = self._unique_objects(
+                [*self._nodes.values(), *self._retired_nodes]
+            )
+            for node in nodes:
+                node.stop()
+
+    def destroy_nodes(self) -> None:
+        with self._lifecycle_lock:
+            nodes = self._unique_objects(
+                [*self._nodes.values(), *self._retired_nodes]
+            )
+            adapter = self._adapter
+            for node in nodes:
+                node.destroy_node()
+            self._nodes.clear()
+            self._retired_nodes.clear()
+            self._adapter = None
+            if adapter is not None:
+                close = getattr(adapter, "close", None)
+                if callable(close):
+                    close()
+
+    def dispatch(self, name: str, args: dict) -> dict | None:
+        with self._lifecycle_lock:
+            return self._dispatch_locked(name, args)
+
+    def _dispatch_locked(self, name: str, args: dict) -> dict | None:
+        action = args.get("action") if name == "ocr" else name
+        instance_id = args.get("instance_id", "")
+
+        if action == "info":
+            input_topic = args.get("input_topic", "")
+
+            if instance_id and instance_id in self._nodes:
+                node = self._nodes[instance_id]
+                return {
+                    "name": "OCR", "manufacture": "Embodied", "model": "ocr",
+                    "state": node.state,
+                    "topic_in": [{"topic": node._input_topic, "format": "image/jpeg", "desc": ""}],
+                    "topic_out": [{"topic": node._output_topic, "format": "data/json", "desc": ""}],
+                    "desc": "OCR service — extracts text from images",
+                }
+
+            if instance_id:
+                inferred_out = f"{input_topic}/ocr" if input_topic else ""
+                return {
+                    "name": "OCR", "manufacture": "Embodied", "model": "ocr",
+                    "state": "idle",
+                    "topic_in": [{"topic": input_topic, "format": "image/jpeg", "desc": ""}] if input_topic else [],
+                    "topic_out": [{"topic": inferred_out, "format": "data/json", "desc": ""}] if inferred_out else [],
+                    "desc": "OCR service — extracts text from images",
+                }
+
+            # 聚合所有实例信息
+            if self._nodes:
+                topics_in = [{"topic": n._input_topic, "format": "image/jpeg", "desc": ""} for n in self._nodes.values()]
+                topics_out = [{"topic": n._output_topic, "format": "data/json", "desc": ""} for n in self._nodes.values()]
+                states = list(set(n.state for n in self._nodes.values()))
+                state = "running" if "running" in states else states[0] if states else "idle"
+            else:
+                inferred_out = f"{input_topic}/ocr" if input_topic else ""
+                topics_in = [{"topic": input_topic, "format": "image/jpeg", "desc": ""}]
+                topics_out = [{"topic": inferred_out, "format": "data/json", "desc": ""}]
+                state = "idle"
+
+            return {
+                "name": "OCR", "manufacture": "Embodied", "model": "ocr",
+                "state": state,
+                "topic_in": topics_in,
+                "topic_out": topics_out,
+                "desc": "OCR service — extracts text from images",
+            }
+
+        elif action == "start":
+            input_topic = args.get("input_topic")
+            if not input_topic:
+                raise ValueError("input_topic is required for start action")
+
+            node_key = instance_id or input_topic
+
+            existing = self._nodes.get(node_key)
+            if existing is not None and existing._input_topic != input_topic:
+                self._retire_node(node_key)
+
+            adapter = self._ensure_adapter()
+            if node_key not in self._nodes:
+                cfg = {
+                    **self._plugin_cfg,
+                    **self._instance_configs.get(instance_id, {}),
+                }
+
+                node = _OCRNode(
+                    input_topic,
+                    adapter,
+                    cfg.get("language", self._language),
+                    node_suffix=node_key.replace('/', '_').replace('-', '_'),
+                    min_interval=float(cfg.get('min_interval_ms', 0)) / 1000.0,
+                )
+                self._executor.add_node(node)
+                self._nodes[node_key] = node
+            elif self._nodes[node_key].state != "running":
+                self._configure_node(self._nodes[node_key], instance_id)
+
+            return self._nodes[node_key].start()
+
+        elif action == "stop":
+            if instance_id and instance_id in self._nodes:
+                return self._nodes[instance_id].stop()
+            elif not instance_id and self._nodes:
+                for node in self._nodes.values():
+                    node.stop()
+                return {"state": "idle"}
+            return {"state": "idle"}
+
+        elif action == "config":
+            cfg = {k: v for k, v in args.items() if k not in ('action', 'instance_id') and v is not None and v != ''}
+
+            if instance_id:
+                shared = set(cfg) - {"language", "min_interval_ms"}
+                if shared:
+                    raise ValueError(
+                        "OCR inference settings are shared: "
+                        + ", ".join(sorted(shared))
+                    )
+                previous = self._instance_configs.get(instance_id, {})
+                self._instance_configs[instance_id] = {**previous, **cfg}
+                if instance_id in self._nodes:
+                    node = self._nodes[instance_id]
+                    node.stop()
+                    self._configure_node(node, instance_id)
+                return {"status": "configured", "instance_id": instance_id}
+            else:
+                updated_cfg = {**self._plugin_cfg, **cfg}
+                rebuild = (
+                    _adapter_signature(updated_cfg)
+                    != _adapter_signature(self._plugin_cfg)
+                )
+                previous_adapter = self._adapter
+                replacement = (
+                    None if rebuild else previous_adapter
+                )
+                for node in self._nodes.values():
+                    node.stop()
+                if rebuild and previous_adapter is not None and any(
+                    node.worker_alive for node in self._nodes.values()
+                ):
+                    raise RuntimeError("OCR workers did not stop for reconfiguration")
+                self._adapter = replacement
+                self._plugin_cfg = updated_cfg
+                self._language = updated_cfg.get('language', self._language)
+                for node_key, node in self._nodes.items():
+                    self._configure_node(node, node_key)
+                if rebuild:
+                    close = getattr(previous_adapter, "close", None)
+                    if callable(close):
+                        close()
+                return {
+                    "status": "configured",
+                    "adapter_loaded": self._adapter is not None,
+                    "reused": previous_adapter is not None and not rebuild,
+                }
+
+        return None

--- a/perception/plugins/ocr_preprocess.py
+++ b/perception/plugins/ocr_preprocess.py
@@ -1,0 +1,47 @@
+"""Shape-preserving image enhancement used before text detection."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import numpy as np
+
+
+def preprocess_for_ocr(image: np.ndarray) -> np.ndarray:
+    import cv2
+    import numpy as np
+
+    if image is None or image.size == 0:
+        raise ValueError("invalid image")
+
+    gray = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
+    result = image
+
+    if float(np.mean(gray)) < 90 and np.count_nonzero(gray < 90) / gray.size > 0.6:
+        result = 255 - result
+        gray = cv2.cvtColor(result, cv2.COLOR_BGR2GRAY)
+
+    if float(np.std(gray)) > 60:
+        kernel = max(result.shape[:2]) // 30
+        kernel = kernel if kernel % 2 else kernel + 1
+        value = result.astype(np.float32)
+        background = np.maximum(
+            cv2.GaussianBlur(value, (kernel, kernel), 0), 1.0
+        )
+        value /= background
+        value /= np.percentile(value, 99.5)
+        result = np.clip(value * 255, 0, 255).astype(np.uint8)
+
+    if float(np.mean(gray)) < 100:
+        lab = cv2.cvtColor(result, cv2.COLOR_BGR2LAB)
+        lightness, channel_a, channel_b = cv2.split(lab)
+        lightness = cv2.createCLAHE(
+            clipLimit=2.0, tileGridSize=(8, 8)
+        ).apply(lightness)
+        result = cv2.cvtColor(
+            cv2.merge([lightness, channel_a, channel_b]),
+            cv2.COLOR_LAB2BGR,
+        )
+
+    return result

--- a/perception/plugins/ocr_runtime.py
+++ b/perception/plugins/ocr_runtime.py
@@ -441,6 +441,35 @@ class _TensorRTModelSession:
     def optimization_shape(self) -> tuple[int, ...]:
         return self._profiles[0][1]
 
+    def fit_input_image_shape(
+        self, height: int, width: int
+    ) -> tuple[int, int]:
+        """Return the smallest profile-compatible HWC canvas for an image."""
+        height = int(height)
+        width = int(width)
+        if height <= 0 or width <= 0:
+            raise ValueError("OCR TensorRT image dimensions must be positive")
+
+        candidates = []
+        for minimum, _optimum, maximum in self._profiles:
+            if (
+                len(minimum) == 4
+                and minimum[0] <= 1 <= maximum[0]
+                and minimum[1] <= 3 <= maximum[1]
+            ):
+                candidate = (
+                    max(height, minimum[2]), max(width, minimum[3])
+                )
+                if candidate[0] <= maximum[2] and candidate[1] <= maximum[3]:
+                    candidates.append(candidate)
+
+        if candidates:
+            return min(candidates, key=lambda shape: shape[0] * shape[1])
+
+        # Reuse the standard diagnostic, including all supported ranges.
+        self._select_profile((1, 3, height, width))
+        raise AssertionError("unreachable")
+
     def _select_profile(self, shape: tuple[int, ...]) -> int:
         candidates = []
         for index, (minimum, _optimum, maximum) in enumerate(self._profiles):
@@ -611,24 +640,88 @@ class _TensorRTPipeline:
 
     def _detector_input(self, image):
         import cv2
+        import numpy as np
 
         height, width = image.shape[:2]
         scale = min(1.0, self._max_side_len / max(height, width))
         target_height = self._multiple_of_32(height * scale)
         target_width = self._multiple_of_32(width * scale)
-        if (target_width, target_height) == (width, height):
-            return image
-        return cv2.resize(
-            image,
-            (target_width, target_height),
-            interpolation=cv2.INTER_AREA,
+        canvas_height, canvas_width = self._det.fit_input_image_shape(
+            target_height, target_width
+        )
+
+        # Uniformly enlarge small images until one canvas edge is filled, then
+        # pad the remaining edge. This preserves aspect ratio while satisfying
+        # TensorRT profiles whose minimum dimensions exceed the camera frame.
+        fit_scale = min(
+            canvas_height / target_height,
+            canvas_width / target_width,
+        )
+        content_height = min(
+            canvas_height,
+            max(target_height, int(round(target_height * fit_scale))),
+        )
+        content_width = min(
+            canvas_width,
+            max(target_width, int(round(target_width * fit_scale))),
+        )
+
+        if (content_width, content_height) == (width, height):
+            resized = image
+        else:
+            shrinking = content_height <= height and content_width <= width
+            resized = cv2.resize(
+                image,
+                (content_width, content_height),
+                interpolation=(
+                    cv2.INTER_AREA if shrinking else cv2.INTER_LINEAR
+                ),
+            )
+
+        if (content_height, content_width) == (
+            canvas_height,
+            canvas_width,
+        ):
+            return resized, (content_height, content_width)
+
+        padded = np.full(
+            (canvas_height, canvas_width, 3), 128, dtype=np.uint8
+        )
+        padded[:content_height, :content_width] = resized
+        return padded, (content_height, content_width)
+
+    @staticmethod
+    def _crop_detector_prediction(
+        prediction, input_shape, content_shape
+    ):
+        if input_shape == content_shape:
+            return prediction
+
+        import numpy as np
+
+        input_height, input_width = input_shape
+        content_height, content_width = content_shape
+        output_height, output_width = prediction.shape[-2:]
+        crop_height = min(
+            output_height,
+            max(1, int(round(output_height * content_height / input_height))),
+        )
+        crop_width = min(
+            output_width,
+            max(1, int(round(output_width * content_width / input_width))),
+        )
+        return np.ascontiguousarray(
+            prediction[..., :crop_height, :crop_width]
         )
 
     def _run_detector(self, image):
-        detector_input = self._detector_input(image)
+        detector_input, content_shape = self._detector_input(image)
         height, width = detector_input.shape[:2]
         prediction = self._det.run_uint8(
             detector_input, (1, 3, height, width)
+        )
+        prediction = self._crop_detector_prediction(
+            prediction, (height, width), content_shape
         )
         return prediction, image.shape[:2]
 

--- a/perception/plugins/ocr_runtime.py
+++ b/perception/plugins/ocr_runtime.py
@@ -1,0 +1,1111 @@
+from __future__ import annotations
+
+import logging
+import math
+import threading
+from dataclasses import dataclass
+from io import BytesIO
+from pathlib import Path
+
+from plugins.ocr_preprocess import preprocess_for_ocr
+
+_log = logging.getLogger(__name__)
+
+
+TENSORRT_MODEL_FILES = ("det.engine", "rec.engine", "keys.txt")
+TENSORRT_CLASSIFIER_MODEL_FILE = "cls.engine"
+MAX_RECOGNITION_WIDTH = 2048
+_OCR_MEAN = (127.5, 127.5, 127.5)
+_OCR_NORMAL = (1 / 127.5, 1 / 127.5, 1 / 127.5)
+DEFAULT_MAX_SIDE_LEN = 1600
+DEFAULT_REC_MIN_SCORE = 0.9
+DEFAULT_DET_THRESH = 0.3
+DEFAULT_DET_BOX_THRESH = 0.5
+DEFAULT_DET_UNCLIP_RATIO = 0.7
+DEFAULT_CLS_THRESH = 0.9
+DEFAULT_CROP_REFINEMENT_ENABLED = True
+DEFAULT_CROP_REFINEMENT_MIN_SCORE = 0.9
+DEFAULT_CROP_REFINEMENT_MIN_GAIN = 0.12
+DEFAULT_CROP_REFINEMENT_PROFILES = (
+    "prefix_65",
+    "upper_center",
+    "upper_tight",
+)
+DEFAULT_EMPTY_RESULT_RETRY_ENABLED = True
+DEFAULT_EMPTY_RESULT_RETRY_DET_THRESH = 0.1
+DEFAULT_EMPTY_RESULT_RETRY_DET_BOX_THRESH = 0.1
+
+_CROP_REFINEMENT_PROFILE_BOXES = {
+    "prefix_65": (0.05, 0.00, 0.70, 1.00),
+    "upper_center": (0.20, 0.05, 0.80, 0.68),
+    "upper_tight": (0.28, 0.10, 0.72, 0.64),
+}
+
+
+@dataclass(frozen=True)
+class CropRefinementConfig:
+    enabled: bool = DEFAULT_CROP_REFINEMENT_ENABLED
+    min_score: float = DEFAULT_CROP_REFINEMENT_MIN_SCORE
+    min_gain: float = DEFAULT_CROP_REFINEMENT_MIN_GAIN
+    min_text_length: int = 2
+    profiles: tuple[str, ...] = DEFAULT_CROP_REFINEMENT_PROFILES
+
+    @classmethod
+    def from_mapping(cls, value: dict | None) -> "CropRefinementConfig":
+        mapping = dict(value or {})
+        profiles = tuple(
+            str(profile).strip()
+            for profile in mapping.get(
+                "profiles", DEFAULT_CROP_REFINEMENT_PROFILES
+            )
+            if str(profile).strip()
+        )
+        unknown = set(profiles) - set(_CROP_REFINEMENT_PROFILE_BOXES)
+        if unknown:
+            raise ValueError(
+                "unknown OCR crop refinement profiles: "
+                + ", ".join(sorted(unknown))
+            )
+        min_score = float(
+            mapping.get("min_score", DEFAULT_CROP_REFINEMENT_MIN_SCORE)
+        )
+        min_gain = float(
+            mapping.get("min_gain", DEFAULT_CROP_REFINEMENT_MIN_GAIN)
+        )
+        min_text_length = int(mapping.get("min_text_length", 2))
+        if not 0.0 <= min_score <= 1.0:
+            raise ValueError("OCR crop refinement min_score must be in [0, 1]")
+        if min_gain < 0.0:
+            raise ValueError("OCR crop refinement min_gain must be non-negative")
+        if min_text_length < 1:
+            raise ValueError(
+                "OCR crop refinement min_text_length must be positive"
+            )
+        return cls(
+            enabled=bool(
+                mapping.get("enabled", DEFAULT_CROP_REFINEMENT_ENABLED)
+            ),
+            min_score=min_score,
+            min_gain=min_gain,
+            min_text_length=min_text_length,
+            profiles=profiles,
+        )
+
+
+@dataclass(frozen=True)
+class EmptyResultRetryConfig:
+    enabled: bool = DEFAULT_EMPTY_RESULT_RETRY_ENABLED
+    det_thresh: float = DEFAULT_EMPTY_RESULT_RETRY_DET_THRESH
+    det_box_thresh: float = DEFAULT_EMPTY_RESULT_RETRY_DET_BOX_THRESH
+
+    @classmethod
+    def from_mapping(cls, value: dict | None) -> "EmptyResultRetryConfig":
+        mapping = dict(value or {})
+        det_thresh = float(
+            mapping.get("det_thresh", DEFAULT_EMPTY_RESULT_RETRY_DET_THRESH)
+        )
+        det_box_thresh = float(
+            mapping.get(
+                "det_box_thresh", DEFAULT_EMPTY_RESULT_RETRY_DET_BOX_THRESH
+            )
+        )
+        if not 0.0 <= det_thresh <= 1.0:
+            raise ValueError("OCR empty-result retry det_thresh must be in [0, 1]")
+        if not 0.0 <= det_box_thresh <= 1.0:
+            raise ValueError(
+                "OCR empty-result retry det_box_thresh must be in [0, 1]"
+            )
+        return cls(
+            enabled=bool(
+                mapping.get("enabled", DEFAULT_EMPTY_RESULT_RETRY_ENABLED)
+            ),
+            det_thresh=det_thresh,
+            det_box_thresh=det_box_thresh,
+        )
+
+
+def decode_vips_overview(image_bytes: bytes, max_side: int):
+    import numpy as np
+    import pyvips
+
+    if max_side <= 0:
+        raise ValueError("max_side must be positive")
+    image = pyvips.Image.thumbnail_buffer(
+        image_bytes,
+        max_side,
+        size="down",
+        no_rotate=False,
+    )
+    if image.hasalpha():
+        image = image.flatten(background=[255, 255, 255])
+    image = image.colourspace("srgb")
+    try:
+        rgb = image.numpy()
+    except ValueError:
+        memory = image.write_to_memory()
+        rgb = np.frombuffer(memory, dtype=np.uint8).reshape(
+            image.height, image.width, min(image.bands, 4)
+        )
+    if rgb.ndim != 3 or rgb.shape[2] != 3:
+        raise ValueError("decoded image must have three color channels")
+    return np.ascontiguousarray(rgb[:, :, ::-1], dtype=np.uint8)
+
+
+def probe_image_header(image_bytes: bytes) -> tuple[int, int]:
+    try:
+        from PIL import Image
+
+        with Image.open(BytesIO(image_bytes)) as image:
+            width, height = image.size
+    except Exception as exc:
+        raise ValueError("invalid or unsupported compressed image header") from exc
+
+    if width <= 0 or height <= 0:
+        raise ValueError("compressed image has invalid dimensions")
+    return width, height
+
+
+def scale_ocr_items(
+    items: list[dict], scale_x: float, scale_y: float
+) -> list[dict]:
+    scaled_items = []
+    for item in items:
+        x1, y1, x2, y2 = item["bbox"]
+        scaled_items.append(
+            {
+                **item,
+                "bbox": [
+                    math.floor(x1 * scale_x),
+                    math.floor(y1 * scale_y),
+                    math.ceil(x2 * scale_x),
+                    math.ceil(y2 * scale_y),
+                ],
+            }
+        )
+    return scaled_items
+
+
+def build_ocr_payload(results, timestamp, language, error=None) -> dict:
+    payload = {
+        "text": " ".join(item["text"] for item in results if item.get("text")),
+        "items": results,
+        "timestamp": timestamp,
+        "language": language,
+    }
+    if error is not None:
+        payload["error"] = str(error)
+    return payload
+
+
+def recognize_to_payload(
+    adapter, image_bytes: bytes, language: str, timestamp: float
+) -> dict:
+    try:
+        return build_ocr_payload(
+            adapter.recognize(image_bytes, language), timestamp, language
+        )
+    except Exception as exc:
+        return build_ocr_payload([], timestamp, language, error=exc)
+
+
+class TensorRTShapeError(ValueError):
+    """Raised when an OCR tensor is not covered by an engine profile."""
+
+
+class _CudaRuntime:
+    """Minimal CUDA Runtime API wrapper for TensorRT device buffers."""
+
+    _MEMCPY_HOST_TO_DEVICE = 1
+    _MEMCPY_DEVICE_TO_HOST = 2
+    _STREAM_NON_BLOCKING = 1
+
+    def __init__(self, device_id: int):
+        import ctypes
+
+        self._ctypes = ctypes
+        self._device_id = int(device_id)
+        self._library = ctypes.CDLL("libcudart.so")
+        self._bind_functions()
+        self._stream = ctypes.c_void_p()
+        self._set_device()
+        self._check(
+            self._library.cudaStreamCreateWithFlags(
+                ctypes.byref(self._stream), self._STREAM_NON_BLOCKING
+            ),
+            "cudaStreamCreateWithFlags",
+        )
+
+    def _bind_functions(self) -> None:
+        ctypes = self._ctypes
+        library = self._library
+        library.cudaGetErrorString.argtypes = [ctypes.c_int]
+        library.cudaGetErrorString.restype = ctypes.c_char_p
+        library.cudaSetDevice.argtypes = [ctypes.c_int]
+        library.cudaSetDevice.restype = ctypes.c_int
+        library.cudaStreamCreateWithFlags.argtypes = [
+            ctypes.POINTER(ctypes.c_void_p),
+            ctypes.c_uint,
+        ]
+        library.cudaStreamCreateWithFlags.restype = ctypes.c_int
+        library.cudaStreamDestroy.argtypes = [ctypes.c_void_p]
+        library.cudaStreamDestroy.restype = ctypes.c_int
+        library.cudaStreamSynchronize.argtypes = [ctypes.c_void_p]
+        library.cudaStreamSynchronize.restype = ctypes.c_int
+        library.cudaMalloc.argtypes = [
+            ctypes.POINTER(ctypes.c_void_p),
+            ctypes.c_size_t,
+        ]
+        library.cudaMalloc.restype = ctypes.c_int
+        library.cudaFree.argtypes = [ctypes.c_void_p]
+        library.cudaFree.restype = ctypes.c_int
+        library.cudaMemcpyAsync.argtypes = [
+            ctypes.c_void_p,
+            ctypes.c_void_p,
+            ctypes.c_size_t,
+            ctypes.c_int,
+            ctypes.c_void_p,
+        ]
+        library.cudaMemcpyAsync.restype = ctypes.c_int
+
+    def _check(self, code: int, operation: str) -> None:
+        if code == 0:
+            return
+        message = self._library.cudaGetErrorString(code)
+        detail = message.decode("utf-8", errors="replace") if message else "unknown"
+        raise RuntimeError(f"{operation} failed with CUDA error {code}: {detail}")
+
+    def _set_device(self) -> None:
+        self._check(
+            self._library.cudaSetDevice(self._device_id), "cudaSetDevice"
+        )
+
+    @property
+    def stream_handle(self) -> int:
+        return int(self._stream.value or 0)
+
+    def malloc(self, size: int) -> int:
+        self._set_device()
+        pointer = self._ctypes.c_void_p()
+        self._check(
+            self._library.cudaMalloc(
+                self._ctypes.byref(pointer), self._ctypes.c_size_t(size)
+            ),
+            "cudaMalloc",
+        )
+        if not pointer.value:
+            raise RuntimeError("cudaMalloc returned a null device pointer")
+        return int(pointer.value)
+
+    def free(self, pointer: int) -> None:
+        if not pointer:
+            return
+        self._set_device()
+        self._check(
+            self._library.cudaFree(self._ctypes.c_void_p(pointer)), "cudaFree"
+        )
+
+    def copy_host_to_device(self, pointer: int, array) -> None:
+        self._set_device()
+        self._check(
+            self._library.cudaMemcpyAsync(
+                self._ctypes.c_void_p(pointer),
+                self._ctypes.c_void_p(array.ctypes.data),
+                self._ctypes.c_size_t(array.nbytes),
+                self._MEMCPY_HOST_TO_DEVICE,
+                self._stream,
+            ),
+            "cudaMemcpyAsync(H2D)",
+        )
+
+    def copy_device_to_host(self, array, pointer: int) -> None:
+        self._set_device()
+        self._check(
+            self._library.cudaMemcpyAsync(
+                self._ctypes.c_void_p(array.ctypes.data),
+                self._ctypes.c_void_p(pointer),
+                self._ctypes.c_size_t(array.nbytes),
+                self._MEMCPY_DEVICE_TO_HOST,
+                self._stream,
+            ),
+            "cudaMemcpyAsync(D2H)",
+        )
+
+    def synchronize(self) -> None:
+        self._set_device()
+        self._check(
+            self._library.cudaStreamSynchronize(self._stream),
+            "cudaStreamSynchronize",
+        )
+
+    def close(self) -> None:
+        if not self._stream.value:
+            return
+        self._set_device()
+        stream = self._stream
+        self._stream = self._ctypes.c_void_p()
+        self._check(
+            self._library.cudaStreamDestroy(stream), "cudaStreamDestroy"
+        )
+
+
+class _TensorRTModelSession:
+    def __init__(
+        self,
+        engine_path: Path,
+        *,
+        device_id: int,
+        mean: tuple[float, float, float],
+        normal: tuple[float, float, float],
+    ):
+        import numpy as np
+        import tensorrt as trt
+        self._np = np
+        self._device_id = int(device_id)
+        self._cuda = None
+        self._input_device = 0
+        self._input_capacity = 0
+        self._output_device = 0
+        self._output_capacity = 0
+        self._context = None
+        self._engine = None
+        self._runtime = None
+
+        try:
+            self._cuda = _CudaRuntime(self._device_id)
+            logger = trt.Logger(trt.Logger.WARNING)
+            self._runtime = trt.Runtime(logger)
+            self._engine = self._runtime.deserialize_cuda_engine(
+                engine_path.read_bytes()
+            )
+            if self._engine is None:
+                raise RuntimeError(
+                    f"failed to deserialize TensorRT engine: {engine_path}"
+                )
+            self._context = self._engine.create_execution_context()
+            if self._context is None:
+                raise RuntimeError(
+                    f"failed to create TensorRT context: {engine_path}"
+                )
+        except Exception:
+            self.close()
+            raise
+
+        inputs = []
+        outputs = []
+        for index in range(self._engine.num_io_tensors):
+            name = self._engine.get_tensor_name(index)
+            mode = self._engine.get_tensor_mode(name)
+            (inputs if mode == trt.TensorIOMode.INPUT else outputs).append(name)
+        if len(inputs) != 1 or len(outputs) != 1:
+            raise RuntimeError(
+                "OCR TensorRT engine must have exactly one input and output; "
+                f"got inputs={inputs}, outputs={outputs}"
+            )
+        self._input_name = inputs[0]
+        self._output_name = outputs[0]
+        self._input_numpy_dtype = _trt_dtype_to_numpy(
+            trt, self._engine.get_tensor_dtype(self._input_name)
+        )
+        self._output_numpy_dtype = _trt_dtype_to_numpy(
+            trt, self._engine.get_tensor_dtype(self._output_name)
+        )
+        self._mean = np.asarray(mean, dtype=np.float32).reshape(1, 3, 1, 1)
+        self._normal = np.asarray(normal, dtype=np.float32).reshape(1, 3, 1, 1)
+        self._profiles = self._read_profiles()
+        self._active_profile = 0
+
+    def _read_profiles(self):
+        static_shape = tuple(
+            int(value) for value in self._engine.get_tensor_shape(self._input_name)
+        )
+        if static_shape and all(value > 0 for value in static_shape):
+            return [(static_shape, static_shape, static_shape)]
+
+        profiles = []
+        for index in range(self._engine.num_optimization_profiles):
+            minimum, optimum, maximum = self._engine.get_tensor_profile_shape(
+                self._input_name, index
+            )
+            profiles.append(
+                tuple(tuple(int(value) for value in shape) for shape in (
+                    minimum,
+                    optimum,
+                    maximum,
+                ))
+            )
+        if not profiles:
+            raise RuntimeError("OCR TensorRT engine has no optimization profile")
+        return profiles
+
+    @property
+    def optimization_shape(self) -> tuple[int, ...]:
+        return self._profiles[0][1]
+
+    def _select_profile(self, shape: tuple[int, ...]) -> int:
+        candidates = []
+        for index, (minimum, _optimum, maximum) in enumerate(self._profiles):
+            if len(shape) != len(minimum):
+                continue
+            if all(
+                lower <= value <= upper
+                for value, lower, upper in zip(shape, minimum, maximum)
+            ):
+                distance = sum(
+                    abs(math.log(max(1, value) / max(1, optimum)))
+                    for value, optimum in zip(shape, _optimum)
+                )
+                candidates.append((distance, index))
+        if candidates:
+            return min(candidates)[1]
+        ranges = [
+            {"min": minimum, "max": maximum}
+            for minimum, _optimum, maximum in self._profiles
+        ]
+        raise TensorRTShapeError(
+            f"OCR TensorRT input shape {shape} is outside profiles {ranges}"
+        )
+
+    def run_uint8(self, image, shape: tuple[int, ...]):
+        image = self._np.ascontiguousarray(image, dtype=self._np.uint8)
+        if len(shape) != 4 or shape[0] != 1 or shape[1] != 3:
+            raise ValueError(f"invalid OCR TensorRT NCHW shape: {shape}")
+        if image.shape[:2] != (shape[2], shape[3]):
+            raise ValueError(
+                f"OCR TensorRT image/shape mismatch: {image.shape} vs {shape}"
+            )
+        return self.run_uint8_batch(image[None], shape)
+
+    def run_uint8_batch(self, images, shape: tuple[int, ...]):
+        images = self._np.ascontiguousarray(images, dtype=self._np.uint8)
+        if len(shape) != 4 or shape[1] != 3:
+            raise ValueError(f"invalid OCR TensorRT NCHW shape: {shape}")
+        if images.ndim != 4 or images.shape != (
+            shape[0], shape[2], shape[3], shape[1]
+        ):
+            raise ValueError(
+                f"OCR TensorRT image batch/shape mismatch: {images.shape} vs "
+                f"{shape}"
+            )
+        nchw = images.transpose(0, 3, 1, 2)
+        if self._input_numpy_dtype == self._np.dtype(self._np.float32):
+            array = self._np.empty(nchw.shape, dtype=self._np.float32)
+            self._np.subtract(nchw, self._mean, out=array)
+            self._np.multiply(array, self._normal, out=array)
+        else:
+            value = (nchw.astype(self._np.float32) - self._mean) * self._normal
+            array = self._np.ascontiguousarray(
+                value, dtype=self._input_numpy_dtype
+            )
+        return self._run(array)
+
+    def max_batch_size(self, height: int, width: int) -> int:
+        compatible = [
+            maximum[0]
+            for minimum, _optimum, maximum in self._profiles
+            if len(minimum) == 4
+            and minimum[1] <= 3 <= maximum[1]
+            and minimum[2] <= height <= maximum[2]
+            and minimum[3] <= width <= maximum[3]
+            and minimum[0] <= 1 <= maximum[0]
+        ]
+        if not compatible:
+            self._select_profile((1, 3, int(height), int(width)))
+        return max(compatible)
+
+    def _run(self, array):
+        shape = tuple(int(value) for value in array.shape)
+        profile = self._select_profile(shape)
+        cuda = self._cuda
+        if profile != self._active_profile:
+            if not self._context.set_optimization_profile_async(
+                profile, cuda.stream_handle
+            ):
+                raise RuntimeError(
+                    f"failed to select TensorRT profile {profile}"
+                )
+            self._active_profile = profile
+        if not self._context.set_input_shape(self._input_name, shape):
+            raise RuntimeError(f"TensorRT rejected OCR input shape {shape}")
+        output_shape = tuple(
+            int(value)
+            for value in self._context.get_tensor_shape(self._output_name)
+        )
+        if any(value < 0 for value in output_shape):
+            raise RuntimeError(
+                f"TensorRT produced unresolved output shape {output_shape}"
+            )
+
+        self._input_device = self._ensure_capacity(
+            "_input_device", "_input_capacity", array.nbytes
+        )
+        output = self._np.empty(output_shape, dtype=self._output_numpy_dtype)
+        self._output_device = self._ensure_capacity(
+            "_output_device", "_output_capacity", output.nbytes
+        )
+        cuda.copy_host_to_device(self._input_device, array)
+        self._context.set_tensor_address(
+            self._input_name, self._input_device
+        )
+        self._context.set_tensor_address(
+            self._output_name, self._output_device
+        )
+        if not self._context.execute_async_v3(cuda.stream_handle):
+            raise RuntimeError("TensorRT OCR execution failed")
+        cuda.copy_device_to_host(output, self._output_device)
+        cuda.synchronize()
+        return output
+
+    def _ensure_capacity(
+        self, pointer_attribute: str, capacity_attribute: str, required: int
+    ) -> int:
+        pointer = getattr(self, pointer_attribute)
+        capacity = getattr(self, capacity_attribute)
+        if required <= capacity:
+            return pointer
+        if pointer:
+            self._cuda.free(pointer)
+            setattr(self, pointer_attribute, 0)
+            setattr(self, capacity_attribute, 0)
+        replacement = self._cuda.malloc(required)
+        setattr(self, pointer_attribute, replacement)
+        setattr(self, capacity_attribute, required)
+        return replacement
+
+    def close(self) -> None:
+        cuda = self._cuda
+        if cuda is not None:
+            if self._input_device:
+                cuda.free(self._input_device)
+                self._input_device = 0
+                self._input_capacity = 0
+            if self._output_device:
+                cuda.free(self._output_device)
+                self._output_device = 0
+                self._output_capacity = 0
+        self._context = None
+        self._engine = None
+        self._runtime = None
+        if cuda is not None:
+            cuda.close()
+            self._cuda = None
+
+    def __del__(self):
+        try:
+            self.close()
+        except Exception:
+            # Interpreter shutdown can unload CUDA before Python finalizers run.
+            pass
+
+
+def _trt_dtype_to_numpy(trt_module, dtype):
+    """Keep TensorRT's deprecated nptype warning isolated in one helper."""
+    import numpy as np
+
+    return np.dtype(trt_module.nptype(dtype))
+
+
+class _TensorRTPipeline:
+    @staticmethod
+    def _multiple_of_32(value: float) -> int:
+        return max(32, int(round(value / 32)) * 32)
+
+    def _detector_input(self, image):
+        import cv2
+
+        height, width = image.shape[:2]
+        scale = min(1.0, self._max_side_len / max(height, width))
+        target_height = self._multiple_of_32(height * scale)
+        target_width = self._multiple_of_32(width * scale)
+        if (target_width, target_height) == (width, height):
+            return image
+        return cv2.resize(
+            image,
+            (target_width, target_height),
+            interpolation=cv2.INTER_AREA,
+        )
+
+    def _run_detector(self, image):
+        detector_input = self._detector_input(image)
+        height, width = detector_input.shape[:2]
+        prediction = self._det.run_uint8(
+            detector_input, (1, 3, height, width)
+        )
+        return prediction, image.shape[:2]
+
+    @staticmethod
+    def _postprocess_detection(prediction, image_shape, postprocess):
+        import numpy as np
+
+        boxes, scores = postprocess(prediction, image_shape)
+        if len(boxes) == 0:
+            return np.empty((0, 4, 2), dtype=np.float32), []
+        order = sorted(
+            range(len(boxes)),
+            key=lambda index: (boxes[index][0][1], boxes[index][0][0]),
+        )
+        return boxes[order], [scores[index] for index in order]
+
+    @staticmethod
+    def _prepare_recognition_crop(crop):
+        import cv2
+        import numpy as np
+
+        height, width = crop.shape[:2]
+        if height <= 0 or width <= 0:
+            return None
+        ratio = width / float(height)
+        target_height = 48
+        target_width = min(
+            MAX_RECOGNITION_WIDTH,
+            max(320, int(math.ceil(target_height * ratio))),
+        )
+        target_width = max(32, int(math.ceil(target_width / 8)) * 8)
+        resized_width = min(
+            target_width, max(1, int(math.ceil(target_height * ratio)))
+        )
+        resized = cv2.resize(
+            crop,
+            (resized_width, target_height),
+            interpolation=cv2.INTER_LINEAR,
+        )
+        padded = np.full(
+            (target_height, target_width, 3), 128, dtype=np.uint8
+        )
+        padded[:, :resized_width] = resized
+        return padded, ratio
+
+    def __init__(
+        self,
+        root: Path,
+        *,
+        device_id: int,
+        max_side_len: int,
+        rec_min_score: float = DEFAULT_REC_MIN_SCORE,
+        enable_preprocess: bool = True,
+        det_thresh: float = DEFAULT_DET_THRESH,
+        det_box_thresh: float = DEFAULT_DET_BOX_THRESH,
+        det_unclip_ratio: float = DEFAULT_DET_UNCLIP_RATIO,
+        crop_refinement: CropRefinementConfig | None = None,
+        empty_result_retry: EmptyResultRetryConfig | None = None,
+        use_angle_cls: bool = False,
+        cls_thresh: float = DEFAULT_CLS_THRESH,
+    ):
+        from rapidocr.ch_ppocr_det.utils import DBPostProcess
+        from rapidocr.ch_ppocr_rec.utils import CTCLabelDecode
+        from rapidocr.utils.process_img import get_rotate_crop_image
+
+        self._det = _TensorRTModelSession(
+            root / "det.engine",
+            device_id=device_id,
+            mean=_OCR_MEAN,
+            normal=_OCR_NORMAL,
+        )
+        try:
+            self._rec = _TensorRTModelSession(
+                root / "rec.engine",
+                device_id=device_id,
+                mean=_OCR_MEAN,
+                normal=_OCR_NORMAL,
+            )
+        except Exception:
+            self._det.close()
+            raise
+        self._cls = None
+        if use_angle_cls:
+            try:
+                self._cls = _TensorRTModelSession(
+                    root / TENSORRT_CLASSIFIER_MODEL_FILE,
+                    device_id=device_id,
+                    mean=_OCR_MEAN,
+                    normal=_OCR_NORMAL,
+                )
+            except Exception:
+                self._rec.close()
+                self._det.close()
+                raise
+        self._det_postprocess = DBPostProcess(
+            thresh=float(det_thresh),
+            box_thresh=float(det_box_thresh),
+            max_candidates=1000,
+            unclip_ratio=float(det_unclip_ratio),
+            use_dilation=True,
+            score_mode="fast",
+        )
+        self._rec_decode = CTCLabelDecode(character_path=root / "keys.txt")
+        self._crop = get_rotate_crop_image
+        self._rec_min_score = float(rec_min_score)
+        self._enable_preprocess = bool(enable_preprocess)
+        self._max_side_len = max(32, int(max_side_len))
+        self._cls_thresh = float(cls_thresh)
+        self._crop_refinement = (
+            crop_refinement
+            if crop_refinement is not None
+            else CropRefinementConfig()
+        )
+        retry = (
+            empty_result_retry
+            if empty_result_retry is not None
+            else EmptyResultRetryConfig()
+        )
+        self._empty_result_retry_postprocess = None
+        if retry.enabled:
+            self._empty_result_retry_postprocess = DBPostProcess(
+                thresh=retry.det_thresh,
+                box_thresh=retry.det_box_thresh,
+                max_candidates=1000,
+                unclip_ratio=float(det_unclip_ratio),
+                use_dilation=True,
+                score_mode="fast",
+            )
+
+    def warm_up(self) -> None:
+        import numpy as np
+
+        det_shape = self._det.optimization_shape
+        rec_shape = self._rec.optimization_shape
+        self._det.run_uint8_batch(
+            np.zeros(
+                (det_shape[0], det_shape[2], det_shape[3], 3),
+                dtype=np.uint8,
+            ),
+            det_shape,
+        )
+        self._rec.run_uint8_batch(
+            np.zeros(
+                (rec_shape[0], rec_shape[2], rec_shape[3], 3),
+                dtype=np.uint8,
+            ),
+            rec_shape,
+        )
+        if self._cls is not None:
+            cls_shape = self._cls.optimization_shape
+            self._cls.run_uint8_batch(
+                np.zeros(
+                    (cls_shape[0], cls_shape[2], cls_shape[3], 3),
+                    dtype=np.uint8,
+                ),
+                cls_shape,
+            )
+
+    @staticmethod
+    def _prepare_classifier_crop(crop):
+        import cv2
+        import numpy as np
+
+        height, width = crop.shape[:2]
+        if height <= 0 or width <= 0:
+            return None
+        target_height = 48
+        target_width = 192
+        resized_width = min(
+            target_width,
+            max(1, int(math.ceil(target_height * width / float(height)))),
+        )
+        resized = cv2.resize(
+            crop,
+            (resized_width, target_height),
+            interpolation=cv2.INTER_LINEAR,
+        )
+        padded = np.zeros(
+            (target_height, target_width, 3), dtype=np.uint8
+        )
+        padded[:, :resized_width] = resized
+        return padded
+
+    def _orient_crops(self, crops):
+        import cv2
+        import numpy as np
+
+        classifier = getattr(self, "_cls", None)
+        if classifier is None:
+            return crops
+        oriented = list(crops)
+        prepared = []
+        for index, crop in enumerate(crops):
+            value = self._prepare_classifier_crop(crop)
+            if value is not None:
+                prepared.append((index, value))
+        max_batch = classifier.max_batch_size(48, 192)
+        for offset in range(0, len(prepared), max_batch):
+            chunk = prepared[offset:offset + max_batch]
+            images = np.stack([entry[1] for entry in chunk])
+            prediction = classifier.run_uint8_batch(
+                images,
+                (len(chunk), 3, 48, 192),
+            )
+            for entry, probabilities in zip(chunk, prediction):
+                label = int(np.argmax(probabilities))
+                score = float(probabilities[label])
+                if label == 1 and score > self._cls_thresh:
+                    oriented[entry[0]] = cv2.rotate(
+                        crops[entry[0]], cv2.ROTATE_180
+                    )
+        return oriented
+
+    def _recognize_boxes(self, image, boxes):
+        import copy
+        from collections import defaultdict
+
+        import numpy as np
+
+        prepared_by_width = defaultdict(list)
+        recognized = [("", 0.0)] * len(boxes)
+        crops = [
+            self._crop(image, copy.deepcopy(box)) for box in boxes
+        ]
+        for index, crop in enumerate(self._orient_crops(crops)):
+            prepared = self._prepare_recognition_crop(crop)
+            if prepared is None:
+                continue
+            padded, ratio = prepared
+            prepared_by_width[padded.shape[1]].append((index, padded, ratio))
+
+        for target_width, group in prepared_by_width.items():
+            max_batch = self._rec.max_batch_size(48, target_width)
+            for offset in range(0, len(group), max_batch):
+                chunk = group[offset:offset + max_batch]
+                images = np.stack([entry[1] for entry in chunk])
+                ratios = tuple(entry[2] for entry in chunk)
+                prediction = self._rec.run_uint8_batch(
+                    images,
+                    (len(chunk), 3, 48, target_width),
+                )
+                line_results, _ = self._rec_decode(
+                    prediction,
+                    False,
+                    wh_ratio_list=ratios,
+                    max_wh_ratio=target_width / 48,
+                )
+                for entry, result in zip(chunk, line_results):
+                    text, score = result
+                    recognized[entry[0]] = str(text), float(score)
+        return recognized
+
+    def close(self) -> None:
+        classifier = getattr(self, "_cls", None)
+        if classifier is not None:
+            classifier.close()
+            self._cls = None
+        self._rec.close()
+        self._det.close()
+
+    @staticmethod
+    def _sub_quad(box, x0: float, y0: float, x1: float, y1: float):
+        import numpy as np
+
+        def point(u: float, v: float):
+            top = box[0] * (1.0 - u) + box[1] * u
+            bottom = box[3] * (1.0 - u) + box[2] * u
+            return top * (1.0 - v) + bottom * v
+
+        return np.asarray(
+            [
+                point(x0, y0),
+                point(x1, y0),
+                point(x1, y1),
+                point(x0, y1),
+            ],
+            dtype=np.float32,
+        )
+
+    @staticmethod
+    def _item(box, text: str, score: float) -> dict:
+        import numpy as np
+
+        xs = box[:, 0]
+        ys = box[:, 1]
+        return {
+            "text": text,
+            "bbox": [
+                float(np.min(xs)),
+                float(np.min(ys)),
+                float(np.max(xs)),
+                float(np.max(ys)),
+            ],
+            "score": score,
+        }
+
+    def _recognize_with_refinement(self, image, boxes) -> list[dict]:
+        recognized = self._recognize_boxes(image, boxes)
+        refinement = getattr(
+            self, "_crop_refinement", CropRefinementConfig(enabled=False)
+        )
+        if not refinement.enabled:
+            return [
+                self._item(box, text, score)
+                for box, (text, score) in zip(boxes, recognized)
+                if text.strip() and score >= self._rec_min_score
+            ]
+
+        refined_boxes = []
+        refined_sources = []
+        for box_index, (box, (_, score)) in enumerate(
+            zip(boxes, recognized)
+        ):
+            if score >= self._rec_min_score:
+                continue
+            for profile in refinement.profiles:
+                refined_boxes.append(
+                    self._sub_quad(
+                        box, *_CROP_REFINEMENT_PROFILE_BOXES[profile]
+                    )
+                )
+                refined_sources.append(box_index)
+
+        refined_results = self._recognize_boxes(image, refined_boxes)
+        candidates_by_box = {}
+        for box, source, result in zip(
+            refined_boxes, refined_sources, refined_results
+        ):
+            text, score = result
+            if len(text.strip()) < refinement.min_text_length:
+                continue
+            candidate = candidates_by_box.get(source)
+            if candidate is None or score > candidate[2]:
+                candidates_by_box[source] = (box, text, score)
+
+        items = []
+        for box_index, (box, (text, score)) in enumerate(
+            zip(boxes, recognized)
+        ):
+            selected_box = box
+            selected_text = text
+            selected_score = score
+            candidate = candidates_by_box.get(box_index)
+            if (
+                candidate is not None
+                and candidate[2] >= refinement.min_score
+                and candidate[2] >= score + refinement.min_gain
+            ):
+                selected_box, selected_text, selected_score = candidate
+
+            score_floor = (
+                refinement.min_score
+                if selected_box is not box
+                else self._rec_min_score
+            )
+            if not selected_text.strip() or selected_score < score_floor:
+                continue
+            items.append(
+                self._item(selected_box, selected_text, selected_score)
+            )
+        return items
+
+    def infer(self, image) -> list[dict]:
+        det_image = image
+        if self._enable_preprocess:
+            try:
+                det_image = preprocess_for_ocr(image)
+            except Exception:
+                _log.debug("preprocess failed, using original image", exc_info=True)
+
+        prediction, image_shape = self._run_detector(det_image)
+        boxes, _ = self._postprocess_detection(
+            prediction, image_shape, self._det_postprocess
+        )
+        items = self._recognize_with_refinement(image, boxes)
+        retry_postprocess = getattr(
+            self, "_empty_result_retry_postprocess", None
+        )
+        if items or retry_postprocess is None:
+            return items
+
+        retry_boxes, _ = self._postprocess_detection(
+            prediction, image_shape, retry_postprocess
+        )
+        return self._recognize_with_refinement(image, retry_boxes)
+
+
+class RapidOCRAdapter:
+    def __init__(
+        self,
+        model_dir: str,
+        device_id: int = 0,
+        use_angle_cls: bool = True,
+        max_side_len: int = DEFAULT_MAX_SIDE_LEN,
+        rec_min_score: float = DEFAULT_REC_MIN_SCORE,
+        enable_preprocess: bool = True,
+        det_thresh: float = DEFAULT_DET_THRESH,
+        det_box_thresh: float = DEFAULT_DET_BOX_THRESH,
+        det_unclip_ratio: float = DEFAULT_DET_UNCLIP_RATIO,
+        crop_refinement: dict | None = None,
+        empty_result_retry: dict | None = None,
+    ):
+        root = Path(model_dir)
+        self._max_side_len = max_side_len
+        self._request_lock = threading.Lock()
+        self._inference_lock = threading.Lock()
+        crop_refinement_config = CropRefinementConfig.from_mapping(
+            crop_refinement
+        )
+        empty_result_retry_config = EmptyResultRetryConfig.from_mapping(
+            empty_result_retry
+        )
+        required_files = TENSORRT_MODEL_FILES + (
+            (TENSORRT_CLASSIFIER_MODEL_FILE,) if use_angle_cls else ()
+        )
+        missing = [name for name in required_files if not (root / name).is_file()]
+        if missing:
+            raise FileNotFoundError(
+                f"OCR TensorRT model files missing: {', '.join(missing)}"
+            )
+        pipeline = _TensorRTPipeline(
+            root,
+            device_id=device_id,
+            crop_refinement=crop_refinement_config,
+            empty_result_retry=empty_result_retry_config,
+            use_angle_cls=use_angle_cls,
+            max_side_len=max_side_len,
+            rec_min_score=rec_min_score,
+            enable_preprocess=enable_preprocess,
+            det_thresh=det_thresh,
+            det_box_thresh=det_box_thresh,
+            det_unclip_ratio=det_unclip_ratio,
+        )
+        try:
+            pipeline.warm_up()
+        except Exception:
+            pipeline.close()
+            raise
+        self._pipeline = pipeline
+
+    @staticmethod
+    def _probe_image_header(image_bytes: bytes) -> tuple[int, int]:
+        return probe_image_header(image_bytes)
+
+    def _infer_image(self, image) -> list[dict]:
+        with self._inference_lock:
+            return self._pipeline.infer(image)
+
+    def _recognize_single_pass(self, image_bytes: bytes) -> list[dict]:
+        source_size = self._probe_image_header(image_bytes)
+        image = decode_vips_overview(image_bytes, self._max_side_len)
+        decoded_height, decoded_width = image.shape[:2]
+        items = self._infer_image(image)
+        source_width, source_height = source_size
+        return scale_ocr_items(
+            items,
+            scale_x=source_width / decoded_width,
+            scale_y=source_height / decoded_height,
+        )
+
+    def recognize(self, image_bytes: bytes, language: str = "zh") -> list:
+        request_lock = getattr(self, "_request_lock", None)
+        if request_lock is None:
+            return self._recognize_single_pass(image_bytes)
+        with request_lock:
+            return self._recognize_single_pass(image_bytes)
+
+    def close(self) -> None:
+        request_lock = getattr(self, "_request_lock", None)
+        if request_lock is None:
+            self._close_resources()
+            return
+        with request_lock:
+            self._close_resources()
+
+    def _close_resources(self) -> None:
+        pipeline = getattr(self, "_pipeline", None)
+        self._pipeline = None
+        if pipeline is not None:
+            pipeline.close()


### PR DESCRIPTION
## 概述

为 Perception Stack 新增可选的端侧 OCR 能力。插件订阅相机 `image/jpeg` ROS2 topic，使用 PP-OCRv6 small TensorRT engine 识别文字，并将文本、置信度和坐标发布到 `<input_topic>/ocr`。

## 实现

- `ocr.py`：MCP `ocr` 工具和 ROS2 节点生命周期，支持多实例、最新帧队列、安全停止与共享 adapter。
- `ocr_runtime.py`：纯 TensorRT GPU 推理，不依赖 PyTorch CUDA runtime；包含检测、0/180 度 CLS、批量识别、低置信度复识别和空结果重试。
- `ocr_preprocess.py`：有界图像解码与预处理。
- `main.py`：按配置注册 OCR、统一释放插件资源，并保证 `MCP_PORT` / `WS_PORT` 环境变量优先于 YAML。
- Fast DDS 大消息配置，支持高分辨率压缩图像传输。
- 同一份 `perception/Dockerfile.jetson` 通过 `JP_VERSION=61|511` 选择对应 TensorRT engine。

## 生命周期与模型分发

- OCR 是新增可选插件，默认 `enabled: false`。
- 即使显式启用，插件构造、`info` 和 `config` 也不创建推理 runtime；首次有效 `action=start` 才加载 engine。
- engine 缺失、版本不兼容或加载失败会明确启动失败，不静默回退或运行时联网下载。
- 仅保留 TensorRT 端侧路径，不包含云 API、Tesseract、MNN 或 ONNX Runtime fallback。
- 模型来自公开的 [ModelScope 仓库](https://www.modelscope.cn/models/Flame4pd/ppocrv6-small-edge-ocr)，固定 revision `0301e9299b3abe09c6a60796d7bed74c23fcc525`。
- JP6/JP5.1.1 的 det、rec、cls 与字典均校验精确字节数和 SHA256；下载包含 timeout、retry、临时文件与原子替换。
- 制品先写入镜像自有 seed layer，容器启动时仅在内容不一致时原子同步到既有 `/models` volume；模型文件不进入 Git。
- 逐帧成功日志与丢帧诊断使用 `debug`，重复推理错误限频记录。

## 默认推理参数

- TensorRT，启用 0/180 度 CLS
- `max_side_len: 1600`
- `det_thresh: 0.3`、`det_box_thresh: 0.5`、`det_unclip_ratio: 0.7`
- `rec_min_score: 0.9`
- `crop_refinement` 与复用 detector 概率图的 `empty_result_retry`

## 当前验证

- 当前提交基于 upstream `main@031a567`，PR 仅 1 个提交、9 个产品代码/配置/运行脚本文件。
- 开发分支的 59 项 OCR、生命周期、打包和 TensorRT builder 回归测试通过。
- Python 源码编译、seed 脚本语法和 `git diff --check` 通过。
- 固定 revision 下两代共 8 个公开制品均重新完整下载，字节数和 SHA256 与 Dockerfile 一致。
- 测试、workflow 与 engine builder 保留在开发分支，不进入本 PR。
- 当前提交尚未重新完成 JP6、JP5.1.1 全镜像构建及平台验证；本地 x86 的 Docker 静态检查停在 ARM-only 基础镜像 manifest 解析，不能替代 Jetson 证据。

