### PR TITLE
fix(ui): reduce x-axis label crowding in usage chart

### DIFF
--- a/agent-core/web/css/style.css
+++ b/agent-core/web/css/style.css
@@ -5035,23 +5035,23 @@ html, body {
   display: flex;
   align-items: flex-end;
   gap: 3px;
-  height: 110px;
+  height: 130px;
   padding: 0;
-  padding-bottom: 20px;
+  padding-bottom: 22px;
+  border-bottom: 1px solid var(--border);
   position: relative;
   z-index: 2;
 }
 .usage-chart-wrap {
   position: relative;
   margin-bottom: 24px;
-  border-bottom: 1px solid var(--border);
 }
 .usage-y-lines {
   position: absolute;
   top: 0;
   left: 0;
   right: 0;
-  bottom: 20px;
+  bottom: 22px;
   pointer-events: none;
   z-index: 1;
 }
@@ -5083,6 +5083,7 @@ html, body {
   align-items: center;
   height: 100%;
   min-width: 0;
+  position: relative;
 }
 .usage-bar-track {
   flex: 1;
@@ -5108,6 +5109,9 @@ html, body {
   color: var(--text-dim);
   margin-top: 5px;
   white-space: nowrap;
+  position: absolute;
+  bottom: 0;
+  transform: translateY(100%);
 }
 
 /* Daily table */

--- a/agent-core/web/js/usage.js
+++ b/agent-core/web/js/usage.js
@@ -94,7 +94,10 @@ function _renderChart(el, breakdown, granularity) {
   // Generate Y-axis reference lines (3-4 lines)
   const yLines = _calcYLines(maxVal);
 
-  const bars = days.map(d => {
+  // Show every Nth label to avoid x-axis crowding
+  const labelStep = days.length > 24 ? Math.ceil(days.length / 12) : days.length > 12 ? 2 : 1;
+
+  const bars = days.map((d, i) => {
     const total = d.prompt_tokens + d.completion_tokens;
     const h = Math.max((total / maxVal) * 100, 3);
     const uncached = Math.max(d.prompt_tokens - (d.cached_tokens || 0), 0);
@@ -103,12 +106,12 @@ function _renderChart(el, breakdown, granularity) {
     // Format label based on granularity
     let dateLabel;
     if (granularity === 'hourly') {
-      // d.date is "2026-07-29 14" → show "14:00" or "07-29 14h"
       const parts = d.date.split(' ');
       dateLabel = parts.length > 1 ? parts[1] + ':00' : d.date;
     } else {
       dateLabel = d.date.slice(5); // MM-DD
     }
+    const showLabel = i % labelStep === 0;
     return `
       <div class="usage-bar" title="${d.date}\n非缓存输入: ${_fmt(uncached)}\n缓存输入: ${_fmt(cached)}\n输出: ${_fmt(comp)}">
         <div class="usage-bar-track">
@@ -118,7 +121,7 @@ function _renderChart(el, breakdown, granularity) {
             ${uncached ? `<div class="usage-bar-segment prompt" style="flex-grow:${uncached}"></div>` : ''}
           </div>
         </div>
-        <span class="usage-bar-date">${dateLabel}</span>
+        <span class="usage-bar-date">${showLabel ? dateLabel : ''}</span>
       </div>`;
   }).join('');
 


### PR DESCRIPTION
## Summary
- Show every Nth x-axis label when bars > 12 to prevent text overlap
- Position labels below the chart border line (was overlapping with axis)
- Increase chart height slightly for better readability

## Test plan
- [x] Deployed to Tianyi 2.0, verified visually

🤖 Generated with [Claude Code](https://claude.com/claude-code)