### PR TITLE
feat(agent-core): TTS 与后续动作同步，避免边说话边走

### DIFF
--- a/agent-core/src/event/llm.py
+++ b/agent-core/src/event/llm.py
@@ -876,6 +876,28 @@ class Event:
                 meta = entry.get('tool_meta', {}).get(name)
                 return bool(meta and meta.get('type') == 'sensor')
 
+
+            def _is_tts_speak(name: str) -> bool:
+                if not name.startswith('mcp__'):
+                    return False
+                short = name.split('__')[-1]
+                return short.startswith('tts')
+            
+            def _estimate_tts_delay(text: str) -> float:
+                if not text:
+                    return 0.0
+                return max(0.3, len(text) / 7.0)
+            
+            def _extract_tts_text(result: str) -> str:
+                import json as _json
+                try:
+                    data = _json.loads(result) if isinstance(result, str) else result
+                    if isinstance(data, dict):
+                        return data.get('text', '') or data.get('content', '')
+                except:
+                    pass
+                return ''
+
             results = []
             _batch = []
             for c in tool_calls:
@@ -885,7 +907,14 @@ class Event:
                     if _batch:
                         results.extend(await asyncio.gather(*[_dispatch(b) for b in _batch]))
                         _batch = []
-                    results.append(await _dispatch(c))
+                    _result = await _dispatch(c)
+                    results.append(_result)
+                    # TTS 等待：如果是 speak 动作，等语音播放完成再执行下一个 actuator
+                    if _is_tts_speak(c['function']['name']):
+                        tts_text = _extract_tts_text(_result.get('result', ''))
+                        delay = _estimate_tts_delay(tts_text)
+                        if delay > 0:
+                            await asyncio.sleep(delay)
             if _batch:
                 results.extend(await asyncio.gather(*[_dispatch(b) for b in _batch]))
 


### PR DESCRIPTION
## Summary
- 修复 G1 机器人语音和动作不同步问题：LLM 一次 turn 中同时调用 `tts.speak()` + `loco.move()` 时，`NativeTtsPlugin` 的 `TtsMaker()` 是 DDS RPC 立即返回，不等 MCU 播放完成，导致机器人边说话边走
- 在 `agent-core/src/event/llm.py` 工具分发循环中，actuator 工具完成后检测是否为 tts 工具，若是则按文本长度估算播放时长并 `await asyncio.sleep()`，确保下一个 actuator 工具在语音播放完毕后执行
- 估算公式：`max(0.3, len(text)/7.0)` 秒（经真机调试，`/7` 最接近实际播报语速）

## Test plan
- [x] 本地真机 G1 (10.100.129.168) 验证：先后测试 `/3`、`/5`、`/8`、`/7` 多个系数，`/7` 手感最接近说完即走
- [ ] 部署后观察 LLM turn 中 `tts.speak + loco.move` 序列的时序日志
- [ ] 验证短文本（<3 字）和长文本（>20 字）场景下的同步效果

🤖 Generated with [phanthy code](https://phanthy.dev/phanthy-code)