### PR TITLE
feat(perception): add duplex audio AEC frontend

### DIFF
--- a/perception/Dockerfile
+++ b/perception/Dockerfile
@@ -6,7 +6,7 @@ ARG PYPI_MIRROR
 RUN apt-get update && \
     mv /sbin/ldconfig /sbin/ldconfig.real && \
     ln -s /bin/true /sbin/ldconfig && \
-    apt-get install -y --no-install-recommends python3-pip && \
+    apt-get install -y --no-install-recommends python3-pip libspeexdsp1 && \
     mv /sbin/ldconfig.real /sbin/ldconfig && \
     rm -rf /var/lib/apt/lists/*
 

--- a/perception/Dockerfile.jetson
+++ b/perception/Dockerfile.jetson
@@ -28,7 +28,7 @@ RUN if ls /etc/apt/sources.list.d/*.list 1>/dev/null 2>&1; then \
 # ── System deps ────────────────────────────────────────────────────
 RUN rm -f /etc/apt/sources.list.d/* && rm -rf /var/cache/apt/archives/* /var/lib/apt/lists/* && \
     apt-get -o Acquire::AllowInsecureRepositories=true update && \
-    apt-get install -y --no-install-recommends --allow-unauthenticated ffmpeg && \
+    apt-get install -y --no-install-recommends --allow-unauthenticated ffmpeg libspeexdsp1 && \
     apt-get clean && rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
 
 RUN pip3 install --no-cache-dir -i ${PYPI_MIRROR} colcon-common-extensions && \

--- a/perception/README.md
+++ b/perception/README.md
@@ -1,6 +1,6 @@
 # Perception Stack
 
-Modular ASR/TTS perception plugins running as an MCP HTTP server. Connects to Agent Core via MCP tool calls and exchanges audio/text over ROS2 DDS topics.
+Modular ASR/TTS/duplex-audio perception plugins running as an MCP HTTP server. Connects to Agent Core via MCP tool calls and exchanges audio/text over ROS2 DDS topics.
 
 ## Audio Requirements for ASR
 
@@ -90,3 +90,44 @@ ASR result JSON:
   "asr_complete_ts": 1234567891.789
 }
 ```
+
+---
+
+## Duplex Audio (external microphone + TTS reference + AEC)
+
+`duplexaudio` owns the timing-sensitive TTS reference and AEC path while leaving
+ASR as an independent downstream card. It has one external-microphone input and
+two PCM outputs:
+
+| Direction | Topic pattern | Format |
+|-----------|---------------|--------|
+| Input | `start.input_topic` | `audio/pcm-16k` |
+| Output port 0 | `{input_topic}/duplexaudio/clean` | `audio/pcm-16k` |
+| Output port 1 | `{input_topic}/duplexaudio/tts` | `audio/pcm-16k` |
+
+Connect output port 0 to the existing ASR card and output port 1 to Speaker. Use
+MCP `duplexaudio.speak(text)` to synthesize speech. Every paced TTS frame is
+also stored as a timestamped AEC reference before it is published to the
+downstream speaker actuator. The mic path aligns that reference using
+`aec_delay_ms`, performs AEC, and re-chunks clean audio to the ASR minimum.
+
+The plugin is disabled by default. When enabling it, keep standalone ASR enabled
+but disable the standalone TTS plugin to avoid loading and playing TTS twice.
+Publishing PCM alone does not prove physical speaker playback.
+
+AEC backends:
+
+- `auto`: try LiveKit WebRTC APM, then SpeexDSP.
+- `livekit`: parity with the `voice-service` AEC3 backend; requires a compatible
+  Python runtime and wheel.
+- `speexdsp`: uses the system `libspeexdsp1` library and supports the current
+  Python 3.8 Jetson image.
+
+`aec_failure_policy=fail_closed` is the default: a missing backend or processing
+failure is reported as an error instead of silently claiming echo cancellation.
+`passthrough` exists only for explicit A/B and recovery tests. After several
+seconds of robot speech, call `aec_calibrate`; apply its `d_real_ms` suggestion
+only when `peak_corr` is credible, then verify `erle_db` and real ASR echo errors.
+
+The full contract, failure semantics, and test gates are in
+`plugins/duplexaudio/README.md`.

--- a/perception/config.yaml
+++ b/perception/config.yaml
@@ -24,6 +24,22 @@ plugins:
     speaker_id: 0
     speed: 1.0
 
+  # TTS + AEC audio front-end. Its clean output connects to the standalone ASR
+  # card; its TTS output connects to Speaker. When enabling this plugin, disable
+  # the standalone TTS plugin above to avoid loading and playing TTS twice.
+  duplexaudio:
+    enabled: false
+    tts:
+      model_dir: /models/sherpa-onnx/tts
+      speaker_id: 0
+      speed: 1.0
+    aec:
+      enabled: true
+      backend: auto       # auto: LiveKit APM first, then SpeexDSP
+      delay_ms: 100       # calibrate for every mic/speaker path; do not copy 910 blindly
+      filter_length_ms: 200
+      failure_policy: fail_closed  # fail_closed | passthrough
+
   htmsg:
     enabled: true
     namespace: ""       # auto-detect from hostname if empty

--- a/perception/main.py
+++ b/perception/main.py
@@ -66,6 +66,13 @@ class PerceptionBundle:
             self._plugins.append(TTSPlugin(plugins_cfg["tts"], executor))
             log.info("TTSPlugin loaded")
 
+        if plugins_cfg.get("duplexaudio", {}).get("enabled", False):
+            from plugins.duplexaudio import DuplexAudioPlugin
+            self._plugins.append(
+                DuplexAudioPlugin(plugins_cfg["duplexaudio"], executor)
+            )
+            log.info("DuplexAudioPlugin loaded")
+
         if plugins_cfg.get("htmsg", {}).get("enabled", False):
             import re, socket
             namespace = plugins_cfg["htmsg"].get("namespace", "").strip()

--- a/perception/plugins/duplexaudio/README.md
+++ b/perception/plugins/duplexaudio/README.md
@@ -1,0 +1,41 @@
+# Duplex Audio 卡片规格
+
+| 项目 | 必填内容 |
+| --- | --- |
+| card id | `duplexaudio` |
+| card type | `processor` |
+| 感知目标 | 接收外接麦克风 16 kHz 单声道 PCM16，用本卡 TTS PCM 和预计播放时间执行 AEC，输出 clean mic 给独立 ASR 卡；同时通过 `speak` 输出 TTS PCM 给 Speaker |
+| input topic | `start.input_topic`；`audio_msgs/AudioChunk`；`audio/pcm-16k`，PCM_S16_LE、16000 Hz、mono；`BEST_EFFORT + KEEP_LAST(50) + VOLATILE` |
+| output topic | clean mic：`{input_topic}/duplexaudio/clean`；TTS：`{input_topic}/duplexaudio/tts`；两者均为 `audio_msgs/AudioChunk` / `audio/pcm-16k` |
+| actions | `info/config/start/stop/speak/aec_stats/aec_calibrate` |
+| 配置 | shared：TTS speaker/speed、AEC backend/filter length；instance：`aec_enabled`、`aec_delay_ms`、`aec_failure_policy`。运行中修改会停止受影响实例，下次 `start` 生效 |
+| 模型 | 只复用 `plugins.tts` 的 sherpa-onnx Matcha + Vocos adapter；ASR/VAD/KWS 由下游独立 ASR 卡负责；AEC 优先 LiveKit WebRTC APM，不可用时回退 SpeexDSP |
+| 部署 | CPU / x86 / Jetson；镜像需 `libspeexdsp1`。Python 3.8 Jetson 路线使用 SpeexDSP，不升级 ROS Python ABI |
+| 测试 | 工具包契约校验；AEC 时间对齐、burst、失败语义、TTS observer 和多实例单测；aarch64 SpeexDSP 冒烟；最后用外接麦克风+真实扬声器做 A/B |
+
+## 画布连接
+
+```text
+external mic -> duplexaudio input
+duplexaudio clean output (port 0) -> standalone ASR input
+duplexaudio TTS output   (port 1) -> Speaker input
+
+MCP duplexaudio.speak(text)
+  -> TTS adapter
+  -> timestamped AEC reference (in-process, before publish)
+  -> TTS PCM output
+```
+
+ASR 不参与 reference 时间对齐；clean mic 经 ROS2 到 ASR 的延迟只计入识别时延，不影响 AEC 对齐。本卡仍不直接驱动扬声器，所以 `aec_delay_ms` 仍需要真机标定；一体化不能消除 Speaker 队列、DAC、声学传播和麦克风缓冲延迟。
+
+## 失败语义
+
+- `fail_closed`（默认）：AEC backend 不可用时不启动；处理失败后停止 clean mic 输出。
+- `passthrough`：只用于显式 A/B/恢复测试；AEC 失败时透传 raw mic，`info/aec_stats` 仍保留错误。
+- 非 `audio/pcm-16k` 或奇数字节 PCM 会让 bridge 进入 `error`，不输出伪 clean mic。
+
+## 已知边界
+
+- TTS reference 基于预计发布节奏；Speaker 内部额外排队由 `aec_delay_ms` 和 `aec_calibrate` 吸收。如果多次 `d_real_ms` 明显多峰，需新增 playback receipt，而不是合并 ASR。
+- AEC 不保证 double-talk 下人声完全无损；唤醒召回率与时延必须单独验收。
+- 同一条语音链路不应同时启用独立 TTS 卡和 `duplexaudio` TTS，否则会重复合成和播放。

--- a/perception/plugins/duplexaudio/__init__.py
+++ b/perception/plugins/duplexaudio/__init__.py
@@ -1,0 +1,5 @@
+from .plugin import DuplexAudioPlugin
+
+PLUGIN_CLASS = DuplexAudioPlugin
+
+__all__ = ["PLUGIN_CLASS", "DuplexAudioPlugin"]

--- a/perception/plugins/duplexaudio/aec.py
+++ b/perception/plugins/duplexaudio/aec.py
@@ -1,0 +1,432 @@
+"""Instance-local acoustic echo cancellation with timestamped TTS references.
+
+The timing model follows the proven voice-service path: TTS PCM is sliced into
+fixed frames carrying their expected playback wall-clock timestamp. Microphone
+frames consume the matching reference at ``capture_time - delay``. Once aligned,
+the stream is consumed in order so bursty ROS delivery does not destroy AEC.
+"""
+
+from __future__ import annotations
+
+import collections
+import ctypes
+import ctypes.util
+import math
+import threading
+from typing import Callable, Deque, Optional, Tuple
+
+import numpy as np
+
+
+SAMPLE_RATE = 16000
+FRAME_MS = 10
+FRAME_SAMPLES = SAMPLE_RATE * FRAME_MS // 1000
+FRAME_BYTES = FRAME_SAMPLES * 2
+FRAME_SECONDS = FRAME_MS / 1000.0
+LOCK_TOLERANCE_SECONDS = 0.15
+DRIFT_TOLERANCE_SECONDS = 0.30
+ENV_HISTORY = 1200
+
+
+class AECBackendError(RuntimeError):
+    pass
+
+
+class _LiveKitBackend:
+    name = "livekit-apm"
+
+    def __init__(self, sample_rate: int, frame_samples: int):
+        try:
+            from livekit.rtc.apm import (  # type: ignore
+                AudioFrame,
+                AudioProcessingModule,
+            )
+        except Exception as exc:
+            raise AECBackendError(f"LiveKit APM unavailable: {exc}") from exc
+        self._frame_class = AudioFrame
+        self._sample_rate = sample_rate
+        self._frame_samples = frame_samples
+        self._apm = AudioProcessingModule(
+            echo_cancellation=True,
+            noise_suppression=True,
+            high_pass_filter=True,
+            auto_gain_control=False,
+        )
+
+    def process(self, mic: np.ndarray, reference: np.ndarray) -> np.ndarray:
+        reference_frame = self._frame_class(
+            reference.tobytes(), self._sample_rate, 1, self._frame_samples
+        )
+        self._apm.process_reverse_stream(reference_frame)
+        mic_frame = self._frame_class(
+            mic.tobytes(), self._sample_rate, 1, self._frame_samples
+        )
+        self._apm.process_stream(mic_frame)
+        return np.frombuffer(mic_frame.data, dtype=np.int16).copy()
+
+    def close(self) -> None:
+        return None
+
+
+class _SpeexDSPBackend:
+    name = "speexdsp"
+    _SET_SAMPLING_RATE = 24
+
+    def __init__(self, sample_rate: int, frame_samples: int, filter_length_ms: int):
+        candidates = []
+        discovered = ctypes.util.find_library("speexdsp")
+        if discovered:
+            candidates.append(discovered)
+        candidates.extend(("libspeexdsp.so.1", "libspeexdsp.so"))
+
+        library = None
+        errors = []
+        for candidate in candidates:
+            try:
+                library = ctypes.CDLL(candidate)
+                break
+            except OSError as exc:
+                errors.append(f"{candidate}: {exc}")
+        if library is None:
+            raise AECBackendError(
+                "SpeexDSP unavailable; install libspeexdsp1 (" + "; ".join(errors) + ")"
+            )
+
+        sample_ptr = ctypes.POINTER(ctypes.c_int16)
+        library.speex_echo_state_init.argtypes = [ctypes.c_int, ctypes.c_int]
+        library.speex_echo_state_init.restype = ctypes.c_void_p
+        library.speex_echo_state_destroy.argtypes = [ctypes.c_void_p]
+        library.speex_echo_state_destroy.restype = None
+        library.speex_echo_cancellation.argtypes = [
+            ctypes.c_void_p,
+            sample_ptr,
+            sample_ptr,
+            sample_ptr,
+        ]
+        library.speex_echo_cancellation.restype = None
+        library.speex_echo_ctl.argtypes = [ctypes.c_void_p, ctypes.c_int, ctypes.c_void_p]
+        library.speex_echo_ctl.restype = ctypes.c_int
+
+        filter_samples = max(frame_samples, sample_rate * filter_length_ms // 1000)
+        state = library.speex_echo_state_init(frame_samples, filter_samples)
+        if not state:
+            raise AECBackendError("speex_echo_state_init returned NULL")
+        rate = ctypes.c_int(sample_rate)
+        if library.speex_echo_ctl(
+            state, self._SET_SAMPLING_RATE, ctypes.byref(rate)
+        ) != 0:
+            library.speex_echo_state_destroy(state)
+            raise AECBackendError("speex_echo_ctl failed to set sampling rate")
+
+        self._library = library
+        self._state = state
+
+    def process(self, mic: np.ndarray, reference: np.ndarray) -> np.ndarray:
+        mic = np.ascontiguousarray(mic, dtype=np.int16)
+        reference = np.ascontiguousarray(reference, dtype=np.int16)
+        output = np.empty_like(mic)
+        sample_ptr = ctypes.POINTER(ctypes.c_int16)
+        self._library.speex_echo_cancellation(
+            self._state,
+            mic.ctypes.data_as(sample_ptr),
+            reference.ctypes.data_as(sample_ptr),
+            output.ctypes.data_as(sample_ptr),
+        )
+        return output
+
+    def close(self) -> None:
+        if getattr(self, "_state", None):
+            self._library.speex_echo_state_destroy(self._state)
+            self._state = None
+
+    def __del__(self):
+        try:
+            self.close()
+        except Exception:
+            pass
+
+
+def build_backend(
+    backend: str,
+    sample_rate: int,
+    frame_samples: int,
+    filter_length_ms: int,
+):
+    backend = (backend or "auto").strip().lower()
+    factories = {
+        "livekit": lambda: _LiveKitBackend(sample_rate, frame_samples),
+        "speexdsp": lambda: _SpeexDSPBackend(
+            sample_rate, frame_samples, filter_length_ms
+        ),
+    }
+    if backend != "auto":
+        if backend not in factories:
+            raise AECBackendError(
+                f"unsupported AEC backend {backend!r}; expected auto/livekit/speexdsp"
+            )
+        return factories[backend]()
+
+    failures = []
+    for name in ("livekit", "speexdsp"):
+        try:
+            return factories[name]()
+        except Exception as exc:
+            failures.append(f"{name}: {exc}")
+    raise AECBackendError("no AEC backend available (" + "; ".join(failures) + ")")
+
+
+class AECProcessor:
+    """Thread-safe reference alignment plus one instance-local AEC backend."""
+
+    def __init__(
+        self,
+        *,
+        delay_ms: int = 100,
+        backend: str = "auto",
+        filter_length_ms: int = 200,
+        backend_factory: Optional[Callable[[], object]] = None,
+    ):
+        if not 0 <= int(delay_ms) <= 2500:
+            raise ValueError("delay_ms must be between 0 and 2500")
+        if not 50 <= int(filter_length_ms) <= 1000:
+            raise ValueError("filter_length_ms must be between 50 and 1000")
+        self.delay_ms = int(delay_ms)
+        self.delay_seconds = self.delay_ms / 1000.0
+        self.filter_length_ms = int(filter_length_ms)
+        self._backend = (
+            backend_factory()
+            if backend_factory is not None
+            else build_backend(
+                backend,
+                SAMPLE_RATE,
+                FRAME_SAMPLES,
+                self.filter_length_ms,
+            )
+        )
+        self.backend_name = getattr(self._backend, "name", backend)
+        self._lock = threading.Lock()
+        self._reference_queue: Deque[Tuple[float, np.ndarray]] = collections.deque(
+            maxlen=4000
+        )
+        self._reference_env: Deque[Tuple[float, float]] = collections.deque(
+            maxlen=ENV_HISTORY
+        )
+        self._mic_env: Deque[Tuple[float, float, float, bool]] = collections.deque(
+            maxlen=ENV_HISTORY
+        )
+        self._mic_carry = bytearray()
+        self._mic_cursor_ts: Optional[float] = None
+        self._locked = False
+        self._frames_processed = 0
+        self._frames_with_reference = 0
+        self._aligned_frames = 0
+        self._silence_frames = 0
+        self._dropped_expired = 0
+        self._reference_overruns = 0
+        self._relocks = 0
+        self._mic_relocks = 0
+        self._process_errors = 0
+
+    def push_reference(self, pcm_bytes: bytes, play_start_ts: float) -> None:
+        if not pcm_bytes:
+            return
+        if len(pcm_bytes) % 2:
+            raise ValueError("TTS reference PCM must contain complete int16 samples")
+        samples = np.frombuffer(pcm_bytes, dtype=np.int16)
+        chunks = []
+        for offset in range(0, len(samples), FRAME_SAMPLES):
+            chunk = samples[offset : offset + FRAME_SAMPLES]
+            if len(chunk) < FRAME_SAMPLES:
+                chunk = np.pad(chunk, (0, FRAME_SAMPLES - len(chunk)))
+            chunk = np.ascontiguousarray(chunk, dtype=np.int16)
+            ts = float(play_start_ts) + (offset / SAMPLE_RATE)
+            rms = float(np.sqrt(np.mean(chunk.astype(np.float32) ** 2)))
+            chunks.append((ts, chunk, rms))
+
+        with self._lock:
+            for ts, chunk, rms in chunks:
+                if len(self._reference_queue) == self._reference_queue.maxlen:
+                    self._reference_overruns += 1
+                self._reference_queue.append((ts, chunk))
+                self._reference_env.append((ts, rms))
+
+    def _take_reference_locked(self, target_ts: float) -> Optional[np.ndarray]:
+        queue = self._reference_queue
+        if not queue:
+            self._locked = False
+            return None
+        if self._locked:
+            if abs(queue[0][0] - target_ts) > DRIFT_TOLERANCE_SECONDS:
+                self._locked = False
+                self._relocks += 1
+            else:
+                return queue.popleft()[1]
+        while queue and queue[0][0] < target_ts - LOCK_TOLERANCE_SECONDS:
+            queue.popleft()
+            self._dropped_expired += 1
+        if queue and queue[0][0] <= target_ts + LOCK_TOLERANCE_SECONDS:
+            self._locked = True
+            return queue.popleft()[1]
+        return None
+
+    def process_pcm(self, pcm_bytes: bytes, capture_ts: float) -> bytes:
+        if not pcm_bytes:
+            return b""
+        if len(pcm_bytes) % 2:
+            raise ValueError("microphone PCM must contain complete int16 samples")
+
+        packet_duration = len(pcm_bytes) / (SAMPLE_RATE * 2)
+        if self._mic_cursor_ts is None:
+            self._mic_cursor_ts = float(capture_ts) - packet_duration
+        self._mic_carry.extend(pcm_bytes)
+        output = bytearray()
+
+        while len(self._mic_carry) >= FRAME_BYTES:
+            raw = bytes(self._mic_carry[:FRAME_BYTES])
+            del self._mic_carry[:FRAME_BYTES]
+            mic = np.frombuffer(raw, dtype=np.int16).copy()
+            mic_start_ts = self._mic_cursor_ts
+            self._mic_cursor_ts += FRAME_SECONDS
+            target_reference_ts = mic_start_ts - self.delay_seconds
+            with self._lock:
+                reference = self._take_reference_locked(target_reference_ts)
+            had_reference = reference is not None
+            if reference is None:
+                reference = np.zeros(FRAME_SAMPLES, dtype=np.int16)
+                self._silence_frames += 1
+            else:
+                self._aligned_frames += 1
+
+            try:
+                clean = self._backend.process(mic, reference)
+            except Exception:
+                self._process_errors += 1
+                raise
+            self._frames_processed += 1
+            if had_reference:
+                self._frames_with_reference += 1
+            in_rms = float(np.sqrt(np.mean(mic.astype(np.float32) ** 2)))
+            out_rms = float(np.sqrt(np.mean(clean.astype(np.float32) ** 2)))
+            with self._lock:
+                self._mic_env.append(
+                    (mic_start_ts, in_rms, out_rms, had_reference)
+                )
+            output.extend(np.ascontiguousarray(clean, dtype=np.int16).tobytes())
+
+        expected_end = self._mic_cursor_ts + len(self._mic_carry) / (SAMPLE_RATE * 2)
+        if abs(expected_end - float(capture_ts)) > DRIFT_TOLERANCE_SECONDS:
+            self._mic_cursor_ts = float(capture_ts) - len(self._mic_carry) / (
+                SAMPLE_RATE * 2
+            )
+            self._mic_relocks += 1
+        return bytes(output)
+
+    def stats(self) -> dict:
+        with self._lock:
+            queue_size = len(self._reference_queue)
+            locked = self._locked
+            mic_env = list(self._mic_env)
+        total = self._aligned_frames + self._silence_frames
+        align_rate = self._aligned_frames / total if total else 0.0
+        return {
+            "backend": self.backend_name,
+            "delay_ms": self.delay_ms,
+            "filter_length_ms": self.filter_length_ms,
+            "locked": locked,
+            "frames_processed": self._frames_processed,
+            "frames_with_reference": self._frames_with_reference,
+            "aligned_frames": self._aligned_frames,
+            "silence_frames": self._silence_frames,
+            "align_rate": round(align_rate, 3),
+            "ref_queue_size": queue_size,
+            "dropped_expired": self._dropped_expired,
+            "reference_overruns": self._reference_overruns,
+            "relocks": self._relocks,
+            "mic_relocks": self._mic_relocks,
+            "process_errors": self._process_errors,
+            "erle_db": self._erle_db(mic_env),
+        }
+
+    @staticmethod
+    def _erle_db(mic_env) -> Optional[float]:
+        input_energy = 0.0
+        output_energy = 0.0
+        for _ts, input_rms, output_rms, had_reference in mic_env:
+            if had_reference:
+                input_energy += input_rms * input_rms
+                output_energy += output_rms * output_rms
+        if input_energy <= 0 or output_energy <= 0:
+            return None
+        return round(10.0 * math.log10(input_energy / output_energy), 1)
+
+    def calibrate(self, min_lag_s: float = -0.5, max_lag_s: float = 2.5) -> dict:
+        with self._lock:
+            mic = list(self._mic_env)
+            reference = list(self._reference_env)
+        if len(mic) < 200 or len(reference) < 100:
+            return {
+                "ok": False,
+                "reason": (
+                    f"history not enough (mic={len(mic)}, ref={len(reference)}); "
+                    "play several seconds of TTS before calibration"
+                ),
+            }
+        start = min(mic[0][0], reference[0][0])
+        end = max(mic[-1][0], reference[-1][0])
+        size = int(round((end - start) / FRAME_SECONDS)) + 2
+        if size > 4000:
+            return {"ok": False, "reason": "time span too large"}
+        # NaN marks time buckets not covered by that stream. Normalizing a
+        # zero-padded union window depresses peak correlation solely because
+        # the two streams are shifted; calibrate each lag on its true overlap.
+        mic_env = np.full(size, np.nan, dtype=np.float64)
+        ref_env = np.full(size, np.nan, dtype=np.float64)
+        for ts, input_rms, _output_rms, _had_reference in mic:
+            mic_env[int(round((ts - start) / FRAME_SECONDS))] = input_rms
+        for ts, rms in reference:
+            ref_env[int(round((ts - start) / FRAME_SECONDS))] = rms
+        low = int(min_lag_s / FRAME_SECONDS)
+        high = int(max_lag_s / FRAME_SECONDS)
+        best_lag = None
+        best_correlation = -1.0
+        for lag in range(low, high + 1):
+            if lag >= 0:
+                mic_slice = mic_env[lag:]
+                ref_slice = ref_env[: size - lag]
+            else:
+                mic_slice = mic_env[: size + lag]
+                ref_slice = ref_env[-lag:]
+            valid = np.isfinite(mic_slice) & np.isfinite(ref_slice)
+            if int(valid.sum()) < 100:
+                continue
+            mic_overlap = mic_slice[valid]
+            ref_overlap = ref_slice[valid]
+            mic_centered = mic_overlap - mic_overlap.mean()
+            ref_centered = ref_overlap - ref_overlap.mean()
+            denominator = float(
+                np.sqrt(np.sum(mic_centered ** 2) * np.sum(ref_centered ** 2))
+            )
+            if denominator <= 0:
+                continue
+            correlation = float(np.dot(mic_centered, ref_centered) / denominator)
+            if correlation > best_correlation:
+                best_correlation = correlation
+                best_lag = lag
+        if best_lag is None:
+            return {"ok": False, "reason": "no non-flat overlapping envelopes"}
+        return {
+            "ok": True,
+            "d_real_ms": int(best_lag * FRAME_SECONDS * 1000),
+            "peak_corr": round(best_correlation, 3),
+            "current_delay_ms": self.delay_ms,
+            "mic_env_points": len(mic),
+            "ref_env_points": len(reference),
+        }
+
+    def close(self) -> None:
+        self._backend.close()
+        with self._lock:
+            self._reference_queue.clear()
+            self._reference_env.clear()
+            self._mic_env.clear()
+            self._mic_carry.clear()

--- a/perception/plugins/duplexaudio/config.example.json
+++ b/perception/plugins/duplexaudio/config.example.json
@@ -1,0 +1,15 @@
+{
+  "enabled": true,
+  "tts": {
+    "model_dir": "/models/sherpa-onnx/tts",
+    "speaker_id": 0,
+    "speed": 1.0
+  },
+  "aec": {
+    "enabled": true,
+    "backend": "auto",
+    "delay_ms": 100,
+    "filter_length_ms": 200,
+    "failure_policy": "fail_closed"
+  }
+}

--- a/perception/plugins/duplexaudio/node.py
+++ b/perception/plugins/duplexaudio/node.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import logging
+import re
+import time
+from typing import Optional
+
+from rclpy.node import Node
+from rclpy.qos import (
+    DurabilityPolicy,
+    HistoryPolicy,
+    QoSProfile,
+    ReliabilityPolicy,
+)
+
+from .aec import AECProcessor
+
+
+log = logging.getLogger(__name__)
+
+_AUDIO_QOS = QoSProfile(
+    reliability=ReliabilityPolicy.BEST_EFFORT,
+    history=HistoryPolicy.KEEP_LAST,
+    depth=50,
+    durability=DurabilityPolicy.VOLATILE,
+)
+_MIN_CLEAN_CHUNK_BYTES = 1024
+
+
+class DuplexAudioNode(Node):
+    """External-mic bridge: AEC then stable clean-PCM re-chunking."""
+
+    def __init__(
+        self,
+        input_topic: str,
+        clean_topic: str,
+        instance_id: str,
+        aec: Optional[AECProcessor],
+        failure_policy: str = "fail_closed",
+    ):
+        safe_id = re.sub(r"[^a-zA-Z0-9_]", "_", instance_id)
+        super().__init__(f"duplexaudio_bridge_{safe_id}")
+        self.input_topic = input_topic
+        self.clean_topic = clean_topic
+        self.state = "running"
+        self.last_error: Optional[str] = None
+        self._aec = aec
+        self._failure_policy = failure_policy
+        self._emit_buffer = bytearray()
+        from audio_msgs.msg import AudioChunk
+
+        self._publisher = self.create_publisher(
+            AudioChunk, clean_topic, _AUDIO_QOS
+        )
+        self._subscription = self.create_subscription(
+            AudioChunk, input_topic, self._on_audio, _AUDIO_QOS
+        )
+        log.info(
+            "[duplexaudio] bridge started: %s -> %s (aec=%s)",
+            input_topic,
+            clean_topic,
+            aec.backend_name if aec is not None else "disabled",
+        )
+
+    def _on_audio(self, msg) -> None:
+        if self.state != "running":
+            return
+        if msg.format != "audio/pcm-16k":
+            self.last_error = (
+                f"unsupported audio format {msg.format!r}; expected audio/pcm-16k"
+            )
+            self.state = "error"
+            log.error("[duplexaudio] %s", self.last_error)
+            return
+
+        pcm = bytes(msg.data)
+        if len(pcm) % 2:
+            self.last_error = "microphone PCM byte length must be even"
+            self.state = "error"
+            log.error("[duplexaudio] %s", self.last_error)
+            return
+        capture_ts = msg.header.stamp.sec + msg.header.stamp.nanosec * 1e-9
+        if capture_ts < 1e9:
+            capture_ts = time.time()
+
+        clean = pcm
+        if self._aec is not None:
+            try:
+                clean = self._aec.process_pcm(pcm, capture_ts)
+            except Exception as exc:
+                self.last_error = f"AEC processing failed: {exc}"
+                log.exception("[duplexaudio] %s", self.last_error)
+                if self._failure_policy == "passthrough":
+                    clean = pcm
+                else:
+                    self.state = "error"
+                    return
+
+        self._emit_buffer.extend(clean)
+        from audio_msgs.msg import AudioChunk
+
+        while len(self._emit_buffer) >= _MIN_CLEAN_CHUNK_BYTES:
+            chunk = bytes(self._emit_buffer[:_MIN_CLEAN_CHUNK_BYTES])
+            del self._emit_buffer[:_MIN_CLEAN_CHUNK_BYTES]
+            output = AudioChunk()
+            output.header = msg.header
+            if output.header.stamp.sec == 0:
+                output.header.stamp = self.get_clock().now().to_msg()
+            output.format = "audio/pcm-16k"
+            output.data = list(chunk)
+            self._publisher.publish(output)
+
+    def stop(self) -> dict:
+        if self._subscription is not None:
+            try:
+                self.destroy_subscription(self._subscription)
+            except Exception:
+                pass
+            self._subscription = None
+        self._emit_buffer.clear()
+        self.state = "idle"
+        return {"state": "idle"}
+
+    def stats(self) -> dict:
+        result = {
+            "enabled": self._aec is not None,
+            "failure_policy": self._failure_policy,
+            "bridge_state": self.state,
+            "last_error": self.last_error,
+            "pending_output_bytes": len(self._emit_buffer),
+        }
+        if self._aec is not None:
+            result.update(self._aec.stats())
+        return result

--- a/perception/plugins/duplexaudio/plugin.py
+++ b/perception/plugins/duplexaudio/plugin.py
@@ -1,0 +1,524 @@
+from __future__ import annotations
+
+import copy
+import hashlib
+import re
+from typing import Any, Optional
+
+
+TOOL = {
+    "name": "duplexaudio",
+    "type": "processor",
+    "multiInstance": True,
+    "description": (
+        "Duplex audio front-end: timestamped TTS reference, external-mic AEC, "
+        "and clean PCM output for a standalone ASR card"
+    ),
+    "inputSchema": {
+        "type": "object",
+        "properties": {
+            "action": {
+                "type": "string",
+                "enum": [
+                    "info",
+                    "config",
+                    "start",
+                    "stop",
+                    "speak",
+                    "aec_stats",
+                    "aec_calibrate",
+                ],
+                "description": "Card lifecycle, speech, or AEC diagnostic action",
+            },
+            "instance_id": {"type": "string"},
+            "input_topic": {
+                "type": "string",
+                "description": "External-mic ROS2 audio/pcm-16k topic",
+            },
+            "text": {
+                "type": "string",
+                "description": "Text to synthesize for action=speak",
+            },
+        },
+        "required": ["action"],
+        "x-action-params": {
+            "info": {"params": ["instance_id", "input_topic"]},
+            "config": {"params": ["instance_id"]},
+            "start": {"params": ["instance_id", "input_topic"]},
+            "stop": {"params": ["instance_id"]},
+            "speak": {"params": ["instance_id", "text"]},
+            "aec_stats": {"params": ["instance_id"]},
+            "aec_calibrate": {"params": ["instance_id"]},
+        },
+    },
+    "configSchema": {
+        "type": "object",
+        "properties": {
+            "speaker_id": {
+                "type": "integer",
+                "default": 0,
+                "scope": "shared",
+            },
+            "speed": {
+                "type": "number",
+                "minimum": 0.5,
+                "maximum": 2.0,
+                "default": 1.0,
+                "scope": "shared",
+            },
+            "aec_enabled": {
+                "type": "boolean",
+                "default": True,
+                "scope": "instance",
+            },
+            "aec_backend": {
+                "type": "string",
+                "enum": ["auto", "livekit", "speexdsp"],
+                "default": "auto",
+                "scope": "shared",
+            },
+            "aec_delay_ms": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 2500,
+                "default": 100,
+                "scope": "instance",
+            },
+            "aec_filter_length_ms": {
+                "type": "integer",
+                "minimum": 50,
+                "maximum": 1000,
+                "default": 200,
+                "scope": "shared",
+            },
+            "aec_failure_policy": {
+                "type": "string",
+                "enum": ["fail_closed", "passthrough"],
+                "default": "fail_closed",
+                "scope": "instance",
+            },
+        },
+        "required": [],
+    },
+    "topic_in": [
+        {"format": "audio/pcm-16k", "desc": "external microphone PCM"}
+    ],
+    "topic_out": [
+        {"format": "audio/pcm-16k", "desc": "AEC-cleaned PCM for ASR"},
+        {"format": "audio/pcm-16k", "desc": "TTS PCM for speaker playback"},
+    ],
+}
+
+
+_SHARED_PATHS = {
+    "speaker_id": ("tts", "speaker_id"),
+    "speed": ("tts", "speed"),
+    "aec_backend": ("aec", "backend"),
+    "aec_filter_length_ms": ("aec", "filter_length_ms"),
+}
+_INSTANCE_PATHS = {
+    "aec_enabled": ("aec", "enabled"),
+    "aec_delay_ms": ("aec", "delay_ms"),
+    "aec_failure_policy": ("aec", "failure_policy"),
+}
+
+
+class _Session:
+    def __init__(
+        self,
+        *,
+        input_topic: str,
+        clean_topic: str,
+        tts_topic: str,
+        bridge,
+        tts_node,
+        aec,
+        aec_init_error: Optional[str] = None,
+    ):
+        self.input_topic = input_topic
+        self.clean_topic = clean_topic
+        self.tts_topic = tts_topic
+        self.bridge = bridge
+        self.tts_node = tts_node
+        self.aec = aec
+        self.aec_init_error = aec_init_error
+
+
+class DuplexAudioPlugin:
+    PREFIX = "duplexaudio"
+
+    def __init__(self, plugin_cfg: dict, executor):
+        self._cfg = copy.deepcopy(plugin_cfg)
+        self._executor = executor
+        self._instances: dict[str, _Session] = {}
+        self._instance_cfg: dict[str, dict] = {}
+        self._tts_adapter = None
+        self._load_error: Optional[str] = None
+
+    def get_tools(self) -> list[dict]:
+        return [TOOL]
+
+    def dispatch(self, name: str, args: dict) -> dict | None:
+        action = args.get("action") if name == self.PREFIX else name
+        instance_id = args.get("instance_id") or "default"
+
+        if action == "info":
+            session = self._instances.get(instance_id)
+            return self._status(
+                "running" if session is not None else "idle",
+                args.get("input_topic", ""),
+                session,
+            )
+
+        if action == "config":
+            return self._configure(instance_id, args)
+
+        if action == "start":
+            input_topic = args.get("input_topic")
+            if not input_topic:
+                topics = args.get("input_topics") or []
+                if topics:
+                    input_topic = topics[0]
+            if not input_topic:
+                raise ValueError("input_topic is required for start")
+            input_topic = input_topic.rstrip("/")
+            if not input_topic:
+                raise ValueError("input_topic must name a ROS audio topic")
+            existing = self._instances.get(instance_id)
+            if existing is not None and existing.input_topic == input_topic:
+                return self._status("running", input_topic, existing)
+            for active_id, session in self._instances.items():
+                if active_id != instance_id and session.input_topic == input_topic:
+                    return {
+                        "state": "error",
+                        "error": "input_topic_in_use",
+                        "message": (
+                            f"input topic {input_topic!r} is already owned by "
+                            f"instance {active_id!r}"
+                        ),
+                    }
+            if existing is not None:
+                self._stop_instance(instance_id)
+            return self._start_instance(instance_id, input_topic)
+
+        if action == "stop":
+            input_topic = ""
+            existing = self._instances.get(instance_id)
+            if existing is not None:
+                input_topic = existing.input_topic
+            self._stop_instance(instance_id)
+            return self._status("idle", input_topic, None)
+
+        if action == "speak":
+            text = str(args.get("text") or "").strip()
+            if not text:
+                raise ValueError("text is required for speak")
+            session = self._select_session(args.get("instance_id"))
+            session.tts_node.enqueue(text, trace_id=args.get("_trace_id", ""))
+            return {
+                "status": "queued",
+                "instance_id": self._instance_id_for(session),
+                "text": text,
+                "topic_out": session.tts_topic,
+            }
+
+        if action == "aec_stats":
+            session = self._select_session(args.get("instance_id"))
+            result = session.bridge.stats()
+            result["init_error"] = session.aec_init_error
+            return result
+
+        if action == "aec_calibrate":
+            session = self._select_session(args.get("instance_id"))
+            if session.aec is None:
+                return {
+                    "ok": False,
+                    "reason": session.aec_init_error or "AEC is disabled",
+                }
+            return session.aec.calibrate()
+
+        return None
+
+    def _start_instance(self, instance_id: str, input_topic: str) -> dict:
+        cfg = self._effective_config(instance_id)
+        aec_cfg = cfg["aec"]
+        failure_policy = aec_cfg["failure_policy"]
+        aec = None
+        aec_init_error = None
+        if aec_cfg["enabled"]:
+            from .aec import AECProcessor
+
+            try:
+                aec = AECProcessor(
+                    delay_ms=aec_cfg["delay_ms"],
+                    backend=aec_cfg["backend"],
+                    filter_length_ms=aec_cfg["filter_length_ms"],
+                )
+            except Exception as exc:
+                aec_init_error = str(exc)
+                if failure_policy == "fail_closed":
+                    return {
+                        "state": "error",
+                        "error": "aec_unavailable",
+                        "message": aec_init_error,
+                    }
+
+        try:
+            tts_adapter = self._ensure_tts_adapter(cfg)
+        except Exception as exc:
+            if aec is not None:
+                aec.close()
+            self._load_error = str(exc)
+            return {
+                "state": "error",
+                "error": "model_load_failed",
+                "message": str(exc),
+            }
+
+        from plugins.tts import _TTSNode
+        from .node import DuplexAudioNode
+
+        safe_stem = re.sub(r"[^a-zA-Z0-9_]", "_", instance_id)[:40]
+        instance_digest = hashlib.blake2s(
+            instance_id.encode("utf-8"), digest_size=4
+        ).hexdigest()
+        safe_id = f"{safe_stem}_{instance_digest}"
+        clean_topic = f"{input_topic}/duplexaudio/clean"
+        tts_topic = f"{input_topic}/duplexaudio/tts"
+        bridge = DuplexAudioNode(
+            input_topic,
+            clean_topic,
+            safe_id,
+            aec,
+            failure_policy=failure_policy,
+        )
+        tts_node = _TTSNode(
+            None,
+            tts_adapter,
+            node_suffix=f"duplexaudio_{safe_id}",
+            output_topic=tts_topic,
+            frame_observer=(aec.push_reference if aec is not None else None),
+        )
+        nodes = (bridge, tts_node)
+        try:
+            for node in nodes:
+                self._executor.add_node(node)
+            tts_result = tts_node.start()
+            if tts_result.get("state") != "running":
+                raise RuntimeError(tts_result.get("message") or "TTS start failed")
+        except Exception as exc:
+            self._cleanup_nodes(nodes, aec)
+            return {
+                "state": "error",
+                "error": "start_failed",
+                "message": str(exc),
+            }
+
+        session = _Session(
+            input_topic=input_topic,
+            clean_topic=clean_topic,
+            tts_topic=tts_topic,
+            bridge=bridge,
+            tts_node=tts_node,
+            aec=aec,
+            aec_init_error=aec_init_error,
+        )
+        self._instances[instance_id] = session
+        return self._status("running", input_topic, session)
+
+    def _stop_instance(self, instance_id: str) -> None:
+        session = self._instances.pop(instance_id, None)
+        if session is None:
+            return
+        self._cleanup_nodes((session.tts_node, session.bridge), session.aec)
+
+    def _cleanup_nodes(self, nodes, aec) -> None:
+        for node in nodes:
+            try:
+                stop = getattr(node, "stop", None)
+                if stop is not None:
+                    stop()
+            except Exception:
+                pass
+            try:
+                self._executor.remove_node(node)
+            except Exception:
+                pass
+            try:
+                node.destroy_node()
+            except Exception:
+                pass
+        if aec is not None:
+            try:
+                aec.close()
+            except Exception:
+                pass
+
+    def _ensure_tts_adapter(self, cfg: dict):
+        if self._tts_adapter is None:
+            from plugins.tts import _build_tts_adapter
+
+            self._tts_adapter = _build_tts_adapter(cfg["tts"])
+            if self._tts_adapter is None:
+                raise RuntimeError("TTS adapter did not load")
+        self._load_error = None
+        return self._tts_adapter
+
+    def _configure(self, instance_id: str, args: dict) -> dict:
+        shared_changed = False
+        instance_changed = False
+        for key, path in _SHARED_PATHS.items():
+            if key in args:
+                self._validate_config_value(key, args[key])
+                self._set_path(self._cfg, path, args[key])
+                shared_changed = True
+        if instance_id not in self._instance_cfg:
+            self._instance_cfg[instance_id] = {}
+        for key, path in _INSTANCE_PATHS.items():
+            if key in args:
+                self._validate_config_value(key, args[key])
+                self._set_path(self._instance_cfg[instance_id], path, args[key])
+                instance_changed = True
+
+        stopped_instances = []
+        if shared_changed:
+            stopped_instances = list(self._instances)
+            for active_id in list(self._instances):
+                self._stop_instance(active_id)
+            self._tts_adapter = None
+            self._load_error = None
+        elif instance_changed and instance_id in self._instances:
+            stopped_instances = [instance_id]
+            self._stop_instance(instance_id)
+        return {
+            "status": "configured",
+            "restart_required": bool(stopped_instances),
+            "stopped_instances": stopped_instances,
+        }
+
+    @staticmethod
+    def _validate_config_value(key: str, value: Any) -> None:
+        if key == "speed" and not 0.5 <= float(value) <= 2.0:
+            raise ValueError("speed must be between 0.5 and 2.0")
+        if key == "aec_delay_ms" and not 0 <= int(value) <= 2500:
+            raise ValueError("aec_delay_ms must be between 0 and 2500")
+        if key == "aec_filter_length_ms" and not 50 <= int(value) <= 1000:
+            raise ValueError("aec_filter_length_ms must be between 50 and 1000")
+        if key == "aec_backend" and value not in {"auto", "livekit", "speexdsp"}:
+            raise ValueError("aec_backend must be auto, livekit, or speexdsp")
+        if key == "aec_failure_policy" and value not in {
+            "fail_closed",
+            "passthrough",
+        }:
+            raise ValueError("aec_failure_policy must be fail_closed or passthrough")
+
+    def _effective_config(self, instance_id: str) -> dict:
+        defaults = {
+            "tts": {
+                "model_dir": "/models/sherpa-onnx/tts",
+                "speaker_id": 0,
+                "speed": 1.0,
+            },
+            "aec": {
+                "enabled": True,
+                "backend": "auto",
+                "delay_ms": 100,
+                "filter_length_ms": 200,
+                "failure_policy": "fail_closed",
+            },
+        }
+        self._deep_merge(defaults, self._cfg)
+        self._deep_merge(defaults, self._instance_cfg.get(instance_id, {}))
+        return defaults
+
+    @staticmethod
+    def _set_path(target: dict, path: tuple[str, ...], value: Any) -> None:
+        current = target
+        for part in path[:-1]:
+            current = current.setdefault(part, {})
+        current[path[-1]] = value
+
+    @classmethod
+    def _deep_merge(cls, target: dict, source: dict) -> None:
+        for key, value in source.items():
+            if isinstance(value, dict) and isinstance(target.get(key), dict):
+                cls._deep_merge(target[key], value)
+            else:
+                target[key] = copy.deepcopy(value)
+
+    def _select_session(self, instance_id: Optional[str]) -> _Session:
+        if instance_id:
+            session = self._instances.get(instance_id)
+            if session is None:
+                raise ValueError(f"duplexaudio instance {instance_id!r} is not running")
+            return session
+        if len(self._instances) == 1:
+            return next(iter(self._instances.values()))
+        if not self._instances:
+            raise ValueError("duplexaudio is not running; call start first")
+        raise ValueError("instance_id is required when multiple duplexaudio instances run")
+
+    def _instance_id_for(self, session: _Session) -> str:
+        for instance_id, candidate in self._instances.items():
+            if candidate is session:
+                return instance_id
+        return ""
+
+    def _status(
+        self, state: str, input_topic: str, session: Optional[_Session]
+    ) -> dict:
+        if session is not None:
+            input_topic = session.input_topic
+            topic_out = [
+                {
+                    "topic": session.clean_topic,
+                    "format": "audio/pcm-16k",
+                    "desc": "AEC-cleaned PCM for ASR",
+                },
+                {
+                    "topic": session.tts_topic,
+                    "format": "audio/pcm-16k",
+                    "desc": "TTS PCM for speaker",
+                },
+            ]
+            aec = session.bridge.stats()
+            aec["init_error"] = session.aec_init_error
+            if session.bridge.state == "error":
+                state = "error"
+        else:
+            input_topic = input_topic.rstrip("/")
+            topic_out = (
+                [
+                    {
+                        "topic": f"{input_topic}/duplexaudio/clean",
+                        "format": "audio/pcm-16k",
+                        "desc": "AEC-cleaned PCM for ASR",
+                    },
+                    {
+                        "topic": f"{input_topic}/duplexaudio/tts",
+                        "format": "audio/pcm-16k",
+                        "desc": "TTS PCM for speaker",
+                    },
+                ]
+                if input_topic
+                else []
+            )
+            aec = {"enabled": False, "configured": True}
+        return {
+            "name": "Duplex audio",
+            "state": state,
+            "topic_in": (
+                [
+                    {
+                        "topic": input_topic,
+                        "format": "audio/pcm-16k",
+                        "desc": "external microphone PCM",
+                    }
+                ]
+                if input_topic
+                else []
+            ),
+            "topic_out": topic_out,
+            "aec": aec,
+            "load_error": self._load_error,
+        }

--- a/perception/plugins/tts.py
+++ b/perception/plugins/tts.py
@@ -12,7 +12,7 @@ import logging
 import queue
 import threading
 from abc import ABC, abstractmethod
-from typing import Optional
+from typing import Callable, Optional
 
 import rclpy
 from rclpy.node import Node
@@ -155,12 +155,15 @@ def _build_tts_adapter(cfg: dict) -> TTSAdapter:
 # ── ROS2 Node ─────────────────────────────────────────────────────────────────
 
 class _TTSNode(Node):
-    def __init__(self, input_topic: Optional[str], adapter: Optional[TTSAdapter], node_suffix: str = ''):
+    def __init__(self, input_topic: Optional[str], adapter: Optional[TTSAdapter], node_suffix: str = '',
+                 output_topic: Optional[str] = None,
+                 frame_observer: Optional[Callable[[bytes, float], None]] = None):
         node_name = f"tts_{node_suffix}" if node_suffix else "tts"
         super().__init__(node_name)
         self._input_topic  = input_topic or ''
-        self._output_topic = f"{input_topic}/tts" if input_topic else '/perception/tts'
+        self._output_topic = output_topic or (f"{input_topic}/tts" if input_topic else '/perception/tts')
         self._adapter      = adapter
+        self._frame_observer = frame_observer
         self.state         = "idle"
         self._text_queue   = queue.Queue()
         self._worker_thread: Optional[threading.Thread] = None
@@ -217,8 +220,19 @@ class _TTSNode(Node):
             log.info(f"[tts] received text from topic: {text[:50]}...")
             self._text_queue.put((text, ''))
 
-    def _worker(self):
+    def _publish_frame(self, frame: bytes, play_start_ts: float) -> None:
+        """Publish one paced PCM frame and optionally expose its playback reference."""
         from audio_msgs.msg import AudioChunk
+
+        if self._frame_observer is not None:
+            self._frame_observer(frame, play_start_ts)
+        msg = AudioChunk()
+        msg.header.stamp = self.get_clock().now().to_msg()
+        msg.format = "audio/pcm-16k"
+        msg.data = list(frame)
+        self._pub.publish(msg)
+
+    def _worker(self):
         import time as _time
 
         # Real-time pacing: publish frames at playback rate to avoid bursts/gaps
@@ -264,11 +278,8 @@ class _TTSNode(Node):
                                 t0 = _time.monotonic()
                                 t0_wall = _time.time()
                                 for pf in prebuf:
-                                    msg = AudioChunk()
-                                    msg.header.stamp = self.get_clock().now().to_msg()
-                                    msg.format = "audio/pcm-16k"
-                                    msg.data   = list(pf)
-                                    self._pub.publish(msg)
+                                    play_ts = t0_wall + frames_sent * FRAME_DURATION
+                                    self._publish_frame(pf, play_ts)
                                     frames_sent += 1
                                 prebuf = []
                             continue
@@ -278,22 +289,17 @@ class _TTSNode(Node):
                         now = _time.monotonic()
                         if now < target:
                             _time.sleep(target - now)
-                        msg = AudioChunk()
-                        msg.header.stamp = self.get_clock().now().to_msg()
-                        msg.format = "audio/pcm-16k"
-                        msg.data   = list(frame)
-                        self._pub.publish(msg)
+                        play_ts = t0_wall + frames_sent * FRAME_DURATION
+                        self._publish_frame(frame, play_ts)
                         frames_sent += 1
 
                 # Flush any remaining pre-buffer (short utterances < PREBUF_FRAMES)
                 if prebuf and not self._stop_event.is_set():
                     t0 = _time.monotonic()
+                    t0_wall = _time.time()
                     for pf in prebuf:
-                        msg = AudioChunk()
-                        msg.header.stamp = self.get_clock().now().to_msg()
-                        msg.format = "audio/pcm-16k"
-                        msg.data   = list(pf)
-                        self._pub.publish(msg)
+                        play_ts = t0_wall + frames_sent * FRAME_DURATION
+                        self._publish_frame(pf, play_ts)
                         frames_sent += 1
 
                 # flush remainder
@@ -303,11 +309,11 @@ class _TTSNode(Node):
                         now = _time.monotonic()
                         if now < target:
                             _time.sleep(target - now)
-                    msg = AudioChunk()
-                    msg.header.stamp = self.get_clock().now().to_msg()
-                    msg.format = "audio/pcm-16k"
-                    msg.data   = list(buf)
-                    self._pub.publish(msg)
+                    if t0_wall is None:
+                        t0_wall = _time.time()
+                    play_ts = t0_wall + frames_sent * FRAME_DURATION
+                    self._publish_frame(buf, play_ts)
+                    frames_sent += 1
                 log.info(f"[tts] spoke {len(text)} chars → {total} bytes ({frames_sent} frames) in {_time.monotonic() - t_start:.2f}s")
                 # 上报 TTS perf spans（生成 + 播放）
                 try:

--- a/perception/tests/test_duplexaudio_aec.py
+++ b/perception/tests/test_duplexaudio_aec.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+import pathlib
+import sys
+import unittest
+from unittest import mock
+
+import numpy as np
+
+
+PERCEPTION_ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(PERCEPTION_ROOT) not in sys.path:
+    sys.path.insert(0, str(PERCEPTION_ROOT))
+
+import plugins.duplexaudio.aec as aec_module  # noqa: E402
+from plugins.duplexaudio.aec import (  # noqa: E402
+    AECBackendError,
+    AECProcessor,
+    FRAME_SAMPLES,
+    build_backend,
+)
+
+
+class _FakeBackend:
+    name = "fake-aec"
+
+    def __init__(self, fail: bool = False):
+        self.fail = fail
+        self.references = []
+        self.closed = False
+
+    def process(self, mic: np.ndarray, reference: np.ndarray) -> np.ndarray:
+        self.references.append(reference.copy())
+        if self.fail:
+            raise RuntimeError("backend failure")
+        return np.clip(
+            mic.astype(np.int32) - reference.astype(np.int32), -32768, 32767
+        ).astype(np.int16)
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def _processor(delay_ms: int = 100, fail: bool = False):
+    backend = _FakeBackend(fail=fail)
+    processor = AECProcessor(
+        delay_ms=delay_ms,
+        backend_factory=lambda: backend,
+    )
+    return processor, backend
+
+
+class AECProcessorTests(unittest.TestCase):
+    def test_timestamped_reference_aligns_and_is_removed(self):
+        processor, backend = _processor(delay_ms=100)
+        start = 1000.0
+        reference = np.full(FRAME_SAMPLES * 3, 1000, dtype=np.int16)
+        microphone = np.full(FRAME_SAMPLES * 3, 1500, dtype=np.int16)
+        processor.push_reference(reference.tobytes(), start)
+
+        capture_end = start + 0.100 + 0.030
+        clean = np.frombuffer(
+            processor.process_pcm(microphone.tobytes(), capture_end),
+            dtype=np.int16,
+        )
+
+        np.testing.assert_array_equal(clean, np.full_like(clean, 500))
+        self.assertEqual(len(backend.references), 3)
+        stats = processor.stats()
+        self.assertEqual(stats["aligned_frames"], 3)
+        self.assertEqual(stats["frames_with_reference"], 3)
+        self.assertEqual(stats["silence_frames"], 0)
+        self.assertEqual(stats["align_rate"], 1.0)
+
+    def test_no_reference_is_a_signal_passthrough_for_fake_backend(self):
+        processor, _backend = _processor()
+        microphone = np.arange(FRAME_SAMPLES * 2, dtype=np.int16)
+        clean = np.frombuffer(
+            processor.process_pcm(microphone.tobytes(), 2000.02),
+            dtype=np.int16,
+        )
+        np.testing.assert_array_equal(clean, microphone)
+        stats = processor.stats()
+        self.assertEqual(stats["aligned_frames"], 0)
+        self.assertEqual(stats["silence_frames"], 2)
+
+    def test_stream_lock_survives_bursty_capture_timestamps(self):
+        processor, _backend = _processor(delay_ms=100)
+        start = 3000.0
+        reference = np.full(FRAME_SAMPLES * 6, 700, dtype=np.int16)
+        microphone = np.full(FRAME_SAMPLES * 3, 900, dtype=np.int16)
+        processor.push_reference(reference.tobytes(), start)
+
+        first = processor.process_pcm(microphone.tobytes(), start + 0.13)
+        second = processor.process_pcm(microphone.tobytes(), start + 0.16 + 0.08)
+
+        self.assertEqual(len(first), microphone.nbytes)
+        self.assertEqual(len(second), microphone.nbytes)
+        stats = processor.stats()
+        self.assertEqual(stats["aligned_frames"], 6)
+        self.assertEqual(stats["relocks"], 0)
+        self.assertEqual(stats["mic_relocks"], 0)
+
+    def test_partial_microphone_frame_is_carried_without_padding(self):
+        processor, _backend = _processor()
+        first = np.full(FRAME_SAMPLES - 10, 123, dtype=np.int16)
+        second = np.full(20, 123, dtype=np.int16)
+
+        self.assertEqual(processor.process_pcm(first.tobytes(), 4000.01), b"")
+        output = processor.process_pcm(second.tobytes(), 4000.02)
+
+        self.assertEqual(len(output), FRAME_SAMPLES * 2)
+        self.assertEqual(processor.stats()["frames_processed"], 1)
+
+    def test_backend_failure_is_visible(self):
+        processor, _backend = _processor(fail=True)
+        microphone = np.zeros(FRAME_SAMPLES, dtype=np.int16)
+        with self.assertRaisesRegex(RuntimeError, "backend failure"):
+            processor.process_pcm(microphone.tobytes(), 5000.01)
+        self.assertEqual(processor.stats()["process_errors"], 1)
+
+    def test_envelope_calibration_recovers_known_delay(self):
+        processor, _backend = _processor(delay_ms=120)
+        rng = np.random.default_rng(7)
+        amplitudes = rng.integers(100, 5000, size=300, dtype=np.int16)
+        chunks = [
+            np.full(FRAME_SAMPLES, int(amplitude), dtype=np.int16)
+            for amplitude in amplitudes
+        ]
+        pcm = np.concatenate(chunks)
+        start = 6000.0
+        processor.push_reference(pcm.tobytes(), start)
+        processor.process_pcm(pcm.tobytes(), start + 0.120 + 3.0)
+
+        result = processor.calibrate()
+
+        self.assertTrue(result["ok"], result)
+        self.assertGreater(result["peak_corr"], 0.9)
+        self.assertLessEqual(abs(result["d_real_ms"] - 120), 10)
+
+    def test_invalid_backend_is_rejected(self):
+        with self.assertRaisesRegex(AECBackendError, "unsupported AEC backend"):
+            build_backend("invalid", 16000, FRAME_SAMPLES, 200)
+
+    def test_auto_backend_falls_back_to_speexdsp(self):
+        speex = _FakeBackend()
+        speex.name = "speexdsp"
+        with mock.patch.object(
+            aec_module,
+            "_LiveKitBackend",
+            side_effect=AECBackendError("LiveKit unavailable"),
+        ), mock.patch.object(aec_module, "_SpeexDSPBackend", return_value=speex):
+            backend = build_backend("auto", 16000, FRAME_SAMPLES, 200)
+
+        self.assertIs(backend, speex)
+
+    def test_close_releases_backend(self):
+        processor, backend = _processor()
+        processor.close()
+        self.assertTrue(backend.closed)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/perception/tests/test_duplexaudio_hooks.py
+++ b/perception/tests/test_duplexaudio_hooks.py
@@ -1,0 +1,218 @@
+from __future__ import annotations
+
+import importlib
+import pathlib
+import sys
+import types
+import unittest
+
+
+PERCEPTION_ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(PERCEPTION_ROOT) not in sys.path:
+    sys.path.insert(0, str(PERCEPTION_ROOT))
+
+
+class _Publisher:
+    def __init__(self):
+        self.messages = []
+
+    def publish(self, message):
+        self.messages.append(message)
+
+
+class _Node:
+    def __init__(self, name):
+        self.name = name
+        self.publishers = []
+
+    def create_publisher(self, _message_type, _topic, _qos):
+        publisher = _Publisher()
+        self.publishers.append(publisher)
+        return publisher
+
+    def create_subscription(self, *_args, **_kwargs):
+        return object()
+
+    def get_clock(self):
+        return types.SimpleNamespace(
+            now=lambda: types.SimpleNamespace(
+                to_msg=lambda: types.SimpleNamespace(sec=1, nanosec=0)
+            )
+        )
+
+
+class _QoSProfile:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+
+
+class _Policy:
+    BEST_EFFORT = "best_effort"
+    KEEP_LAST = "keep_last"
+    VOLATILE = "volatile"
+
+
+class _String:
+    def __init__(self):
+        self.data = ""
+
+
+class _AudioChunk:
+    def __init__(self):
+        self.header = types.SimpleNamespace(
+            stamp=types.SimpleNamespace(sec=0, nanosec=0)
+        )
+        self.format = ""
+        self.data = []
+
+
+def _install_ros_stubs() -> None:
+    rclpy = types.ModuleType("rclpy")
+    rclpy_node = types.ModuleType("rclpy.node")
+    rclpy_qos = types.ModuleType("rclpy.qos")
+    rclpy_node.Node = _Node
+    rclpy_qos.QoSProfile = _QoSProfile
+    rclpy_qos.ReliabilityPolicy = _Policy
+    rclpy_qos.HistoryPolicy = _Policy
+    rclpy_qos.DurabilityPolicy = _Policy
+    std_msgs = types.ModuleType("std_msgs")
+    std_msgs_msg = types.ModuleType("std_msgs.msg")
+    std_msgs_msg.String = _String
+    audio_msgs = types.ModuleType("audio_msgs")
+    audio_msgs_msg = types.ModuleType("audio_msgs.msg")
+    audio_msgs_msg.AudioChunk = _AudioChunk
+    sys.modules.update(
+        {
+            "rclpy": rclpy,
+            "rclpy.node": rclpy_node,
+            "rclpy.qos": rclpy_qos,
+            "std_msgs": std_msgs,
+            "std_msgs.msg": std_msgs_msg,
+            "audio_msgs": audio_msgs,
+            "audio_msgs.msg": audio_msgs_msg,
+        }
+    )
+
+
+_install_ros_stubs()
+tts = importlib.import_module("plugins.tts")
+duplex_node = importlib.import_module("plugins.duplexaudio.node")
+
+
+class _FakeAEC:
+    backend_name = "fake-aec"
+
+    def __init__(self, *, fail: bool = False):
+        self.fail = fail
+        self.calls = []
+
+    def process_pcm(self, pcm: bytes, capture_ts: float) -> bytes:
+        self.calls.append((pcm, capture_ts))
+        if self.fail:
+            raise RuntimeError("backend failed")
+        return pcm
+
+    def stats(self) -> dict:
+        return {"backend": self.backend_name, "calls": len(self.calls)}
+
+
+def _audio_message(pcm: bytes, fmt: str = "audio/pcm-16k") -> _AudioChunk:
+    message = _AudioChunk()
+    message.header.stamp.sec = 1000
+    message.format = fmt
+    message.data = list(pcm)
+    return message
+
+
+class ExistingNodeHookTests(unittest.TestCase):
+    def test_tts_output_topic_default_remains_backward_compatible(self):
+        default = tts._TTSNode("/text", object())
+        no_input = tts._TTSNode(None, object())
+        custom = tts._TTSNode(
+            None, object(), output_topic="/duplexaudio/tts"
+        )
+
+        self.assertEqual(default._output_topic, "/text/tts")
+        self.assertEqual(no_input._output_topic, "/perception/tts")
+        self.assertEqual(custom._output_topic, "/duplexaudio/tts")
+
+    def test_tts_frame_observer_receives_exact_published_pcm_and_timestamp(self):
+        observed = []
+        node = tts._TTSNode(
+            None,
+            object(),
+            output_topic="/duplexaudio/tts",
+            frame_observer=lambda pcm, ts: observed.append((pcm, ts)),
+        )
+        frame = b"\x01\x00\x02\x00"
+
+        node._publish_frame(frame, 1234.5)
+
+        self.assertEqual(observed, [(frame, 1234.5)])
+        self.assertEqual(len(node._pub.messages), 1)
+        published = node._pub.messages[0]
+        self.assertEqual(bytes(published.data), frame)
+        self.assertEqual(published.format, "audio/pcm-16k")
+
+
+class DuplexAudioBridgeTests(unittest.TestCase):
+    def test_clean_pcm_is_rechunked_without_padding_or_loss(self):
+        aec = _FakeAEC()
+        node = duplex_node.DuplexAudioNode(
+            "/mic", "/clean", "card", aec
+        )
+
+        node._on_audio(_audio_message(b"\x01\x00" * 300))
+        self.assertEqual(node.stats()["pending_output_bytes"], 600)
+        self.assertEqual(node._publisher.messages, [])
+
+        node._on_audio(_audio_message(b"\x02\x00" * 300))
+
+        self.assertEqual(len(node._publisher.messages), 1)
+        published = node._publisher.messages[0]
+        self.assertEqual(len(published.data), 1024)
+        self.assertEqual(node.stats()["pending_output_bytes"], 176)
+        self.assertEqual(len(aec.calls), 2)
+
+    def test_unsupported_format_stops_bridge_without_output(self):
+        node = duplex_node.DuplexAudioNode(
+            "/mic", "/clean", "card", _FakeAEC()
+        )
+
+        node._on_audio(_audio_message(b"\x00\x00" * 512, "audio/wav"))
+
+        self.assertEqual(node.state, "error")
+        self.assertIn("unsupported audio format", node.last_error)
+        self.assertEqual(node._publisher.messages, [])
+
+    def test_processing_failure_is_fail_closed_by_default(self):
+        node = duplex_node.DuplexAudioNode(
+            "/mic", "/clean", "card", _FakeAEC(fail=True)
+        )
+
+        node._on_audio(_audio_message(b"\x00\x00" * 512))
+
+        self.assertEqual(node.state, "error")
+        self.assertIn("AEC processing failed", node.last_error)
+        self.assertEqual(node._publisher.messages, [])
+
+    def test_processing_failure_passthrough_remains_visible(self):
+        raw = b"\x01\x00" * 512
+        node = duplex_node.DuplexAudioNode(
+            "/mic",
+            "/clean",
+            "card",
+            _FakeAEC(fail=True),
+            failure_policy="passthrough",
+        )
+
+        node._on_audio(_audio_message(raw))
+
+        self.assertEqual(node.state, "running")
+        self.assertIn("AEC processing failed", node.last_error)
+        self.assertEqual(len(node._publisher.messages), 1)
+        self.assertEqual(bytes(node._publisher.messages[0].data), raw)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/perception/tests/test_duplexaudio_plugin.py
+++ b/perception/tests/test_duplexaudio_plugin.py
@@ -1,0 +1,303 @@
+from __future__ import annotations
+
+import pathlib
+import sys
+import types
+import unittest
+from unittest import mock
+
+
+PERCEPTION_ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(PERCEPTION_ROOT) not in sys.path:
+    sys.path.insert(0, str(PERCEPTION_ROOT))
+
+from plugins.duplexaudio.plugin import DuplexAudioPlugin  # noqa: E402
+
+
+class _Executor:
+    def __init__(self):
+        self.added = []
+        self.removed = []
+
+    def add_node(self, node):
+        self.added.append(node)
+
+    def remove_node(self, node):
+        self.removed.append(node)
+
+
+class _NodeBase:
+    def __init__(self):
+        self.state = "idle"
+        self.destroyed = False
+
+    def start(self):
+        self.state = "running"
+        return {"state": "running"}
+
+    def stop(self):
+        self.state = "idle"
+        return {"state": "idle"}
+
+    def destroy_node(self):
+        self.destroyed = True
+
+
+class _TTSNode(_NodeBase):
+    def __init__(self, input_topic, adapter, **kwargs):
+        super().__init__()
+        self.input_topic = input_topic
+        self.adapter = adapter
+        self.output_topic = kwargs["output_topic"]
+        self.frame_observer = kwargs["frame_observer"]
+        self.queued = []
+
+    def enqueue(self, text, trace_id=""):
+        self.queued.append((text, trace_id))
+
+
+class _Bridge(_NodeBase):
+    def __init__(self, input_topic, clean_topic, instance_id, aec, failure_policy):
+        super().__init__()
+        self.state = "running"
+        self.input_topic = input_topic
+        self.clean_topic = clean_topic
+        self.instance_id = instance_id
+        self.aec = aec
+        self.failure_policy = failure_policy
+
+    def stats(self):
+        return {
+            "enabled": self.aec is not None,
+            "bridge_state": self.state,
+            "failure_policy": self.failure_policy,
+        }
+
+
+class _AEC:
+    name = "fake-aec"
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        self.closed = False
+        self.references = []
+
+    def push_reference(self, pcm, play_start_ts):
+        self.references.append((pcm, play_start_ts))
+
+    def calibrate(self):
+        return {"ok": True, "d_real_ms": self.kwargs["delay_ms"]}
+
+    def close(self):
+        self.closed = True
+
+
+def _fake_modules(aec_class=_AEC):
+    tts_module = types.ModuleType("plugins.tts")
+    tts_module._TTSNode = _TTSNode
+    tts_module._build_tts_adapter = lambda cfg: {"kind": "tts", "cfg": cfg}
+    node_module = types.ModuleType("plugins.duplexaudio.node")
+    node_module.DuplexAudioNode = _Bridge
+    import plugins.duplexaudio.aec as aec_module
+
+    return {
+        "plugins.tts": tts_module,
+        "plugins.duplexaudio.node": node_module,
+    }, mock.patch.object(aec_module, "AECProcessor", aec_class)
+
+
+class DuplexAudioPluginTests(unittest.TestCase):
+    def test_start_speak_stats_and_stop_form_one_instance_lifecycle(self):
+        executor = _Executor()
+        plugin = DuplexAudioPlugin({"enabled": True}, executor)
+        modules, aec_patch = _fake_modules()
+        with mock.patch.dict(sys.modules, modules), aec_patch:
+            started = plugin.dispatch(
+                "duplexaudio",
+                {
+                    "action": "start",
+                    "instance_id": "card-1",
+                    "input_topic": "/robot/ext_mic/audio",
+                },
+            )
+            spoken = plugin.dispatch(
+                "duplexaudio",
+                {
+                    "action": "speak",
+                    "instance_id": "card-1",
+                    "text": "你好",
+                    "_trace_id": "trace-1",
+                },
+            )
+            stats = plugin.dispatch(
+                "duplexaudio", {"action": "aec_stats", "instance_id": "card-1"}
+            )
+            stopped = plugin.dispatch(
+                "duplexaudio", {"action": "stop", "instance_id": "card-1"}
+            )
+
+        self.assertEqual(started["state"], "running")
+        self.assertEqual(
+            [item["topic"] for item in started["topic_out"]],
+            [
+                "/robot/ext_mic/audio/duplexaudio/clean",
+                "/robot/ext_mic/audio/duplexaudio/tts",
+            ],
+        )
+        self.assertEqual(spoken["status"], "queued")
+        tts_node = executor.added[1]
+        self.assertEqual(tts_node.queued, [("你好", "trace-1")])
+        self.assertIsNotNone(tts_node.frame_observer)
+        self.assertTrue(stats["enabled"])
+        self.assertEqual(stopped["state"], "idle")
+        self.assertEqual(len(executor.added), 2)
+        self.assertEqual(len(executor.removed), 2)
+        self.assertTrue(all(node.destroyed for node in executor.added))
+
+    def test_effective_config_has_no_asr_model(self):
+        plugin = DuplexAudioPlugin({"enabled": True}, _Executor())
+
+        config = plugin._effective_config("card-1")
+
+        self.assertNotIn("asr", config)
+        self.assertIn("tts", config)
+        self.assertIn("aec", config)
+
+    def test_missing_aec_backend_fails_closed_before_tts_model_load(self):
+        class BrokenAEC:
+            def __init__(self, **kwargs):
+                raise RuntimeError("no backend")
+
+        executor = _Executor()
+        plugin = DuplexAudioPlugin({"enabled": True}, executor)
+        modules, aec_patch = _fake_modules(BrokenAEC)
+        with mock.patch.dict(sys.modules, modules), aec_patch:
+            result = plugin.dispatch(
+                "duplexaudio",
+                {
+                    "action": "start",
+                    "instance_id": "card-1",
+                    "input_topic": "/robot/ext_mic/audio",
+                },
+            )
+        self.assertEqual(result["state"], "error")
+        self.assertEqual(result["error"], "aec_unavailable")
+        self.assertEqual(executor.added, [])
+
+    def test_passthrough_policy_keeps_error_visible(self):
+        class BrokenAEC:
+            def __init__(self, **kwargs):
+                raise RuntimeError("no backend")
+
+        executor = _Executor()
+        plugin = DuplexAudioPlugin({"enabled": True}, executor)
+        modules, aec_patch = _fake_modules(BrokenAEC)
+        with mock.patch.dict(sys.modules, modules), aec_patch:
+            plugin.dispatch(
+                "duplexaudio",
+                {
+                    "action": "config",
+                    "instance_id": "card-1",
+                    "aec_failure_policy": "passthrough",
+                },
+            )
+            result = plugin.dispatch(
+                "duplexaudio",
+                {
+                    "action": "start",
+                    "instance_id": "card-1",
+                    "input_topic": "/robot/ext_mic/audio",
+                },
+            )
+            stats = plugin.dispatch(
+                "duplexaudio", {"action": "aec_stats", "instance_id": "card-1"}
+            )
+        self.assertEqual(result["state"], "running")
+        self.assertFalse(stats["enabled"])
+        self.assertEqual(stats["init_error"], "no backend")
+        self.assertEqual(stats["failure_policy"], "passthrough")
+
+    def test_instance_aec_config_stops_only_target_instance(self):
+        executor = _Executor()
+        plugin = DuplexAudioPlugin({"enabled": True}, executor)
+        modules, aec_patch = _fake_modules()
+        with mock.patch.dict(sys.modules, modules), aec_patch:
+            for instance_id in ("one", "two"):
+                result = plugin.dispatch(
+                    "duplexaudio",
+                    {
+                        "action": "start",
+                        "instance_id": instance_id,
+                        "input_topic": f"/{instance_id}/mic",
+                    },
+                )
+                self.assertEqual(result["state"], "running")
+            configured = plugin.dispatch(
+                "duplexaudio",
+                {
+                    "action": "config",
+                    "instance_id": "one",
+                    "aec_delay_ms": 350,
+                },
+            )
+            one = plugin.dispatch(
+                "duplexaudio", {"action": "info", "instance_id": "one"}
+            )
+            two = plugin.dispatch(
+                "duplexaudio", {"action": "info", "instance_id": "two"}
+            )
+        self.assertEqual(configured["stopped_instances"], ["one"])
+        self.assertEqual(one["state"], "idle")
+        self.assertEqual(two["state"], "running")
+
+    def test_duplicate_microphone_topic_is_rejected(self):
+        executor = _Executor()
+        plugin = DuplexAudioPlugin({"enabled": True}, executor)
+        modules, aec_patch = _fake_modules()
+        with mock.patch.dict(sys.modules, modules), aec_patch:
+            first = plugin.dispatch(
+                "duplexaudio",
+                {
+                    "action": "start",
+                    "instance_id": "one",
+                    "input_topic": "/shared/mic/",
+                },
+            )
+            second = plugin.dispatch(
+                "duplexaudio",
+                {
+                    "action": "start",
+                    "instance_id": "two",
+                    "input_topic": "/shared/mic",
+                },
+            )
+
+        self.assertEqual(first["state"], "running")
+        self.assertEqual(second["state"], "error")
+        self.assertEqual(second["error"], "input_topic_in_use")
+        self.assertEqual(len(executor.added), 2)
+
+    def test_sanitized_instance_ids_keep_distinct_internal_topics(self):
+        executor = _Executor()
+        plugin = DuplexAudioPlugin({"enabled": True}, executor)
+        modules, aec_patch = _fake_modules()
+        with mock.patch.dict(sys.modules, modules), aec_patch:
+            for instance_id, topic in (("card-a", "/mic/a"), ("card_a", "/mic/b")):
+                result = plugin.dispatch(
+                    "duplexaudio",
+                    {
+                        "action": "start",
+                        "instance_id": instance_id,
+                        "input_topic": topic,
+                    },
+                )
+                self.assertEqual(result["state"], "running")
+
+        bridges = executor.added[::2]
+        self.assertEqual(len(bridges), 2)
+        self.assertNotEqual(bridges[0].clean_topic, bridges[1].clean_topic)
+        self.assertNotEqual(bridges[0].instance_id, bridges[1].instance_id)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Visible result

This draft adds a disabled-by-default `duplexaudio` MCP processor for external-microphone deployments:

```text
external mic -> DuplexAudio input
DuplexAudio clean output (port 0) -> existing standalone ASR
DuplexAudio TTS output   (port 1) -> Speaker
```

`duplexaudio.speak(text)` synthesizes TTS PCM and records the same paced frames in-process as the AEC reference before publishing them to Speaker. ASR remains a separate card because its ROS 2 hop is not part of the timing-critical echo-reference loop.

Current evidence covers the card contract, lifecycle/failure behavior, timestamp alignment, and the real SpeexDSP backend in the existing aarch64 perception image. Physical microphone/speaker A/B acceptance has not yet been performed, so this PR remains Draft.

## Ownership

- Changed directory: `perception/`
- Behavior owner: PR author (`@NBStarry`)
- Directory DRI: not declared; this repository has no `CODEOWNERS` file
- Review / final acceptance: must be assigned by a `4paradigm/phanthymotus` maintainer before converting from Draft

## Root cause / design choice

Putting ASR, TTS, and AEC in one process does not remove physical speaker queue, DAC, acoustic propagation, or microphone-buffer delay. The timing-sensitive boundary is TTS reference generation plus AEC. This change keeps those together while preserving the existing ASR plugin as an independent downstream consumer.

## Demo in 5 minutes

1. Run the focused suite:

   ```bash
   python3 -m unittest discover -s perception/tests -p 'test_*.py'
   ```

2. Enable `plugins.duplexaudio`, disable the standalone `plugins.tts`, and keep standalone `plugins.asr` enabled.
3. Start `duplexaudio` with an external `audio/pcm-16k` topic.
4. Connect output port 0 to ASR and output port 1 to Speaker.
5. Call `duplexaudio.speak`, then inspect `duplexaudio.aec_stats` for backend, aligned frames, error count, alignment rate, and ERLE.

Expected visible result: clean PCM is emitted on `{input_topic}/duplexaudio/clean`, TTS PCM on `{input_topic}/duplexaudio/tts`, and the existing ASR consumes only the clean output.

## Failure path

- Missing AEC backend with the default `fail_closed` policy returns `aec_unavailable` before TTS model load.
- Runtime AEC failure stops clean output and leaves the bridge in a visible error state.
- Unsupported audio format or malformed PCM is rejected instead of being labeled as clean audio.
- Explicit `passthrough` is available only for A/B or recovery and keeps the AEC error visible.

## Scope / Non-goals

Included:

- TTS + timestamped reference + instance-local AEC processor
- LiveKit-first / SpeexDSP fallback backend selection
- Clean/TTS output ports, lifecycle, configuration, calibration, and diagnostics
- Existing TTS output-topic and frame-observer hooks
- CPU and Jetson image dependency plus focused tests and documentation

Not included:

- ASR model loading inside `duplexaudio`
- Changing the existing ASR implementation
- Claiming physical echo cancellation or barge-in acceptance without hardware A/B
- Speaker playback receipts or automatic multimodal-delay tracking

## Tests and evidence

- `python3 -m unittest discover -s perception/tests -p 'test_*.py'` -> 22 passed
- `python3 ../../perception-card-kit/scripts/validate_card.py perception/plugins/duplexaudio` -> PASS
- `python3 -m unittest discover -s ../../perception-card-kit/tests -p 'test_*.py'` -> 2 passed
- `python3 -m compileall -q perception/plugins/duplexaudio perception/plugins/tts.py perception/main.py perception/tests` -> passed
- Python 3.8 grammar parse for the changed Python entrypoints -> passed
- Existing `phanthy-perception:g1-general-navigation5` aarch64 image with Ubuntu `libspeexdsp1` package `1.2~rc1.2-1.1ubuntu3_arm64`: 4/4 frames aligned, 1280 output bytes, 0 process errors

The expected tracebacks in the unit-test output are deliberate failure-path exercises. Core Canvas wiring and physical microphone/speaker A/B are not yet evidenced.

## Safety and permissions

- No locomotion or physical motion commands are added.
- The new plugin is disabled by default.
- Speaker audio is produced only after an explicit `speak` call.
- AEC defaults to fail closed; no new device, network, IPC, PID, or container privilege is added.

## Compatibility and license

- Existing ASR and TTS topics and default TTS construction remain unchanged; the TTS hooks are optional.
- Enabling `duplexaudio` requires disabling standalone TTS on the same route to prevent duplicate synthesis/playback.
- SpeexDSP is loaded dynamically from the distribution `libspeexdsp1` package; no third-party source is vendored. Speex/SpeexDSP uses the revised BSD license.
- LiveKit APM remains an optional runtime backend and is not added as a mandatory dependency.

## Rollback

Set `plugins.duplexaudio.enabled: false` and re-enable standalone TTS, or revert commit `e788941`. Existing standalone ASR/TTS behavior remains the fallback.

## Dependencies / Next

- Runtime dependency: `libspeexdsp1`, added to both perception Dockerfiles.
- Before Ready for Review: assign directory DRI and final acceptance reviewer, connect one real external microphone and Speaker path, calibrate `aec_delay_ms`, and record ASR/wake-word A/B evidence under robot speech and double-talk.
- If calibrated delay remains multimodal, add an explicit Speaker playback receipt as a separate capability; do not merge ASR into the timing-critical process solely to hide transport variance.
