### PR TITLE
feat: agent loop interrupt mechanism + TTS EOF marker + prompt cleanup

### DIFF
--- a/agent-core/src/collector.py
+++ b/agent-core/src/collector.py
@@ -2,10 +2,13 @@
 collector.py — 双队列事件收集器。
 
 架构：
-  - P>0 事件（ASR/message/channel）→ 立即送 main agent，或 busy 时暂存等 turn 结束
+  - P>0 事件（ASR/message/channel）→ 立即送 main agent，或 busy 时按模式处理：
+    - steer: 推入 steering_queue，agent loop 在 tool batch 间消费
+    - interrupt: 触发 cancel_event，中止当前 turn
+    - followup: 暂存 _priority_pending，等 turn 结束后 drain
   - P=0 事件（sensor/scheduler 等）→ 独立节奏送 bg subagent，main agent 永远不看到
   - Ring buffer 保留所有事件（供 raw_input_info 按需查询）
-  - 支持 cancel_event 信号（仅 P>P_current 时 cancel）
+  - 语音 barge-in 检测：ASR 事件 duration_ms < 阈值时视为 backchannel 丢弃
 """
 
 import asyncio
@@ -19,8 +22,9 @@ import event_bus
 
 
 # ── P>0 管道 ─────────────────────────────────────────────────────────────────
-_priority_pending: deque = deque()   # P>0 事件（busy 时暂存）
+_priority_pending: deque = deque()   # P>0 事件（followup 模式：busy 时暂存）
 _output: asyncio.Queue = asyncio.Queue(maxsize=64)  # main agent 消费端
+_steering_queue: asyncio.Queue = asyncio.Queue(maxsize=32)  # steer 模式：busy 时推入
 
 # ── P=0 管道 ─────────────────────────────────────────────────────────────────
 _bg_buffer: deque = deque()          # P=0 事件（按节奏送 bg subagent）
@@ -35,6 +39,11 @@ _source_ring: dict[str, deque] = {}  # per-source ring buffer（所有事件）
 
 # 优先级判定规则
 _PRIORITY_SOURCES = {'asr', 'message', 'channel', 'subagent'}
+
+# 打断模式：steer(默认) | interrupt | followup
+_interrupt_mode: str = "steer"
+# barge-in 阈值（ms），ASR 事件 duration_ms 低于此值时视为 backchannel 丢弃
+_barge_in_threshold_ms: int = 500
 
 
 def _extract_priority(ev: dict) -> int:
@@ -101,6 +110,35 @@ def set_turn_priority(priority: int):
     """由 agent loop 调用：设置当前 turn 的 priority。"""
     global _current_turn_priority
     _current_turn_priority = priority
+
+
+def set_interrupt_mode(mode: str):
+    """设置打断模式：steer | interrupt | followup。"""
+    global _interrupt_mode
+    if mode in ('steer', 'interrupt', 'followup'):
+        _interrupt_mode = mode
+
+
+def set_barge_in_threshold(ms: int):
+    """设置 barge-in 阈值（毫秒）。"""
+    global _barge_in_threshold_ms
+    _barge_in_threshold_ms = max(0, ms)
+
+
+def get_interrupt_mode() -> str:
+    """返回当前打断模式。"""
+    return _interrupt_mode
+
+
+async def drain_steering() -> list[dict]:
+    """非阻塞地 drain steering_queue 中的所有待处理消息。由 agent loop 在 tool batch 间调用。"""
+    items = []
+    while not _steering_queue.empty():
+        try:
+            items.append(_steering_queue.get_nowait())
+        except asyncio.QueueEmpty:
+            break
+    return items
 
 
 async def next_trigger() -> dict:
@@ -307,9 +345,30 @@ async def _drain_loop():
             if not _busy:
                 await _emit_batch([ev], urgent=True)
             else:
-                _priority_pending.append(ev)
-                if priority > _current_turn_priority and _cancel_event:
-                    _cancel_event.set()
+                # Barge-in 检测：ASR 事件 duration 不足时视为 backchannel，丢弃
+                if 'asr' in source.lower() and _barge_in_threshold_ms > 0:
+                    duration_ms = ev.get('payload', {}).get('duration_ms', 0)
+                    if 0 < duration_ms < _barge_in_threshold_ms:
+                        continue  # backchannel，不打断
+
+                # 按模式处理
+                if _interrupt_mode == 'steer':
+                    # Steer: 推入 steering_queue，agent loop 在 tool batch 间消费
+                    try:
+                        _steering_queue.put_nowait(ev)
+                    except asyncio.QueueFull:
+                        # queue 满时退化为 followup
+                        _priority_pending.append(ev)
+                elif _interrupt_mode == 'interrupt':
+                    # Interrupt: 缓存事件并触发 cancel
+                    _priority_pending.append(ev)
+                    if _cancel_event:
+                        _cancel_event.set()
+                else:
+                    # Followup: 暂存，等 turn 结束后 drain（原有行为）
+                    _priority_pending.append(ev)
+                    if priority > _current_turn_priority and _cancel_event:
+                        _cancel_event.set()
         else:
             # ── P=0: 送 bg buffer ──
             _bg_buffer_add(ev)
@@ -329,7 +388,14 @@ async def _bg_trigger_loop():
 
 def start():
     """启动 collector 后台任务。"""
+    # 从配置加载打断模式和 barge-in 阈值
+    event_cfg = config.main.get('event', {}).get('llm', {})
+    mode = event_cfg.get('interrupt_mode', 'steer')
+    set_interrupt_mode(mode)
+    threshold = event_cfg.get('barge_in_threshold_ms', 500)
+    set_barge_in_threshold(threshold)
+
     asyncio.ensure_future(_drain_loop())
     asyncio.ensure_future(_bg_trigger_loop())
-    interval = config.main.get('event', {}).get('llm', {}).get('trigger_interval_ms', 1000)
-    print(f'[collector] started: dual-queue mode, bg_interval={interval}ms')
+    interval = event_cfg.get('trigger_interval_ms', 1000)
+    print(f'[collector] started: dual-queue mode, bg_interval={interval}ms, interrupt_mode={_interrupt_mode}, barge_in={_barge_in_threshold_ms}ms')

--- a/agent-core/src/config.py
+++ b/agent-core/src/config.py
@@ -59,6 +59,8 @@ _DB_DEFAULTS = {
             'compress_threshold_chars': 80000,  # 约 20K tokens，超过此字符数触发压缩
             'compress_keep_recent': 6,          # 压缩时保留最近 N 轮不动
             'source_ring_size': 50,             # per-source ring buffer 大小（供 raw_input_info 查询）
+            'interrupt_mode': 'steer',          # 打断模式: steer | interrupt | followup
+            'barge_in_threshold_ms': 500,       # 语音 barge-in 阈值（ms），低于此值视为 backchannel
         },
         'subscribe_topics': [],  # DDS topics core subscribes to directly (e.g. ["/robot/mic/audio/asr_event"])
     },

--- a/agent-core/src/event/llm.py
+++ b/agent-core/src/event/llm.py
@@ -491,6 +491,33 @@ class Event:
 
         return schemas
 
+    # ── 打断：中止正在进行的输出 ─────────────────────────────────────────────
+
+    async def _interrupt_active_outputs(self):
+        """中止所有正在进行的输出（TTS + 动作）。在 TurnCancelled 时调用。"""
+        tasks = []
+        for mcp_id, info in mcp_client.registry.items():
+            tools = info.get('tools', [])
+            tool_meta = info.get('tool_meta', {})
+            # 查找 TTS 工具并发送 interrupt
+            for t in tools:
+                short_name = t.split('__')[-1] if '__' in t else t
+                if short_name == 'tts':
+                    tasks.append(mcp_client.call_tool(t, {'action': 'interrupt'}))
+                    break
+            # 查找 loco 工具并发送 stop_move
+            for t in tools:
+                short_name = t.split('__')[-1] if '__' in t else t
+                if short_name == 'loco':
+                    tasks.append(mcp_client.call_tool(t, {'action': 'stop_move'}))
+                    break
+        if tasks:
+            results = await asyncio.gather(*tasks, return_exceptions=True)
+            for i, r in enumerate(results):
+                if isinstance(r, Exception):
+                    print(f'[decision] interrupt_active_outputs: task {i} failed: {r}')
+            print(f'[decision] interrupted {len(tasks)} active output(s)')
+
     # ── 主循环 ───────────────────────────────────────────────────────────────
 
     async def run_forever(self):
@@ -511,6 +538,8 @@ class Event:
                     'role': 'assistant',
                     'content': '[turn interrupted by user message]',
                 })
+                # 中止正在进行的 TTS 播放和动作
+                await self._interrupt_active_outputs()
                 await push_event({'type': 'turn_cancelled', 'payload': {}})
             except asyncio.CancelledError:
                 raise
@@ -891,6 +920,22 @@ class Event:
             skill_tools = {'activate_skill', 'deactivate_skill'}
             if any(c['function']['name'] in skill_tools for c in tool_calls):
                 frozen_system = prompt_mod.build_system(mcp_client.registry, bound_tool_names)
+
+            # ── Steering: 检查是否有用户消息需要注入 ─────────────────────────
+            steered = await collector.drain_steering()
+            if steered:
+                for sev in steered:
+                    s_text = sev.get('text', '')
+                    s_source = sev.get('source', '')
+                    turn_messages.append({
+                        'role': 'user',
+                        'content': f'[用户插入消息 source={s_source}]\n{s_text}',
+                    })
+                await push_event({'type': 'turn_steered', 'payload': {
+                    'count': len(steered),
+                    'sources': [s.get('source', '') for s in steered],
+                }})
+                print(f'[decision] steered {len(steered)} user message(s) into current turn')
 
             # ── 取消检查点：工具执行完毕后，下一轮 LLM 调用前 ────────────────
             if cancel_event and cancel_event.is_set():

--- a/agent-core/src/prompt.py
+++ b/agent-core/src/prompt.py
@@ -178,21 +178,12 @@ def _env_static(mcp_registry: dict, bound_tools: set | None = None) -> str:
 # ── L2 动态部分（时间/任务/事件统计）─────────────────────────────────────────
 
 def _env_dynamic() -> str:
-    """生成 L2 动态环境快照（时间、活跃任务、最近事件）。
+    """生成 L2 动态环境快照（时间、活跃任务）。
 
     每次调用都重新生成，但作为 user message 放在历史之后，
     不影响 system message 的缓存命中。
     """
     now = datetime.datetime.now(_TZ_CN).strftime('%Y-%m-%d %H:%M:%S')
-
-    # 最近事件来源统计（精简格式）
-    recents = event_bus.recent(10)
-    if recents:
-        from collections import Counter
-        counts = Counter(e['source'].split('/')[-1] for e in recents)
-        recent_str = ', '.join(f'{src} ×{n}' for src, n in counts.most_common(5))
-    else:
-        recent_str = 'none'
 
     # 活跃任务
     import task_store
@@ -217,7 +208,6 @@ def _env_dynamic() -> str:
 
     return (
         f'<status time="{now}">\n'
-        f'  <recent_sources>{len(recents)} events ({recent_str})</recent_sources>\n'
         f'{tasks_section}'
         f'</status>'
     )

--- a/agent-core/web/css/style.css
+++ b/agent-core/web/css/style.css
@@ -1516,6 +1516,14 @@ html, body {
   pointer-events: none;
 }
 
+/* Read-only mode: visual hint that editing is disabled */
+.canvas-readonly .canvas-card-close,
+.canvas-readonly .canvas-exec-btn:not(.locked),
+.canvas-readonly .canvas-field-input {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
 .canvas-mic-btn {
   all: unset;
   cursor: pointer;

--- a/agent-core/web/css/style.css
+++ b/agent-core/web/css/style.css
@@ -6023,13 +6023,14 @@ html, body {
 
   .canvas-editor-bar {
     position: fixed;
-    top: auto;
-    bottom: calc(56px + env(safe-area-inset-bottom, 0px) + 52px);
+    top: 12px;
     left: 12px;
+    bottom: auto;
     right: auto;
     padding: 4px 8px;
     font-size: 11px;
     gap: 5px;
+    z-index: 100;
   }
 }
 

--- a/agent-core/web/js/canvas.js
+++ b/agent-core/web/js/canvas.js
@@ -805,6 +805,7 @@ function _buildCardEl({ id, mcpId, toolName, driverName, x, y, topicIn: savedTop
     if (sensorExecBtn) {
       sensorExecBtn.addEventListener('click', async (e) => {
         e.stopPropagation();
+        if (!_canEdit()) return;
         await _executeCard(el, mcpId, toolName, id);
       });
     }
@@ -939,7 +940,13 @@ function _buildCardEl({ id, mcpId, toolName, driverName, x, y, topicIn: savedTop
             field.style.display = paramKeys.includes(key) ? '' : 'none';
           });
         };
-        actionSelect.addEventListener('change', _applyActionParams);
+        actionSelect.addEventListener('change', () => {
+          if (!_canEdit()) {
+            _applyActionParams();  // revert visual to match current state
+            return;
+          }
+          _applyActionParams();
+        });
         _applyActionParams();  // 初始应用
       }
     }
@@ -973,6 +980,7 @@ function _buildCardEl({ id, mcpId, toolName, driverName, x, y, topicIn: savedTop
     if (execBtn) {
       execBtn.addEventListener('click', async (e) => {
         e.stopPropagation();
+        if (!_canEdit()) return;
         await _executeCard(el, mcpId, toolName);
       });
     }
@@ -1929,6 +1937,7 @@ function _makeDraggable(el, cardData) {
     if (e.target.closest('.canvas-card-info-btn')) return;
     if (e.target.closest('.canvas-card-instance-cfg-btn')) return;
     if (_projectRunning) return;
+    if (!_canEdit()) return;
     e.preventDefault();
     e.stopPropagation();
 
@@ -2044,7 +2053,7 @@ function _updateEditorUI() {
 
 function _setCanvasReadonly(readonly) {
   if (_viewport) {
-    _viewport.style.pointerEvents = readonly ? 'none' : '';
+    _viewport.classList.toggle('canvas-readonly', readonly);
   }
   // Also disable sidebar drag if readonly
   document.querySelectorAll('.sidebar-tool-item').forEach(el => {

--- a/perception/plugins/tts.py
+++ b/perception/plugins/tts.py
@@ -42,7 +42,7 @@ TOOLS = [
             "properties": {
                 "action": {
                     "type": "string",
-                    "enum": ["start", "stop", "speak", "info", "config"],
+                    "enum": ["start", "stop", "speak", "info", "config", "interrupt"],
                     "description": "Action to perform"
                 },
                 "input_topic": {
@@ -165,6 +165,7 @@ class _TTSNode(Node):
         self._text_queue   = queue.Queue()
         self._worker_thread: Optional[threading.Thread] = None
         self._stop_event   = threading.Event()
+        self._interrupt_flag = threading.Event()  # 打断标志：设置后立即停止当前 utterance
         from audio_msgs.msg import AudioChunk
         self._pub = self.create_publisher(AudioChunk, self._output_topic, _LOW_LAT_QOS)
         self._perf_pub = self.create_publisher(String, '/perception/perf_spans', _LOW_LAT_QOS)
@@ -201,6 +202,21 @@ class _TTSNode(Node):
             self._worker_thread.join(timeout=3)
         self.state = "idle"
         return {"state": "idle"}
+
+    def interrupt(self) -> dict:
+        """立即中止当前播放：清空队列 + 设置 interrupt flag 让 worker 停止当前 utterance。"""
+        # 清空待播放队列
+        cleared = 0
+        while not self._text_queue.empty():
+            try:
+                self._text_queue.get_nowait()
+                cleared += 1
+            except queue.Empty:
+                break
+        # 设置 interrupt flag（worker 在每个 frame 前检查）
+        self._interrupt_flag.set()
+        log.info(f"[tts] interrupted: cleared {cleared} queued item(s)")
+        return {"status": "interrupted", "cleared": cleared}
 
     def enqueue(self, text: str, trace_id: str = ''):
         if self.state != "running":
@@ -247,7 +263,7 @@ class _TTSNode(Node):
                 prebuf = []   # pre-buffer queue
 
                 for raw_chunk in self._adapter.synthesize_stream(text):
-                    if self._stop_event.is_set():
+                    if self._stop_event.is_set() or self._interrupt_flag.is_set():
                         break
                     buf  += raw_chunk
                     total += len(raw_chunk)
@@ -255,6 +271,10 @@ class _TTSNode(Node):
                     while len(buf) >= CHUNK_BYTES:
                         frame = buf[:CHUNK_BYTES]
                         buf   = buf[CHUNK_BYTES:]
+
+                        # Check interrupt before publishing each frame
+                        if self._interrupt_flag.is_set():
+                            break
 
                         # Pre-buffer phase: accumulate a few frames before pacing
                         if t0 is None:
@@ -286,7 +306,7 @@ class _TTSNode(Node):
                         frames_sent += 1
 
                 # Flush any remaining pre-buffer (short utterances < PREBUF_FRAMES)
-                if prebuf and not self._stop_event.is_set():
+                if prebuf and not self._stop_event.is_set() and not self._interrupt_flag.is_set():
                     t0 = _time.monotonic()
                     for pf in prebuf:
                         msg = AudioChunk()
@@ -297,7 +317,7 @@ class _TTSNode(Node):
                         frames_sent += 1
 
                 # flush remainder
-                if buf and not self._stop_event.is_set():
+                if buf and not self._stop_event.is_set() and not self._interrupt_flag.is_set():
                     if t0 is not None:
                         target = t0 + frames_sent * FRAME_DURATION
                         now = _time.monotonic()
@@ -308,7 +328,13 @@ class _TTSNode(Node):
                     msg.format = "audio/pcm-16k"
                     msg.data   = list(buf)
                     self._pub.publish(msg)
-                log.info(f"[tts] spoke {len(text)} chars → {total} bytes ({frames_sent} frames) in {_time.monotonic() - t_start:.2f}s")
+
+                # Clear interrupt flag after utterance is done (interrupted or complete)
+                if self._interrupt_flag.is_set():
+                    self._interrupt_flag.clear()
+                    log.info(f"[tts] utterance interrupted after {frames_sent} frames")
+                else:
+                    log.info(f"[tts] spoke {len(text)} chars → {total} bytes ({frames_sent} frames) in {_time.monotonic() - t_start:.2f}s")
                 # 上报 TTS perf spans（生成 + 播放）
                 try:
                     import json as _json
@@ -521,6 +547,22 @@ class TTSPlugin:
                 self._executor.remove_node(self._nodes[key])
                 del self._nodes[key]
             return {"status": "configured"}
+
+        elif action == "interrupt":
+            # 立即中止所有 TTS 播放（清空队列 + 停止当前 utterance）
+            total_cleared = 0
+            interrupted_count = 0
+            if instance_id and instance_id in self._nodes:
+                result = self._nodes[instance_id].interrupt()
+                total_cleared += result.get('cleared', 0)
+                interrupted_count += 1
+            elif not instance_id:
+                for node in self._nodes.values():
+                    if node.state == "running":
+                        result = node.interrupt()
+                        total_cleared += result.get('cleared', 0)
+                        interrupted_count += 1
+            return {"status": "interrupted", "nodes": interrupted_count, "cleared": total_cleared}
 
         return None
 

--- a/perception/plugins/tts.py
+++ b/perception/plugins/tts.py
@@ -24,6 +24,11 @@ log = logging.getLogger(__name__)
 SAMPLE_RATE = 16000
 CHUNK_BYTES = 3200  # 100ms @ 16kHz 16-bit mono
 
+# EOF magic: 8 bytes (4 samples [1, -1, 1, -1])，标记 utterance 结束
+# 正常 chunk 始终 3200 bytes，8 bytes 短 chunk 不会被误判
+# 即使被不识别 EOF 的旧 Speaker 播放，也只是 0.25ms 极微弱交流声
+AUDIO_EOF_MAGIC = b'\x01\x00\xff\xff\x01\x00\xff\xff'
+
 _LOW_LAT_QOS = QoSProfile(
     reliability=ReliabilityPolicy.BEST_EFFORT,
     history=HistoryPolicy.KEEP_LAST,
@@ -335,6 +340,9 @@ class _TTSNode(Node):
                     log.info(f"[tts] utterance interrupted after {frames_sent} frames")
                 else:
                     log.info(f"[tts] spoke {len(text)} chars → {total} bytes ({frames_sent} frames) in {_time.monotonic() - t_start:.2f}s")
+
+                # 发布 EOF 标记：告知下游 Speaker 当前 utterance 已结束
+                self._publish_eof()
                 # 上报 TTS perf spans（生成 + 播放）
                 try:
                     import json as _json
@@ -370,6 +378,15 @@ class _TTSNode(Node):
             "topic_in":  [{"topic": self._input_topic,  "format": "data/json",     "desc": "text to synthesize"}],
             "topic_out": [{"topic": self._output_topic, "format": "audio/pcm-16k", "desc": "synthesized PCM audio"}],
         }
+
+    def _publish_eof(self):
+        """发布 EOF magic chunk，标记当前 utterance 结束。"""
+        from audio_msgs.msg import AudioChunk
+        msg = AudioChunk()
+        msg.header.stamp = self.get_clock().now().to_msg()
+        msg.format = "audio/pcm-16k"
+        msg.data = list(AUDIO_EOF_MAGIC)
+        self._pub.publish(msg)
 
 
 # ── Plugin ────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Add steer/interrupt/followup modes to agent loop (collector steering_queue)
- TTS publishes EOF magic chunk at utterance end for Speaker mute/unmute
- Remove redundant `<recent_sources>` from L2 dynamic prompt

## Test plan
- [ ] Steer: send message during active turn → LLM sees it in next round
- [ ] Interrupt: switch to interrupt mode → TurnCancelled + outputs stopped
- [ ] TTS EOF: tts speak → interrupt → new speak works normally
- [ ] Prompt: no more `<recent_sources>` in LLM request logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)