### PR TITLE
新增 G1 π0.5 VLA 感知卡片

### DIFF
--- a/perception/README.md
+++ b/perception/README.md
@@ -2,6 +2,18 @@
 
 Modular ASR/TTS perception plugins running as an MCP HTTP server. Connects to Agent Core via MCP tool calls and exchanges audio/text over ROS2 DDS topics.
 
+## Host Identity
+
+Every Perception host must provide two different, globally unique identities in `config.yaml`:
+
+```yaml
+identity:
+  core_display_name: "Perception Stack · Shanghai G1"
+  mcp_server_name: "perception-stack-shanghai-g1"
+```
+
+`core_display_name` is shown in Agent Core. `mcp_server_name` is returned as MCP `initialize.serverInfo.name` and is used by Core for deduplication. Missing values, equal values, and the legacy defaults `Perception Stack` / `perception-bundle` are rejected at startup so one host cannot silently replace another host's URL.
+
 ## Audio Requirements for ASR
 
 The ASR plugin (VAD + speech recognition) has strict requirements on the audio stream it receives. Any mic driver that does not meet these requirements will produce no output.

--- a/perception/config.yaml
+++ b/perception/config.yaml
@@ -1,5 +1,9 @@
 mcp_port: 15720
 
+identity:
+  core_display_name: "Perception Stack · Shanghai G1"
+  mcp_server_name: "perception-stack-shanghai-g1"
+
 plugins:
   asr:
     enabled: true
@@ -45,3 +49,14 @@ plugins:
     confidence: 0.3
     classes: []         # empty = default broad set
     fps: 5
+
+  vlapi05g1:
+    enabled: true
+    policy_url: "http://127.0.0.1:18080/predict"
+    health_url: ""
+    request_timeout_s: 120.0
+    max_image_bytes: 8388608
+    task: "move blue box back and forth between tables"
+    seed: 0
+    max_image_age_s: 1.0
+    max_state_age_s: 0.5

--- a/perception/main.py
+++ b/perception/main.py
@@ -49,6 +49,26 @@ def _load_config() -> dict:
         return yaml.safe_load(f)
 
 
+def _load_host_identity(cfg: dict) -> tuple[str, str]:
+    identity = cfg.get("identity")
+    if not isinstance(identity, dict):
+        raise ValueError("identity config is required for every Perception host")
+
+    core_display_name = identity.get("core_display_name")
+    mcp_server_name = identity.get("mcp_server_name")
+    if not isinstance(core_display_name, str) or not isinstance(mcp_server_name, str):
+        raise ValueError("identity.core_display_name and identity.mcp_server_name must be strings")
+    core_display_name = core_display_name.strip()
+    mcp_server_name = mcp_server_name.strip()
+    if not core_display_name or not mcp_server_name:
+        raise ValueError("identity.core_display_name and identity.mcp_server_name are required")
+    if core_display_name.casefold() == mcp_server_name.casefold():
+        raise ValueError("Core display name and MCP server name must be different")
+    if core_display_name == "Perception Stack" or mcp_server_name == "perception-bundle":
+        raise ValueError("default Perception host identities are forbidden")
+    return core_display_name, mcp_server_name
+
+
 # ── Bundle ────────────────────────────────────────────────────────────────────
 
 class PerceptionBundle:
@@ -87,6 +107,11 @@ class PerceptionBundle:
             self._plugins.append(plugin)
             log.info("VideoObjectPerceptionPlugin loaded (namespace=%s)", namespace)
 
+        if plugins_cfg.get("vlapi05g1", {}).get("enabled", False):
+            from plugins.vlapi05g1 import PLUGIN_CLASS
+            self._plugins.append(PLUGIN_CLASS(plugins_cfg["vlapi05g1"], executor))
+            log.info("VLAPi05G1Plugin loaded")
+
     def get_all_tools(self) -> list:
         tools = []
         for p in self._plugins:
@@ -115,7 +140,7 @@ class PerceptionBundle:
 _bundle: PerceptionBundle | None = None
 
 
-def make_handler():
+def make_handler(mcp_server_name: str):
     class Handler(BaseHTTPRequestHandler):
         def log_message(self, fmt, *args):
             if args and "/sse" in str(args[0]):
@@ -239,7 +264,7 @@ def make_handler():
                 if method == "initialize":
                     log.debug(f"[mcp] initialize request from client")
                     ok({"protocolVersion": "2024-11-05", "capabilities": {"tools": {}},
-                        "serverInfo": {"name": "perception-bundle", "version": "1.0.0"}})
+                        "serverInfo": {"name": mcp_server_name, "version": "1.0.0"}})
                 elif method == "tools/list":
                     ok({"tools": _bundle.get_all_tools()})
                 elif method == "tools/call":
@@ -393,8 +418,11 @@ def main():
     cfg      = _load_config()
     mcp_port = int(cfg.get("mcp_port", 15720))
     ws_port  = int(cfg.get("ws_port",  15721))
+    core_display_name, mcp_server_name = _load_host_identity(cfg)
 
     log.info(f"perception bundle starting, mcp_port={mcp_port}, ws_port={ws_port}")
+    log.info("host identity: core_display_name=%s, mcp_server_name=%s",
+             core_display_name, mcp_server_name)
     log.info(f"config: plugins.asr.enabled={cfg.get('plugins',{}).get('asr',{}).get('enabled')}, "
              f"plugins.tts.enabled={cfg.get('plugins',{}).get('tts',{}).get('enabled')}")
     asr_cfg = cfg.get('plugins',{}).get('asr',{})
@@ -419,9 +447,9 @@ def main():
     # Start WebSocket ASR server in a separate thread
     threading.Thread(target=_start_ws_thread, args=(ws_port,), daemon=True, name="ws_asr").start()
 
-    _start_registration(mcp_port, "Perception Stack", "perception")
+    _start_registration(mcp_port, core_display_name, "perception")
 
-    server = ThreadingHTTPServer(("", mcp_port), make_handler())
+    server = ThreadingHTTPServer(("", mcp_port), make_handler(mcp_server_name))
     log.info(f"MCP server → http://0.0.0.0:{mcp_port}")
 
     def _shutdown(signum, frame):

--- a/perception/plugins/vlapi05g1/README.md
+++ b/perception/plugins/vlapi05g1/README.md
@@ -1,0 +1,317 @@
+# `vlapi05g1` Perception 卡片规格
+
+> 状态：阶段四 Gate A/B/C、阶段五 PerceptionBundle/MCP/Core 接入和阶段六 Gate D/E/F 的 ROS2/Core/故障现场验证已于 2026-07-14 通过；用户于 2026-07-15 修复代理并实际进入 Dashboard，阶段六浏览器访问 blocker 已关闭。详见[阶段四验证记录](阶段四验证记录.md)、[阶段五验证记录](阶段五验证记录.md)和[阶段六验证记录](阶段六验证记录.md)。
+>
+> 安全边界：本卡片只生成 action proposal，不持有 execution token，不调用 G1 executor，也不向 `rt/arm_sdk` 发布命令。proposal 生成后是否仍可执行，由下游 actuator 根据机器人实时状态和控制权重新判断。
+
+## 规格摘要
+
+| 项目           | 必填内容                                                                                                                                                                                                              |
+| ------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| card id      | `vlapi05g1`                                                                                                                                                                                                       |
+| card type    | `processor`；消费图像与机器人状态，输出动作提案                                                                                                                                                                                     |
+| 感知目标         | 缓存最新 RGB 图像和 29 维 G1 关节状态，结合任务文本调用外部 π0.5 policy server，输出物理空间的 `[1,50,18]` action chunk                                                                                                                          |
+| input topic  | `image_topic`：`sensor_msgs/msg/CompressedImage`、`image/jpeg`、`BEST_EFFORT + KEEP_LAST(1) + VOLATILE`；`state_topic`：本卡片约定的 `std_msgs/msg/String` JSON 适配 topic、`data/json`、`BEST_EFFORT + KEEP_LAST(1) + VOLATILE` |
+| output topic | 默认 `{image_topic}/vlapi05g1`；`std_msgs/msg/String`；`data/json`，schema=`pi05.g1.action_chunk.v1`；`RELIABLE + KEEP_LAST(1) + VOLATILE`                                                                              |
+| actions      | `info`、`config`、`start`、`stop`、`predict`；具体请求、返回与状态约束见下文                                                                                                                                                          |
+| 配置           | shared：policy endpoint、超时和输入大小上限；instance：任务文本、seed、图像/状态新鲜度；非法值必须失败，禁止零 observation 和隐式运行路线降级                                                                                                                    |
+| 模型           | `xiaopeng-wu/pi05_unitree_g1`，revision `580238372153c51ad564b894d8fea736ab4cdeb8`，Apache-2.0；LeRobot π0.5，4,143,404,816 参数                                                                                        |
+| 部署           | 卡片运行在可同时访问 ROS2 数据面和 policy endpoint 的 Perception 宿主；policy 固定在 wlcb-23 外部 GPU runtime，第一阶段不在 G1 Jetson 上加载模型；北京 G1 通过[腾讯云 TLS Relay](../../../../../team-utils/北京G1到wlcb23推理网络.md)访问 policy                                                         |
+| 测试           | Gate A/B/C/D/E/F 的自动化与现场 API/ROS 验证通过；已覆盖真实 ROS2 双输入单输出、多实例、Core 重启配置恢复、故障隔离、10 次资源回收和日志脱敏；用户已实际进入 Dashboard，未单独保留四项视觉检查截图                                                                                                          |
+
+## 职责与非职责
+
+本卡片负责：
+
+1. 从两个正式 input topic 缓存每个实例最新的 JPEG 图像和 G1 joints 状态。
+2. 校验 observation 完整性、新鲜度和维度。
+3. 接受 `predict` 触发，将图像、29D state、task、seed 发送给外部 policy server。
+4. 校验 policy 响应并发布 action proposal。
+5. 暴露实例状态、最近一次推理耗时和错误原因。
+
+本卡片不负责：
+
+1. 不解释或执行 action，不直接连接 `rt/arm_sdk`。
+2. 不持有 G1 executor token、`confirm` 字符串或执行步数权限。
+3. 不屏蔽关节或 remote 维度；这些执行安全策略由独立 actuator 卡负责。
+4. 不在输入缺失时生成零图像、零 state 或零 token 继续推理。
+5. 不自动把每一帧图像送入 policy；只有显式 `predict` 才触发推理。
+6. 不判断 action proposal 生成后机器人是否因其他运控、人工操作或外力发生状态变化，也不据此授权或拒绝执行；该门禁属于下游 actuator。
+
+## 输入契约
+
+### 图像输入 `image_topic`
+
+- topic：由 `start.image_topic` 指定。
+- ROS type：`sensor_msgs/msg/CompressedImage`。
+- format：`image/jpeg`；`msg.data` 必须是可解码的完整 JPEG。
+- 模型输入：RGB，policy server 解码后统一 resize 为 `640 x 480`。
+- 大小上限：默认 8 MiB，由 shared 配置 `max_image_bytes` 控制。
+- 溯源语义：保留 `header.frame_id`；时间优先使用非零 `header.stamp`，否则使用卡片接收消息时的墙钟时间，并标记时间来源；新鲜度始终按本机单调时钟计算。
+- QoS：`BEST_EFFORT + KEEP_LAST(1) + VOLATILE`；只缓存最新帧，不反压相机、不积压旧帧。
+
+### 状态输入 `state_topic`
+
+- topic：由 `start.state_topic` 指定，是与 `image_topic` 并列的正式 input topic；上海 G1 当前已验证的原始数据源是 Agent Core WebSocket bus `/embodied_unitree_g1/state/joints`。
+- ROS type：`std_msgs/msg/String`。上游 state provider 负责把机器人状态发布成该 ROS2 topic；卡片不得绕过 topic 在内部直接轮询 WebSocket、HTTP 或机器人 SDK。
+- format：`data/json`，最小结构：
+
+```json
+{
+  "joints": [
+    {"idx": 0, "q": -0.0336},
+    {"idx": 1, "q": -0.046}
+  ],
+  "imu_quat": [0.9989, 0.0076, 0.0030, 0.0456]
+}
+```
+
+- 映射：必须包含 `idx=0..28` 的有限数值 `q`；按 index 升序构造 29 维 `observation.state`。额外 joints 和 `imu_quat` 不进入当前模型输入。
+- 当前部署前置：需要把已验证的 WebSocket joints JSON 原样桥接为上述 ROS2 `String` topic；桥接实现不属于本卡片阶段二。
+- 时间语义：当前 WebSocket 样本没有可用的源时间戳，按卡片收到状态消息时的单调时钟判断新鲜度。
+- QoS：`BEST_EFFORT + KEEP_LAST(1) + VOLATILE`。
+
+### Observation 组合规则
+
+1. `start` 后只缓存输入，不自动推理。
+2. `predict` 使用调用瞬间最新的图像与 state，并复制为本次请求的不可变快照。
+3. 图像或 state 缺失、格式错误、包含 NaN/Inf，或年龄超过实例配置上限时，`predict` 失败且不得请求 policy。
+4. 不做近似时间同步；输出必须带两路 input topic、接收时间、请求时年龄、图像 `header.frame_id` / `header.stamp` 和推理使用的 29D state 快照，供下游判断关联质量和 proposal 是否仍有效。
+5. 同一实例最多一个在途推理；并发 `predict` 返回 `busy`，不排无界队列。
+6. 新鲜度只在冻结推理输入快照时检查；推理期间或结果发布后机器人状态发生变化，不由本卡片判定 proposal 失效。
+
+## Policy 请求契约
+
+默认请求 `POST {policy_url}`，body：
+
+```json
+{
+  "image_base64": "<JPEG bytes as base64>",
+  "state": ["29 finite float values"],
+  "task": "move blue box back and forth between tables",
+  "seed": 0
+}
+```
+
+约束：
+
+- `image_base64`、`state` 和 `task` 在 production 都是必填项。
+- `state` 固定 29 维。
+- `task` 必须是去除首尾空白后非空的字符串；当前只验证过训练任务原文，其他任务不得标记为已验证能力。
+- `seed` 范围 `0..2147483647`，默认 0。
+- 不从卡片传 `task_tokens` 或 `attention_mask`；tokenizer 由 production policy runtime 管理。
+- HTTP 请求显式绕过环境代理，避免 loopback/tunnel endpoint 被代理转发。
+
+## 输出契约
+
+默认输出 topic 为 `{image_topic}/vlapi05g1`。每次成功 `predict` 只发布一条 `std_msgs/msg/String` JSON：
+
+```json
+{
+  "schema": "pi05.g1.action_chunk.v1",
+  "request_id": "vlapi05g1-main-000001",
+  "created_at": 0.0,
+  "observation": {
+    "image_topic": "/robot/camera/image/compressed",
+    "image_frame_id": "g1_front_camera",
+    "image_stamp": 0.0,
+    "image_stamp_source": "header_or_receive_time",
+    "image_received_at": 0.0,
+    "image_age_at_request_s": 0.0,
+    "state_topic": "/robot/state/joints",
+    "state_received_at": 0.0,
+    "state_age_at_request_s": 0.0,
+    "state": ["29 finite float values"]
+  },
+  "task": "move blue box back and forth between tables",
+  "action_space": "physical_quantile_unnormalized",
+  "frequency_hz": 30,
+  "action_shape": [1, 50, 18],
+  "action_chunk": [["18 finite float values"]],
+  "fresh_inference_per_request": true,
+  "num_inference_steps": 10,
+  "seed": 0,
+  "policy_infer_seconds": 0.0,
+  "card_elapsed_seconds": 0.0,
+  "execution_authorized": false
+}
+```
+
+发布前必须校验：
+
+- `ok=true`；
+- `action_shape == [1,50,18]`；
+- `action_chunk` 为 50 行、每行 18 个有限数值；
+- `action_space == "physical_quantile_unnormalized"`；
+- `fresh_inference_per_request == true`；
+- `num_inference_steps == 10`；
+- 返回 seed 与请求 seed 一致。
+
+任一项不满足都视为 policy contract error，不发布 action proposal。卡片不在此阶段做 URDF 限位、18D→10 关节映射或执行授权。
+
+action proposal 表达的是“基于 `observation.state` 快照得到的候选动作”，不是可直接执行命令。下游 actuator 必须在执行前重新读取机器人实时状态，并自行检查 proposal 年龄、控制权、状态漂移和动作安全；即使推理期间机器人被其他运控改变，本卡片仍只发布带原始快照的 proposal，不代替下游作有效性判断。
+
+## Actions
+
+### `info`
+
+- 请求：`action`；可选 `instance_id`。不传 `instance_id` 时返回全部实例摘要。
+- 允许状态：任何状态。
+- 行为：每次调用同步执行一次只读 `GET health_url`，超时取 `min(request_timeout_s, 5.0)`；不得创建 ROS node、启动线程或触发 policy 推理。
+- 返回：卡片版本、实例状态、实际 topics、当前配置、缓存是否就绪、两路输入年龄、是否有在途请求、最近一次 request id/耗时/错误，以及本次只读 `/health` 结果。
+- `/health` 失败不使 `info` 整体失败；`last_health.status=error` 并包含 `error_code`、`message`、检查时间和耗时。
+
+### `config`
+
+- 请求：`action` 加待更新字段；instance 字段要求 `instance_id`。
+- shared 配置在已有实例运行时拒绝真实修改并返回 `restart_required=true`；Core 重放与当前值完全相同的已保存配置时作为幂等 no-op 接受，不静默重启。
+- instance 配置可立即更新，只影响下一次 `predict`，不修改已在途请求快照。
+- 非法字段、范围错误和空 task 必须失败，不能截断或回退默认值。
+- 返回：`status=configured`、实际生效字段、`applied` 和 `restart_required`。
+
+### `start`
+
+- 必填：`instance_id`，以及显式的 `image_topic` + `state_topic` 或 Dashboard 画布形态的 `input_topics=[image_topic, state_topic]`；两种形态不得混用。可选 `output_topic`。
+- `input_topics` 的顺序严格等于卡片 `topic_in` 端口顺序：第一路图像，第二路机器人 state；这是 Agent Core Dashboard 对多输入 processor 的通用启动参数。
+- 行为：校验 shared 配置，创建两个订阅、一个发布器和单工作线程；不在 `start` 时触发推理。
+- 相同参数重复调用保持幂等。
+- 同一 `instance_id` 使用不同 topic 重复调用时拒绝，要求先 `stop`。
+- 成功返回：`state=running`、三个实际 topic、缓存就绪状态。
+
+### `stop`
+
+- 必填：`instance_id`；不支持用空 `instance_id` 一次停止全部实例。
+- 行为：停止接受新请求，等待在途 HTTP 请求至超时上限，释放订阅、发布器、worker 和缓存。
+- 重复调用或实例不存在时返回稳定的 `state=idle`。
+- 不发送任何释放机器人控制权的命令，因为本卡片从未取得控制权。
+
+### `predict`
+
+- 必填：`instance_id`；可选 `task` 和 `seed` 仅覆盖本次请求。
+- 前置状态：实例必须为 `running`，图像和 state 缓存必须完整且新鲜，没有其他在途推理。
+- 行为：冻结两个 input topic 的 observation 快照，调用一次外部 policy，校验响应并发布包含该快照来源的 action proposal；不在响应返回后用最新 state 作二次执行有效性判断。
+- 成功返回：`status=published`、`request_id`、`output_topic`、`policy_infer_seconds`、`card_elapsed_seconds`。
+- 失败返回：结构化 `status=error`、`error_code`、`message`；失败时不发布 action proposal。
+- 超时后可由调用方安全重试；卡片自身不自动重试，避免迟到响应形成陈旧动作。
+
+## 配置
+
+### Shared 配置
+
+| 字段 | 类型 | 默认值 | 范围与更新行为 |
+| --- | --- | --- | --- |
+| `policy_url` | string | `http://127.0.0.1:18080/predict` | 仅允许 `http://` 或 `https://`；运行中修改需先 stop 全部实例 |
+| `health_url` | string | 从 `policy_url` 同源推导 `/health` | 可显式覆盖；运行中修改需重启实例 |
+| `request_timeout_s` | number | `120.0` | `0.1..300.0`；运行中修改需重启实例 |
+| `max_image_bytes` | integer | `8388608` | `1024..16777216`；运行中修改需重启实例 |
+
+### Instance 配置
+
+| 字段 | 类型 | 默认值 | 范围与更新行为 |
+| --- | --- | --- | --- |
+| `task` | string | `move blue box back and forth between tables` | 非空；立即生效于下一次 `predict`；其他任务尚未验证 |
+| `seed` | integer | `0` | `0..2147483647`；立即生效于下一次 `predict` |
+| `max_image_age_s` | number | `1.0` | `0.05..10.0`；按卡片接收时的单调时钟判断 |
+| `max_state_age_s` | number | `0.5` | `0.05..10.0`；按状态接收时间判断 |
+
+禁止配置：`allow_zero_observation`、execution token、执行确认字符串、执行步数、关节限位和 remote 映射。这些字段不属于本卡片权限面。
+
+## 模型与运行路线
+
+| 项 | 当前 production 契约 |
+| --- | --- |
+| model | `xiaopeng-wu/pi05_unitree_g1` |
+| revision | `580238372153c51ad564b894d8fea736ab4cdeb8` |
+| license | Apache-2.0 |
+| dataset | `nepyope/unitree_box_move_blue_full`，550 episodes、475,206 frames、30 Hz |
+| parameters | 4,143,404,816 |
+| main weight | `model.safetensors`，9,354,050,752 B |
+| input | RGB `3 x 480 x 640`、29D G1 state、task text |
+| output | 50 steps x 18D，物理反归一化绝对关节目标；每步 30 Hz |
+| tokenizer | openpi `paligemma_tokenizer.model`，由 policy runtime 持有 |
+| runtime image | `pi05-g1:runtime-v3`，image id `sha256:cf89490a504d49649e663fbd1e7c3d400121cfd7fd0999add6843d80a3dc13dd` |
+| policy location | wlcb-23，A100-SXM4-80GB，当前 GPU 6 / port 18080 |
+| dtype / denoising | float32 / 10 steps |
+| local fallback | 无；policy 不可达时明确失败，不降级到 Jetson 或 mock |
+
+已验证单次 production shadow 的 policy 推理约 `0.391..0.675 s`，adapter 总耗时约 `0.738..1.195 s`；CUDA 峰值显存记录为 `16,736,264,192 B`。阶段四 Gate C 已用三次正式样本重测 policy P95 `0.3875 s`、SSH tunnel 端到端 P95 `2.9224 s`；样本数仍不足以上升为 production SLO。
+
+## 故障与状态
+
+实例状态：`idle -> running`；`predict` 期间通过 `in_flight=true` 表示忙，不额外引入不可恢复的 `loading` 状态。最近错误记录在实例状态中，但单次推理失败不退出 MCP server、不销毁实例。
+
+| error_code | 条件 | 行为 |
+| --- | --- | --- |
+| `not_running` | 实例未启动 | 拒绝 predict |
+| `invalid_request` | 单次 task 为空或 seed 不是范围内整数 | 拒绝 predict，不请求 policy |
+| `observation_missing` | 缺图像或 state | 拒绝 predict，不请求 policy |
+| `observation_stale` | 冻结请求快照时任一路输入超过新鲜度上限 | 拒绝 predict，不请求 policy |
+| `invalid_image` | 非 JPEG、截断或超过大小限制 | 丢弃该帧，保留服务 |
+| `invalid_state` | JSON 错误、缺少 0..28、非有限数值 | 丢弃该状态帧，保留服务 |
+| `busy` | 同实例已有在途推理 | 立即失败，不排队 |
+| `policy_unreachable` | 连接失败或超时 | 不自动重试，不发布 proposal |
+| `policy_rejected` | HTTP 非 2xx 或 `ok != true` | 记录远端错误，不发布 proposal |
+| `policy_contract_error` | shape、action space、steps、seed 或数值不合约 | 拒绝结果，不发布 proposal |
+
+日志不得打印完整 base64 图像、完整 action chunk、token 或整帧隐私数据；只记录 request id、长度、shape、耗时和错误摘要。
+
+## 测试验收矩阵
+
+### 纯函数与契约
+
+- 29D joints 映射：正常、缺 index、重复 index、NaN/Inf、额外 joints。
+- JPEG：有效样本、非 JPEG、截断、超过大小上限。
+- policy payload：字段、维度、task、seed 和 base64 解码一致。
+- policy response：正确 `[1,50,18]`、错误 shape、空 chunk、NaN/Inf、错误 action space、错误 seed。
+- action proposal：schema 完整、JSON 可序列化、`execution_authorized` 恒为 false。
+- proposal provenance：完整保留 image/state topic、时间元数据和推理所用 29D state 快照。
+
+### 生命周期与并发
+
+- `info` 在 idle/running 都不创建 ROS node 或触发推理，只执行一次有界的只读 policy health 检查。
+- 非法/合法 `config`，shared 运行中修改门禁，instance 热更新。
+- 相同参数连续 `start` 两次不创建重复 node；不同 topic 明确失败。
+- 连续 `stop` 两次均为 idle；start/stop 十轮无线程、订阅和缓存残留。
+- 两实例 topic、缓存、request id、配置与输出互不串扰。
+- 同实例并发 predict：一个执行，其他稳定返回 busy。
+
+### 录制数据与性能
+
+- 固定使用 `vla-g1-deployment/artifacts/shadow/g1-fixed-frame.jpg`、29D state artifact 和训练任务原文。
+- 同一 revision、同一 observation、seed 0 连续至少三次，action chunk 在严格相等或预先定义的数值容差内一致。
+- 记录端到端 P50/P95、policy P50/P95、吞吐、CPU、RSS 和 policy CUDA 峰值显存。
+- 阶段四实测基线：policy P95 `0.3875 s`、SSH tunnel 端到端 P95 `2.9224 s`；仅有三次正式计量样本，不把该数值上升为 production SLO。硬门禁仍是单实例一个在途请求、不积压、严格确定性和完整响应契约。
+
+### ROS2 与外部故障
+
+- 向两个真实 input topic 发布录制图像和 state，`predict` 后只出现一条匹配 request id 的 output。
+- 缺一路输入、输入过期、输入断流时不得发布陈旧 proposal。
+- 推理期间发布更新 state 时，proposal 仍保留请求开始时的 state 快照；卡片不自行判断其执行有效性。
+- policy 连接拒绝、超时、HTTP 400、错误 JSON 和 contract mismatch 均不拖死 ROS executor 或 MCP server。
+- policy 恢复后下一次显式 predict 可成功，不依赖重启卡片。
+
+### PerceptionBundle / MCP / Agent Core
+
+- Bundle 显式 loader 与运行配置能加载 `vlapi05g1`，进程日志出现 `VLAPi05G1Plugin loaded`。
+- Core display name 和 MCP `serverInfo.name` 由宿主配置显式提供，缺失、同名或继续使用默认名时拒绝启动。
+- `initialize`、`tools/list`、`info`、非法/合法 `config`、重复 `start/stop` 均通过 MCP HTTP 验证。
+- 真实 Agent Core 在未保存 tool config 时拒绝业务 action；通过 tool-config API 保存 shared 配置后，Core 代理 `start/info/predict/stop` 成功。
+- 阶段五的 Core `predict` 预期返回 `observation_missing`：这证明业务 action 已路由到卡片且缺输入时 fail closed，不代表 ROS2 数据闭环已完成。
+
+### 当前未验证边界
+
+- WebSocket joints JSON 到正式 ROS2 state input topic 的上游 state provider 尚未实现和验证。
+- 录制数据已通过真实 ROS2 双输入/单输出闭环、断流/陈旧输入和多实例隔离；本结论不代表上述 live state provider 已存在。
+- Agent Core 唯一注册、tool-config 保存/懒恢复、Dashboard `input_topics` 启动参数、输出 topic 推导和多实例已通过 API/ROS 现场验证；用户已实际进入 Dashboard，但未单独保留侧栏、配置表单和多实例拖拽四项截图。
+- wlcb-23 Gate F 当时的画布没有 `vlapi05g1` 卡片，因此未触发可选的 AgentLoop 执行线绑定项；现有录制 observation 的真实 policy `predict` 已经 Core 代理调用并通过 Gate D。
+- 北京 G1 已完成独立 overlay 构建、policy health 和 Core 注册，但尚未用北京 G1 的 live RGB + joints state 完成一次 `predict`。
+- 本卡片不会证明 G1 实机动作安全；物理执行必须由独立 actuator 卡和现场 owner 验证。
+
+## 资料依据
+
+- [pi0.5 上海 G1 实机连续控制部署](../../../../vla-g1-deployment/details/pi05实机连续控制部署.md)
+- [VLA 动作到 G1 实机指令](../../../../vla-g1-deployment/details/VLA动作到G1实机指令.md)
+- [pi0.5 模型选择与 HF 验证](../../../../vla-g1-deployment/details/pi05模型选择与HF验证.md)
+- [训练数据 Action 契约](../../../../vla-g1-deployment/artifacts/dataset-contract/action-contract.md)
+- [production policy server](../../../../vla-g1-deployment/scripts/pi05_policy_server.py)
+- [真实 10-step shadow artifact](../../../../vla-g1-deployment/artifacts/shadow/g1-real-runtime-v2-step10.json)

--- a/perception/plugins/vlapi05g1/__init__.py
+++ b/perception/plugins/vlapi05g1/__init__.py
@@ -1,0 +1,5 @@
+from .plugin import VLAPi05G1Plugin
+
+PLUGIN_CLASS = VLAPi05G1Plugin
+
+__all__ = ["PLUGIN_CLASS", "VLAPi05G1Plugin"]

--- a/perception/plugins/vlapi05g1/config.example.json
+++ b/perception/plugins/vlapi05g1/config.example.json
@@ -1,0 +1,11 @@
+{
+  "enabled": true,
+  "policy_url": "http://127.0.0.1:18080/predict",
+  "health_url": "",
+  "request_timeout_s": 120.0,
+  "max_image_bytes": 8388608,
+  "task": "move blue box back and forth between tables",
+  "seed": 0,
+  "max_image_age_s": 1.0,
+  "max_state_age_s": 0.5
+}

--- a/perception/plugins/vlapi05g1/node.py
+++ b/perception/plugins/vlapi05g1/node.py
@@ -1,0 +1,318 @@
+from __future__ import annotations
+
+import concurrent.futures
+import hashlib
+import json
+import re
+import threading
+import time
+from typing import Any
+
+from rclpy.node import Node
+from rclpy.qos import DurabilityPolicy, HistoryPolicy, QoSProfile, ReliabilityPolicy
+from sensor_msgs.msg import CompressedImage
+from std_msgs.msg import String
+
+from .policy import (
+    CardError,
+    ObservationSnapshot,
+    PolicyClient,
+    build_action_proposal,
+    build_policy_payload,
+    parse_state_message,
+    validate_jpeg,
+    validate_policy_response,
+    validate_seed,
+    validate_task,
+)
+
+
+_INPUT_QOS = QoSProfile(
+    reliability=ReliabilityPolicy.BEST_EFFORT,
+    history=HistoryPolicy.KEEP_LAST,
+    depth=1,
+    durability=DurabilityPolicy.VOLATILE,
+)
+
+_OUTPUT_QOS = QoSProfile(
+    reliability=ReliabilityPolicy.RELIABLE,
+    history=HistoryPolicy.KEEP_LAST,
+    depth=1,
+    durability=DurabilityPolicy.VOLATILE,
+)
+
+
+class VLAPi05G1Node(Node):
+    def __init__(
+        self,
+        *,
+        image_topic: str,
+        state_topic: str,
+        output_topic: str,
+        instance_id: str,
+        shared_config: dict[str, Any],
+        instance_config: dict[str, Any],
+    ):
+        normalized_id = re.sub(r"[^a-zA-Z0-9_]", "_", instance_id)
+        instance_hash = hashlib.sha256(instance_id.encode("utf-8")).hexdigest()[:8]
+        safe_id = f"{normalized_id}_{instance_hash}"
+        super().__init__(f"vlapi05g1_{safe_id}")
+        self.instance_id = instance_id
+        self.image_topic = image_topic
+        self.state_topic = state_topic
+        self.output_topic = output_topic
+        self._shared_config = dict(shared_config)
+        self._instance_config = dict(instance_config)
+
+        self._data_lock = threading.Lock()
+        self._predict_lock = threading.Lock()
+        self._accepting_predictions = True
+        self._request_sequence = 0
+        self._latest_image: dict[str, Any] | None = None
+        self._latest_state: dict[str, Any] | None = None
+        self._last_request_id: str | None = None
+        self._last_policy_infer_seconds: float | None = None
+        self._last_card_elapsed_seconds: float | None = None
+        self._last_error: dict[str, str] | None = None
+
+        self._policy = PolicyClient(
+            self._shared_config["policy_url"],
+            self._shared_config["request_timeout_s"],
+        )
+        self._worker = concurrent.futures.ThreadPoolExecutor(
+            max_workers=1,
+            thread_name_prefix=f"vlapi05g1_{safe_id}_predict",
+        )
+        self._publisher = self.create_publisher(String, output_topic, _OUTPUT_QOS)
+        self._image_subscription = self.create_subscription(
+            CompressedImage,
+            image_topic,
+            self._on_image,
+            _INPUT_QOS,
+        )
+        self._state_subscription = self.create_subscription(
+            String,
+            state_topic,
+            self._on_state,
+            _INPUT_QOS,
+        )
+
+    def _record_error(self, error: CardError) -> None:
+        with self._data_lock:
+            self._last_error = {"error_code": error.code, "message": error.message}
+        self.get_logger().warning(f"[{error.code}] {error.message}")
+
+    def _on_image(self, msg: CompressedImage) -> None:
+        received_at = time.time()
+        received_monotonic = time.monotonic()
+        try:
+            image_bytes = validate_jpeg(
+                bytes(msg.data),
+                int(self._shared_config["max_image_bytes"]),
+            )
+        except CardError as exc:
+            self._record_error(exc)
+            return
+
+        stamp = float(msg.header.stamp.sec) + float(msg.header.stamp.nanosec) / 1_000_000_000.0
+        if stamp > 0:
+            stamp_source = "header"
+        else:
+            stamp = received_at
+            stamp_source = "receive_time"
+        with self._data_lock:
+            self._latest_image = {
+                "bytes": image_bytes,
+                "frame_id": str(msg.header.frame_id),
+                "stamp": stamp,
+                "stamp_source": stamp_source,
+                "received_at": received_at,
+                "received_monotonic": received_monotonic,
+            }
+
+    def _on_state(self, msg: String) -> None:
+        received_at = time.time()
+        received_monotonic = time.monotonic()
+        try:
+            state = parse_state_message(msg.data)
+        except CardError as exc:
+            self._record_error(exc)
+            return
+        with self._data_lock:
+            self._latest_state = {
+                "state": tuple(state),
+                "received_at": received_at,
+                "received_monotonic": received_monotonic,
+            }
+
+    def update_instance_config(self, config: dict[str, Any]) -> None:
+        with self._data_lock:
+            self._instance_config = dict(config)
+
+    def _freeze_observation(self, config: dict[str, Any]) -> ObservationSnapshot:
+        now_monotonic = time.monotonic()
+        with self._data_lock:
+            image = dict(self._latest_image) if self._latest_image is not None else None
+            state = dict(self._latest_state) if self._latest_state is not None else None
+        if image is None or state is None:
+            missing = []
+            if image is None:
+                missing.append("image")
+            if state is None:
+                missing.append("state")
+            raise CardError("observation_missing", f"missing observation inputs: {missing}")
+
+        image_age = max(0.0, now_monotonic - image["received_monotonic"])
+        state_age = max(0.0, now_monotonic - state["received_monotonic"])
+        if image_age > float(config["max_image_age_s"]):
+            raise CardError(
+                "observation_stale",
+                f"image age {image_age:.6f}s exceeds max_image_age_s={config['max_image_age_s']}",
+            )
+        if state_age > float(config["max_state_age_s"]):
+            raise CardError(
+                "observation_stale",
+                f"state age {state_age:.6f}s exceeds max_state_age_s={config['max_state_age_s']}",
+            )
+        return ObservationSnapshot(
+            image_bytes=image["bytes"],
+            image_topic=self.image_topic,
+            image_frame_id=image["frame_id"],
+            image_stamp=image["stamp"],
+            image_stamp_source=image["stamp_source"],
+            image_received_at=image["received_at"],
+            image_age_at_request_s=image_age,
+            state=state["state"],
+            state_topic=self.state_topic,
+            state_received_at=state["received_at"],
+            state_age_at_request_s=state_age,
+        )
+
+    def _next_request_id(self) -> str:
+        with self._data_lock:
+            self._request_sequence += 1
+            return f"vlapi05g1-{self.instance_id}-{self._request_sequence:06d}"
+
+    def predict(self, *, task: Any = None, seed: Any = None) -> dict[str, Any]:
+        if not self._accepting_predictions:
+            raise CardError("not_running", f"instance {self.instance_id} is stopping")
+        if not self._predict_lock.acquire(blocking=False):
+            raise CardError("busy", f"instance {self.instance_id} already has an in-flight prediction")
+        try:
+            if not self._accepting_predictions:
+                raise CardError("not_running", f"instance {self.instance_id} is stopping")
+            with self._data_lock:
+                config = dict(self._instance_config)
+            try:
+                effective_task = validate_task(config["task"] if task is None else task)
+                effective_seed = validate_seed(config["seed"] if seed is None else seed)
+            except ValueError as exc:
+                raise CardError("invalid_request", str(exc)) from exc
+            snapshot = self._freeze_observation(config)
+            request_id = self._next_request_id()
+            future = self._worker.submit(
+                self._run_prediction,
+                request_id,
+                snapshot,
+                effective_task,
+                effective_seed,
+            )
+            return future.result()
+        finally:
+            self._predict_lock.release()
+
+    def _run_prediction(
+        self,
+        request_id: str,
+        snapshot: ObservationSnapshot,
+        task: str,
+        seed: int,
+    ) -> dict[str, Any]:
+        started = time.monotonic()
+        try:
+            payload = build_policy_payload(snapshot, task, seed)
+            response = self._policy.predict(payload)
+            validated = validate_policy_response(response, seed)
+            elapsed = time.monotonic() - started
+            proposal = build_action_proposal(
+                request_id=request_id,
+                created_at=time.time(),
+                snapshot=snapshot,
+                task=task,
+                seed=seed,
+                validated_response=validated,
+                card_elapsed_seconds=elapsed,
+            )
+            output = String()
+            output.data = json.dumps(proposal, ensure_ascii=False, separators=(",", ":"))
+            self._publisher.publish(output)
+            with self._data_lock:
+                self._last_request_id = request_id
+                self._last_policy_infer_seconds = validated["policy_infer_seconds"]
+                self._last_card_elapsed_seconds = elapsed
+                self._last_error = None
+            return {
+                "status": "published",
+                "request_id": request_id,
+                "output_topic": self.output_topic,
+                "policy_infer_seconds": validated["policy_infer_seconds"],
+                "card_elapsed_seconds": elapsed,
+            }
+        except CardError as exc:
+            self._record_error(exc)
+            raise
+        except Exception as exc:
+            wrapped = CardError("policy_contract_error", f"unexpected prediction failure: {exc}")
+            self._record_error(wrapped)
+            raise wrapped from exc
+
+    def status(self) -> dict[str, Any]:
+        now = time.monotonic()
+        with self._data_lock:
+            image = dict(self._latest_image) if self._latest_image is not None else None
+            state = dict(self._latest_state) if self._latest_state is not None else None
+            config = dict(self._instance_config)
+            last_error = dict(self._last_error) if self._last_error is not None else None
+            last_request_id = self._last_request_id
+            last_policy_infer_seconds = self._last_policy_infer_seconds
+            last_card_elapsed_seconds = self._last_card_elapsed_seconds
+        return {
+            "name": "π0.5 G1 VLA 推理",
+            "state": "running" if self._accepting_predictions else "idle",
+            "instance_id": self.instance_id,
+            "topic_in": [
+                {"topic": self.image_topic, "format": "image/jpeg"},
+                {"topic": self.state_topic, "format": "data/json"},
+            ],
+            "topic_out": [{"topic": self.output_topic, "format": "data/json"}],
+            "config": config,
+            "observation": {
+                "image_ready": image is not None,
+                "image_age_s": (max(0.0, now - image["received_monotonic"]) if image else None),
+                "state_ready": state is not None,
+                "state_age_s": (max(0.0, now - state["received_monotonic"]) if state else None),
+            },
+            "in_flight": self._predict_lock.locked(),
+            "last_request_id": last_request_id,
+            "last_policy_infer_seconds": last_policy_infer_seconds,
+            "last_card_elapsed_seconds": last_card_elapsed_seconds,
+            "last_error": last_error,
+        }
+
+    def shutdown_card(self) -> None:
+        self._accepting_predictions = False
+        with self._predict_lock:
+            pass
+        if self._image_subscription is not None:
+            self.destroy_subscription(self._image_subscription)
+            self._image_subscription = None
+        if self._state_subscription is not None:
+            self.destroy_subscription(self._state_subscription)
+            self._state_subscription = None
+        if self._publisher is not None:
+            self.destroy_publisher(self._publisher)
+            self._publisher = None
+        self._worker.shutdown(wait=True, cancel_futures=True)
+        with self._data_lock:
+            self._latest_image = None
+            self._latest_state = None

--- a/perception/plugins/vlapi05g1/plugin.py
+++ b/perception/plugins/vlapi05g1/plugin.py
@@ -1,0 +1,501 @@
+from __future__ import annotations
+
+import copy
+import threading
+import time
+from typing import Any
+
+from .policy import (
+    CardError,
+    DEFAULT_TASK,
+    PolicyClient,
+    derive_health_url,
+    validate_http_url,
+    validate_seed,
+    validate_task,
+)
+
+
+TOOL = {
+    "name": "vlapi05g1",
+    "type": "processor",
+    "multiInstance": True,
+    "description": "π0.5 G1 VLA inference — combine image and robot state topics into action proposals",
+    "inputSchema": {
+        "type": "object",
+        "properties": {
+            "action": {
+                "type": "string",
+                "enum": ["info", "config", "start", "stop", "predict"],
+                "description": "Card lifecycle or prediction action",
+            },
+            "instance_id": {
+                "type": "string",
+                "description": "Stable instance identifier",
+            },
+            "image_topic": {
+                "type": "string",
+                "description": "sensor_msgs/msg/CompressedImage input topic required by start",
+            },
+            "state_topic": {
+                "type": "string",
+                "description": "std_msgs/msg/String joints JSON input topic required by start",
+            },
+            "input_topics": {
+                "type": "array",
+                "items": {"type": "string"},
+                "minItems": 2,
+                "maxItems": 2,
+                "description": "Dashboard start compatibility: [image_topic, state_topic] in topic_in port order",
+            },
+            "output_topic": {
+                "type": "string",
+                "description": "Optional action proposal topic; defaults to {image_topic}/vlapi05g1",
+            },
+            "task": {
+                "type": "string",
+                "description": "Instance task or one-shot predict override",
+            },
+            "seed": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 2147483647,
+                "description": "Instance seed or one-shot predict override",
+            },
+            "policy_url": {"type": "string"},
+            "health_url": {"type": "string"},
+            "request_timeout_s": {"type": "number", "minimum": 0.1, "maximum": 300.0},
+            "max_image_bytes": {"type": "integer", "minimum": 1024, "maximum": 16777216},
+            "max_image_age_s": {"type": "number", "minimum": 0.05, "maximum": 10.0},
+            "max_state_age_s": {"type": "number", "minimum": 0.05, "maximum": 10.0},
+        },
+        "required": ["action"],
+    },
+    "configSchema": {
+        "type": "object",
+        "properties": {
+            "policy_url": {
+                "type": "string",
+                "default": "http://127.0.0.1:18080/predict",
+                "scope": "shared",
+            },
+            "health_url": {
+                "type": "string",
+                "default": "",
+                "scope": "shared",
+            },
+            "request_timeout_s": {
+                "type": "number",
+                "default": 120.0,
+                "minimum": 0.1,
+                "maximum": 300.0,
+                "scope": "shared",
+            },
+            "max_image_bytes": {
+                "type": "integer",
+                "default": 8388608,
+                "minimum": 1024,
+                "maximum": 16777216,
+                "scope": "shared",
+            },
+            "task": {
+                "type": "string",
+                "default": DEFAULT_TASK,
+                "scope": "instance",
+            },
+            "seed": {
+                "type": "integer",
+                "default": 0,
+                "minimum": 0,
+                "maximum": 2147483647,
+                "scope": "instance",
+            },
+            "max_image_age_s": {
+                "type": "number",
+                "default": 1.0,
+                "minimum": 0.05,
+                "maximum": 10.0,
+                "scope": "instance",
+            },
+            "max_state_age_s": {
+                "type": "number",
+                "default": 0.5,
+                "minimum": 0.05,
+                "maximum": 10.0,
+                "scope": "instance",
+            },
+        },
+        "required": [],
+    },
+    "topic_in": [
+        {"format": "image/jpeg", "desc": "sensor_msgs/msg/CompressedImage RGB observation"},
+        {"format": "data/json", "desc": "std_msgs/msg/String G1 joints state observation"},
+    ],
+    "topic_out": [
+        {"format": "data/json", "desc": "pi05.g1.action_chunk.v1 action proposal"},
+    ],
+}
+
+
+SHARED_DEFAULTS = {
+    "policy_url": "http://127.0.0.1:18080/predict",
+    "health_url": "",
+    "request_timeout_s": 120.0,
+    "max_image_bytes": 8 * 1024 * 1024,
+}
+
+INSTANCE_DEFAULTS = {
+    "task": DEFAULT_TASK,
+    "seed": 0,
+    "max_image_age_s": 1.0,
+    "max_state_age_s": 0.5,
+}
+
+SHARED_FIELDS = frozenset(SHARED_DEFAULTS)
+INSTANCE_FIELDS = frozenset(INSTANCE_DEFAULTS)
+CONFIG_FIELDS = SHARED_FIELDS | INSTANCE_FIELDS
+
+
+def _bounded_number(value: Any, name: str, minimum: float, maximum: float) -> float:
+    if isinstance(value, bool):
+        raise ValueError(f"{name} must be within {minimum}..{maximum}")
+    try:
+        number = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{name} must be within {minimum}..{maximum}") from exc
+    if not minimum <= number <= maximum:
+        raise ValueError(f"{name} must be within {minimum}..{maximum}")
+    return number
+
+
+def _bounded_integer(value: Any, name: str, minimum: int, maximum: int) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or not minimum <= value <= maximum:
+        raise ValueError(f"{name} must be an integer within {minimum}..{maximum}")
+    return value
+
+
+def _validate_topic(value: Any, name: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{name} must be a non-empty ROS topic")
+    topic = value.strip()
+    if any(character.isspace() for character in topic):
+        raise ValueError(f"{name} must not contain whitespace")
+    return topic
+
+
+def _validate_shared(config: dict[str, Any]) -> dict[str, Any]:
+    policy_url = validate_http_url(config["policy_url"], "policy_url")
+    health_value = config.get("health_url")
+    health_url = (
+        validate_http_url(health_value, "health_url")
+        if isinstance(health_value, str) and health_value.strip()
+        else derive_health_url(policy_url)
+    )
+    return {
+        "policy_url": policy_url,
+        "health_url": health_url,
+        "request_timeout_s": _bounded_number(config["request_timeout_s"], "request_timeout_s", 0.1, 300.0),
+        "max_image_bytes": _bounded_integer(config["max_image_bytes"], "max_image_bytes", 1024, 16 * 1024 * 1024),
+    }
+
+
+def _validate_instance(config: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "task": validate_task(config["task"]),
+        "seed": validate_seed(config["seed"]),
+        "max_image_age_s": _bounded_number(config["max_image_age_s"], "max_image_age_s", 0.05, 10.0),
+        "max_state_age_s": _bounded_number(config["max_state_age_s"], "max_state_age_s", 0.05, 10.0),
+    }
+
+
+class VLAPi05G1Plugin:
+    PREFIX = "vlapi05g1"
+    HEALTH_TIMEOUT_CAP_S = 5.0
+
+    def __init__(self, plugin_cfg: dict, executor):
+        self._lifecycle_lock = threading.RLock()
+        self._health_lock = threading.Lock()
+        shared = dict(SHARED_DEFAULTS)
+        instance = dict(INSTANCE_DEFAULTS)
+        for key in SHARED_FIELDS:
+            if key in plugin_cfg:
+                shared[key] = plugin_cfg[key]
+        for key in INSTANCE_FIELDS:
+            if key in plugin_cfg:
+                instance[key] = plugin_cfg[key]
+        health_value = plugin_cfg.get("health_url")
+        self._health_url_is_explicit = isinstance(health_value, str) and bool(health_value.strip())
+        self._shared_config = _validate_shared(shared)
+        self._default_instance_config = _validate_instance(instance)
+        self._instance_configs: dict[str, dict[str, Any]] = {}
+        self._instances: dict[str, Any] = {}
+        self._last_health: dict[str, Any] | None = None
+        self._executor = executor
+
+    def get_tools(self) -> list[dict[str, Any]]:
+        return [TOOL]
+
+    def dispatch(self, name: str, args: dict) -> dict[str, Any]:
+        action = args.get("action") if name == self.PREFIX else name
+        if action == "info":
+            self._refresh_health()
+            with self._lifecycle_lock:
+                return self._info(args.get("instance_id"))
+        if action == "config":
+            with self._lifecycle_lock:
+                return self._config(args)
+        if action == "start":
+            with self._lifecycle_lock:
+                return self._start(args)
+        if action == "stop":
+            with self._lifecycle_lock:
+                return self._stop(args)
+        if action == "predict":
+            return self._predict(args)
+        raise ValueError(f"unsupported vlapi05g1 action: {action}")
+
+    def _instance_config(self, instance_id: str) -> dict[str, Any]:
+        return dict(self._instance_configs.get(instance_id, self._default_instance_config))
+
+    def _refresh_health(self) -> None:
+        with self._health_lock:
+            with self._lifecycle_lock:
+                shared = dict(self._shared_config)
+            timeout_s = min(
+                float(shared["request_timeout_s"]),
+                self.HEALTH_TIMEOUT_CAP_S,
+            )
+            checked_at = time.time()
+            started = time.monotonic()
+            try:
+                client = PolicyClient(
+                    shared["policy_url"],
+                    timeout_s,
+                    shared["health_url"],
+                )
+                response = client.health()
+                result = {
+                    "status": "ok" if response.get("ok") is True else "error",
+                    "checked_at": checked_at,
+                    "health_url": shared["health_url"],
+                    "latency_s": time.monotonic() - started,
+                    "response": response,
+                }
+            except CardError as exc:
+                result = {
+                    "status": "error",
+                    "checked_at": checked_at,
+                    "health_url": shared["health_url"],
+                    "latency_s": time.monotonic() - started,
+                    "error_code": exc.code,
+                    "message": exc.message,
+                }
+            with self._lifecycle_lock:
+                if self._shared_config["health_url"] == shared["health_url"]:
+                    self._last_health = result
+
+    def _info(self, instance_id: Any) -> dict[str, Any]:
+        if instance_id is not None:
+            instance_id = str(instance_id).strip()
+            node = self._instances.get(instance_id)
+            if node is not None:
+                status = node.status()
+                status["shared_config"] = dict(self._shared_config)
+                status["last_health"] = copy.deepcopy(self._last_health)
+                return status
+            return {
+                "name": "π0.5 G1 VLA 推理",
+                "state": "idle",
+                "instance_id": instance_id,
+                "topic_in": [],
+                "topic_out": [],
+                "config": self._instance_config(instance_id),
+                "shared_config": dict(self._shared_config),
+                "in_flight": False,
+                "last_health": copy.deepcopy(self._last_health),
+            }
+
+        instances = {key: node.status() for key, node in self._instances.items()}
+        topics_in = []
+        topics_out = []
+        for status in instances.values():
+            status["last_health"] = copy.deepcopy(self._last_health)
+            topics_in.extend(status["topic_in"])
+            topics_out.extend(status["topic_out"])
+        return {
+            "name": "π0.5 G1 VLA 推理",
+            "state": "running" if instances else "idle",
+            "topic_in": topics_in,
+            "topic_out": topics_out,
+            "shared_config": dict(self._shared_config),
+            "default_instance_config": dict(self._default_instance_config),
+            "instances": instances,
+            "last_health": copy.deepcopy(self._last_health),
+        }
+
+    def _config(self, args: dict[str, Any]) -> dict[str, Any]:
+        updates = {
+            key: value
+            for key, value in args.items()
+            if key not in {"action", "instance_id"} and value is not None
+        }
+        unknown = sorted(set(updates) - CONFIG_FIELDS)
+        if unknown:
+            raise ValueError(f"unknown vlapi05g1 config fields: {unknown}")
+        shared_updates = {key: value for key, value in updates.items() if key in SHARED_FIELDS}
+        instance_updates = {key: value for key, value in updates.items() if key in INSTANCE_FIELDS}
+        if shared_updates and instance_updates:
+            raise ValueError("shared and instance config must be updated in separate calls")
+
+        if shared_updates:
+            candidate = dict(self._shared_config)
+            candidate.update(shared_updates)
+            health_url_is_explicit = self._health_url_is_explicit
+            if "policy_url" in shared_updates and "health_url" not in shared_updates:
+                if not self._health_url_is_explicit:
+                    candidate["health_url"] = ""
+            if "health_url" in shared_updates:
+                health_value = shared_updates["health_url"]
+                health_url_is_explicit = isinstance(health_value, str) and bool(health_value.strip())
+            validated = _validate_shared(candidate)
+            changed = validated != self._shared_config
+            if changed and self._instances:
+                return {
+                    "status": "error",
+                    "error_code": "restart_required",
+                    "message": "shared config changes require all vlapi05g1 instances to be stopped",
+                    "applied": "none",
+                    "restart_required": True,
+                }
+            self._health_url_is_explicit = health_url_is_explicit
+            if changed:
+                self._shared_config = validated
+                self._last_health = None
+            return {
+                "status": "configured",
+                "scope": "shared",
+                "config": dict(self._shared_config),
+                "applied": "immediate" if changed else "none",
+                "restart_required": False,
+            }
+
+        if instance_updates:
+            instance_id = args.get("instance_id")
+            if not isinstance(instance_id, str) or not instance_id.strip():
+                raise ValueError("instance_id is required for instance config")
+            instance_id = instance_id.strip()
+            candidate = self._instance_config(instance_id)
+            candidate.update(instance_updates)
+            validated = _validate_instance(candidate)
+            self._instance_configs[instance_id] = validated
+            node = self._instances.get(instance_id)
+            if node is not None:
+                node.update_instance_config(validated)
+            return {
+                "status": "configured",
+                "scope": "instance",
+                "instance_id": instance_id,
+                "config": dict(validated),
+                "applied": "immediate",
+                "restart_required": False,
+            }
+
+        return {
+            "status": "configured",
+            "scope": "none",
+            "shared_config": dict(self._shared_config),
+            "applied": "none",
+            "restart_required": False,
+        }
+
+    def _start(self, args: dict[str, Any]) -> dict[str, Any]:
+        instance_id = args.get("instance_id")
+        if not isinstance(instance_id, str) or not instance_id.strip():
+            raise ValueError("instance_id is required for start")
+        instance_id = instance_id.strip()
+        input_topics = args.get("input_topics")
+        if input_topics is not None:
+            if args.get("image_topic") is not None or args.get("state_topic") is not None:
+                raise ValueError("input_topics cannot be combined with image_topic or state_topic")
+            if not isinstance(input_topics, list) or len(input_topics) != 2:
+                raise ValueError("input_topics must be [image_topic, state_topic]")
+            image_topic = _validate_topic(input_topics[0], "input_topics[0]")
+            state_topic = _validate_topic(input_topics[1], "input_topics[1]")
+        else:
+            image_topic = _validate_topic(args.get("image_topic"), "image_topic")
+            state_topic = _validate_topic(args.get("state_topic"), "state_topic")
+        output_value = args.get("output_topic")
+        output_topic = (
+            _validate_topic(output_value, "output_topic")
+            if output_value is not None and str(output_value).strip()
+            else f"{image_topic.rstrip('/')}/{self.PREFIX}"
+        )
+        if len({image_topic, state_topic, output_topic}) != 3:
+            raise ValueError("image_topic, state_topic and output_topic must be distinct")
+
+        existing = self._instances.get(instance_id)
+        if existing is not None:
+            if (
+                existing.image_topic != image_topic
+                or existing.state_topic != state_topic
+                or existing.output_topic != output_topic
+            ):
+                raise ValueError("instance is already running with different topics; stop it first")
+            return existing.status()
+
+        from .node import VLAPi05G1Node
+
+        node = VLAPi05G1Node(
+            image_topic=image_topic,
+            state_topic=state_topic,
+            output_topic=output_topic,
+            instance_id=instance_id,
+            shared_config=self._shared_config,
+            instance_config=self._instance_config(instance_id),
+        )
+        try:
+            added = self._executor.add_node(node)
+            if added is False:
+                raise RuntimeError("executor rejected vlapi05g1 node")
+        except Exception:
+            node.shutdown_card()
+            node.destroy_node()
+            raise
+        self._instances[instance_id] = node
+        return node.status()
+
+    def _stop(self, args: dict[str, Any]) -> dict[str, Any]:
+        instance_id = args.get("instance_id")
+        if not isinstance(instance_id, str) or not instance_id.strip():
+            raise ValueError("instance_id is required for stop")
+        instance_id = instance_id.strip()
+        node = self._instances.pop(instance_id, None)
+        if node is not None:
+            try:
+                node.shutdown_card()
+            finally:
+                try:
+                    self._executor.remove_node(node)
+                finally:
+                    node.destroy_node()
+        return {
+            "name": "π0.5 G1 VLA 推理",
+            "state": "idle",
+            "instance_id": instance_id,
+            "topic_in": [],
+            "topic_out": [],
+        }
+
+    def _predict(self, args: dict[str, Any]) -> dict[str, Any]:
+        instance_id = args.get("instance_id")
+        if not isinstance(instance_id, str) or not instance_id.strip():
+            raise ValueError("instance_id is required for predict")
+        instance_id = instance_id.strip()
+        with self._lifecycle_lock:
+            node = self._instances.get(instance_id)
+        if node is None:
+            return CardError("not_running", f"instance {instance_id} is not running").as_result()
+        try:
+            return node.predict(task=args.get("task"), seed=args.get("seed"))
+        except CardError as exc:
+            return exc.as_result()

--- a/perception/plugins/vlapi05g1/policy.py
+++ b/perception/plugins/vlapi05g1/policy.py
@@ -1,0 +1,262 @@
+from __future__ import annotations
+
+import base64
+import json
+import math
+import socket
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from typing import Any
+from urllib.parse import urlparse
+
+
+STATE_DIM = 29
+ACTION_DIM = 18
+ACTION_STEPS = 50
+ACTION_SHAPE = [1, ACTION_STEPS, ACTION_DIM]
+ACTION_SPACE = "physical_quantile_unnormalized"
+NUM_INFERENCE_STEPS = 10
+FREQUENCY_HZ = 30
+DEFAULT_TASK = "move blue box back and forth between tables"
+
+
+class CardError(RuntimeError):
+    def __init__(self, code: str, message: str):
+        super().__init__(message)
+        self.code = code
+        self.message = message
+
+    def as_result(self) -> dict[str, Any]:
+        return {"status": "error", "error_code": self.code, "message": self.message}
+
+
+@dataclass(frozen=True)
+class ObservationSnapshot:
+    image_bytes: bytes
+    image_topic: str
+    image_frame_id: str
+    image_stamp: float
+    image_stamp_source: str
+    image_received_at: float
+    image_age_at_request_s: float
+    state: tuple[float, ...]
+    state_topic: str
+    state_received_at: float
+    state_age_at_request_s: float
+
+
+def _finite_number(value: Any, name: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise CardError("policy_contract_error", f"{name} must be a number")
+    number = float(value)
+    if not math.isfinite(number):
+        raise CardError("policy_contract_error", f"{name} must be finite")
+    return number
+
+
+def validate_http_url(value: Any, name: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{name} must be a non-empty string")
+    url = value.strip()
+    parsed = urlparse(url)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise ValueError(f"{name} must be an absolute http:// or https:// URL")
+    return url
+
+
+def derive_health_url(policy_url: str) -> str:
+    parsed = urlparse(policy_url)
+    return parsed._replace(path="/health", params="", query="", fragment="").geturl()
+
+
+def validate_task(value: Any) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError("task must be a non-empty string")
+    return value.strip()
+
+
+def validate_seed(value: Any) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or not 0 <= value <= 2**31 - 1:
+        raise ValueError("seed must be an integer within 0..2147483647")
+    return value
+
+
+def validate_jpeg(image_bytes: bytes, max_image_bytes: int) -> bytes:
+    if not isinstance(image_bytes, bytes):
+        image_bytes = bytes(image_bytes)
+    if not image_bytes:
+        raise CardError("invalid_image", "JPEG payload is empty")
+    if len(image_bytes) > max_image_bytes:
+        raise CardError(
+            "invalid_image",
+            f"JPEG payload exceeds max_image_bytes={max_image_bytes}",
+        )
+    if len(image_bytes) < 4 or not image_bytes.startswith(b"\xff\xd8") or not image_bytes.endswith(b"\xff\xd9"):
+        raise CardError("invalid_image", "payload is not a complete JPEG byte stream")
+    return image_bytes
+
+
+def parse_state_message(text: str) -> list[float]:
+    try:
+        payload = json.loads(text)
+    except (TypeError, json.JSONDecodeError) as exc:
+        raise CardError("invalid_state", "state message must be valid JSON") from exc
+    if not isinstance(payload, dict) or not isinstance(payload.get("joints"), list):
+        raise CardError("invalid_state", "state message must contain a joints array")
+
+    by_index: dict[int, float] = {}
+    for position, item in enumerate(payload["joints"]):
+        if not isinstance(item, dict) or "idx" not in item or "q" not in item:
+            raise CardError("invalid_state", f"joints[{position}] must contain idx and q")
+        idx = item["idx"]
+        if isinstance(idx, bool) or not isinstance(idx, int):
+            raise CardError("invalid_state", f"joints[{position}].idx must be an integer")
+        if idx in by_index:
+            raise CardError("invalid_state", f"duplicate joint index: {idx}")
+        try:
+            q = _finite_number(item["q"], f"joints[{position}].q")
+        except CardError as exc:
+            raise CardError("invalid_state", exc.message) from exc
+        by_index[idx] = q
+
+    missing = [idx for idx in range(STATE_DIM) if idx not in by_index]
+    if missing:
+        raise CardError("invalid_state", f"state is missing joint indices: {missing}")
+    return [by_index[idx] for idx in range(STATE_DIM)]
+
+
+def build_policy_payload(snapshot: ObservationSnapshot, task: str, seed: int) -> dict[str, Any]:
+    return {
+        "image_base64": base64.b64encode(snapshot.image_bytes).decode("ascii"),
+        "state": list(snapshot.state),
+        "task": validate_task(task),
+        "seed": validate_seed(seed),
+    }
+
+
+def validate_policy_response(payload: Any, expected_seed: int) -> dict[str, Any]:
+    if not isinstance(payload, dict):
+        raise CardError("policy_contract_error", "policy response must be a JSON object")
+    if payload.get("ok") is not True:
+        message = payload.get("message") or payload.get("error") or "policy returned ok != true"
+        raise CardError("policy_rejected", str(message))
+    if payload.get("action_shape") != ACTION_SHAPE:
+        raise CardError("policy_contract_error", f"action_shape must be {ACTION_SHAPE}")
+    if payload.get("action_space") != ACTION_SPACE:
+        raise CardError("policy_contract_error", f"action_space must be {ACTION_SPACE}")
+    if payload.get("fresh_inference_per_request") is not True:
+        raise CardError("policy_contract_error", "fresh_inference_per_request must be true")
+    if payload.get("num_inference_steps") != NUM_INFERENCE_STEPS:
+        raise CardError(
+            "policy_contract_error",
+            f"num_inference_steps must be {NUM_INFERENCE_STEPS}",
+        )
+    if payload.get("seed") != expected_seed:
+        raise CardError("policy_contract_error", "response seed does not match request seed")
+
+    raw_chunk = payload.get("action_chunk")
+    if not isinstance(raw_chunk, list) or len(raw_chunk) != ACTION_STEPS:
+        raise CardError("policy_contract_error", f"action_chunk must contain {ACTION_STEPS} rows")
+    chunk: list[list[float]] = []
+    for row_index, raw_row in enumerate(raw_chunk):
+        if not isinstance(raw_row, list) or len(raw_row) != ACTION_DIM:
+            raise CardError(
+                "policy_contract_error",
+                f"action_chunk[{row_index}] must contain {ACTION_DIM} values",
+            )
+        chunk.append(
+            [
+                _finite_number(value, f"action_chunk[{row_index}][{column_index}]")
+                for column_index, value in enumerate(raw_row)
+            ]
+        )
+
+    infer_seconds = _finite_number(payload.get("infer_seconds"), "infer_seconds")
+    if infer_seconds < 0:
+        raise CardError("policy_contract_error", "infer_seconds must be non-negative")
+    return {"action_chunk": chunk, "policy_infer_seconds": infer_seconds}
+
+
+def build_action_proposal(
+    *,
+    request_id: str,
+    created_at: float,
+    snapshot: ObservationSnapshot,
+    task: str,
+    seed: int,
+    validated_response: dict[str, Any],
+    card_elapsed_seconds: float,
+) -> dict[str, Any]:
+    return {
+        "schema": "pi05.g1.action_chunk.v1",
+        "request_id": request_id,
+        "created_at": created_at,
+        "observation": {
+            "image_topic": snapshot.image_topic,
+            "image_frame_id": snapshot.image_frame_id,
+            "image_stamp": snapshot.image_stamp,
+            "image_stamp_source": snapshot.image_stamp_source,
+            "image_received_at": snapshot.image_received_at,
+            "image_age_at_request_s": snapshot.image_age_at_request_s,
+            "state_topic": snapshot.state_topic,
+            "state_received_at": snapshot.state_received_at,
+            "state_age_at_request_s": snapshot.state_age_at_request_s,
+            "state": list(snapshot.state),
+        },
+        "task": task,
+        "action_space": ACTION_SPACE,
+        "frequency_hz": FREQUENCY_HZ,
+        "action_shape": list(ACTION_SHAPE),
+        "action_chunk": validated_response["action_chunk"],
+        "fresh_inference_per_request": True,
+        "num_inference_steps": NUM_INFERENCE_STEPS,
+        "seed": seed,
+        "policy_infer_seconds": validated_response["policy_infer_seconds"],
+        "card_elapsed_seconds": card_elapsed_seconds,
+        "execution_authorized": False,
+    }
+
+
+class PolicyClient:
+    def __init__(self, policy_url: str, timeout_s: float, health_url: str | None = None):
+        self.policy_url = validate_http_url(policy_url, "policy_url")
+        self.health_url = validate_http_url(
+            health_url or derive_health_url(self.policy_url),
+            "health_url",
+        )
+        self.timeout_s = float(timeout_s)
+        self._opener = urllib.request.build_opener(urllib.request.ProxyHandler({}))
+
+    def _request_json(self, request: urllib.request.Request) -> Any:
+        try:
+            with self._opener.open(request, timeout=self.timeout_s) as response:
+                raw = response.read()
+        except urllib.error.HTTPError as exc:
+            detail = exc.read().decode("utf-8", errors="replace").strip()
+            raise CardError("policy_rejected", f"policy HTTP {exc.code}: {detail}") from exc
+        except (urllib.error.URLError, TimeoutError, socket.timeout) as exc:
+            reason = getattr(exc, "reason", exc)
+            raise CardError("policy_unreachable", f"policy request failed: {reason}") from exc
+        try:
+            decoded = json.loads(raw.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise CardError("policy_contract_error", "policy response is not valid JSON") from exc
+        return decoded
+
+    def health(self) -> dict[str, Any]:
+        decoded = self._request_json(
+            urllib.request.Request(self.health_url, method="GET")
+        )
+        if not isinstance(decoded, dict):
+            raise CardError("policy_contract_error", "policy health response must be a JSON object")
+        return decoded
+
+    def predict(self, payload: dict[str, Any]) -> dict[str, Any]:
+        request = urllib.request.Request(
+            self.policy_url,
+            data=json.dumps(payload, separators=(",", ":")).encode("utf-8"),
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        return self._request_json(request)

--- a/perception/plugins/vlapi05g1/tests/core_gate_f.py
+++ b/perception/plugins/vlapi05g1/tests/core_gate_f.py
@@ -1,0 +1,339 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shlex
+import ssl
+import subprocess
+import time
+import urllib.error
+import urllib.request
+
+
+class HttpClient:
+    def __init__(self, core_url: str, mcp_url: str, server_name: str):
+        self.core_url = core_url.rstrip("/")
+        self.mcp_url = mcp_url
+        self.server_name = server_name
+        context = ssl.create_default_context()
+        context.check_hostname = False
+        context.verify_mode = ssl.CERT_NONE
+        self.core_opener = urllib.request.build_opener(
+            urllib.request.ProxyHandler({}),
+            urllib.request.HTTPSHandler(context=context),
+        )
+        self.mcp_opener = urllib.request.build_opener(urllib.request.ProxyHandler({}))
+        self.mcp_id = ""
+        self.request_id = 0
+
+    def core_request(self, method: str, path: str, body=None) -> dict:
+        data = None if body is None else json.dumps(body).encode("utf-8")
+        request = urllib.request.Request(
+            self.core_url + path,
+            data=data,
+            headers={"Content-Type": "application/json"},
+            method=method,
+        )
+        with self.core_opener.open(request, timeout=30.0) as response:
+            return json.loads(response.read())
+
+    def wait_for_unique_registration(self, timeout_s: float = 20.0) -> dict:
+        deadline = time.monotonic() + timeout_s
+        matches = []
+        while time.monotonic() < deadline:
+            items = self.core_request("GET", "/api/mcp")["data"]
+            matches = [item for item in items if item.get("server_name") == self.server_name]
+            if len(matches) == 1 and matches[0].get("tools"):
+                self.mcp_id = matches[0]["id"]
+                return matches[0]
+            time.sleep(0.5)
+        raise RuntimeError(f"expected one Core registration, got {len(matches)}")
+
+    def save_config(self, request_timeout_s: float) -> None:
+        response = self.core_request(
+            "PUT",
+            f"/api/canvas/tool-config/{self.mcp_id}/vlapi05g1",
+            {
+                "policy_url": "http://127.0.0.1:18080/predict",
+                "health_url": "",
+                "request_timeout_s": request_timeout_s,
+                "max_image_bytes": 8388608,
+            },
+        )
+        if response.get("code") != 200:
+            raise RuntimeError(f"Core config save failed: {response}")
+
+    def core_call(self, arguments: dict) -> dict:
+        response = self.core_request(
+            "POST",
+            f"/api/mcp/{self.mcp_id}/call",
+            {"tool": "vlapi05g1", "arguments": arguments},
+        )
+        if response.get("code") != 200:
+            raise RuntimeError(f"Core tool call failed: {response}")
+        return json.loads(response["data"][0]["text"])
+
+    def direct_rpc(self, method: str, params=None) -> dict:
+        self.request_id += 1
+        request = urllib.request.Request(
+            self.mcp_url,
+            data=json.dumps(
+                {
+                    "jsonrpc": "2.0",
+                    "id": self.request_id,
+                    "method": method,
+                    "params": params or {},
+                }
+            ).encode("utf-8"),
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with self.mcp_opener.open(request, timeout=10.0) as response:
+            return json.loads(response.read())
+
+    def direct_call(self, arguments: dict) -> dict:
+        response = self.direct_rpc(
+            "tools/call", {"name": "vlapi05g1", "arguments": arguments}
+        )
+        if "error" in response:
+            raise RuntimeError(f"direct MCP call failed: {response}")
+        return json.loads(response["result"]["content"][0]["text"])
+
+    def wait_for_direct_initialize(self, timeout_s: float = 20.0) -> dict:
+        deadline = time.monotonic() + timeout_s
+        last_error = None
+        while time.monotonic() < deadline:
+            try:
+                return self.direct_rpc("initialize")
+            except urllib.error.URLError as exc:
+                last_error = exc
+                time.sleep(0.5)
+        raise RuntimeError(f"direct MCP did not become ready: {last_error}")
+
+    def wait_for_actual_timeout(self, expected: float, timeout_s: float = 10.0) -> dict:
+        deadline = time.monotonic() + timeout_s
+        last_info = None
+        while time.monotonic() < deadline:
+            last_info = self.direct_call({"action": "info"})
+            if last_info["shared_config"]["request_timeout_s"] == expected:
+                return last_info
+            time.sleep(0.2)
+        raise RuntimeError(
+            f"card request_timeout_s did not become {expected}: {last_info}"
+        )
+
+
+def run(*command: str) -> str:
+    return subprocess.check_output(command, text=True, stderr=subprocess.STDOUT).strip()
+
+
+def container_resource_sample(card_container: str, policy_container: str) -> dict:
+    card_pid = int(run("docker", "inspect", "-f", "{{.State.Pid}}", card_container))
+    status_text = open(f"/proc/{card_pid}/status", encoding="utf-8").read()
+    status = {}
+    for key in ("Threads", "VmRSS"):
+        match = re.search(rf"^{key}:\s+(\d+)", status_text, re.MULTILINE)
+        if match is None:
+            raise RuntimeError(f"missing {key} in /proc/{card_pid}/status")
+        status[key] = int(match.group(1))
+
+    process_lines = run("docker", "top", card_container, "-eo", "pid,comm").splitlines()
+    graph_script = """
+import time
+import rclpy
+from rclpy.node import Node
+rclpy.init()
+node = Node("vlapi05g1_gate_f_graph_probe")
+deadline = time.monotonic() + 0.5
+while time.monotonic() < deadline:
+    rclpy.spin_once(node, timeout_sec=0.05)
+print("\\n".join(sorted(node.get_node_names())))
+node.destroy_node()
+rclpy.shutdown()
+"""
+    ros_nodes = run(
+        "docker",
+        "exec",
+        card_container,
+        "bash",
+        "-lc",
+        "source /opt/ros/humble/setup.bash && python3 -c " + shlex.quote(graph_script),
+    ).splitlines()
+    policy_pid = int(run("docker", "inspect", "-f", "{{.State.Pid}}", policy_container))
+    gpu_rows = run(
+        "nvidia-smi",
+        "--query-compute-apps=pid,used_memory",
+        "--format=csv,noheader,nounits",
+    ).splitlines()
+    policy_gpu_memory_mib = None
+    for row in gpu_rows:
+        columns = [column.strip() for column in row.split(",")]
+        if len(columns) == 2 and columns[0] == str(policy_pid):
+            policy_gpu_memory_mib = int(columns[1])
+            break
+    device_requests = json.loads(
+        run("docker", "inspect", "-f", "{{json .HostConfig.DeviceRequests}}", card_container)
+    )
+    return {
+        "card_pid": card_pid,
+        "card_threads": status["Threads"],
+        "card_rss_kib": status["VmRSS"],
+        "card_process_count": max(0, len(process_lines) - 1),
+        "vlapi05g1_ros_nodes": sorted(
+            name for name in ros_nodes if name.startswith("/vlapi05g1_")
+        ),
+        "card_gpu_device_requests": device_requests,
+        "policy_pid": policy_pid,
+        "policy_gpu_memory_mib": policy_gpu_memory_mib,
+    }
+
+
+def assert_logs_redacted(card_container: str) -> dict:
+    logs = run("docker", "logs", "--since", "30m", card_container)
+    patterns = {
+        "credential_value": re.compile(
+            r"authorization[ \t]*[:=][ \t]*[\"']?(?:bearer[ \t]+)?[a-z0-9._~+/=-]{8,}"
+            r"|bearer[ \t]+[a-z0-9._~+/=-]{8,}"
+            r"|api[_-]?key[ \t]*[:=][ \t]*[\"']?[a-z0-9._~+/=-]{8,}"
+            r"|x-execution-token[ \t]*[:=][ \t]*[\"']?[a-z0-9._~+/=-]{8,}",
+            re.IGNORECASE,
+        ),
+        "image_base64": re.compile(
+            r"image_base64.{0,80}[A-Za-z0-9+/]{80}", re.IGNORECASE | re.DOTALL
+        ),
+        "action_chunk": re.compile(r'"action_chunk"\s*:'),
+    }
+    hits = {name: bool(pattern.search(logs)) for name, pattern in patterns.items()}
+    if any(hits.values()):
+        raise AssertionError(f"sensitive or oversized payload found in logs: {hits}")
+    return {"checked_bytes": len(logs.encode("utf-8")), "pattern_hits": hits}
+
+
+def stop_test_ros_daemon(card_container: str) -> None:
+    subprocess.run(
+        [
+            "docker",
+            "exec",
+            card_container,
+            "bash",
+            "-lc",
+            "source /opt/ros/humble/setup.bash && ros2 daemon stop",
+        ],
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run vlapi05g1 Core restart/resource Gate F")
+    parser.add_argument("--core-url", default="https://127.0.0.1:15678")
+    parser.add_argument("--mcp-url", default="http://127.0.0.1:15735/mcp")
+    parser.add_argument("--server-name", required=True)
+    parser.add_argument("--card-container", required=True)
+    parser.add_argument("--policy-container", default="pi05-g1-policy")
+    args = parser.parse_args()
+
+    client = HttpClient(args.core_url, args.mcp_url, args.server_name)
+    first_registration = client.wait_for_unique_registration()
+    original_mcp_id = first_registration["id"]
+    client.save_config(121.0)
+    run("docker", "restart", args.card_container)
+    initialize = client.wait_for_direct_initialize()
+    restarted_registration = client.wait_for_unique_registration()
+    if initialize["result"]["serverInfo"]["name"] != args.server_name:
+        raise AssertionError("MCP identity changed after restart")
+    before_lazy = client.direct_call({"action": "info"})
+    if before_lazy["shared_config"]["request_timeout_s"] != 120.0:
+        raise AssertionError(f"unexpected startup config: {before_lazy['shared_config']}")
+
+    lazy_result = client.core_call(
+        {"action": "predict", "instance_id": "stage6-gate-f-lazy-config"}
+    )
+    if lazy_result.get("error_code") != "not_running":
+        raise AssertionError(f"unexpected lazy replay business result: {lazy_result}")
+    after_lazy = client.direct_call({"action": "info"})
+    if after_lazy["shared_config"]["request_timeout_s"] != 121.0:
+        raise AssertionError(f"Core saved config was not replayed: {after_lazy['shared_config']}")
+    client.save_config(120.0)
+    restored = client.wait_for_actual_timeout(120.0)
+
+    stop_test_ros_daemon(args.card_container)
+    instance_id = "stage6-gate-f-cycle"
+
+    def run_cycle(label: str) -> None:
+        started = client.core_call(
+            {
+                "action": "start",
+                "instance_id": instance_id,
+                "input_topics": [
+                    "/stage6/gate_f/cycle/camera/compressed",
+                    "/stage6/gate_f/cycle/g1/joints",
+                ],
+            }
+        )
+        if started.get("state") != "running":
+            raise AssertionError(f"{label} start failed: {started}")
+        stopped = client.core_call({"action": "stop", "instance_id": instance_id})
+        if stopped.get("state") != "idle":
+            raise AssertionError(f"{label} stop failed: {stopped}")
+        direct_info = client.direct_call({"action": "info"})
+        if direct_info.get("instances"):
+            raise AssertionError(f"{label} left registered instances")
+
+    run_cycle("warm-up cycle")
+    time.sleep(1.0)
+    baseline = container_resource_sample(args.card_container, args.policy_container)
+    for index in range(10):
+        run_cycle(f"cycle {index + 1}")
+
+    time.sleep(2.0)
+    final = container_resource_sample(args.card_container, args.policy_container)
+    if final["card_process_count"] != baseline["card_process_count"]:
+        raise AssertionError("card process count changed across 10 cycles")
+    if final["card_threads"] > baseline["card_threads"] + 1:
+        raise AssertionError("card threads leaked across 10 cycles")
+    if final["card_rss_kib"] > baseline["card_rss_kib"] + 8192:
+        raise AssertionError(
+            "card RSS grew by more than 8 MiB across 10 stable-state cycles: "
+            f"{baseline['card_rss_kib']} -> {final['card_rss_kib']} KiB"
+        )
+    if final["vlapi05g1_ros_nodes"]:
+        raise AssertionError("vlapi05g1 ROS nodes remain after 10 cycles")
+    if final["card_gpu_device_requests"]:
+        raise AssertionError("card container unexpectedly requests a GPU")
+    if final["policy_pid"] != baseline["policy_pid"]:
+        raise AssertionError("external policy process restarted during card lifecycle test")
+    if final["policy_gpu_memory_mib"] != baseline["policy_gpu_memory_mib"]:
+        raise AssertionError("external policy GPU memory changed during card lifecycle test")
+    log_result = assert_logs_redacted(args.card_container)
+
+    print(
+        json.dumps(
+            {
+                "status": "PASS",
+                "mcp_id_before_restart": original_mcp_id,
+                "mcp_id_after_restart": restarted_registration["id"],
+                "registration_count_after_restart": 1,
+                "startup_request_timeout_s": before_lazy["shared_config"]["request_timeout_s"],
+                "lazy_business_result": lazy_result["error_code"],
+                "replayed_request_timeout_s": after_lazy["shared_config"]["request_timeout_s"],
+                "restored_request_timeout_s": restored["shared_config"]["request_timeout_s"],
+                "lifecycle_warmup_cycles": 1,
+                "lifecycle_cycles": 10,
+                "resource_baseline": baseline,
+                "resource_final": final,
+                "logs": log_result,
+            },
+            ensure_ascii=False,
+            indent=2,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/perception/plugins/vlapi05g1/tests/replay_gate_c.py
+++ b/perception/plugins/vlapi05g1/tests/replay_gate_c.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import resource
+import statistics
+import sys
+import time
+from pathlib import Path
+
+
+CARD_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(CARD_DIR.parent))
+
+from vlapi05g1.policy import (
+    ACTION_DIM,
+    ACTION_SHAPE,
+    ACTION_SPACE,
+    ACTION_STEPS,
+    NUM_INFERENCE_STEPS,
+    ObservationSnapshot,
+    PolicyClient,
+    build_action_proposal,
+    build_policy_payload,
+    derive_health_url,
+    validate_jpeg,
+    validate_policy_response,
+)
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def percentile(values: list[float], percent: float) -> float:
+    ordered = sorted(values)
+    if len(ordered) == 1:
+        return ordered[0]
+    position = (len(ordered) - 1) * percent / 100.0
+    lower = math.floor(position)
+    upper = math.ceil(position)
+    if lower == upper:
+        return ordered[lower]
+    weight = position - lower
+    return ordered[lower] * (1.0 - weight) + ordered[upper] * weight
+
+
+def process_cpu_seconds() -> float:
+    usage = resource.getrusage(resource.RUSAGE_SELF)
+    return usage.ru_utime + usage.ru_stime
+
+
+def process_max_rss_bytes() -> int:
+    value = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+    return int(value if sys.platform == "darwin" else value * 1024)
+
+
+def load_state(path: Path) -> tuple[float, ...]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, list) or len(payload) != 29:
+        raise ValueError("recorded state must be a 29-value JSON array")
+    state = []
+    for index, value in enumerate(payload):
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise ValueError(f"state[{index}] must be numeric")
+        number = float(value)
+        if not math.isfinite(number):
+            raise ValueError(f"state[{index}] must be finite")
+        state.append(number)
+    return tuple(state)
+
+
+def action_hash(action_chunk: list[list[float]]) -> str:
+    encoded = json.dumps(action_chunk, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def max_abs_difference(
+    baseline: list[list[float]],
+    candidate: list[list[float]],
+) -> float:
+    return max(
+        abs(baseline[row][column] - candidate[row][column])
+        for row in range(ACTION_STEPS)
+        for column in range(ACTION_DIM)
+    )
+
+
+def validate_health(payload: dict) -> None:
+    expected = {
+        "ok": True,
+        "action_dim": ACTION_DIM,
+        "action_chunk_size": ACTION_STEPS,
+        "action_space": ACTION_SPACE,
+        "fresh_inference_per_request": True,
+        "num_inference_steps": NUM_INFERENCE_STEPS,
+        "task_text_supported": True,
+        "tokenizer_loaded": True,
+        "allow_zero_observation": False,
+    }
+    mismatches = {
+        key: {"expected": value, "actual": payload.get(key)}
+        for key, value in expected.items()
+        if payload.get(key) != value
+    }
+    if mismatches:
+        raise ValueError(f"policy health contract mismatch: {mismatches}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run vlapi05g1 recorded-data Gate C")
+    parser.add_argument("--policy-url", required=True)
+    parser.add_argument("--health-url")
+    parser.add_argument("--image", required=True, type=Path)
+    parser.add_argument("--state", required=True, type=Path)
+    parser.add_argument("--task", required=True)
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--runs", type=int, default=3)
+    parser.add_argument("--timeout-s", type=float, default=120.0)
+    parser.add_argument("--revision", required=True)
+    parser.add_argument("--output", required=True, type=Path)
+    args = parser.parse_args()
+
+    if args.runs < 3:
+        raise ValueError("Gate C requires at least three runs")
+    image_path = args.image.resolve()
+    state_path = args.state.resolve()
+    image_bytes = validate_jpeg(image_path.read_bytes(), 16 * 1024 * 1024)
+    state = load_state(state_path)
+    health_url = args.health_url or derive_health_url(args.policy_url)
+    client = PolicyClient(args.policy_url, args.timeout_s, health_url)
+    health = client.health()
+    validate_health(health)
+
+    snapshot = ObservationSnapshot(
+        image_bytes=image_bytes,
+        image_topic="recorded://g1-fixed-frame.jpg",
+        image_frame_id="recorded_g1_front_camera",
+        image_stamp=image_path.stat().st_mtime,
+        image_stamp_source="recorded_file_mtime",
+        image_received_at=time.time(),
+        image_age_at_request_s=0.0,
+        state=state,
+        state_topic="recorded://g1-real-runtime-v2-step10.state.json",
+        state_received_at=time.time(),
+        state_age_at_request_s=0.0,
+    )
+    request = build_policy_payload(snapshot, args.task, args.seed)
+
+    runs = []
+    chunks: list[list[list[float]]] = []
+    total_started = time.monotonic()
+    cpu_started = process_cpu_seconds()
+    for index in range(args.runs):
+        started = time.monotonic()
+        response = client.predict(request)
+        validated = validate_policy_response(response, args.seed)
+        elapsed = time.monotonic() - started
+        proposal = build_action_proposal(
+            request_id=f"vlapi05g1-gate-c-{index + 1:03d}",
+            created_at=time.time(),
+            snapshot=snapshot,
+            task=args.task,
+            seed=args.seed,
+            validated_response=validated,
+            card_elapsed_seconds=elapsed,
+        )
+        if proposal["execution_authorized"] is not False:
+            raise ValueError("Gate C proposal unexpectedly authorizes execution")
+        json.dumps(proposal)
+        chunk = validated["action_chunk"]
+        chunks.append(chunk)
+        runs.append(
+            {
+                "run": index + 1,
+                "action_sha256": action_hash(chunk),
+                "end_to_end_seconds": elapsed,
+                "policy_infer_seconds": validated["policy_infer_seconds"],
+                "cuda_max_memory_allocated": response.get("cuda_max_memory_allocated"),
+            }
+        )
+    total_elapsed = time.monotonic() - total_started
+    cpu_elapsed = process_cpu_seconds() - cpu_started
+
+    differences = [max_abs_difference(chunks[0], chunk) for chunk in chunks[1:]]
+    max_difference = max(differences, default=0.0)
+    action_hashes = [run["action_sha256"] for run in runs]
+    if max_difference != 0.0 or len(set(action_hashes)) != 1:
+        raise ValueError(
+            f"determinism gate failed: max_abs_difference={max_difference}, hashes={action_hashes}"
+        )
+
+    end_to_end = [run["end_to_end_seconds"] for run in runs]
+    policy_times = [run["policy_infer_seconds"] for run in runs]
+    cuda_peaks = [
+        run["cuda_max_memory_allocated"]
+        for run in runs
+        if isinstance(run["cuda_max_memory_allocated"], int)
+    ]
+    report = {
+        "status": "PASS",
+        "gate": "C",
+        "recorded_at": time.time(),
+        "model": "xiaopeng-wu/pi05_unitree_g1",
+        "revision": args.revision,
+        "policy_url": args.policy_url,
+        "health_url": health_url,
+        "health": health,
+        "source": {
+            "image_path": str(image_path),
+            "image_format": "JPEG 1920x1080 RGB",
+            "image_bytes": len(image_bytes),
+            "image_sha256": sha256_file(image_path),
+            "state_path": str(state_path),
+            "state_format": "JSON array of 29 finite joint positions",
+            "state_sha256": sha256_file(state_path),
+            "task": args.task,
+            "seed": args.seed,
+        },
+        "expected": {
+            "action_shape": ACTION_SHAPE,
+            "action_space": ACTION_SPACE,
+            "fresh_inference_per_request": True,
+            "num_inference_steps": NUM_INFERENCE_STEPS,
+            "execution_authorized": False,
+            "determinism_tolerance": 0.0,
+        },
+        "runs": runs,
+        "determinism": {
+            "action_sha256": action_hashes[0],
+            "max_abs_difference": max_difference,
+            "strict_equal": True,
+        },
+        "performance": {
+            "end_to_end_p50_seconds": statistics.median(end_to_end),
+            "end_to_end_p95_seconds": percentile(end_to_end, 95.0),
+            "policy_p50_seconds": statistics.median(policy_times),
+            "policy_p95_seconds": percentile(policy_times, 95.0),
+            "throughput_requests_per_second": args.runs / total_elapsed,
+            "client_cpu_seconds": cpu_elapsed,
+            "client_cpu_percent_one_core": cpu_elapsed / total_elapsed * 100.0,
+            "client_max_rss_bytes": process_max_rss_bytes(),
+            "policy_cuda_peak_bytes": max(cuda_peaks) if cuda_peaks else None,
+        },
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(
+        json.dumps(report, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    print(json.dumps(report, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/perception/plugins/vlapi05g1/tests/ros2_gate_d.py
+++ b/perception/plugins/vlapi05g1/tests/ros2_gate_d.py
@@ -1,0 +1,347 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import ssl
+import subprocess
+import sys
+import time
+import urllib.request
+from pathlib import Path
+
+import rclpy
+from rclpy.node import Node
+from rclpy.qos import DurabilityPolicy, HistoryPolicy, QoSProfile, ReliabilityPolicy
+from sensor_msgs.msg import CompressedImage
+from std_msgs.msg import String
+
+
+INPUT_QOS = QoSProfile(
+    reliability=ReliabilityPolicy.BEST_EFFORT,
+    history=HistoryPolicy.KEEP_LAST,
+    depth=1,
+    durability=DurabilityPolicy.VOLATILE,
+)
+OUTPUT_QOS = QoSProfile(
+    reliability=ReliabilityPolicy.RELIABLE,
+    history=HistoryPolicy.KEEP_LAST,
+    depth=10,
+    durability=DurabilityPolicy.VOLATILE,
+)
+
+
+class CoreClient:
+    def __init__(self, core_url: str, server_name: str):
+        self.core_url = core_url.rstrip("/")
+        self.server_name = server_name
+        context = ssl.create_default_context()
+        context.check_hostname = False
+        context.verify_mode = ssl.CERT_NONE
+        self.opener = urllib.request.build_opener(
+            urllib.request.ProxyHandler({}),
+            urllib.request.HTTPSHandler(context=context),
+        )
+        registrations = self.request("GET", "/api/mcp")["data"]
+        matches = [item for item in registrations if item.get("server_name") == server_name]
+        if len(matches) != 1:
+            raise RuntimeError(f"expected one Core registration for {server_name}, got {len(matches)}")
+        self.mcp = matches[0]
+        self.mcp_id = self.mcp["id"]
+
+    def request(self, method: str, path: str, body=None):
+        data = None if body is None else json.dumps(body).encode("utf-8")
+        request = urllib.request.Request(
+            self.core_url + path,
+            data=data,
+            headers={"Content-Type": "application/json"},
+            method=method,
+        )
+        with self.opener.open(request, timeout=30.0) as response:
+            return json.loads(response.read())
+
+    def save_shared_config(self, config: dict) -> None:
+        response = self.request(
+            "PUT",
+            f"/api/canvas/tool-config/{self.mcp_id}/vlapi05g1",
+            config,
+        )
+        if response.get("code") != 200:
+            raise RuntimeError(f"Core tool-config save failed: {response}")
+
+    def call(self, arguments: dict) -> dict:
+        response = self.request(
+            "POST",
+            f"/api/mcp/{self.mcp_id}/call",
+            {"tool": "vlapi05g1", "arguments": arguments},
+        )
+        if response.get("code") != 200:
+            raise RuntimeError(f"Core tool call failed: {response}")
+        content = response.get("data") or []
+        if not isinstance(content, list) or not content:
+            raise RuntimeError(f"Core tool call returned no content: {response}")
+        return json.loads(content[0]["text"])
+
+
+class GateDNode(Node):
+    def __init__(self, image_topic: str, state_topic: str, output_topic: str):
+        super().__init__("vlapi05g1_gate_d_replay")
+        self.outputs: list[dict] = []
+        self.image_publisher = self.create_publisher(CompressedImage, image_topic, INPUT_QOS)
+        self.state_publisher = self.create_publisher(String, state_topic, INPUT_QOS)
+        self.output_subscription = self.create_subscription(
+            String,
+            output_topic,
+            self._on_output,
+            OUTPUT_QOS,
+        )
+
+    def _on_output(self, message: String) -> None:
+        self.outputs.append(json.loads(message.data))
+
+
+def wait_until(node: Node, predicate, timeout_s: float, description: str) -> None:
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        rclpy.spin_once(node, timeout_sec=0.05)
+        if predicate():
+            return
+    raise TimeoutError(f"timed out waiting for {description}")
+
+
+def action_hash(action_chunk: list[list[float]]) -> str:
+    encoded = json.dumps(action_chunk, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run vlapi05g1 Gate D over real ROS2 topics")
+    parser.add_argument("--core-url", default="https://127.0.0.1:15678")
+    parser.add_argument("--server-name", required=True)
+    parser.add_argument("--image", required=True, type=Path)
+    parser.add_argument("--state", required=True, type=Path)
+    parser.add_argument("--output", required=True, type=Path)
+    parser.add_argument("--expected-action-sha256", required=True)
+    parser.add_argument("--instance-id", default="stage6-gate-d")
+    args = parser.parse_args()
+
+    image_bytes = args.image.read_bytes()
+    state_values = json.loads(args.state.read_text(encoding="utf-8"))
+    if not isinstance(state_values, list) or len(state_values) != 29:
+        raise ValueError("recorded state must contain 29 values")
+    state_payload = json.dumps(
+        {"joints": [{"idx": index, "q": value} for index, value in enumerate(state_values)]},
+        separators=(",", ":"),
+    )
+
+    image_topic = "/stage6/gate_d/camera/compressed"
+    state_topic = "/stage6/gate_d/g1/joints"
+    output_topic = "/stage6/gate_d/vla/action_proposal"
+    frame_id = "stage6_g1_front_camera"
+    core = CoreClient(args.core_url, args.server_name)
+    core.save_shared_config(
+        {
+            "policy_url": "http://127.0.0.1:18080/predict",
+            "health_url": "",
+            "request_timeout_s": 120.0,
+            "max_image_bytes": 8388608,
+        }
+    )
+
+    start_arguments = {
+        "action": "start",
+        "instance_id": args.instance_id,
+        "image_topic": image_topic,
+        "state_topic": state_topic,
+        "output_topic": output_topic,
+    }
+    core.call({"action": "stop", "instance_id": args.instance_id})
+    started = False
+    rclpy.init()
+    node = GateDNode(image_topic, state_topic, output_topic)
+    try:
+        started_result = core.call(start_arguments)
+        started = True
+        if started_result.get("state") != "running":
+            raise AssertionError(f"card did not start: {started_result}")
+        wait_until(
+            node,
+            lambda: node.image_publisher.get_subscription_count() >= 1
+            and node.state_publisher.get_subscription_count() >= 1
+            and node.count_publishers(output_topic) >= 1,
+            8.0,
+            "ROS2 publisher/subscriber discovery",
+        )
+
+        image_message = CompressedImage()
+        image_message.header.frame_id = frame_id
+        image_message.header.stamp = node.get_clock().now().to_msg()
+        image_message.format = "jpeg"
+        image_message.data = list(image_bytes)
+        published_image_stamp = (
+            float(image_message.header.stamp.sec)
+            + float(image_message.header.stamp.nanosec) / 1_000_000_000.0
+        )
+        state_message = String()
+        state_message.data = state_payload
+
+        for _ in range(5):
+            node.image_publisher.publish(image_message)
+            node.state_publisher.publish(state_message)
+            rclpy.spin_once(node, timeout_sec=0.08)
+
+        predict_result = core.call({"action": "predict", "instance_id": args.instance_id})
+        if predict_result.get("status") != "published":
+            raise AssertionError(f"predict did not publish: {predict_result}")
+        wait_until(node, lambda: len(node.outputs) >= 1, 8.0, "action proposal output")
+        if len(node.outputs) != 1:
+            raise AssertionError(f"expected one action proposal, got {len(node.outputs)}")
+        proposal = node.outputs[0]
+
+        if proposal.get("request_id") != predict_result.get("request_id"):
+            raise AssertionError("MCP result and ROS output request_id differ")
+        if proposal.get("schema") != "pi05.g1.action_chunk.v1":
+            raise AssertionError(f"unexpected proposal schema: {proposal.get('schema')}")
+        observation = proposal.get("observation") or {}
+        expected_observation = {
+            "image_topic": image_topic,
+            "image_frame_id": frame_id,
+            "image_stamp_source": "header",
+            "state_topic": state_topic,
+            "state": state_values,
+        }
+        for key, expected in expected_observation.items():
+            if observation.get(key) != expected:
+                raise AssertionError(f"observation.{key} mismatch")
+        if abs(float(observation["image_stamp"]) - published_image_stamp) > 1e-9:
+            raise AssertionError("image header stamp was not preserved")
+        image_received_at = float(observation["image_received_at"])
+        state_received_at = float(observation["state_received_at"])
+        created_at = float(proposal["created_at"])
+        if image_received_at <= 0.0 or state_received_at <= 0.0 or created_at <= 0.0:
+            raise AssertionError("proposal timestamps must be positive")
+        if created_at < max(image_received_at, state_received_at):
+            raise AssertionError("proposal created_at predates the cached observation")
+        if not 0.0 <= float(observation["image_age_at_request_s"]) <= 1.0:
+            raise AssertionError("image age is outside configured freshness window")
+        if not 0.0 <= float(observation["state_age_at_request_s"]) <= 0.5:
+            raise AssertionError("state age is outside configured freshness window")
+        if proposal.get("action_shape") != [1, 50, 18]:
+            raise AssertionError(f"unexpected action shape: {proposal.get('action_shape')}")
+        if proposal.get("action_space") != "physical_quantile_unnormalized":
+            raise AssertionError("unexpected action space")
+        if proposal.get("execution_authorized") is not False:
+            raise AssertionError("proposal unexpectedly authorizes execution")
+        actual_action_hash = action_hash(proposal["action_chunk"])
+        if actual_action_hash != args.expected_action_sha256:
+            raise AssertionError(
+                f"action hash mismatch: expected {args.expected_action_sha256}, got {actual_action_hash}"
+            )
+        if "confidence" in proposal:
+            raise AssertionError("policy does not define confidence; card must not invent one")
+
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(
+            json.dumps(proposal, ensure_ascii=False, indent=2) + "\n",
+            encoding="utf-8",
+        )
+
+        output_count_before_stale = len(node.outputs)
+        stale_deadline = time.monotonic() + 1.2
+        while time.monotonic() < stale_deadline:
+            rclpy.spin_once(node, timeout_sec=0.05)
+        stale_result = core.call({"action": "predict", "instance_id": args.instance_id})
+        if stale_result.get("error_code") != "observation_stale":
+            raise AssertionError(f"stale observation was not rejected: {stale_result}")
+        stale_output_deadline = time.monotonic() + 0.8
+        while time.monotonic() < stale_output_deadline:
+            rclpy.spin_once(node, timeout_sec=0.05)
+        if len(node.outputs) != output_count_before_stale:
+            raise AssertionError("stale predict unexpectedly published another proposal")
+
+        invalid_state = String()
+        invalid_state.data = "{invalid-json"
+        node.state_publisher.publish(invalid_state)
+        time.sleep(0.2)
+        invalid_state_info = core.call({"action": "info", "instance_id": args.instance_id})
+        if (invalid_state_info.get("last_error") or {}).get("error_code") != "invalid_state":
+            raise AssertionError(f"invalid state did not produce invalid_state: {invalid_state_info}")
+
+        empty_image = CompressedImage()
+        empty_image.header.frame_id = frame_id
+        empty_image.header.stamp = node.get_clock().now().to_msg()
+        empty_image.format = "jpeg"
+        empty_image.data = []
+        node.image_publisher.publish(empty_image)
+        time.sleep(0.2)
+        invalid_image_info = core.call({"action": "info", "instance_id": args.instance_id})
+        if (invalid_image_info.get("last_error") or {}).get("error_code") != "invalid_image":
+            raise AssertionError(f"empty image did not produce invalid_image: {invalid_image_info}")
+
+        wrong_type_script = """
+import sys
+import time
+import rclpy
+from rclpy.node import Node
+from std_msgs.msg import Int32
+
+rclpy.init()
+node = Node("vlapi05g1_gate_d_wrong_type")
+publisher = node.create_publisher(Int32, sys.argv[1], 1)
+message = Int32()
+message.data = 1
+deadline = time.monotonic() + 0.6
+while time.monotonic() < deadline:
+    publisher.publish(message)
+    rclpy.spin_once(node, timeout_sec=0.05)
+node.destroy_node()
+rclpy.shutdown()
+"""
+        wrong_type_result = subprocess.run(
+            [sys.executable, "-c", wrong_type_script, state_topic],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=5.0,
+        )
+        if wrong_type_result.returncode != 0:
+            raise AssertionError(
+                f"wrong-type ROS publisher failed: {wrong_type_result.stderr.strip()}"
+            )
+        time.sleep(0.2)
+        alive_info = core.call({"action": "info", "instance_id": args.instance_id})
+        if alive_info.get("state") != "running":
+            raise AssertionError("wrong ROS message type disrupted the card")
+
+        summary = {
+            "status": "PASS",
+            "mcp_id": core.mcp_id,
+            "instance_id": args.instance_id,
+            "request_id": proposal["request_id"],
+            "output_path": str(args.output),
+            "action_sha256": actual_action_hash,
+            "image_frame_id": observation["image_frame_id"],
+            "image_stamp": observation["image_stamp"],
+            "image_stamp_source": observation["image_stamp_source"],
+            "confidence": "not_applicable_policy_does_not_emit_confidence",
+            "stale_predict_error": stale_result["error_code"],
+            "output_count_after_stale_predict": len(node.outputs),
+            "invalid_state_error": invalid_state_info["last_error"]["error_code"],
+            "invalid_image_error": invalid_image_info["last_error"]["error_code"],
+            "wrong_message_type_card_state": alive_info["state"],
+        }
+        print(json.dumps(summary, ensure_ascii=False, indent=2))
+    finally:
+        if started:
+            first_stop = core.call({"action": "stop", "instance_id": args.instance_id})
+            second_stop = core.call({"action": "stop", "instance_id": args.instance_id})
+            if first_stop != second_stop or first_stop.get("state") != "idle":
+                raise AssertionError("Gate D cleanup stop is not idempotent")
+        node.destroy_node()
+        rclpy.shutdown()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/perception/plugins/vlapi05g1/tests/ros2_gate_e_multiinstance.py
+++ b/perception/plugins/vlapi05g1/tests/ros2_gate_e_multiinstance.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+
+import rclpy
+from rclpy.node import Node
+from sensor_msgs.msg import CompressedImage
+from std_msgs.msg import String
+
+from ros2_gate_d import CoreClient, INPUT_QOS, OUTPUT_QOS, action_hash, wait_until
+
+
+class GateENode(Node):
+    def __init__(self, topics: dict[str, dict[str, str]]):
+        super().__init__("vlapi05g1_gate_e_multiinstance")
+        self.outputs: dict[str, list[dict]] = {key: [] for key in topics}
+        self.image_publishers = {}
+        self.state_publishers = {}
+        self.output_subscriptions = []
+        for key, item in topics.items():
+            self.image_publishers[key] = self.create_publisher(
+                CompressedImage, item["image"], INPUT_QOS
+            )
+            self.state_publishers[key] = self.create_publisher(
+                String, item["state"], INPUT_QOS
+            )
+            self.output_subscriptions.append(
+                self.create_subscription(
+                    String,
+                    item["output"],
+                    lambda message, instance_key=key: self.outputs[instance_key].append(
+                        json.loads(message.data)
+                    ),
+                    OUTPUT_QOS,
+                )
+            )
+
+
+def expected_node_name(instance_id: str) -> str:
+    normalized = "".join(character if character.isalnum() or character == "_" else "_" for character in instance_id)
+    suffix = hashlib.sha256(instance_id.encode("utf-8")).hexdigest()[:8]
+    return f"vlapi05g1_{normalized}_{suffix}"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run vlapi05g1 Gate E multi-instance isolation")
+    parser.add_argument("--core-url", default="https://127.0.0.1:15678")
+    parser.add_argument("--server-name", required=True)
+    parser.add_argument("--image", required=True, type=Path)
+    parser.add_argument("--state", required=True, type=Path)
+    parser.add_argument("--output", required=True, type=Path)
+    parser.add_argument("--expected-action-sha256", required=True)
+    args = parser.parse_args()
+
+    image_bytes = args.image.read_bytes()
+    state_values = json.loads(args.state.read_text(encoding="utf-8"))
+    if not isinstance(state_values, list) or len(state_values) != 29:
+        raise ValueError("recorded state must contain 29 values")
+    state_payload = json.dumps(
+        {"joints": [{"idx": index, "q": value} for index, value in enumerate(state_values)]},
+        separators=(",", ":"),
+    )
+
+    instance_ids = {"a": "stage6-gate-e-a", "b": "stage6-gate-e-b"}
+    topics = {
+        key: {
+            "image": f"/stage6/gate_e/{key}/camera/compressed",
+            "state": f"/stage6/gate_e/{key}/g1/joints",
+            "output": f"/stage6/gate_e/{key}/vla/action_proposal",
+        }
+        for key in instance_ids
+    }
+    core = CoreClient(args.core_url, args.server_name)
+    core.save_shared_config(
+        {
+            "policy_url": "http://127.0.0.1:18080/predict",
+            "health_url": "",
+            "request_timeout_s": 120.0,
+            "max_image_bytes": 8388608,
+        }
+    )
+    for instance_id in instance_ids.values():
+        core.call({"action": "stop", "instance_id": instance_id})
+
+    started: set[str] = set()
+    rclpy.init()
+    node = GateENode(topics)
+    try:
+        for key, instance_id in instance_ids.items():
+            result = core.call(
+                {
+                    "action": "start",
+                    "instance_id": instance_id,
+                    "image_topic": topics[key]["image"],
+                    "state_topic": topics[key]["state"],
+                    "output_topic": topics[key]["output"],
+                }
+            )
+            started.add(instance_id)
+            if result.get("state") != "running":
+                raise AssertionError(f"instance {key} did not start: {result}")
+
+        expected_nodes = {expected_node_name(instance_id) for instance_id in instance_ids.values()}
+        wait_until(
+            node,
+            lambda: expected_nodes.issubset(set(node.get_node_names())),
+            8.0,
+            "two distinct vlapi05g1 ROS nodes",
+        )
+        wait_until(
+            node,
+            lambda: all(
+                node.image_publishers[key].get_subscription_count() >= 1
+                and node.state_publishers[key].get_subscription_count() >= 1
+                and node.count_publishers(topics[key]["output"]) >= 1
+                for key in instance_ids
+            ),
+            8.0,
+            "multi-instance ROS2 topic discovery",
+        )
+
+        all_info = core.call({"action": "info"})
+        if set((all_info.get("instances") or {}).keys()) != set(instance_ids.values()):
+            raise AssertionError(f"Core does not report exactly two instances: {all_info}")
+
+        missing_b = core.call({"action": "predict", "instance_id": instance_ids["b"]})
+        if missing_b.get("error_code") != "observation_missing":
+            raise AssertionError(f"instance B unexpectedly received instance A data: {missing_b}")
+
+        proposals = {}
+        for key in ("a", "b"):
+            image_message = CompressedImage()
+            image_message.header.frame_id = f"stage6_gate_e_{key}_camera"
+            image_message.header.stamp = node.get_clock().now().to_msg()
+            image_message.format = "jpeg"
+            image_message.data = list(image_bytes)
+            state_message = String()
+            state_message.data = state_payload
+            for _ in range(5):
+                node.image_publishers[key].publish(image_message)
+                node.state_publishers[key].publish(state_message)
+                rclpy.spin_once(node, timeout_sec=0.08)
+
+            other_key = "b" if key == "a" else "a"
+            other_count_before = len(node.outputs[other_key])
+            predict = core.call({"action": "predict", "instance_id": instance_ids[key]})
+            if predict.get("status") != "published":
+                raise AssertionError(f"instance {key} did not publish: {predict}")
+            wait_until(
+                node,
+                lambda instance_key=key: len(node.outputs[instance_key]) == 1,
+                8.0,
+                f"instance {key} output",
+            )
+            if len(node.outputs[other_key]) != other_count_before:
+                raise AssertionError(f"instance {key} prediction leaked to instance {other_key}")
+            proposal = node.outputs[key][0]
+            expected_request_prefix = f"vlapi05g1-{instance_ids[key]}-"
+            if not str(proposal.get("request_id", "")).startswith(expected_request_prefix):
+                raise AssertionError(f"instance {key} output has wrong request_id prefix")
+            observation = proposal.get("observation") or {}
+            if observation.get("image_topic") != topics[key]["image"]:
+                raise AssertionError(f"instance {key} output has wrong image topic")
+            if observation.get("state_topic") != topics[key]["state"]:
+                raise AssertionError(f"instance {key} output has wrong state topic")
+            if action_hash(proposal["action_chunk"]) != args.expected_action_sha256:
+                raise AssertionError(f"instance {key} action hash differs from Gate C")
+            proposals[key] = proposal
+
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(
+            json.dumps({"proposals": proposals}, ensure_ascii=False, indent=2) + "\n",
+            encoding="utf-8",
+        )
+        print(
+            json.dumps(
+                {
+                    "status": "PASS",
+                    "mcp_id": core.mcp_id,
+                    "instances": instance_ids,
+                    "ros_nodes": sorted(expected_nodes),
+                    "topics": topics,
+                    "request_ids": {
+                        key: proposals[key]["request_id"] for key in instance_ids
+                    },
+                    "action_sha256": args.expected_action_sha256,
+                    "instance_b_before_input": missing_b["error_code"],
+                    "output_counts": {
+                        key: len(node.outputs[key]) for key in instance_ids
+                    },
+                    "output_path": str(args.output),
+                },
+                ensure_ascii=False,
+                indent=2,
+            )
+        )
+    finally:
+        for instance_id in instance_ids.values():
+            if instance_id in started:
+                first_stop = core.call({"action": "stop", "instance_id": instance_id})
+                second_stop = core.call({"action": "stop", "instance_id": instance_id})
+                if first_stop != second_stop or first_stop.get("state") != "idle":
+                    raise AssertionError(f"cleanup stop is not idempotent for {instance_id}")
+        node.destroy_node()
+        rclpy.shutdown()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/perception/plugins/vlapi05g1/tests/ros2_gate_f_policy_error.py
+++ b/perception/plugins/vlapi05g1/tests/ros2_gate_f_policy_error.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import rclpy
+from rclpy.node import Node
+from sensor_msgs.msg import CompressedImage
+from std_msgs.msg import String
+
+from ros2_gate_d import CoreClient, INPUT_QOS, wait_until
+
+
+class GateFNode(Node):
+    def __init__(self, image_topic: str, state_topic: str):
+        super().__init__("vlapi05g1_gate_f_policy_error")
+        self.image_publisher = self.create_publisher(CompressedImage, image_topic, INPUT_QOS)
+        self.state_publisher = self.create_publisher(String, state_topic, INPUT_QOS)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Verify policy failures do not stop vlapi05g1 MCP")
+    parser.add_argument("--core-url", default="https://127.0.0.1:15678")
+    parser.add_argument("--server-name", required=True)
+    parser.add_argument("--image", required=True, type=Path)
+    parser.add_argument("--state", required=True, type=Path)
+    parser.add_argument("--instance-id", default="stage6-gate-f-policy-error")
+    args = parser.parse_args()
+
+    image_bytes = args.image.read_bytes()
+    state_values = json.loads(args.state.read_text(encoding="utf-8"))
+    state_payload = json.dumps(
+        {"joints": [{"idx": index, "q": value} for index, value in enumerate(state_values)]},
+        separators=(",", ":"),
+    )
+    image_topic = "/stage6/gate_f/camera/compressed"
+    state_topic = "/stage6/gate_f/g1/joints"
+    output_topic = "/stage6/gate_f/vla/action_proposal"
+    core = CoreClient(args.core_url, args.server_name)
+    core.call({"action": "stop", "instance_id": args.instance_id})
+    core.save_shared_config(
+        {
+            "policy_url": "http://127.0.0.1:1/predict",
+            "health_url": "",
+            "request_timeout_s": 0.2,
+            "max_image_bytes": 8388608,
+        }
+    )
+
+    started = False
+    rclpy.init()
+    node = GateFNode(image_topic, state_topic)
+    try:
+        start = core.call(
+            {
+                "action": "start",
+                "instance_id": args.instance_id,
+                "input_topics": [image_topic, state_topic],
+                "output_topic": output_topic,
+            }
+        )
+        started = True
+        if start.get("state") != "running":
+            raise AssertionError(f"card did not start: {start}")
+        wait_until(
+            node,
+            lambda: node.image_publisher.get_subscription_count() >= 1
+            and node.state_publisher.get_subscription_count() >= 1,
+            8.0,
+            "Gate F ROS2 subscriptions",
+        )
+
+        image_message = CompressedImage()
+        image_message.header.frame_id = "stage6_gate_f_camera"
+        image_message.header.stamp = node.get_clock().now().to_msg()
+        image_message.format = "jpeg"
+        image_message.data = list(image_bytes)
+        state_message = String()
+        state_message.data = state_payload
+        for _ in range(5):
+            node.image_publisher.publish(image_message)
+            node.state_publisher.publish(state_message)
+            rclpy.spin_once(node, timeout_sec=0.08)
+
+        predict = core.call({"action": "predict", "instance_id": args.instance_id})
+        if predict.get("error_code") != "policy_unreachable":
+            raise AssertionError(f"policy failure was not isolated: {predict}")
+        alive = core.call({"action": "info", "instance_id": args.instance_id})
+        if alive.get("state") != "running":
+            raise AssertionError(f"MCP/card stopped after policy failure: {alive}")
+        if (alive.get("last_error") or {}).get("error_code") != "policy_unreachable":
+            raise AssertionError(f"policy failure was not retained as structured status: {alive}")
+        print(
+            json.dumps(
+                {
+                    "status": "PASS",
+                    "mcp_id": core.mcp_id,
+                    "instance_id": args.instance_id,
+                    "predict_error": predict["error_code"],
+                    "card_state_after_error": alive["state"],
+                    "last_error": alive["last_error"]["error_code"],
+                },
+                ensure_ascii=False,
+                indent=2,
+            )
+        )
+    finally:
+        if started:
+            core.call({"action": "stop", "instance_id": args.instance_id})
+        core.save_shared_config(
+            {
+                "policy_url": "http://127.0.0.1:18080/predict",
+                "health_url": "",
+                "request_timeout_s": 120.0,
+                "max_image_bytes": 8388608,
+            }
+        )
+        node.destroy_node()
+        rclpy.shutdown()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/perception/plugins/vlapi05g1/tests/test_bundle_integration.py
+++ b/perception/plugins/vlapi05g1/tests/test_bundle_integration.py
@@ -1,0 +1,314 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import threading
+import types
+import unittest
+import urllib.request
+from pathlib import Path
+
+
+PERCEPTION_DIR = Path(__file__).resolve().parents[3]
+MAIN_PATH = PERCEPTION_DIR / "main.py"
+sys.path.insert(0, str(PERCEPTION_DIR))
+
+
+def _load_perception_main():
+    rclpy = types.ModuleType("rclpy")
+    executors = types.ModuleType("rclpy.executors")
+    executors.MultiThreadedExecutor = object
+    rclpy.executors = executors
+    sys.modules.setdefault("rclpy", rclpy)
+    sys.modules.setdefault("rclpy.executors", executors)
+
+    spec = importlib.util.spec_from_file_location("vlapi05g1_bundle_main", MAIN_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("cannot load Perception Bundle entry point")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class _FakeExecutor:
+    def __init__(self):
+        self.added = []
+        self.removed = []
+
+    def add_node(self, node):
+        self.added.append(node)
+        return True
+
+    def remove_node(self, node):
+        self.removed.append(node)
+        return True
+
+
+class _FakeVLAPi05G1Node:
+    created = []
+
+    def __init__(
+        self,
+        *,
+        image_topic,
+        state_topic,
+        output_topic,
+        instance_id,
+        shared_config,
+        instance_config,
+    ):
+        self.image_topic = image_topic
+        self.state_topic = state_topic
+        self.output_topic = output_topic
+        self.instance_id = instance_id
+        self.shared_config = dict(shared_config)
+        self.instance_config = dict(instance_config)
+        self.shutdown_count = 0
+        self.destroy_count = 0
+        self.__class__.created.append(self)
+
+    def status(self):
+        return {
+            "name": "π0.5 G1 VLA 推理",
+            "state": "running",
+            "instance_id": self.instance_id,
+            "topic_in": [
+                {"topic": self.image_topic, "format": "image/jpeg"},
+                {"topic": self.state_topic, "format": "data/json"},
+            ],
+            "topic_out": [{"topic": self.output_topic, "format": "data/json"}],
+            "config": dict(self.instance_config),
+            "in_flight": False,
+        }
+
+    def update_instance_config(self, config):
+        self.instance_config = dict(config)
+
+    def shutdown_card(self):
+        self.shutdown_count += 1
+
+    def destroy_node(self):
+        self.destroy_count += 1
+
+
+class BundleIntegrationTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.main = _load_perception_main()
+
+    def setUp(self):
+        self.executor = _FakeExecutor()
+        self.cfg = {
+            "identity": {
+                "core_display_name": "Perception Stack · Shanghai G1 Test",
+                "mcp_server_name": "perception-stack-shanghai-g1-test",
+            },
+            "plugins": {
+                "vlapi05g1": {
+                    "enabled": True,
+                    "policy_url": "http://127.0.0.1:1/predict",
+                    "health_url": "",
+                    "request_timeout_s": 0.1,
+                }
+            },
+        }
+        _FakeVLAPi05G1Node.created.clear()
+        fake_node_module = types.ModuleType("plugins.vlapi05g1.node")
+        fake_node_module.VLAPi05G1Node = _FakeVLAPi05G1Node
+        self.node_module_name = "plugins.vlapi05g1.node"
+        self.previous_node_module = sys.modules.get(self.node_module_name)
+        sys.modules[self.node_module_name] = fake_node_module
+
+        with self.assertLogs(self.main.log, level="INFO") as captured:
+            self.bundle = self.main.PerceptionBundle(self.cfg, self.executor)
+        self.load_logs = captured.output
+        self.main._bundle = self.bundle
+        self.server = self.main.ThreadingHTTPServer(
+            ("127.0.0.1", 0),
+            self.main.make_handler(self.cfg["identity"]["mcp_server_name"]),
+        )
+        self.server_thread = threading.Thread(target=self.server.serve_forever, daemon=True)
+        self.server_thread.start()
+        self.url = f"http://127.0.0.1:{self.server.server_port}/mcp"
+        self.opener = urllib.request.build_opener(urllib.request.ProxyHandler({}))
+        self.request_id = 0
+
+    def tearDown(self):
+        self.server.shutdown()
+        self.server.server_close()
+        self.server_thread.join(timeout=2.0)
+        self.main._bundle = None
+        if self.previous_node_module is None:
+            sys.modules.pop(self.node_module_name, None)
+        else:
+            sys.modules[self.node_module_name] = self.previous_node_module
+
+    def rpc(self, method, params=None):
+        self.request_id += 1
+        payload = json.dumps(
+            {
+                "jsonrpc": "2.0",
+                "id": self.request_id,
+                "method": method,
+                "params": params or {},
+            }
+        ).encode("utf-8")
+        request = urllib.request.Request(
+            self.url,
+            data=payload,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with self.opener.open(request, timeout=2.0) as response:
+            return json.loads(response.read())
+
+    def call_tool(self, arguments):
+        response = self.rpc(
+            "tools/call",
+            {"name": "vlapi05g1", "arguments": arguments},
+        )
+        if "error" in response:
+            return response
+        text = response["result"]["content"][0]["text"]
+        return json.loads(text)
+
+    def test_bundle_mcp_schema_config_and_idempotent_lifecycle(self):
+        self.assertTrue(any("VLAPi05G1Plugin loaded" in line for line in self.load_logs))
+
+        initialize = self.rpc("initialize")
+        self.assertEqual(
+            "perception-stack-shanghai-g1-test",
+            initialize["result"]["serverInfo"]["name"],
+        )
+        self.assertNotEqual("perception-bundle", initialize["result"]["serverInfo"]["name"])
+
+        tools = self.rpc("tools/list")["result"]["tools"]
+        self.assertEqual(1, len(tools))
+        tool = tools[0]
+        self.assertEqual("vlapi05g1", tool["name"])
+        self.assertEqual("processor", tool["type"])
+        self.assertTrue(tool["multiInstance"])
+        self.assertIn("configSchema", tool)
+        self.assertIn("action", tool["inputSchema"]["properties"])
+        self.assertEqual(
+            2,
+            tool["inputSchema"]["properties"]["input_topics"]["minItems"],
+        )
+        self.assertEqual(2, len(tool["topic_in"]))
+        self.assertEqual(1, len(tool["topic_out"]))
+
+        invalid = self.call_tool({"action": "config", "request_timeout_s": 0.0})
+        self.assertEqual(-32603, invalid["error"]["code"])
+
+        valid = self.call_tool(
+            {
+                "action": "config",
+                "policy_url": "http://127.0.0.1:18081/predict",
+                "request_timeout_s": 1.0,
+            }
+        )
+        self.assertEqual("configured", valid["status"])
+        self.assertEqual("shared", valid["scope"])
+        self.assertEqual("http://127.0.0.1:18081/health", valid["config"]["health_url"])
+
+        start_args = {
+            "action": "start",
+            "instance_id": "stage5",
+            "image_topic": "/stage5/camera/compressed",
+            "state_topic": "/stage5/g1/joints",
+            "output_topic": "/stage5/vla/action_proposal",
+        }
+        first_start = self.call_tool(start_args)
+        replayed_config = self.call_tool(
+            {
+                "action": "config",
+                "policy_url": "http://127.0.0.1:18081/predict",
+                "health_url": "",
+                "request_timeout_s": 1.0,
+                "max_image_bytes": 8388608,
+                "instance_id": "stage5",
+            }
+        )
+        changed_config = self.call_tool({"action": "config", "request_timeout_s": 2.0})
+        second_start = self.call_tool(start_args)
+        self.assertEqual("running", first_start["state"])
+        self.assertEqual("configured", replayed_config["status"])
+        self.assertEqual("none", replayed_config["applied"])
+        self.assertFalse(replayed_config["restart_required"])
+        self.assertEqual("restart_required", changed_config["error_code"])
+        self.assertEqual(first_start, second_start)
+        self.assertEqual(1, len(self.executor.added))
+        self.assertEqual(1, len(_FakeVLAPi05G1Node.created))
+
+        info = self.call_tool({"action": "info", "instance_id": "stage5"})
+        self.assertEqual(2, len(info["topic_in"]))
+        self.assertEqual("/stage5/vla/action_proposal", info["topic_out"][0]["topic"])
+        self.assertEqual("error", info["last_health"]["status"])
+
+        first_stop = self.call_tool({"action": "stop", "instance_id": "stage5"})
+        second_stop = self.call_tool({"action": "stop", "instance_id": "stage5"})
+        self.assertEqual("idle", first_stop["state"])
+        self.assertEqual(first_stop, second_stop)
+        self.assertEqual(1, len(self.executor.removed))
+        node = _FakeVLAPi05G1Node.created[0]
+        self.assertEqual(1, node.shutdown_count)
+        self.assertEqual(1, node.destroy_count)
+        self.assertEqual({}, self.bundle._plugins[0]._instances)
+
+    def test_dashboard_input_topics_start_maps_port_order(self):
+        started = self.call_tool(
+            {
+                "action": "start",
+                "instance_id": "canvas-card",
+                "input_topics": [
+                    "/canvas/camera/compressed",
+                    "/canvas/g1/joints",
+                ],
+            }
+        )
+        self.assertEqual("running", started["state"])
+        self.assertEqual(
+            [
+                {"topic": "/canvas/camera/compressed", "format": "image/jpeg"},
+                {"topic": "/canvas/g1/joints", "format": "data/json"},
+            ],
+            started["topic_in"],
+        )
+        self.assertEqual(
+            "/canvas/camera/compressed/vlapi05g1",
+            started["topic_out"][0]["topic"],
+        )
+        invalid = self.call_tool(
+            {
+                "action": "start",
+                "instance_id": "invalid-canvas-card",
+                "input_topics": ["/only/one"],
+            }
+        )
+        self.assertEqual(-32603, invalid["error"]["code"])
+
+        stopped = self.call_tool({"action": "stop", "instance_id": "canvas-card"})
+        self.assertEqual("idle", stopped["state"])
+
+    def test_host_identity_is_explicit_distinct_and_not_default(self):
+        good = self.main._load_host_identity(self.cfg)
+        self.assertEqual(
+            ("Perception Stack · Shanghai G1 Test", "perception-stack-shanghai-g1-test"),
+            good,
+        )
+        for identity in (
+            None,
+            {},
+            {"core_display_name": None, "mcp_server_name": "unique"},
+            {"core_display_name": "same", "mcp_server_name": "same"},
+            {"core_display_name": "Perception Stack", "mcp_server_name": "unique"},
+            {"core_display_name": "unique", "mcp_server_name": "perception-bundle"},
+        ):
+            with self.subTest(identity=identity):
+                with self.assertRaises(ValueError):
+                    self.main._load_host_identity({"identity": identity})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/perception/plugins/vlapi05g1/tests/test_policy.py
+++ b/perception/plugins/vlapi05g1/tests/test_policy.py
@@ -1,0 +1,262 @@
+from __future__ import annotations
+
+import base64
+import copy
+import json
+import math
+import sys
+import threading
+import unittest
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+
+CARD_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(CARD_DIR.parent))
+
+from vlapi05g1.plugin import VLAPi05G1Plugin
+from vlapi05g1.policy import (
+    ACTION_DIM,
+    ACTION_SHAPE,
+    ACTION_SPACE,
+    ACTION_STEPS,
+    CardError,
+    ObservationSnapshot,
+    build_action_proposal,
+    build_policy_payload,
+    parse_state_message,
+    validate_jpeg,
+    validate_policy_response,
+    validate_seed,
+)
+
+
+def make_snapshot() -> ObservationSnapshot:
+    return ObservationSnapshot(
+        image_bytes=b"\xff\xd8recorded-jpeg\xff\xd9",
+        image_topic="/camera/image/compressed",
+        image_frame_id="g1_front_camera",
+        image_stamp=100.25,
+        image_stamp_source="header",
+        image_received_at=101.0,
+        image_age_at_request_s=0.05,
+        state=tuple(float(index) / 100.0 for index in range(29)),
+        state_topic="/robot/state/joints",
+        state_received_at=101.1,
+        state_age_at_request_s=0.02,
+    )
+
+
+def make_policy_response() -> dict:
+    return {
+        "ok": True,
+        "action_shape": list(ACTION_SHAPE),
+        "action_space": ACTION_SPACE,
+        "fresh_inference_per_request": True,
+        "num_inference_steps": 10,
+        "seed": 0,
+        "infer_seconds": 0.25,
+        "action_chunk": [
+            [float(row * ACTION_DIM + column) / 1000.0 for column in range(ACTION_DIM)]
+            for row in range(ACTION_STEPS)
+        ],
+    }
+
+
+class StateParsingTest(unittest.TestCase):
+    def test_maps_indices_and_ignores_extra_joints(self):
+        joints = [{"idx": index, "q": index + 0.5} for index in reversed(range(29))]
+        joints.append({"idx": 34, "q": 9.0})
+
+        state = parse_state_message(json.dumps({"joints": joints, "imu_quat": [1, 0, 0, 0]}))
+
+        self.assertEqual(29, len(state))
+        self.assertEqual(0.5, state[0])
+        self.assertEqual(28.5, state[-1])
+
+    def test_rejects_missing_duplicate_and_nonfinite_state(self):
+        valid = [{"idx": index, "q": float(index)} for index in range(29)]
+        cases = {
+            "missing": valid[:-1],
+            "duplicate": valid + [{"idx": 0, "q": 0.0}],
+            "nan": [*valid[:-1], {"idx": 28, "q": math.nan}],
+            "infinity": [*valid[:-1], {"idx": 28, "q": math.inf}],
+        }
+        for name, joints in cases.items():
+            with self.subTest(name=name):
+                with self.assertRaisesRegex(CardError, "state|joint"):
+                    parse_state_message(json.dumps({"joints": joints}))
+
+
+class JpegValidationTest(unittest.TestCase):
+    def test_accepts_exact_size_boundary(self):
+        payload = b"\xff\xd8abc\xff\xd9"
+        self.assertEqual(payload, validate_jpeg(payload, len(payload)))
+
+    def test_rejects_empty_truncated_and_oversized_input(self):
+        cases = (
+            (b"", 10),
+            (b"\xff\xd8truncated", 100),
+            (b"not-jpeg", 100),
+            (b"\xff\xd8abc\xff\xd9", 6),
+        )
+        for payload, limit in cases:
+            with self.subTest(payload=payload, limit=limit):
+                with self.assertRaisesRegex(CardError, "JPEG|payload"):
+                    validate_jpeg(payload, limit)
+
+
+class PolicyContractTest(unittest.TestCase):
+    def test_payload_is_deterministic_and_preserves_inputs(self):
+        snapshot = make_snapshot()
+
+        first = build_policy_payload(snapshot, "task", 0)
+        second = build_policy_payload(snapshot, "task", 0)
+
+        self.assertEqual(first, second)
+        self.assertEqual(snapshot.image_bytes, base64.b64decode(first["image_base64"]))
+        self.assertEqual(list(snapshot.state), first["state"])
+        self.assertEqual("task", first["task"])
+        self.assertEqual(0, first["seed"])
+
+    def test_seed_boundaries_are_strict_integers(self):
+        self.assertEqual(0, validate_seed(0))
+        self.assertEqual(2**31 - 1, validate_seed(2**31 - 1))
+        for value in (-1, 2**31, True, 0.0, "0", None):
+            with self.subTest(value=value):
+                with self.assertRaises(ValueError):
+                    validate_seed(value)
+
+    def test_validates_deterministic_positive_response(self):
+        response = make_policy_response()
+
+        first = validate_policy_response(copy.deepcopy(response), 0)
+        second = validate_policy_response(copy.deepcopy(response), 0)
+
+        self.assertEqual(first, second)
+        self.assertEqual(ACTION_STEPS, len(first["action_chunk"]))
+        self.assertTrue(all(len(row) == ACTION_DIM for row in first["action_chunk"]))
+        self.assertEqual(0.25, first["policy_infer_seconds"])
+
+    def test_rejects_empty_and_malformed_policy_results(self):
+        cases = {}
+
+        empty = make_policy_response()
+        empty["action_chunk"] = []
+        cases["empty"] = empty
+
+        wrong_shape = make_policy_response()
+        wrong_shape["action_shape"] = [1, 1, ACTION_DIM]
+        cases["shape"] = wrong_shape
+
+        wrong_space = make_policy_response()
+        wrong_space["action_space"] = "normalized"
+        cases["space"] = wrong_space
+
+        wrong_seed = make_policy_response()
+        wrong_seed["seed"] = 1
+        cases["seed"] = wrong_seed
+
+        nonfinite = make_policy_response()
+        nonfinite["action_chunk"][0][0] = math.nan
+        cases["nonfinite"] = nonfinite
+
+        for name, response in cases.items():
+            with self.subTest(name=name):
+                with self.assertRaises(CardError):
+                    validate_policy_response(response, 0)
+
+    def test_proposal_keeps_provenance_and_never_authorizes_execution(self):
+        snapshot = make_snapshot()
+        validated = validate_policy_response(make_policy_response(), 0)
+
+        proposal = build_action_proposal(
+            request_id="vlapi05g1-main-000001",
+            created_at=102.0,
+            snapshot=snapshot,
+            task="task",
+            seed=0,
+            validated_response=validated,
+            card_elapsed_seconds=0.3,
+        )
+
+        self.assertEqual("pi05.g1.action_chunk.v1", proposal["schema"])
+        self.assertEqual(list(snapshot.state), proposal["observation"]["state"])
+        self.assertEqual(snapshot.image_topic, proposal["observation"]["image_topic"])
+        self.assertEqual(snapshot.image_frame_id, proposal["observation"]["image_frame_id"])
+        self.assertEqual(snapshot.state_topic, proposal["observation"]["state_topic"])
+        self.assertIs(False, proposal["execution_authorized"])
+        json.dumps(proposal)
+
+
+class _HealthHandler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        payload = json.dumps(self.server.health_payload).encode("utf-8")
+        self.send_response(self.server.health_status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def log_message(self, _format, *_args):
+        return
+
+
+class _FakeExecutor:
+    def add_node(self, _node):
+        raise AssertionError("info must not create a ROS node")
+
+    def remove_node(self, _node):
+        raise AssertionError("info must not remove a ROS node")
+
+
+class InfoHealthTest(unittest.TestCase):
+    def setUp(self):
+        self.server = ThreadingHTTPServer(("127.0.0.1", 0), _HealthHandler)
+        self.server.health_status = 200
+        self.server.health_payload = {
+            "ok": True,
+            "action_dim": ACTION_DIM,
+            "action_chunk_size": ACTION_STEPS,
+            "action_space": ACTION_SPACE,
+        }
+        self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
+        self.thread.start()
+
+    def tearDown(self):
+        self.server.shutdown()
+        self.server.server_close()
+        self.thread.join(timeout=2.0)
+
+    def make_plugin(self) -> VLAPi05G1Plugin:
+        root_url = f"http://127.0.0.1:{self.server.server_port}"
+        return VLAPi05G1Plugin(
+            {
+                "policy_url": f"{root_url}/predict",
+                "health_url": f"{root_url}/health",
+                "request_timeout_s": 1.0,
+            },
+            _FakeExecutor(),
+        )
+
+    def test_info_embeds_current_health_without_starting_ros(self):
+        result = self.make_plugin().dispatch("vlapi05g1", {"action": "info"})
+
+        self.assertEqual("idle", result["state"])
+        self.assertEqual("ok", result["last_health"]["status"])
+        self.assertEqual(ACTION_DIM, result["last_health"]["response"]["action_dim"])
+        self.assertGreaterEqual(result["last_health"]["latency_s"], 0.0)
+
+    def test_info_contains_health_error_instead_of_failing(self):
+        self.server.health_status = 503
+        self.server.health_payload = {"ok": False, "error": "loading"}
+
+        result = self.make_plugin().dispatch("vlapi05g1", {"action": "info"})
+
+        self.assertEqual("idle", result["state"])
+        self.assertEqual("error", result["last_health"]["status"])
+        self.assertEqual("policy_rejected", result["last_health"]["error_code"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/perception/plugins/vlapi05g1/阶段五验证记录.md
+++ b/perception/plugins/vlapi05g1/阶段五验证记录.md
@@ -1,0 +1,121 @@
+# `vlapi05g1` 阶段五验证记录
+
+验证日期：2026-07-14
+
+结论：**PASS**。`vlapi05g1` 已显式接入 PerceptionBundle，MCP 契约、宿主唯一身份、配置和实例生命周期均通过本地集成验证；现有 wlcb-23 Agent Core 上的真实 tool-config 门禁、Core 代理业务 action 与 ROS node 资源回收也已通过。本阶段没有发布 ROS2 输入数据或 action proposal，数据面闭环仍属于阶段六。
+
+## 代码与配置改动
+
+- `perception/main.py`
+  - 按 `plugins.vlapi05g1.enabled` 显式导入 `PLUGIN_CLASS`；
+  - MCP `initialize.serverInfo.name` 改为宿主配置；
+  - Core display name 改为宿主配置；
+  - 两个身份缺失、非字符串、同名或继续使用 `Perception Stack` / `perception-bundle` 默认名时 fail closed。
+- `perception/config.yaml`
+  - 生产宿主 Core display name：`Perception Stack · Shanghai G1`；
+  - 生产宿主 MCP server name：`perception-stack-shanghai-g1`；
+  - 新增并启用 `plugins.vlapi05g1`，配置与卡片 shared/instance 默认值一致。
+- `plugin.py`
+  - 修正 Agent Core 已保存 shared config 重放：与当前值完全一致时返回 `configured + applied=none`；
+  - 运行中真正改变 endpoint、超时或输入大小上限时仍返回 `restart_required`。
+- `tests/test_bundle_integration.py`
+  - 通过真实回环 MCP HTTP server 覆盖 loader、initialize、tools/list、info、config 和幂等生命周期。
+
+## 本地验证
+
+### 卡片与 Bundle 测试
+
+```text
+python3 -m unittest discover -s phanthymotus/perception/plugins/vlapi05g1/tests -p 'test_*.py' -v
+Ran 13 tests in 2.161s
+OK
+```
+
+关键断言：
+
+- loader 日志包含 `VLAPi05G1Plugin loaded`；
+- `initialize.serverInfo.name` 不是默认值；
+- `tools/list` 只暴露完整的 `vlapi05g1` processor schema；
+- `request_timeout_s=0` 返回 JSON-RPC `-32603`，合法 shared config 立即生效；
+- 运行中重放相同 shared config 是 no-op，真实改变仍是 `restart_required`；
+- 相同参数连续 `start` 只调用一次 executor `add_node`；
+- 连续 `stop` 只移除/销毁一次 node，实例表为空。
+
+### 契约与编译门禁
+
+```text
+python3 -m unittest discover -s perception-card-kit/tests -p 'test_*.py' -v
+Ran 2 tests
+OK
+
+python3 perception-card-kit/scripts/validate_card.py phanthymotus/perception/plugins/vlapi05g1
+{"prefix":"vlapi05g1","plugin_class":"VLAPi05G1Plugin","tools":["vlapi05g1"],"status":"PASS"}
+
+python3 -m compileall -q phanthymotus/perception/main.py phanthymotus/perception/plugins/vlapi05g1
+PASS
+```
+
+## wlcb-23 真实 Perception / MCP / Core 验证
+
+### 独立验证宿主
+
+| 项 | 值 |
+| --- | --- |
+| container | `phanthy-motus-vlapi05g1-stage5-dev` |
+| image | `local/phanthy-motus/perception:cpu-min-c124798` |
+| source mount | `/mnt/data/hanzebei/tmp/vlapi05g1-stage5:/stage5:ro` |
+| MCP / WS port | `15735` / `15736` |
+| restart policy | `no` |
+| Core display name | `VLA Perception Stage5 · Shanghai G1` |
+| MCP server name | `vla-perception-stage5-shanghai-g1-wlcb23` |
+| Core MCP id | `mcp-1784014902` |
+
+验证后宿主保持 `running`、`RestartCount=0`，供用户复核；卡片实例已 stop，没有遗留 `vlapi05g1` ROS node。
+
+### MCP 和唯一身份
+
+- 进程日志明确出现 `VLAPi05G1Plugin loaded`、MCP 端口和 Core heartbeat 成功。
+- `initialize` 返回 `vla-perception-stage5-shanghai-g1-wlcb23`。
+- Core 列表中该 `server_name` 只有一条，display name 与 MCP server name 不同。
+- Core 发现 `vlapi05g1` 的 `type=processor`、`multiInstance=true`、完整 `inputSchema`、`configSchema`、2 个 input format 和 1 个 output format。
+
+### Agent Core tool-config 与业务 action
+
+1. 清空本验证 MCP id 的 tool config 后，从 Core 调用 `predict` 返回 `code=400`、“尚未配置”。
+2. `PUT /api/canvas/tool-config/{mcp_id}/vlapi05g1` 保存并读回以下 shared 配置：
+   - `policy_url=http://127.0.0.1:18080/predict`；
+   - `health_url=""`；
+   - `request_timeout_s=120.0`；
+   - `max_image_bytes=8388608`。
+3. 从 Core 连续调用两次 `start`，返回完全一致，ROS graph 中只有 `/vlapi05g1_stage5_core_9950b6f6` 一个 node。
+4. 从 Core 调用 `info`，返回 2 个真实 input topic、1 个 output topic，`last_health.status=ok`。
+5. 从 Core 调用业务 action `predict`，返回 `observation_missing`；这是阶段五未发布 ROS 输入时的预期 fail-closed 结果。
+6. 从 Core 连续调用两次 `stop`，均返回 `idle`，ROS graph 中目标 node 数量为 0。
+
+Core 回归摘要：
+
+```json
+{
+  "status": "PASS",
+  "pre_config_gate_code": 400,
+  "start_idempotent": true,
+  "policy_health_status": "ok",
+  "core_predict_result": {
+    "status": "error",
+    "error_code": "observation_missing"
+  },
+  "stop_idempotent": true,
+  "nodes_after_stop": []
+}
+```
+
+## 阶段边界
+
+本记录只证明控制面和宿主接入完成：
+
+- 未向 `image_topic` / `state_topic` 发布录制数据；
+- 未订阅或断言 output topic 内容；
+- 未验证断流、陈旧 observation、多实例数据隔离、Dashboard 表单和容器重启后配置懒恢复；
+- 未发送任何 G1 动作或 executor 请求。
+
+上述内容统一留到阶段六 Gate D/E。

--- a/perception/plugins/vlapi05g1/阶段六验证记录.md
+++ b/perception/plugins/vlapi05g1/阶段六验证记录.md
@@ -1,0 +1,170 @@
+# `vlapi05g1` 阶段六验证记录
+
+验证日期：2026-07-14；浏览器确认：2026-07-15
+
+结论：**Gate D/E/F 的 ROS2、Agent Core、多实例、重启、故障和资源现场验证 PASS；用户随后修复代理并实际进入 Dashboard，阶段六总状态为 PASS**。Codex 没有把未亲自观察的 DOM 冒充为工具验证；浏览器部分以用户实际访问确认记录，未单独保留四项检查截图。
+
+本阶段只操作 wlcb-23 隔离验证容器、Agent Core 和录制/合成 ROS2 topic；没有连接 G1 执行器、没有发送动作、没有获取或使用 execution token。
+
+## 阶段六发现并修复的集成问题
+
+1. 卡片已读取 `CompressedImage.header.frame_id`，但未写入 action proposal。现已把 `image_frame_id` 纳入不可变 observation 快照、输出 schema 和单测。
+2. Dashboard 对多输入 processor 的通用启动形态是 `input_topics`，原卡片只接受 `image_topic` + `state_topic`，会导致手工 MCP 可启动而画布启动失败。现增加 `input_topics=[image_topic, state_topic]` 兼容入口，保留显式字段并禁止两种形态混用。
+3. 错误 ROS 消息类型不能由同一 DDS participant 在同名 topic 上创建；Gate D 改用独立 ROS2 进程注入 `Int32`，模拟真实外部错误发布者。
+4. 资源验证脚本最初使用 `ros2 node list`，它会自行启动常驻 ROS2 daemon 并污染进程基线。现改用一次性 `rclpy` 图查询，并在稳定态计量前执行一次 warm-up。
+
+## Gate D：ROS2 topic 闭环
+
+环境：
+
+| 项 | 值 |
+| --- | --- |
+| Perception container | `phanthy-motus-vlapi05g1-stage5-dev` |
+| MCP / WS port | `15735` / `15736` |
+| Core MCP id | `mcp-1784014902` |
+| policy | `pi05-g1-policy` / `pi05-g1:runtime-v3` / A100 GPU 6 |
+| image input | `g1-fixed-frame.jpg`，SHA-256 `5effd74a83c37da5a4087caffc93e5f807068d725e256fd6201105e31144eaac` |
+| state input | 29D `g1-real-runtime-v2-step10.state.json`，SHA-256 `af8e1174c665d093a53d117e260c9b86c4b8bdd3b22ba2bf3633a1f72450a32f` |
+
+`tests/ros2_gate_d.py` 经 Core 启动卡片，向真实 ROS2 输入 topic 发布录制图像和 state，订阅并保存完整 action proposal。
+
+结果：
+
+- schema：`pi05.g1.action_chunk.v1`；shape：`[1,50,18]`；action space：`physical_quantile_unnormalized`。
+- request id：`vlapi05g1-stage6-gate-d-000001`。
+- action chunk SHA-256：`fc89babc5f5d898eaf802f66fdb26b9793cc9a6e03edc24dca758726633aeac6`，与 Gate C 严格一致。
+- `image_frame_id=stage6_g1_front_camera`，图像 header stamp 原值保留，`created_at` 不早于两路输入接收时间。
+- policy 未定义 confidence；本卡片不虚构该字段，验收记为 `N/A`。
+- 停止输入 1.2 秒后，`predict` 返回 `observation_stale`，output 总数仍为 1，没有持续发布陈旧结果。
+- 坏 JSON state 返回 `invalid_state`，空 JPEG 返回 `invalid_image`，错误 `Int32` 类型注入后卡片仍为 `running`。
+
+完整输出保存在 wlcb-23：`/mnt/data/hanzebei/tmp/vlapi05g1-stage5/stage6/gate-d-output.json`，26,565 B，SHA-256 `64229591cbe6ccb5fc8a84f1bc64a6fbc4b39061ab750a0d08e14af833c19b87`。
+
+## Gate E：Agent Core 与 Dashboard 契约
+
+### Core 注册与 tool schema
+
+- `server_name=vla-perception-stage5-shanghai-g1-wlcb23` 在 Core 中只有 1 条记录，稳定 id 为 `mcp-1784014902`。
+- tool 为 `type=processor`、`multiInstance=true`，有 2 个 input format 和 1 个 output format。
+- Dashboard shared 表单来自 `configSchema`：`policy_url`、`health_url`、`request_timeout_s`、`max_image_bytes`。
+- instance 表单字段：`task`、`seed`、`max_image_age_s`、`max_state_age_s`。
+
+Dashboard 前端脚本已核对：侧栏根据 tool `type` 渲染 `processor` badge，根据 shared/instance scope 生成两级配置表单，`multiInstance=true` 允许重复拖入。2026-07-15 用户修复代理后已实际进入 Dashboard；没有单独留存 DOM 截图，因此自动化证据与用户视觉证据继续分开记录。
+
+### Dashboard 启动形态与 topic 推导
+
+通过 Core 以画布实际参数启动：
+
+```json
+{
+  "action": "start",
+  "instance_id": "stage6-dashboard-contract",
+  "input_topics": [
+    "/stage6/dashboard/camera/compressed",
+    "/stage6/dashboard/g1/joints"
+  ]
+}
+```
+
+`start` 和后续 `info` 一致返回两路输入，默认输出推导为 `/stage6/dashboard/camera/compressed/vlapi05g1`；重复 `stop` 为幂等 idle。
+
+### 多实例隔离
+
+`tests/ros2_gate_e_multiinstance.py` 同时启动 `stage6-gate-e-a` 和 `stage6-gate-e-b`：
+
+- ROS node 分别为 `vlapi05g1_stage6_gate_e_a_5bb0874d` 和 `vlapi05g1_stage6_gate_e_b_111e80ef`。
+- B 未获得自身输入时返回 `observation_missing`，没有读到 A 的缓存。
+- A/B 各发布 1 条，request id 分别含自身 instance id，observation topic 分属各自命名空间，无串流。
+- 两个 action chunk 均与 Gate C 哈希一致。
+
+完整多实例输出保存在 wlcb-23：`/mnt/data/hanzebei/tmp/vlapi05g1-stage5/stage6/gate-e-output.json`，61,676 B，SHA-256 `650b370c22b338f77582203b466292e064f8714233a1f0bf12eb94884a19f92e`。
+
+### AgentLoop 条件项
+
+验证时当前画布有 2 张其他卡片、1 条 execution connection，但没有 `vlapi05g1` 卡片，project 为 stopped。本阶段没有擅自改写用户画布或人工绑定 AgentLoop，因此 SOP 中“若允许 AgentLoop 调用”的条件项为 `N/A`。Core 代理真实 `predict` 已在 Gate D 通过。
+
+## Gate F：重启与故障
+
+### 重启注册和配置懒恢复
+
+`tests/core_gate_f.py` 设置 Core 已保存超时为 `121.0`，然后重启 Perception 容器：
+
+1. 重启后 MCP id 仍为 `mcp-1784014902`，Core 只有 1 条注册。
+2. 直连 MCP 检查刚启动时实际配置为宿主默认 `120.0`。
+3. 第一次 Core 非系统业务 action 前懒下发已保存配置；业务结果因实例未启动返回 `not_running`，直连 MCP 实际配置已变为 `121.0`。
+4. 测试后 Core 存储和卡片实际配置都恢复为 `120.0`。
+
+### 推理故障隔离
+
+`tests/ros2_gate_f_policy_error.py` 临时使用 `http://127.0.0.1:1/predict`，发布有效图像/state 后触发一次推理：
+
+- `predict.error_code=policy_unreachable`；
+- 实例仍为 `running`；
+- `info.last_error.error_code=policy_unreachable`；
+- MCP 后续 `info` 正常；脚本 `finally` 恢复真实 policy 配置。
+
+### 模型文件缺失
+
+使用 `pi05-g1:runtime-v3` 启动不分配 GPU 的 `--rm` 临时容器，指向不存在的模型路径：
+
+`/mnt/data/hanzebei/model/vla/MISSING-xiaopeng-wu_pi05_unitree_g1@580238372153c51ad564b894d8fea736ab4cdeb8`
+
+容器在 `6.363 s` 内以退出码 1 失败，错误类型为 `FileNotFoundError`，同时包含模型 revision 和缺失的 `config.json` 路径。常驻 `pi05-g1-policy` 未重启。
+
+### 十次生命周期与日志
+
+先 warm-up 1 次，再计量连续 10 次 Core `start/stop`：
+
+| 资源 | 基线 | 终值 |
+| --- | ---: | ---: |
+| Perception 进程数 | 1 | 1 |
+| Perception 线程数 | 8 | 8 |
+| Perception RSS | 62,200 KiB | 63,248 KiB |
+| 遗留 `vlapi05g1` ROS node | 0 | 0 |
+| 卡片 GPU device request | none | none |
+| policy PID | 28284 | 28284 |
+| policy GPU 显存 | 16,718 MiB | 16,718 MiB |
+
+卡片容器 97,351 B 日志中，非空凭据值、整帧 `image_base64` 和完整 `action_chunk` 的命中均为 false。其他 Bundle 配置中的空 `api_key` 字段名不视为凭据泄漏。
+
+## 本地门禁
+
+```text
+python3 -m compileall -q phanthymotus/perception/plugins/vlapi05g1
+PASS
+
+python3 perception-card-kit/scripts/validate_card.py phanthymotus/perception/plugins/vlapi05g1
+{"prefix":"vlapi05g1","plugin_class":"VLAPi05G1Plugin","tools":["vlapi05g1"],"status":"PASS"}
+
+python3 -m unittest discover -s phanthymotus/perception/plugins/vlapi05g1/tests -p 'test_*.py'
+Ran 14 tests
+OK
+```
+
+## 验证后现场
+
+- Core 唯一注册：1；MCP id：`mcp-1784014902`。
+- 卡片状态：`idle`；实例表：空；shared `request_timeout_s=120.0`。
+- `phanthy-motus-vlapi05g1-stage5-dev` 运行中，容器内只有 `python3 /stage5/main.py` 1 个进程。
+- `pi05-g1-policy` 运行中，未被阶段六测试重启。
+- 当前 Dashboard project 为 stopped，原有画布 2 张卡片和 1 条 execution connection 未改写。
+
+## Dashboard 视觉确认与后续状态
+
+Mac 直连 `https://172.28.4.23:15678` 会超时；2026-07-15 实测 wlcb-23 本机和 Clash 代理路径均返回 HTTP 200，根因是浏览器未走内网代理或私网 IP 被列入代理绕过。在 Mac 终端保持以下 SSH 隧道：
+
+```bash
+ssh -S none -N -o ExitOnForwardFailure=yes \
+  -L 127.0.0.1:15678:127.0.0.1:15678 wlcb-23
+```
+
+然后访问 `https://127.0.0.1:15678`；首次访问若出现自签名证书警告，选择继续访问。原计划保持当前 project 为 stopped，并确认：
+
+1. 侧栏搜索 `vlapi05g1`，卡片显示 `processor` badge，并有配置按钮。
+2. shared 表单只显示 `policy_url`、`health_url`、`request_timeout_s`、`max_image_bytes`；拖入后 instance 表单显示 `task`、`seed`、`max_image_age_s`、`max_state_age_s`。
+3. 可拖入两张 `vlapi05g1`，每张有 `image/jpeg` + `data/json` 两个输入端口和 `data/json` 输出端口，无单实例重复限制。
+4. 临时卡片检查后删除，不要保留对现有画布的改动。
+
+2026-07-15 用户修复代理并实际进入 Dashboard，访问 blocker 关闭；随后发现 `decision_core` 未配置，这是 wlcb-23 部署配置问题，不是 `vlapi05g1` 卡片契约问题。上述四项没有逐项截图留档，因此本记录不把它们表述为 Codex DOM 自动化结果。
+
+后续测试目标已切换到北京 G1：独立 overlay 的 MCP/Core 注册和远端 production policy health 已通过，但北京 G1 的 live RGB + joints state `predict` 和物理动作执行仍未验收，不属于阶段六 Dashboard 门禁的完成证据。

--- a/perception/plugins/vlapi05g1/阶段四验证记录.md
+++ b/perception/plugins/vlapi05g1/阶段四验证记录.md
@@ -1,0 +1,124 @@
+# `vlapi05g1` 阶段四验证记录
+
+验证日期：2026-07-14（Asia/Shanghai）
+
+结论：Gate A、Gate B、Gate C 全部通过。该结论覆盖语法与卡片契约、纯算法边界和录制 observation 到 production policy 的离线回放，不覆盖 ROS2 topic 闭环、PerceptionBundle、Agent Core、Dashboard 或 G1 动作执行。
+
+## Gate A：语法与契约
+
+在 `phanthy-motus/` 执行：
+
+```bash
+CARD_DIR="phanthymotus/perception/plugins/vlapi05g1"
+python3 -m compileall -q "$CARD_DIR"
+python3 perception-card-kit/scripts/validate_card.py "$CARD_DIR"
+```
+
+结果：
+
+- `compileall`：exit 0。
+- `validate_card.py`：`status=PASS`，`prefix=vlapi05g1`，导出类为 `VLAPi05G1Plugin`。
+- 工具包附加回归：`python3 -m unittest discover -s perception-card-kit/tests -v`，2/2 通过。
+
+## Gate B：算法单测
+
+命令：
+
+```bash
+python3 -m unittest discover \
+  -s phanthymotus/perception/plugins/vlapi05g1/tests \
+  -v
+```
+
+结果：11/11 通过。覆盖：
+
+- 29D state 正常映射、额外 joints、缺 index、重复 index、NaN 和 Inf。
+- JPEG 大小边界、空输入、非 JPEG、截断和超限。
+- payload 确定性、base64/state/task/seed 保真。
+- seed 最小值、最大值和非法类型边界。
+- 正确 50×18 响应、空 chunk、错误 shape/action space/seed 和非有限 action。
+- proposal 溯源与 `execution_authorized=false`。
+- `info` 内嵌 health 成功和 HTTP 失败时仍稳定返回，且不创建 ROS node。
+
+首次在受限沙箱运行时，两项 health 测试因禁止绑定 `127.0.0.1` 临时端口而报 `PermissionError`；相同命令在允许本机临时端口后 11/11 通过，业务断言未修改。
+
+## Gate C：录制数据回放
+
+### Runtime 前置
+
+wlcb-23 只读核验：
+
+| 项目 | 实测值 |
+| --- | --- |
+| container | `pi05-g1-policy`，连续运行 3 天 |
+| image | `pi05-g1:runtime-v3` |
+| image id | `sha256:cf89490a504d49649e663fbd1e7c3d400121cfd7fd0999add6843d80a3dc13dd` |
+| GPU | 物理 GPU 6，NVIDIA A100-SXM4-80GB；容器内 `cuda:0` |
+| dtype | `torch.float32` |
+| health contract | 50×18、10 denoising steps、fresh inference、task tokenizer loaded、`allow_zero_observation=false` |
+
+模型按卡片规格固定为 `xiaopeng-wu/pi05_unitree_g1` revision `580238372153c51ad564b894d8fea736ab4cdeb8`。当前 `/health` 不返回 revision，因此在线核验以固定 runtime-v3 image id、模型目录和同一常驻进程为证据，revision 字段来自已确认的模型资产规格。
+
+### 录制输入
+
+测试数据保留在共享 `vla-g1-deployment/artifacts/shadow/`，没有复制进卡片目录或 Docker layer。
+
+| 输入 | 格式 | SHA-256 |
+| --- | --- | --- |
+| `g1-fixed-frame.jpg` | JPEG，1920×1080 RGB，238,961 B | `5effd74a83c37da5a4087caffc93e5f807068d725e256fd6201105e31144eaac` |
+| `g1-real-runtime-v2-step10.state.json` | 29 个有限关节位置组成的 JSON array | `af8e1174c665d093a53d117e260c9b86c4b8bdd3b22ba2bf3633a1f72450a32f` |
+| task | `move blue box back and forth between tables` | 固定文本 |
+| seed | integer `0` | 固定值 |
+
+期望输出：`action_shape=[1,50,18]`、`action_space=physical_quantile_unnormalized`、10 steps、fresh inference、proposal `execution_authorized=false`，三次 action chunk 在零容差下严格相等。
+
+### 回放命令
+
+先建立临时 tunnel：
+
+```bash
+ssh -S none -o ExitOnForwardFailure=yes -N \
+  -L 18081:127.0.0.1:18080 wlcb-23
+```
+
+另一个终端执行：
+
+```bash
+python3 phanthymotus/perception/plugins/vlapi05g1/tests/replay_gate_c.py \
+  --policy-url http://127.0.0.1:18081/predict \
+  --health-url http://127.0.0.1:18081/health \
+  --image vla-g1-deployment/artifacts/shadow/g1-fixed-frame.jpg \
+  --state vla-g1-deployment/artifacts/shadow/g1-real-runtime-v2-step10.state.json \
+  --task "move blue box back and forth between tables" \
+  --seed 0 \
+  --runs 3 \
+  --timeout-s 120 \
+  --revision 580238372153c51ad564b894d8fea736ab4cdeb8 \
+  --output /private/tmp/vlapi05g1-gate-c.json
+```
+
+### 确定性与性能结果
+
+正式计量轮结果：
+
+| run | 端到端耗时 | policy 推理耗时 | action SHA-256 |
+| --- | ---: | ---: | --- |
+| 1 | 2.3969 s | 0.387789 s | `fc89babc5f5d898eaf802f66fdb26b9793cc9a6e03edc24dca758726633aeac6` |
+| 2 | 1.6990 s | 0.356905 s | 同上 |
+| 3 | 2.9808 s | 0.384513 s | 同上 |
+
+| 指标 | 结果 |
+| --- | ---: |
+| action 最大绝对差 | `0.0`，严格相等 |
+| 端到端 P50 / P95 | 2.3969 s / 2.9224 s |
+| policy P50 / P95 | 0.3845 s / 0.3875 s |
+| 顺序吞吐 | 0.4231 requests/s |
+| 卡片客户端 CPU | 0.035472 CPU-s；单核占用折算 0.5003% |
+| 卡片客户端最大 RSS | 31,522,816 B |
+| policy 容器采样峰值 CPU | 150.53% |
+| policy 容器采样峰值内存 | 4.829 GiB |
+| policy CUDA 峰值显存 | 16,736,264,192 B |
+
+回放器生成的机器可读报告位于 `/private/tmp/vlapi05g1-gate-c.json`，是临时验证产物，不纳入代码或镜像。为补齐 policy 容器 CPU/内存，正式计量轮期间并行执行只读 `docker stats`；验证结束后监控进程与 SSH tunnel 均已关闭，常驻 policy 容器未被重启或修改。
+
+P95 只有三次正式计量样本，满足 SOP 的最小重复次数，但不足以定义 production SLO；阶段四只把它作为回放基线。硬门禁是响应契约完整、三次严格确定、无隐式重试且 `execution_authorized=false`。


### PR DESCRIPTION
## 变更内容

- 新增多实例 `vlapi05g1` Perception processor 卡片。
- 以 `image/jpeg` 图像 topic 和 `data/json` G1 关节状态 topic 作为输入，发布 `pi05.g1.action_chunk.v1` 动作提案。
- 新增 Policy HTTP 客户端、健康信息、配置校验、输入新鲜度与图像大小门禁。
- 接入 Perception Bundle loader 与默认配置，并补充单元测试、Bundle 集成测试和阶段验证记录。

## 设计边界

- 卡片只负责 VLA 推理并输出动作提案，不直接控制机器人；下游执行器负责判断提案是否仍然有效并决定是否执行。
- `state` 遵循系统规范作为 input topic。
- Policy health 信息通过 `info` 返回，不增加独立 action。
- 当前输出动作维度不包含灵巧手/手指动作。

## 验证

- `validate_card.py`：PASS
- `python3 -m compileall -q perception/main.py perception/plugins/vlapi05g1`：PASS
- `/Users/hanzebei/miniconda3/bin/python -m unittest discover -s perception/plugins/vlapi05g1/tests -p 'test_*.py' -v`：14/14 PASS
- `git diff --check upstream/main...HEAD`：PASS

## 当前限制

- 本次 PR 前验证未重新执行北京 G1 真机动作闭环；仓库内阶段记录保留此前完成的接口、容器、ROS2 与 Core 门禁证据。
- 当前公开 Policy checkpoint 输出 18 维动作：14 维手臂关节与 4 维远端动作；卡片不会把未验证的远端动作直接下发。
- 数据集样例和测试道具的 3D 模型不在本 PR 范围内。
