### PR TITLE
feat(deploy-panel): deploy logs + marketplace UX improvements

### DIFF
--- a/agent-core/src/api/drivers.py
+++ b/agent-core/src/api/drivers.py
@@ -45,18 +45,37 @@ def _container_name(driver_id: str) -> str:
     return f'embodied-{driver_id}'
 
 
+# ── Deploy log buffer (in-memory, per driver) ─────────────────────────────
+
+_deploy_logs: dict[str, str] = {}
+
+
+def _log_deploy(driver_id: str, msg: str):
+    _deploy_logs.setdefault(driver_id, '')
+    _deploy_logs[driver_id] += msg + '\n'
+
+
+def _clear_deploy_log(driver_id: str):
+    _deploy_logs.pop(driver_id, None)
+
+
 def _get_status_sync(driver_id: str) -> dict:
     try:
         client = _docker()
         name = _container_name(driver_id)
         containers = client.containers.list(all=True, filters={'name': f'^{name}$'})
         if not containers:
-            return {'status': 'stopped'}
+            deploy_log = _deploy_logs.get(driver_id, '')
+            return {'status': 'stopped', 'logs': deploy_log}
         c = containers[0]
         try:
             logs = c.logs(tail=30).decode('utf-8', errors='replace')
         except Exception:
             logs = ''
+        # Prepend deploy logs if available
+        deploy_log = _deploy_logs.get(driver_id, '')
+        if deploy_log:
+            logs = deploy_log + logs
         running_image = c.attrs.get('Config', {}).get('Image', '')
         return {'status': c.status, 'logs': logs, 'running_image': running_image}
     except Exception as e:
@@ -89,7 +108,21 @@ def _deploy_sync(driver: dict) -> dict:
         pass
 
     # Pull image
-    client.images.pull(target_image)
+    _clear_deploy_log(driver['id'])
+    _log_deploy(driver['id'], f'[pull] {target_image}')
+    try:
+        for line in client.api.pull(target_image, stream=True, decode=True):
+            status = line.get('status', '')
+            progress = line.get('progress', '')
+            layer_id = line.get('id', '')
+            if status:
+                msg = f'  {layer_id} {status}' if layer_id else f'  {status}'
+                if progress:
+                    msg += f' {progress}'
+                _log_deploy(driver['id'], msg)
+    except Exception as e:
+        _log_deploy(driver['id'], f'[pull] failed: {e}')
+        return {'status': 'error', 'error': f'pull failed: {e}'}
 
     # Extract service.yml from image
     compose_dir = os.environ.get('COMPOSE_DIR', '/opt/phanthy-motus')
@@ -153,10 +186,19 @@ def _deploy_sync(driver: dict) -> dict:
             pass
 
     # docker compose up
-    subprocess.run(
+    _log_deploy(driver['id'], f'[compose] up -d {service_name}')
+    result = subprocess.run(
         ['docker', 'compose', '-f', compose_file, 'up', '-d', '--no-deps', '--force-recreate', service_name],
-        check=True,
+        capture_output=True, text=True,
     )
+    if result.stdout:
+        _log_deploy(driver['id'], result.stdout.strip())
+    if result.stderr:
+        _log_deploy(driver['id'], result.stderr.strip())
+    if result.returncode != 0:
+        _log_deploy(driver['id'], f'[compose] exit code {result.returncode}')
+        return {'status': 'error', 'error': f'compose up failed (rc={result.returncode})'}
+    _log_deploy(driver['id'], '[deploy] done')
     return {'status': 'starting', 'service': service_name}
 
 
@@ -222,7 +264,9 @@ def _deploy_sync_legacy(driver: dict) -> dict:
 
     run_kwargs['log_config'] = {'type': 'local'}
 
+    _log_deploy(driver['id'], f'[run] {name}')
     container = client.containers.run(**run_kwargs)
+    _log_deploy(driver['id'], f'[deploy] done, container={container.id[:12]}')
     return {'status': 'starting', 'container_id': container.id[:12]}
 
 

--- a/agent-core/src/api/drivers.py
+++ b/agent-core/src/api/drivers.py
@@ -69,7 +69,7 @@ def _get_status_sync(driver_id: str) -> dict:
             return {'status': 'stopped', 'logs': deploy_log}
         c = containers[0]
         try:
-            logs = c.logs(tail=30).decode('utf-8', errors='replace')
+            logs = c.logs(tail=100).decode('utf-8', errors='replace')
         except Exception:
             logs = ''
         # Prepend deploy logs if available
@@ -265,7 +265,11 @@ def _deploy_sync_legacy(driver: dict) -> dict:
     run_kwargs['log_config'] = {'type': 'local'}
 
     _log_deploy(driver['id'], f'[run] {name}')
-    container = client.containers.run(**run_kwargs)
+    try:
+        container = client.containers.run(**run_kwargs)
+    except Exception as e:
+        _log_deploy(driver['id'], f'[error] {e}')
+        raise
     _log_deploy(driver['id'], f'[deploy] done, container={container.id[:12]}')
     return {'status': 'starting', 'container_id': container.id[:12]}
 
@@ -469,6 +473,7 @@ async def driver_deploy(driver_id: str, body: dict = fastapi.Body(default={})):
     try:
         result = await _run_in_executor(_deploy_sync, driver)
     except Exception as e:
+        _log_deploy(driver_id, f'[error] {e}')
         return {'code': 500, 'message': str(e)}
 
     # Persist updated image into manifest (so DB remembers last deployed image)

--- a/agent-core/web/css/style.css
+++ b/agent-core/web/css/style.css
@@ -2557,6 +2557,33 @@ html, body {
   max-height: 240px;
   overflow-y: auto;
 }
+.mp-card .deploy-log {
+  border: none;
+  border-top: 1px solid var(--border);
+  border-radius: 0;
+  margin: 6px -14px -12px;
+  padding: 8px 14px;
+}
+.mp-card-log {
+  font-size: 10px;
+  color: var(--text-dim);
+  margin-top: 4px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  line-height: 1.6;
+}
+.mp-detail .deploy-log {
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  margin: 10px 0;
+}
+.deploy-log-title {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-muted);
+  margin-bottom: 4px;
+}
 .deploy-log-line { line-height: 1.6; }
 .deploy-log-line.success { color: var(--green); }
 .deploy-log-line.error   { color: var(--red); }

--- a/agent-core/web/css/style.css
+++ b/agent-core/web/css/style.css
@@ -2039,6 +2039,9 @@ html, body {
 .svc-btn-remove { color: var(--text-dim); }
 .svc-btn-remove:hover:not(:disabled) { color: var(--red); border-color: var(--red); }
 
+.svc-btn-log { color: var(--text-dim); }
+.svc-btn-log:hover:not(:disabled) { color: var(--text); border-color: var(--border-med); }
+
 /* Version switcher in My Services */
 .svc-ver-wrap { position: relative; }
 .svc-btn-ver { color: var(--text-muted); }
@@ -2281,7 +2284,7 @@ html, body {
   overflow: hidden;
 }
 .mp-card-action {
-  margin-top: 4px;
+  margin-top: auto;
   text-align: center;
 }
 

--- a/agent-core/web/css/style.css
+++ b/agent-core/web/css/style.css
@@ -2554,7 +2554,7 @@ html, body {
   padding: 8px 14px;
   font-size: 11px;
   color: var(--text-muted);
-  max-height: 120px;
+  max-height: 240px;
   overflow-y: auto;
 }
 .deploy-log-line { line-height: 1.6; }

--- a/agent-core/web/js/deploy-panel.js
+++ b/agent-core/web/js/deploy-panel.js
@@ -239,6 +239,9 @@ function _renderMyServices() {
   container.querySelectorAll('[data-action="remove"]').forEach(btn => {
     btn.addEventListener('click', () => _removeDriver(btn.dataset.driverId, btn));
   });
+  container.querySelectorAll('[data-action="log"]').forEach(btn => {
+    btn.addEventListener('click', () => _toggleLog(btn.dataset.driverId));
+  });
   // Version switcher dropdowns
   container.querySelectorAll('[data-action="switch-version"]').forEach(btn => {
     btn.addEventListener('click', (e) => {
@@ -331,6 +334,11 @@ function _svcRowHTML({ item, id, s, latestTag, currentTag, hasUpdate }) {
       actions += `<button class="svc-btn svc-btn-start" data-action="start" data-driver-id="${id}" data-image="${lastImage}">启动</button>`;
     }
     actions += `<button class="svc-btn svc-btn-remove" data-action="remove" data-driver-id="${id}">卸载</button>`;
+  }
+
+  // Log button (always available for non-core)
+  if (item._cat !== 'core') {
+    actions += `<button class="svc-btn svc-btn-log" data-action="log" data-driver-id="${id}">日志</button>`;
   }
 
   const versionText = currentTag || (s.running_image?.split(':').pop()) || '—';
@@ -877,6 +885,35 @@ async function _executeDeploys(entries) {
 }
 
 // ── Deploy log (inline) ───────────────────────────────────────────────────
+
+async function _toggleLog(driverId) {
+  const el = document.getElementById(`log-${driverId}`);
+  if (!el) return;
+
+  if (!el.classList.contains('hidden')) {
+    el.classList.add('hidden');
+    return;
+  }
+
+  el.innerHTML = `<div class="deploy-log-line" style="color:var(--text-dim)">加载中…</div>`;
+  el.classList.remove('hidden');
+
+  try {
+    const res = await fetch(`/api/drivers/${driverId}/status`);
+    const json = await res.json();
+    const data = json.data || {};
+    const logs = data.logs || '';
+
+    if (logs.trim()) {
+      const lines = logs.trim().split('\n').slice(-20);
+      el.innerHTML = `<pre class="log-output">${lines.join('\n')}</pre>`;
+    } else {
+      el.innerHTML = `<div class="deploy-log-line" style="color:var(--text-dim)">暂无日志</div>`;
+    }
+  } catch {
+    el.innerHTML = `<div class="deploy-log-line error">获取日志失败</div>`;
+  }
+}
 
 function _showDeployLog(driverId, msg) {
   const el = document.getElementById(`log-${driverId}`);

--- a/agent-core/web/js/deploy-panel.js
+++ b/agent-core/web/js/deploy-panel.js
@@ -336,10 +336,8 @@ function _svcRowHTML({ item, id, s, latestTag, currentTag, hasUpdate }) {
     actions += `<button class="svc-btn svc-btn-remove" data-action="remove" data-driver-id="${id}">卸载</button>`;
   }
 
-  // Log button (always available for non-core)
-  if (item._cat !== 'core') {
-    actions += `<button class="svc-btn svc-btn-log" data-action="log" data-driver-id="${id}">日志</button>`;
-  }
+  // Log button (always available)
+  actions += `<button class="svc-btn svc-btn-log" data-action="log" data-driver-id="${id}">日志</button>`;
 
   const versionText = currentTag || (s.running_image?.split(':').pop()) || '—';
 
@@ -457,7 +455,7 @@ function _mpCardHTML(item) {
   const isInstalled = s && (s.running || s.last_deploy);
   const tags = item.tags || [];
   const imageBase = item.full_repo || item.image;
-  const desc = item.description || '';
+  const desc = item.description || (cat === 'perception' ? '语音感知套件 — ASR 语音识别 + TTS 语音合成 + VAD 静音检测 + 唤醒词检测' : '');
   const fullName = item.name || label;
 
   const versionOpts = tags.map(t => {
@@ -485,6 +483,7 @@ function _mpCardHTML(item) {
       ${desc ? `<div class="mp-card-desc">${_escHTML(desc)}</div>` : ''}
       <div class="mp-card-action">${installBtn}</div>
       <div class="mp-versions hidden">${versionOpts}</div>
+      <div class="mp-card-log hidden" id="mp-log-${driverId}"></div>
     </div>`;
 }
 
@@ -611,6 +610,7 @@ function _showDriverDetail(card) {
         ${isInstalled ? '<span class="mp-installed-badge" style="margin-top:8px;display:inline-block">已安装</span>' : ''}
       </div>
       ${desc ? `<div class="mp-detail-desc">${desc}</div>` : '<div class="mp-detail-desc" style="color:var(--text-dim)">暂无描述</div>'}
+      <div class="deploy-log hidden" id="mp-log-${driverId}"></div>
       <div class="mp-detail-versions">
         <div class="mp-detail-section-title">可用版本</div>
         ${versionsHTML || '<div style="color:var(--text-dim);font-size:12px">暂无版本</div>'}
@@ -634,6 +634,20 @@ function _showDriverDetail(card) {
       );
     });
   });
+
+  // Always fetch and show deploy logs on detail page
+  const logEl = document.getElementById(`mp-log-${driverId}`);
+  if (logEl) {
+    fetch(`/api/drivers/${driverId}/status`).then(r => r.json()).then(json => {
+      const logs = (json.data || {}).logs || '';
+      if (logs.trim()) {
+        const lines = logs.trim().split('\n');
+        logEl.innerHTML = `<div class="deploy-log-title">上次部署日志</div><pre class="log-output">${lines.join('\n')}</pre>`;
+        logEl.scrollTop = logEl.scrollHeight;
+        logEl.classList.remove('hidden');
+      }
+    }).catch(() => {});
+  }
 }
 
 // ══════════════════════════════════════════════════════════════════════════
@@ -859,7 +873,7 @@ async function _executeDeploys(entries) {
         _appendLog(driverId, `✗ 网络错误: ${e.message}`, 'error');
       }
     } else {
-      _showDeployLog(driverId, '正在请求部署…');
+      _showDeployLogAny(driverId, '正在请求部署…');
       try {
         const res = await fetch(`/api/drivers/${driverId}/deploy`, {
           method: 'POST',
@@ -868,13 +882,13 @@ async function _executeDeploys(entries) {
         });
         const json = await res.json();
         if (json.code !== 200) {
-          _appendLog(driverId, `✗ 错误: ${json.message || '未知错误'}`, 'error');
+          _appendLogAny(driverId, `✗ 错误: ${json.message || '未知错误'}`, 'error');
         } else {
-          _appendLog(driverId, '容器启动中…');
+          _appendLogAny(driverId, '镜像拉取中…');
           _startLogPolling(driverId);
         }
       } catch (e) {
-        _appendLog(driverId, `✗ 网络错误: ${e.message}`, 'error');
+        _appendLogAny(driverId, `✗ 网络错误: ${e.message}`, 'error');
       }
     }
   }
@@ -885,6 +899,23 @@ async function _executeDeploys(entries) {
 }
 
 // ── Deploy log (inline) ───────────────────────────────────────────────────
+
+function _ensureLogElement(driverId) {
+  if (document.getElementById(`log-${driverId}`)) return;
+  // Create a temporary card + log area for new installs
+  const container = document.getElementById('pane-my-services');
+  if (!container) return;
+  const html = `
+    <div class="svc-row" id="card-${driverId}">
+      <div class="svc-row-dot deploying" id="dot-${driverId}"></div>
+      <div class="svc-row-info">
+        <span class="svc-row-name">${driverId}</span>
+        <div class="svc-row-version-line"><span class="svc-row-version">部署中…</span></div>
+      </div>
+    </div>
+    <div class="deploy-log" id="log-${driverId}"></div>`;
+  container.insertAdjacentHTML('afterbegin', html);
+}
 
 async function _toggleLog(driverId) {
   const el = document.getElementById(`log-${driverId}`);
@@ -932,6 +963,42 @@ function _appendLog(driverId, msg, type = '') {
   el.scrollTop = el.scrollHeight;
 }
 
+// Variants that check both marketplace (mp-log-) and my-services (log-) elements
+function _getLogEl(driverId) {
+  return document.getElementById(`mp-log-${driverId}`) || document.getElementById(`log-${driverId}`);
+}
+
+function _isCardLog(el) {
+  return el && el.classList.contains('mp-card-log');
+}
+
+function _showDeployLogAny(driverId, msg) {
+  const el = _getLogEl(driverId);
+  if (!el) return;
+  el.textContent = msg;
+  el.classList.remove('hidden');
+}
+
+function _appendLogAny(driverId, msg, type = '') {
+  const el = _getLogEl(driverId);
+  if (!el) return;
+  if (_isCardLog(el)) {
+    // Single-line overwrite on card
+    el.textContent = msg;
+    if (type === 'error') { el.style.color = 'var(--red)'; }
+    else if (type === 'success') { el.style.color = 'var(--green)'; }
+    else { el.style.color = ''; }
+    el.classList.remove('hidden');
+  } else {
+    // Multi-line append on detail/my-services
+    const line = document.createElement('div');
+    line.className = 'deploy-log-line' + (type ? ` ${type}` : '');
+    line.textContent = msg;
+    el.appendChild(line);
+    el.scrollTop = el.scrollHeight;
+  }
+}
+
 function _startLogPolling(driverId) {
   if (_logPolls[driverId]) clearInterval(_logPolls[driverId]);
 
@@ -945,28 +1012,37 @@ function _startLogPolling(driverId) {
       const status = data.status || '';
       const logs   = data.logs   || '';
 
-      const el = document.getElementById(`log-${driverId}`);
+      const el = _getLogEl(driverId);
       if (el && logs) {
-        const lines = logs.trim().split('\n').slice(-20);
-        el.querySelectorAll('.log-output').forEach(e => e.remove());
-        const pre = document.createElement('pre');
-        pre.className = 'log-output';
-        pre.textContent = lines.join('\n');
-        el.appendChild(pre);
+        if (_isCardLog(el)) {
+          // Single-line: show last meaningful line
+          const lastLine = logs.trim().split('\n').filter(Boolean).pop() || '';
+          el.textContent = lastLine;
+          el.style.color = '';
+        } else {
+          // Multi-line: show full log
+          const lines = logs.trim().split('\n').slice(-30);
+          el.querySelectorAll('.log-output').forEach(e => e.remove());
+          const pre = document.createElement('pre');
+          pre.className = 'log-output';
+          pre.textContent = lines.join('\n');
+          el.appendChild(pre);
+          el.scrollTop = el.scrollHeight;
+        }
       }
 
       if (status === 'running') {
         _stopLogPolling(driverId);
-        _appendLog(driverId, '✓ 运行中', 'success');
+        _appendLogAny(driverId, '✓ 运行中', 'success');
         setTimeout(() => {
-          const logEl = document.getElementById(`log-${driverId}`);
+          const logEl = _getLogEl(driverId);
           if (logEl) logEl.classList.add('hidden');
         }, 5000);
         await _loadStatuses();
         _render();
       } else if (status === 'error' || attempts > 30) {
         _stopLogPolling(driverId);
-        _appendLog(driverId, `✗ ${status === 'error' ? (data.error || '启动失败') : '部署超时'}`, 'error');
+        _appendLogAny(driverId, `✗ ${status === 'error' ? (data.error || '启动失败') : '部署超时'}`, 'error');
       }
     } catch {
       // ignore

--- a/agent-core/web/js/deploy-panel.js
+++ b/agent-core/web/js/deploy-panel.js
@@ -947,7 +947,7 @@ function _startLogPolling(driverId) {
 
       const el = document.getElementById(`log-${driverId}`);
       if (el && logs) {
-        const lines = logs.trim().split('\n').slice(-5);
+        const lines = logs.trim().split('\n').slice(-20);
         el.querySelectorAll('.log-output').forEach(e => e.remove());
         const pre = document.createElement('pre');
         pre.className = 'log-output';

--- a/deploy/build_perception.sh
+++ b/deploy/build_perception.sh
@@ -105,7 +105,8 @@ if ${PUSH_ENABLED} && [ -n "${RESOURCE_CENTER_API_KEY:-}" ]; then
                 \"registryImage\": \"perception\",
                 \"tag\": \"${TAG}\",
                 \"category\": \"perception\",
-                \"name\": \"Perception Stack\"
+                \"name\": \"Perception Stack\",
+                \"description\": \"语音感知套件 — ASR 语音识别 + TTS 语音合成 + VAD 静音检测 + 唤醒词检测\"
             }")
 
         if [ "${HTTP_STATUS}" = "200" ] || [ "${HTTP_STATUS}" = "201" ]; then


### PR DESCRIPTION
## Summary
- 部署卡片增加「日志」按钮，点击展开容器日志
- 驱动市场卡片部署时显示单行实时状态
- 驱动详情页展示完整"上次部署日志"（含错误信息）
- 后端捕获 docker 异常写入 deploy log buffer
- 安装按钮贴底对齐（margin-top: auto）
- build_perception.sh 注册时补充 description 字段

## Test plan
- [ ] 部署服务 → 我的服务 → 点击日志按钮，验证展开/收起容器日志
- [ ] 驱动市场 → 安装驱动 → 卡片底部显示一行部署状态
- [ ] 点击卡片进入详情页 → 显示"上次部署日志"完整内容
- [ ] 部署失败时错误信息完整保留在日志中
- [ ] 驱动市场卡片安装按钮对齐在底部

🤖 Generated with [Claude Code](https://claude.com/claude-code)