### PR TITLE
fix(drivers): check nvidia runtime before using it

### DIFF
--- a/agent-core/src/api/drivers.py
+++ b/agent-core/src/api/drivers.py
@@ -231,8 +231,17 @@ def _deploy_sync_legacy(driver: dict) -> dict:
     )
 
     if '-jetson' in target_image:
-        run_kwargs['runtime'] = 'nvidia'
-        env_base = {'NVIDIA_VISIBLE_DEVICES': 'all'}
+        # Only use nvidia runtime if available on host
+        try:
+            runtimes = client.info().get('Runtimes', {})
+        except Exception:
+            runtimes = {}
+        if 'nvidia' in runtimes:
+            run_kwargs['runtime'] = 'nvidia'
+            env_base = {'NVIDIA_VISIBLE_DEVICES': 'all'}
+        else:
+            run_kwargs['privileged'] = True
+            env_base = {}
     else:
         run_kwargs['privileged'] = True
         env_base = {}


### PR DESCRIPTION
## Summary
- `-jetson` 镜像部署时先检测 docker host 是否有 nvidia runtime
- 没有则 fallback 到 privileged 模式，不再直接报 400 错误
- 配合 install.sh 的 nvidia runtime 自动配置作为运行时兜底

## Test plan
- [ ] 在无 nvidia runtime 的机器上部署 `-jetson` 镜像，应成功启动（privileged 模式）
- [ ] 在有 nvidia runtime 的机器上部署，仍使用 nvidia runtime

🤖 Generated with [Claude Code](https://claude.com/claude-code)