### PR TITLE
fix(acp): interrupt not cancelling pending actions

### DIFF
--- a/agent-core/src/event/llm.py
+++ b/agent-core/src/event/llm.py
@@ -902,7 +902,7 @@ class Event:
                         _entry = mcp_client.registry.get(_mcp_id, {})
                         _split = _entry.get('split_map', {}).get(name, {})
                         _tool = _split.get('tool', parts[-1] if len(parts) > 2 else '')
-                        _act = _split.get('action', parts[-1] if len(parts) > 2 else '')
+                        _act = _split.get('action', args.get('action', ''))
                         if _hooks.is_interrupt_binding(_mcp_id, _tool, _act):
                             for aid in list(mcp_client._pending_actions.keys()):
                                 mcp_client._pending_results[aid] = {


### PR DESCRIPTION
## Summary
- Fix `_act` fallback in `_dispatch()` post-interrupt logic: was using `parts[-1]` (tool name "tts") instead of `args.get('action')` ("interrupt") for non-split tools
- This caused `is_interrupt_binding()` to always return False for perception TTS interrupt, leaving speak ACP pending and blocking the barrier indefinitely

## Test plan
- [ ] Trigger KWS → LLM calls tts interrupt → verify `[acp] interrupt: cancelled pending` appears in logs
- [ ] Next actuator tool should NOT be blocked by barrier waiting for old speak

🤖 Generated with [Claude Code](https://claude.com/claude-code)