### PR TITLE
feat(遥操作): 新增可信 OpenXR 会话控制面

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ curl -fsSL https://motus.phanthy.com/install.sh | sudo bash -s <tag>
 
 The install script will automatically install Docker (if needed), pull the latest Agent Core image, and start the service.
 
-Open `http://<device-ip>:15678` to access the Web Dashboard.
+Open `https://<device-host>:15678` to access the Web Dashboard. Agent Core's
+compatibility certificate is self-signed, so a browser may show a certificate
+warning until a deployment certificate is configured as described below.
 
 Browse available versions and images at the [Resource Center](https://motus.phanthy.com).
 
@@ -86,7 +88,7 @@ The Agent Core is designed for **continuous operation over days or months**. The
 
 ## Web Dashboard
 
-The dashboard at `http://<device-ip>:15678` provides:
+The dashboard at `https://<device-host>:15678` provides:
 
 ### Canvas — Visual Orchestration
 
@@ -217,7 +219,77 @@ See [phanthymotus-driver/README_dev.md](../phanthymotus-driver/README_dev.md) fo
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, architecture details, and guidelines.
 
+### Shadow teleop session console
+
+Agent Core serves `https://<robot-host>:15678/teleop.html` as the authenticated Shadow teleop console. Viewers get a de-identified trusted-device/busy directory; operators and owners can acquire one exclusive session, renew its Core lease, enter Pause or HOLD, inspect Driver diagnostics and audit events, negotiate a real two-channel WebRTC peer, and release it. On a secure-context browser that reports `immersive-vr` support, an operator can explicitly enter Quest WebXR after the exact Core session is Active, owned by this tab, and both RTC channels are open. The page then samples the `local-floor` viewer and unique left/right `tracked-pointer` grip poses and sends `motus.teleop.rtc-frame.v1` frames over `teleop-pose`. Normal samples are limited to 60 Hz; a tracking/deadman degradation may preempt the next rate slot so the fail-safe frame is not delayed.
+
+For a repeatable Quest deployment, use one exact hostname to open the console
+and install a certificate whose Subject Alternative Name (SAN) covers that
+hostname and whose complete chain is accepted by Quest Browser. Place the
+files under the host's mounted deployment directory and configure both paths
+in `/opt/phanthy-motus/.env`:
+
+```dotenv
+MOTUS_TLS_CERT_FILE=/opt/phanthy-motus/tls/fullchain.pem
+MOTUS_TLS_KEY_FILE=/opt/phanthy-motus/tls/privkey.pem
+```
+
+Both settings are required together and refer to paths inside the Core
+container. The private key must be owner-only (`0600` or `0400`). If exactly
+one setting is present, either configured path is not a regular file, the key
+permissions are broader, or the certificate and key do not form a parseable
+matching server pair, Core stops instead of silently replacing deployment
+material. Restart Core after certificate rotation. With neither setting, Core keeps the backwards-compatible
+`/work/resource/certs/cert.pem` and `key.pem` pair and generates a self-signed
+pair only when both files are absent; an older, Core-owned unlinked fallback
+key is automatically restricted to `0600`. Core never changes the target mode
+of a symlinked or multiply-linked managed key. That fallback provides TLS transport but
+does **not** guarantee browser trust, a WebXR secure context, or Quest-device
+readiness.
+
+Before a Quest session, open the exact configured hostname in Quest Browser
+and verify all of the following: there is no certificate interstitial, the
+console reports `window.isSecureContext=true`, `immersive-vr` is supported, and
+an explicit user click successfully obtains the required `local-floor` XR
+session. Merely seeing an `https://` URL or finding a certificate file on Core
+is not acceptance evidence.
+
+WebXR deadman is opt-in: both valid `xr-standard` squeeze buttons must be held, and entry, reconnect, or tracking loss requires an observed release before a deliberate re-grip can re-arm it. Emulated positions are untracked. A 64 KiB message limit, a 16 KiB DataChannel buffered-amount high-water mark, send errors, RTC loss, XR or document visibility loss, `local-floor` reset, page exit, logout, and Pause/HOLD/Release all fail safe by releasing deadman and closing XR plus RTC; none of these paths automatically reconnect, re-enter VR, or Acquire. The XR animation loop also invokes the existing authenticated Core heartbeat near every five seconds when its single-flight guard is idle, because headset timer throttling must not move lease renewal onto RTC pose traffic.
+
+The transmitted values are raw right-handed WebXR `local-floor` coordinates in metres: +X right, +Y up, -Z forward, with quaternion order `[x,y,z,w]`. They are **not mapped to a robot frame**. The Driver remains `recording`/`would_apply` Shadow-only with `hardware output false`; the UI exposes pose freshness/latest sequence and dispatch evidence. This path has not yet been validated on a physical Quest and robot, and it cannot actuate a robot. The current immersive view is intentionally a diagnostic black field: it contains neither robot video nor an in-headset HUD. Tracking, deadman, sequence, and dispatch evidence remain on the 2D mirror page, so use Quest casting or a desktop browser to observe them.
+
+Core's default self-signed TLS fallback does **not** prove that Quest Browser will trust the site or expose WebXR on a physical headset. Use the exact hostname by which Quest accesses Core, a certificate whose hostname/SAN and trust chain are accepted by that browser, and treat the console's displayed origin plus live `isSecureContext` and `immersive-vr` results as the acceptance check. Explicit certificate/key deployment is intentionally outside this slice.
+
+Configure `ACCESS_TOKEN` for the backwards-compatible owner and named identities in `MOTUS_OPERATOR_TOKENS` / `MOTUS_VIEWER_TOKENS`. For a multi-Driver deployment, use strict JSON maps keyed by the exact stable MCP `id`:
+
+```dotenv
+MOTUS_DRIVER_TOKENS={"teleop-shadow-lab-a":"unique-driver-token-a-000001","teleop-shadow-lab-b":"unique-driver-token-b-000002"}
+MOTUS_TELEOP_TICKET_SECRETS={"teleop-shadow-lab-a":"at-least-32-unique-random-bytes-a","teleop-shadow-lab-b":"at-least-32-unique-random-bytes-b"}
+MOTUS_ENFORCE_DRIVER_AUTH=true
+```
+
+Core rejects duplicate ids, invalid ids, duplicate values across dedicated Bearer/ticket credential classes, and reuse with human or legacy credentials. A dedicated Bearer must contain 24–4096 restricted ASCII characters (`A-Z`, `a-z`, digits, `.`, `_`, `~`, `+`, `/`, `=`, `-`), can register only its mapped `driver_id`, and is accepted only through `X-Motus-Driver-Token` or `Authorization: Bearer`—registration query parameters never carry credentials. Every capability, MCP, SSE, teleop-session, and WebRTC `/offer` request selects that exact Driver's secret; an empty or invalid identity fails before a trusted network request. A dedicated registration persists only a one-way, id-bound credential binding—not the token. Adding or rotating that Driver's map entry quarantines the old trusted record before startup networking and requires a fresh inbound registration with the selected token; a stale dedicated binding cannot silently downgrade to the legacy fallback. The corresponding per-Driver ticket secret (at least 32 UTF-8 bytes) signs only that Driver's 20-second one-use offers. A robot is not teleop-ready and Acquire fails with `teleop_signaling_unavailable` when no exact or legacy ticket secret is selectable. Neither map, selected secret, ticket, nor fence is persisted in the Driver directory, registry, audit, or browser response.
+
+`MOTUS_DRIVER_TOKEN` and `MOTUS_TELEOP_TICKET_SECRET` remain optional migration fallbacks for ids absent from their maps; a mapped id never falls back. Remove both after every Driver has migrated. Operators are restricted to the dedicated `/api/teleop/*` session surface, viewers cannot mutate sessions, and existing APIs, Canvas calls, and WebSockets remain owner-only. Configuring any Driver or ticket credential automatically enables this API authentication boundary; without an `ACCESS_TOKEN` owner, protected management APIs fail closed with `401`. Core reads these values from `/opt/phanthy-motus/.env` as well as explicit process environment variables.
+
+`MOTUS_ENFORCE_DRIVER_AUTH=false` is the compatibility default: legacy MCP services continue to run but never receive teleop trust. After every service supports authenticated registration and MCP requests, set it to `true` so unauthenticated registrations remain quarantined discovery records. See [`deploy/.env.example`](deploy/.env.example) for the exact format.
+
+In-process desktop code, mutation, and arbitrary URL fetch tools (`Bash`, `PythonExec`, `Write`, `Edit`, and `WebFetch`) are not exposed to the LLM by default and cannot be enabled while human, Driver, or teleop credentials are configured. Read-only local file tools also deny deployment `.env`, private-key, certificate-container, and runtime configuration database paths, including symlink aliases. `MOTUS_ENABLE_UNSAFE_DESKTOP_CODE_TOOLS=true` is an explicit secret-free development escape hatch only; these in-process tools are not a security sandbox and must never be enabled in an authenticated deployment.
+
+Bearer and ticket changes are loaded only when Core starts; each Driver loads its paired values when that Driver starts. Never rotate credentials during an acquired session. Pause and Release the session, verify lifecycle `stop`/watchdog-safe evidence, update both sides, restart the Driver and Core in a coordinated maintenance window, then require fresh registration, ping, Shadow session, health `rtc_enabled=true`, and a real `/offer` smoke before restoring use. Remove a legacy fallback only after every instance passes. Dedicated credential bindings prevent a newly selected dedicated Bearer from being sent before re-registration. For an id still using the unbound legacy fallback, if the old endpoint itself may be compromised, first keep robot execution stopped and remove or owner-isolate that persisted trusted target after resolving any authority guard; otherwise startup can send the new legacy Bearer to the old owner-pinned URL. A shared-secret rollback is not a normal recovery path.
+
+The supported descriptor requires `protocol="motus.teleop.shadow.v1"`, `dispatch_contract="motus.teleop.dispatch.recording.v1"`, `mode="shadow"`, `actuation_enabled=false`, a 64-character lowercase hexadecimal `capability_digest`, actions `prepare_shadow/heartbeat/pause/release/soft_stop/status/stop`, and signaling declared as `motus.teleop.webrtc-offer-answer.v1` at `/offer` with `authenticated-core-proxy-only` access. `stop` is the fence-free lifecycle safety boundary used during restart reconciliation. Tools carrying `x-teleop` are excluded from ordinary Canvas, LLM schemas, and generic MCP calls.
+
+The browser sends only `{type: "offer", sdp}` to the authenticated same-origin Core route. Core binds a 20-second one-use HMAC ticket to the exact session, authority fence, capability digest, and SDP hash, then proxies it with the Driver bearer to the already pinned Driver `/offer` endpoint. Only `{type: "answer", sdp}` returns to the browser; the ticket and fence stay server-side. WebRTC DataChannels then run directly between the browser/Quest and Driver, so the Driver's ICE candidates must be reachable from the headset even though its HTTP endpoint remains loopback-only for Core. Entering immersive VR is always a direct user-click action that requests the required `local-floor` feature; support probing never opens a session.
+
+The console exposes a fixed, secret-free final-dispatch projection (state, generation, admitted/recorded sequence, stop acknowledgement and counters). Before the first `prepare_shadow` call, Core now commits a secret-free authority guard to SQLite. A Core restart restores that record only as a deny-only robot gate: it never restores the old session, fence, browser identity, or control authority. Ordinary actuator commands and new Acquire attempts remain blocked, and the guarded Driver/root target cannot be removed, retargeted, or rebound while recovery is pending.
+
+Only an owner may call `POST /api/teleop/authority-guards/{robot_id}/reconcile`. Core first requires the exact trusted Driver identity, capability digest, and target fingerprint recorded before the crash. It then clears the guard only when the same Driver boot proves a newer `safe_revoked` generation, a new boot proves `safe_unarmed` with its startup stop acknowledgement, or a fence-free lifecycle `stop` returns a strictly validated safe response. The persistent row is deleted before the in-process command gate is reopened; an unreadable store, changed target, malformed proof, uncertain delete, or pending stop keeps the robot quarantined and retryable.
+
+This recovery design supports one Core process using its configured SQLite database; active/active Core replicas or independent database copies do not share an authority gate and are not supported. When upgrading from a version without persistent guards, safely stop and release every existing teleop/robot session before replacing and restarting Core—the new table cannot represent authority that belonged to the old process. Do not roll back to a pre-guard Core while any guard or recovery is pending: first complete owner reconciliation and verify the Driver is safe, or keep Core and robot execution stopped. Older Core versions silently ignore this table. This remains a Shadow-only path with `hardware output false`; persistent recovery does not enable physical actuation.
+
+Authority uses two independent leases. The browser renews a 15-second Core ownership lease every five seconds; Core alone sends the trusted Driver heartbeat at up to 250 ms intervals, inside the Driver's default one-second watchdog. Pose traffic never renews either ownership boundary. A closed/throttled page, Core shutdown, Driver restart, identity mismatch, or heartbeat failure therefore terminates authority without an automatic reacquire. Internal deadlines use a monotonic clock, Driver epochs persist in SQLite, and the fence credential is never returned to the browser, audit database, Activity stream, or generic MCP paths.
+
 ## License
 
 [Apache License 2.0](LICENSE)
-

--- a/README_zh.md
+++ b/README_zh.md
@@ -20,7 +20,7 @@ curl -fsSL https://motus.phanthy.com/install.sh | sudo bash -s <tag>
 
 安装脚本会自动安装 Docker（如未安装）、拉取最新 Agent Core 镜像并启动服务。
 
-打开 `http://<设备IP>:15678` 进入 Web Dashboard。
+打开 `https://<设备主机名>:15678` 进入 Web Dashboard。Agent Core 的兼容证书为自签名证书，在按下文配置部署证书前，浏览器可能显示证书警告。
 
 在 [Resource Center](https://motus.phanthy.com) 浏览可用版本和镜像。
 
@@ -49,7 +49,7 @@ curl -fsSL https://motus.phanthy.com/install.sh | sudo bash -s <tag>
 
 ## Web Dashboard
 
-Dashboard（`http://<设备IP>:15678`）提供：
+Dashboard（`https://<设备主机名>:15678`）提供：
 
 ### Canvas — 可视化编排
 
@@ -109,6 +109,61 @@ Dashboard（`http://<设备IP>:15678`）提供：
 ## 贡献
 
 参见 [CONTRIBUTING.md](CONTRIBUTING.md) 了解开发环境搭建、架构细节和贡献指南。
+
+### Shadow 遥操会话控制台与身份配置
+
+Agent Core 提供 `https://<robot-host>:15678/teleop.html` Shadow 遥操控制台。viewer 只能查看去身份化的可信设备与忙闲状态；operator/owner 可以获取单机器人独占会话、查看 15 秒倒计时与 Driver 诊断、进入 Pause/HOLD、建立真实的双 DataChannel WebRTC peer、查看审计事件并释放会话。在浏览器处于安全上下文且报告支持 `immersive-vr` 时，只有精确 Core 会话为 Active、本标签页持有且 RTC 双通道均已打开，操作者才能通过明确点击进入 Quest WebXR。页面随后从 `local-floor` 采样 viewer 与唯一左右 `tracked-pointer` grip 姿态，并通过 `teleop-pose` 发送 `motus.teleop.rtc-frame.v1`。普通采样限频为 60 Hz；tracking/deadman 由安全变为不安全时可以抢占下一个限频槽，避免延迟 fail-safe frame。
+
+为了可重复地在 Quest 上部署，请固定使用一个精确主机名访问控制台，并使证书的 Subject Alternative Name（SAN）覆盖该主机名，完整证书链也必须被 Quest Browser 接受。将证书放到宿主机已挂载的部署目录，并在 `/opt/phanthy-motus/.env` 中成对配置：
+
+```dotenv
+MOTUS_TLS_CERT_FILE=/opt/phanthy-motus/tls/fullchain.pem
+MOTUS_TLS_KEY_FILE=/opt/phanthy-motus/tls/privkey.pem
+```
+
+两项必须同时配置，且都是 Core 容器内可见路径；私钥必须为 owner-only（`0600` 或 `0400`）。如果只配一项、任一路径不是普通文件、私钥权限过宽，或证书和私钥不是可解析且相互匹配的服务端 pair，Core 会直接停止启动，不会悄悄替换部署材料。证书轮换后需要重启 Core。两项都未配置时，Core 继续兼容 `/work/resource/certs/cert.pem` 与 `key.pem`，且只在两个文件都不存在时生成自签名 pair；Core 自有且没有链接的旧 fallback 私钥会自动收紧为 `0600`，但不会修改软链接或多重硬链接所指向的托管私钥权限。该 fallback 只提供 TLS 传输，**不保证**浏览器信任、WebXR 安全上下文或 Quest 真机可用。
+
+真机会话前，用 Quest Browser 打开上述精确主机名，并逐项验证：没有证书拦截页或警告；控制台报告 `window.isSecureContext=true`；`immersive-vr` 受支持；操作者明确点击后成功获取必需的 `local-floor` XR session。仅看到 `https://` URL 或 Core 上存在证书文件，不能作为验收证据。
+
+WebXR deadman 必须显式触发：两个有效 `xr-standard` squeeze 都按下才可能为 true；首次进入、重连或 tracking 丢失后，必须先观察到一次松开，再主动重握才能重新武装。`emulatedPosition` 一律按未追踪处理。单帧协议上限为 64 KiB，DataChannel `bufferedAmount` 高水位为 16 KiB；消息过大、背压、send 异常、RTC 断开、XR 或 document 不可见、`local-floor` reset、离页、退出登录以及 Pause/HOLD/Release 都会先释放 deadman 并关闭 XR 与 RTC，不会自动恢复、重连、重进 VR 或 Acquire。为防头显节流普通 timer，XR animation frame 会在既有认证 Core heartbeat 的 single-flight 空闲时约每 5 秒触发一次续租；RTC 姿态包仍不能续任何租约。
+
+当前发送的是 WebXR 右手系原始 `local-floor` 数据，单位为米：+X 向右、+Y 向上、-Z 向前，四元数顺序为 `[x,y,z,w]`；**尚未映射到机器人坐标系**。Driver 仍只做 `recording` / `would_apply` Shadow 记录，`hardware output false`；页面展示 pose freshness/latest sequence 与 dispatch 证据。该链路尚未在真实 Quest 和真实机器人上完成验证，也没有机器人执行输出。当前 immersive 画面有意保持为诊断黑场：既没有机器人视频，也没有头显内 HUD；tracking、deadman、sequence 与 dispatch 证据仍只在 2D 镜像页显示，需要通过 Quest 投屏或桌面浏览器观察。
+
+Core 默认的自签 TLS fallback **不能证明** Quest Browser 会信任站点或在真机暴露 WebXR。必须使用 Quest 实际访问 Core 的精确 hostname，确保证书 hostname/SAN 与信任链均被该浏览器接受，并以控制台显示的 origin、实时 `isSecureContext` 与 `immersive-vr` 检测结果作为验收依据。显式证书/密钥部署不属于当前切片。
+
+在部署目录的 `.env` 中配置：
+
+```dotenv
+ACCESS_TOKEN=owner-long-random-token
+MOTUS_OPERATOR_TOKENS={"lab-operator":"operator-long-random-token"}
+MOTUS_VIEWER_TOKENS={"auditor":"viewer-long-random-token"}
+MOTUS_DRIVER_TOKENS={"teleop-shadow-lab-a":"unique-driver-token-a-000001","teleop-shadow-lab-b":"unique-driver-token-b-000002"}
+MOTUS_TELEOP_TICKET_SECRETS={"teleop-shadow-lab-a":"at-least-32-unique-random-bytes-a","teleop-shadow-lab-b":"at-least-32-unique-random-bytes-b"}
+MOTUS_ENFORCE_DRIVER_AUTH=true
+```
+
+- `ACCESS_TOKEN` 保持向后兼容并映射为 owner；只有 owner 能访问已有 API、Canvas 和 WebSocket。
+- operator 只能使用专用 `/api/teleop/*` 会话接口，viewer 无法创建或修改会话；两者仍不能访问已有 API、Canvas 和 WebSocket。
+- `MOTUS_DRIVER_TOKENS` 是严格 JSON 对象，键必须是 Driver 注册和 `x-teleop.driver_id` 使用的精确稳定 MCP id；每个 Bearer 必须是 24–4096 个受限 ASCII 字符（`A-Z`、`a-z`、数字以及 `._~+/=-`）。每个值必须唯一且不能复用人类或旧凭证；注册凭证只接受 `X-Motus-Driver-Token` 或 `Authorization: Bearer`，URL 查询参数永远不承载 Driver 密钥。A 的凭证声明 B 会直接返回 403、零配置写入、零 ping。Core 对 capability、普通 MCP、SSE、遥操控制和 `/offer` 都按精确、非空 Driver id 选择 Bearer，缺失或非法 id 会在网络请求前失败。专属凭证注册只持久化单向、绑定 id 的 credential binding，不存 token；新增或轮换该 id 的映射后，旧 trusted 记录会在启动联网前隔离，必须由新 token 主动重新注册，旧专属 binding 也不能静默降级到 legacy fallback。
+- `MOTUS_TELEOP_TICKET_SECRETS` 同样按精确 Driver id 配置唯一 HMAC secret，每个至少 32 个 UTF-8 字节，只用于该 Driver 的 20 秒、一次性 WebRTC offer ticket；Core 也会拒绝 ticket secret 与任一专属 Bearer、人类或旧凭证交叉复用。精确 id 与 legacy fallback 都无法选出 ticket secret 时，目录显示 `teleop_signaling_unavailable`，Acquire 会在 Driver 调用前拒绝。Core 可直接从 `/opt/phanthy-motus/.env` 读取；映射、密钥、ticket 和 fence 都不写入 Driver 目录、runtime registry、审计或 Quest 响应。
+- `MOTUS_DRIVER_TOKEN` 与 `MOTUS_TELEOP_TICKET_SECRET` 仅保留为迁移 fallback：只对各自映射中不存在的 id 生效，已映射 id 永远不会回退。所有 Driver 迁移后应删除这两个旧变量。配置任意 Driver 或 ticket 凭据都会自动启用 API 认证边界；如果没有配置 `ACCESS_TOKEN` owner，受保护的管理 API 会以 `401` fail closed。
+- `MOTUS_ENFORCE_DRIVER_AUTH=false` 仍是默认兼容模式：旧 MCP 继续工作，但永远没有遥操信任。多 Driver 隔离部署应在所有服务升级后切换为 `true`；未认证服务届时只保留 discovery 记录，不进入运行时 registry 或 LLM schema。
+
+带认证凭据的部署默认不会向 LLM 暴露同进程代码、本地修改或任意 URL 抓取工具（`Bash`、`PythonExec`、`Write`、`Edit`、`WebFetch`），配置了人类、Driver 或遥操密钥时也禁止开启。只读文件工具会拒绝部署 `.env`、私钥、证书容器和运行时配置数据库，包括指向这些文件的符号链接。`MOTUS_ENABLE_UNSAFE_DESKTOP_CODE_TOOLS=true` 只允许用于完全无凭据的显式开发逃生口；这些同进程工具不是安全沙箱，认证部署绝不能开启。
+
+Bearer 与 ticket 只有在 Core 启动时加载，每台 Driver 也只在自身启动时加载对应值；已经 Acquire 的会话中禁止轮换。维护时应先 Pause/Release，确认 lifecycle `stop` 或 watchdog-safe 证据，再同步更新两端并协调重启 Driver/Core；随后必须重新注册、ping、跑 Shadow 会话、确认 `health.rtc_enabled=true`，并完成一次真实 `/offer` smoke 后才能恢复使用。所有实例通过后才删除 legacy fallback。专属 credential binding 会阻止新专属 Bearer 在重新注册前被发出；如果某个 id 仍使用未绑定的 legacy fallback 且怀疑旧 endpoint 已失陷，则应先保持机器人执行停机，并在处理完 authority guard 后删除或由 owner 隔离旧 trusted target，否则启动仍可能把新 legacy Bearer 发给旧的 owner-pinned URL。回退到共享密钥不能作为普通恢复方案。
+
+当前支持的 `x-teleop` 描述要求 `protocol="motus.teleop.shadow.v1"`、`dispatch_contract="motus.teleop.dispatch.recording.v1"`、`mode="shadow"`、`actuation_enabled=false`、64 位小写十六进制 `capability_digest`，action enum 至少包含 `prepare_shadow/heartbeat/pause/release/soft_stop/status/stop`，且 signaling 必须声明 `motus.teleop.webrtc-offer-answer.v1` + `/offer` + `authenticated-core-proxy-only`。其中 `stop` 是不携带旧 fence 的 lifecycle 安全停机边界。所有带 `x-teleop` 的工具都会从普通 Canvas、LLM schema 和通用 MCP call 中排除。
+
+浏览器只向同源、已认证的 Core 接口发送 `{type: "offer", sdp}`。Core 将一次性 ticket 绑定到精确会话、authority fence、capability digest 和 SDP 哈希，再携带 Driver bearer 代理到已固定的 Driver `/offer`；浏览器仅收到 `{type: "answer", sdp}`。之后 WebRTC DataChannel 由浏览器/Quest 与 Driver 直连，因此即使 Driver HTTP 只绑定 loopback，Driver 生成的 ICE candidate 仍必须能被头显访问。进入 immersive VR 永远由用户点击直接触发，并强制请求 `local-floor`；能力探测不会打开 session。
+
+控制台会显示固定且不含密钥的 final-dispatch 证据，包括状态、generation、已接收/已记录 sequence、停机回执和计数器。在第一次调用 `prepare_shadow` 之前，Core 现在会先把一条不含密钥的 authority guard 写入 SQLite。Core 重启后只把它恢复成拒绝普通写入的机器人安全锁，不会恢复旧 session、fence、浏览器身份或任何控制权；恢复完成前，普通执行器命令和新的 Acquire 都会被拒绝，受保护的 Driver/机器人根目标也不能被删除、改址或改绑。
+
+只有 owner 可以调用 `POST /api/teleop/authority-guards/{robot_id}/reconcile`。Core 会先核对崩溃前固定的可信 Driver 身份、capability digest 和目标指纹；随后只有同一 Driver boot 证明了更高 generation 的 `safe_revoked`、新 boot 以启动停机回执证明 `safe_unarmed`，或一次不携带旧 fence 的 lifecycle `stop` 返回严格校验通过的安全结果时，才会清锁。持久记录必须先删除，进程内普通命令门才会开放；数据库不可读、目标变化、证明畸形、删除结果不确定或停机仍 pending 时都会继续隔离，并允许 owner 稍后重试。
+
+这套恢复机制只支持单个 Core 进程使用其配置的 SQLite 数据库；active/active Core 副本或各自独立的数据库不会共享 authority gate，因此不受支持。从没有持久 guard 的旧版本升级时，必须先安全停止并 Release 所有现有遥操/机器人会话，再替换并重启 Core，因为新表无法追溯旧进程曾持有的控制权。存在任何 guard 或未完成恢复时，禁止回滚到不认识该表的旧版 Core：必须先由 owner 完成恢复核验并确认 Driver 安全，或者让 Core 与机器人执行保持停机；旧版 Core 会静默忽略这张表。当前路径仍是 `hardware output false` 的 Shadow 模式；持久恢复本身不会启用真实机器人执行。
+
+权限由两层独立租约约束：浏览器每 5 秒续一次 Core 的 15 秒操作者租约；只有 Core 会以不超过 250 ms 的间隔续 Driver 默认 1 秒 watchdog。姿态包和 RTC ping 都不能续租。页面关闭或被节流、Core 关闭、Driver 重启、身份不匹配或心跳故障都会终止 authority，网络恢复后不会自动重新获取。Core 内部只用单调时钟判定 deadline，per-Driver epoch 持久化到 SQLite；fence 凭据不会返回浏览器，也不会进入审计库、Activity 或通用 MCP 路径。
 
 ## 许可证
 

--- a/agent-core/clients/quest-capture-native/.gitignore
+++ b/agent-core/clients/quest-capture-native/.gitignore
@@ -1,0 +1,6 @@
+.gradle/
+.idea/
+app/.cxx/
+app/build/
+build/
+local.properties

--- a/agent-core/clients/quest-capture-native/README.md
+++ b/agent-core/clients/quest-capture-native/README.md
@@ -1,0 +1,158 @@
+# PhanthyMotus Android OpenXR Capture
+
+This is the native, menu-free Android OpenXR pose endpoint for the generic
+teleoperation platform. One shared codebase produces separate Meta Quest and
+PICO APKs. Both send the public `motus.teleop.rtc-frame.v1` contract directly to
+a Driver over WebRTC. The Capture app does not own a Core session, lease, fence,
+operator token, Acquire action, or Live confirmation.
+
+## Supported build targets
+
+| Build target | Target device family | Application ID | Debug APK |
+| --- | --- | --- | --- |
+| `meta` | Meta Quest 3 | `com.phanthymotus.questcapture` | `app/build/outputs/apk/meta/debug/app-meta-debug.apk` |
+| `pico` | PICO 4 / 4 Enterprise / 4 Ultra / Ultra Enterprise | `com.phanthymotus.picocapture` | `app/build/outputs/apk/pico/debug/app-pico-debug.apk` |
+
+The PICO target uses the standard Khronos Android OpenXR loader, which PICO
+supports starting with PICO OS 5.9.0. Update the headset to at least that version
+before testing. See PICO's [standard-loader announcement][pico-loader] and
+[Native SDK release notes][pico-native].
+
+Use PICO OS 5.13.0 or newer as the shared acceptance baseline. At startup the
+same PICO APK enables only the controller extensions actually exposed by the
+runtime: `XR_BD_controller_interaction` for PICO 4-class controllers and
+`XR_BD_ultra_controller_interaction` for PICO 4 Ultra-class controllers. If
+neither current Khronos profile is available, the app stops instead of emitting
+apparently valid input from an unknown controller.
+
+The PICO APK has build and static validation, but has not yet completed hardware
+acceptance on a PICO headset. Do not claim device support until install, OpenXR
+session, controller profile, dual-squeeze deadman, tracking-loss HOLD, reconnect,
+and end-to-end Driver frame checks pass on each target device/OS combination.
+
+[pico-loader]: https://developer.picoxr.com/blog/muz6s63x/
+[pico-native]: https://developer.picoxr.com/document/native/
+
+## Operator flow
+
+1. On the PC teleoperation page, create a one-time Capture pairing.
+2. Install the correct APK once and launch it with the pairing bootstrap from
+   the PC. The pairing code is consumed once; the resulting credential is stored
+   in that application's private Android preferences.
+3. On subsequent days, start it from the PC with `launch_capture.sh --platform
+   meta --resume` or `--platform pico --resume`. The app calls `xrBeginSession`
+   automatically when the runtime enters `READY`; the wearer does not click a VR
+   page or menu.
+4. The PC operator alone performs Acquire, explicit Live confirmation, Capture
+   attachment, Pause/HOLD, and Release. The wearer still physically uses both
+   squeeze controls as the motion deadman.
+
+An Android or OpenXR system permission prompt may still appear on first install.
+The application cannot collect controller poses while Android backgrounds it or
+OpenXR removes `FOCUSED` input ownership; that transition closes RTC locally and
+Core independently forces the session into HOLD.
+
+## Build
+
+Required versions are fixed in the project:
+
+- JDK 17
+- Android platform 35 and build-tools 35.0.1
+- NDK 27.0.12077973
+- CMake 3.22.1
+- Gradle 8.9 (downloaded and SHA-256 verified by the build script)
+- OpenXR Android loader 1.1.60 (AAR SHA-256 verified by Gradle)
+- libdatachannel 0.24.3 and Mbed TLS 3.6.7 (immutable Git revisions)
+
+After accepting the Android SDK/NDK licenses in your own SDK installation, build
+both APKs (the default):
+
+```sh
+export JAVA_HOME=/path/to/jdk-17
+export ANDROID_SDK_ROOT=/path/to/android-sdk
+./scripts/build_android.sh
+```
+
+For a shorter incremental build, select one target explicitly:
+
+```sh
+./scripts/build_android.sh --platform meta
+./scripts/build_android.sh --platform pico
+```
+
+The flavors pass `MOTUS_CAPTURE_HEADSET=meta` or
+`MOTUS_CAPTURE_HEADSET=pico` to the native build. The Meta APK accepts only the
+Oculus Touch profile; the PICO APK dynamically accepts the current PICO 4 and
+PICO 4 Ultra profiles described above.
+
+## Install and first pairing
+
+Install the APK that matches the headset:
+
+```sh
+adb install -r app/build/outputs/apk/meta/debug/app-meta-debug.apk
+# Or:
+adb install -r app/build/outputs/apk/pico/debug/app-pico-debug.apk
+```
+
+Then launch and pair it from the PC:
+
+```sh
+export CORE_WSS_URL='wss://core-host:15678/ws/teleop-capture'
+export PAIRING_ID='the-id-shown-on-the-PC'
+export CA_CERT_BASE64='the-public-value-shown-on-the-PC'
+./scripts/launch_capture.sh --platform meta
+# Or: ./scripts/launch_capture.sh --platform pico
+```
+
+The script prompts without terminal echo for the one-time pairing code. Resume a
+previously paired app with:
+
+```sh
+./scripts/launch_capture.sh --platform meta --resume
+./scripts/launch_capture.sh --platform pico --resume
+```
+
+When multiple or wireless-ADB devices are visible, target one explicitly without
+changing the command:
+
+```sh
+ADB_SERIAL='10.110.15.178:5555' \
+  ./scripts/launch_capture.sh --platform meta --resume
+```
+
+`CA_CERT_FILE=/path/to/public-chain.pem` may be used instead of the Base64 field.
+If Core was restarted or the enrollment was revoked, generate a new pairing on
+the PC and run the first-pairing command again. An explicit new bootstrap
+replaces the stored credential; clearing app data or using a headset menu is not
+required. Meta and PICO use different application IDs, so their credentials
+cannot be mixed accidentally.
+
+No G1 connection or robot output is involved in build, pairing, or Shadow
+validation.
+
+## Host protocol and launcher tests
+
+```sh
+./tests/launch_capture_test.sh
+
+NLOHMANN_JSON_INCLUDE=/path/to/nlohmann/include \
+PHANTHYMOTUS_DRIVER_G1_ROOT=/path/to/teleop-driver/unitree/g1 \
+./tests/run_host_tests.sh
+```
+
+After building both APKs, verify package identity, permissions, PICO-only
+metadata, ABI, ELF dependencies, alignment and signature:
+
+```sh
+ANDROID_SDK_ROOT=/path/to/android-sdk \
+JAVA_HOME=/path/to/jdk-17 \
+python3 ./tests/verify_android_apks.py
+```
+
+The launcher test uses a fake ADB executable and covers exact Meta/PICO package
+selection, `ADB_SERIAL`, resume, first pairing, secret-free output, and malformed
+arguments. The protocol checks cover release-neutral-regrip, reconnect
+watermarks, exact WSS envelopes, duplicate-key rejection, one-shot SDP,
+exported-Activity origin/CA pinning, and the real G1 Driver's strict RTC frame
+parser without starting a publisher.

--- a/agent-core/clients/quest-capture-native/THIRD_PARTY_NOTICES.md
+++ b/agent-core/clients/quest-capture-native/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,14 @@
+# Third-party components
+
+- Khronos OpenXR Android loader 1.1.60, Apache-2.0. The Android lifecycle,
+  loader initialization, and session-state handling follow the public
+  `hello_xr` sample from OpenXR-SDK-Source release 1.1.60.
+- libdatachannel 0.24.3 (`c47f5d77...`), MPL-2.0, built without media support.
+- Mbed TLS 3.6.7 (`068ff080...`), Apache-2.0 or GPL-2.0-or-later; this build
+  consumes it under Apache-2.0.
+- nlohmann/json is consumed at libdatachannel's pinned submodule revision and
+  is MIT licensed.
+
+All dependencies are pinned by immutable source revision or Maven version in
+the build files. Their complete license texts remain available from their
+respective distributions.

--- a/agent-core/clients/quest-capture-native/app/build.gradle.kts
+++ b/agent-core/clients/quest-capture-native/app/build.gradle.kts
@@ -1,0 +1,100 @@
+import java.security.MessageDigest
+
+plugins {
+    id("com.android.application")
+}
+
+android {
+    namespace = "com.phanthymotus.questcapture"
+    compileSdk = 35
+    ndkVersion = "27.0.12077973"
+
+    defaultConfig {
+        applicationId = "com.phanthymotus.questcapture"
+        minSdk = 29
+        targetSdk = 35
+        versionCode = 2
+        versionName = "0.2.0"
+
+        ndk {
+            abiFilters += "arm64-v8a"
+        }
+        externalNativeBuild {
+            cmake {
+                cppFlags += listOf("-std=c++20", "-fexceptions", "-frtti")
+                arguments += listOf(
+                    "-DANDROID_STL=c++_shared",
+                    "-DCMAKE_BUILD_TYPE=RelWithDebInfo",
+                )
+                targets += "motus_quest_capture"
+            }
+        }
+    }
+
+    flavorDimensions += "headset"
+    productFlavors {
+        create("meta") {
+            dimension = "headset"
+            applicationId = "com.phanthymotus.questcapture"
+            externalNativeBuild {
+                cmake {
+                    arguments += "-DMOTUS_CAPTURE_HEADSET=meta"
+                }
+            }
+        }
+        create("pico") {
+            dimension = "headset"
+            applicationId = "com.phanthymotus.picocapture"
+            externalNativeBuild {
+                cmake {
+                    arguments += "-DMOTUS_CAPTURE_HEADSET=pico"
+                }
+            }
+        }
+    }
+
+    buildFeatures {
+        prefab = true
+    }
+    externalNativeBuild {
+        cmake {
+            path = file("src/main/cpp/CMakeLists.txt")
+            version = "3.22.1"
+        }
+    }
+    buildTypes {
+        debug {
+            isJniDebuggable = true
+        }
+        release {
+            isMinifyEnabled = false
+        }
+    }
+    packaging {
+        jniLibs.useLegacyPackaging = true
+    }
+}
+
+dependencies {
+    implementation("org.khronos.openxr:openxr_loader_for_android:1.1.60")
+}
+
+val verifyOpenXrArtifact by tasks.registering {
+    val artifact = configurations.detachedConfiguration(
+        dependencies.create("org.khronos.openxr:openxr_loader_for_android:1.1.60"),
+    )
+    inputs.files(artifact)
+    doLast {
+        val file = artifact.singleFile
+        val digest = MessageDigest.getInstance("SHA-256")
+            .digest(file.readBytes())
+            .joinToString("") { "%02x".format(it) }
+        check(digest == "9a21ecea6b308d3a7fcf261412bec4cb1ae9148ba053d6b24da468fef96029c7") {
+            "OpenXR Android loader checksum mismatch: $digest"
+        }
+    }
+}
+
+tasks.named("preBuild").configure {
+    dependsOn(verifyOpenXrArtifact)
+}

--- a/agent-core/clients/quest-capture-native/app/src/main/AndroidManifest.xml
+++ b/agent-core/clients/quest-capture-native/app/src/main/AndroidManifest.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
+
+    <uses-feature
+        android:name="android.hardware.vr.headtracking"
+        android:required="true"
+        android:version="1" />
+    <uses-feature
+        android:glEsVersion="0x00030000"
+        android:required="true" />
+
+    <application
+        android:allowBackup="false"
+        android:hasCode="false"
+        android:label="@string/app_name"
+        android:supportsRtl="false"
+        android:theme="@android:style/Theme.Black.NoTitleBar.Fullscreen">
+        <activity
+            android:name="android.app.NativeActivity"
+            android:configChanges="screenSize|screenLayout|orientation|keyboardHidden|keyboard|navigation|uiMode|density"
+            android:excludeFromRecents="false"
+            android:exported="true"
+            android:launchMode="singleTask"
+            android:resizeableActivity="false"
+            android:screenOrientation="landscape">
+            <meta-data
+                android:name="android.app.lib_name"
+                android:value="motus_quest_capture" />
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+                <category android:name="org.khronos.openxr.intent.category.IMMERSIVE_HMD" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>

--- a/agent-core/clients/quest-capture-native/app/src/main/cpp/CMakeLists.txt
+++ b/agent-core/clients/quest-capture-native/app/src/main/cpp/CMakeLists.txt
@@ -1,0 +1,119 @@
+cmake_minimum_required(VERSION 3.22.1)
+project(motus_quest_capture LANGUAGES C CXX)
+
+include(FetchContent)
+
+set(MOTUS_CAPTURE_HEADSET "meta" CACHE STRING "OpenXR headset target: meta or pico")
+set_property(CACHE MOTUS_CAPTURE_HEADSET PROPERTY STRINGS meta pico)
+if(MOTUS_CAPTURE_HEADSET STREQUAL "meta")
+    set(motus_capture_headset_definition MOTUS_CAPTURE_HEADSET_META=1)
+elseif(MOTUS_CAPTURE_HEADSET STREQUAL "pico")
+    set(motus_capture_headset_definition MOTUS_CAPTURE_HEADSET_PICO=1)
+else()
+    message(FATAL_ERROR "MOTUS_CAPTURE_HEADSET must be 'meta' or 'pico'")
+endif()
+
+# This is an Android application build, not an installable CMake package.  In
+# particular, libdatachannel's install export cannot describe our in-tree
+# static Mbed TLS target.  Suppress dependency install/export rules instead of
+# weakening the TLS linkage or patching third-party sources.
+set(CMAKE_SKIP_INSTALL_RULES ON CACHE BOOL "" FORCE)
+set(BUILD_SHARED_LIBS OFF CACHE BOOL "" FORCE)
+set(ENABLE_PROGRAMS OFF CACHE BOOL "" FORCE)
+set(ENABLE_TESTING OFF CACHE BOOL "" FORCE)
+set(MBEDTLS_FATAL_WARNINGS OFF CACHE BOOL "" FORCE)
+set(DISABLE_PACKAGE_CONFIG_AND_INSTALL ON CACHE BOOL "" FORCE)
+set(
+    MBEDTLS_USER_CONFIG_FILE
+    "${CMAKE_CURRENT_LIST_DIR}/mbedtls_user_config.h"
+    CACHE FILEPATH "" FORCE
+)
+FetchContent_Declare(
+    mbedtls
+    GIT_REPOSITORY https://github.com/Mbed-TLS/mbedtls.git
+    GIT_TAG 068ff080b369adfac81509f9b57b2afabaf82dc5
+    GIT_SUBMODULES_RECURSE TRUE
+)
+FetchContent_MakeAvailable(mbedtls)
+if(NOT TARGET MbedTLS::MbedTLS)
+    add_library(MbedTLS::MbedTLS ALIAS mbedtls)
+endif()
+
+set(USE_MBEDTLS ON CACHE BOOL "" FORCE)
+set(NO_MEDIA ON CACHE BOOL "" FORCE)
+set(NO_EXAMPLES ON CACHE BOOL "" FORCE)
+set(NO_TESTS ON CACHE BOOL "" FORCE)
+set(WARNINGS_AS_ERRORS OFF CACHE BOOL "" FORCE)
+set(BUILD_SHARED_DEPS_LIBS OFF CACHE BOOL "" FORCE)
+FetchContent_Declare(
+    libdatachannel
+    GIT_REPOSITORY https://github.com/paullouisageneau/libdatachannel.git
+    GIT_TAG c47f5d77c124c35c31ac8378ad613295a124d354
+    GIT_SUBMODULES
+        deps/json
+        deps/libjuice
+        deps/plog
+        deps/usrsctp
+    GIT_SUBMODULES_RECURSE TRUE
+)
+FetchContent_MakeAvailable(libdatachannel)
+if(NOT TARGET nlohmann_json::nlohmann_json)
+    set(JSON_BuildTests OFF CACHE INTERNAL "")
+    add_subdirectory(
+        "${libdatachannel_SOURCE_DIR}/deps/json"
+        "${libdatachannel_BINARY_DIR}/deps/json"
+        EXCLUDE_FROM_ALL
+    )
+endif()
+
+find_package(OpenXR REQUIRED CONFIG)
+find_library(android-lib android REQUIRED)
+find_library(egl-lib EGL REQUIRED)
+find_library(gles-lib GLESv3 REQUIRED)
+find_library(log-lib log REQUIRED)
+
+set(project_root "${CMAKE_CURRENT_LIST_DIR}/../../../..")
+set(native_app_glue "${ANDROID_NDK}/sources/android/native_app_glue")
+
+add_library(android_native_app_glue STATIC "${native_app_glue}/android_native_app_glue.c")
+target_include_directories(android_native_app_glue PUBLIC "${native_app_glue}")
+
+add_library(motus_quest_capture SHARED
+    android_main.cpp
+    capture_transport.cpp
+    openxr_capture.cpp
+    runtime_profile.cpp
+    "${project_root}/src/capture_session.cpp"
+    "${project_root}/src/capture_wire.cpp"
+    "${project_root}/src/enrollment.cpp"
+    "${project_root}/src/frame_v1.cpp"
+)
+target_include_directories(motus_quest_capture PRIVATE
+    "${project_root}/include"
+)
+target_compile_features(motus_quest_capture PRIVATE cxx_std_20)
+target_compile_definitions(motus_quest_capture PRIVATE
+    ${motus_capture_headset_definition}
+    XR_USE_PLATFORM_ANDROID
+    XR_USE_GRAPHICS_API_OPENGL_ES
+)
+target_compile_options(motus_quest_capture PRIVATE
+    -Wall
+    -Wextra
+    -Werror
+    -Wpedantic
+    # OpenXR's C structs intentionally use aggregate initialization with the
+    # mandatory type tag while every remaining member is zero-initialized.
+    -Wno-missing-field-initializers
+)
+target_link_options(motus_quest_capture PRIVATE "-uANativeActivity_onCreate")
+target_link_libraries(motus_quest_capture PRIVATE
+    android_native_app_glue
+    OpenXR::openxr_loader
+    LibDataChannel::LibDataChannelStatic
+    nlohmann_json::nlohmann_json
+    ${android-lib}
+    ${egl-lib}
+    ${gles-lib}
+    ${log-lib}
+)

--- a/agent-core/clients/quest-capture-native/app/src/main/cpp/android_main.cpp
+++ b/agent-core/clients/quest-capture-native/app/src/main/cpp/android_main.cpp
@@ -1,0 +1,392 @@
+#include <android/log.h>
+#include <android/native_activity.h>
+#include <android/window.h>
+#include <android_native_app_glue.h>
+#include <jni.h>
+
+#include <chrono>
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <thread>
+#include <utility>
+
+#include "capture_transport.hpp"
+#include "motus/quest_capture/enrollment.hpp"
+#include "openxr_capture.hpp"
+
+namespace motus::quest_capture {
+namespace {
+
+constexpr char kLogTag[] = "MotusOpenXrCapture";
+constexpr char kPreferencesName[] = "motus_capture";
+constexpr char kAppVersion[] = "0.2.0";
+
+struct AndroidLifecycle {
+  bool resumed{false};
+  bool window_ready{false};
+};
+
+void Log(android_LogPriority priority, const std::string& message) {
+  __android_log_write(priority, kLogTag, message.c_str());
+}
+
+void ThrowIfJavaException(JNIEnv* environment, const char* operation) {
+  if (environment->ExceptionCheck() == JNI_FALSE) {
+    return;
+  }
+  environment->ExceptionClear();
+  throw std::runtime_error(std::string(operation) + " raised a Java exception");
+}
+
+std::string JavaString(JNIEnv* environment, jstring value) {
+  if (value == nullptr) {
+    return {};
+  }
+  const char* characters = environment->GetStringUTFChars(value, nullptr);
+  ThrowIfJavaException(environment, "GetStringUTFChars");
+  std::string result = characters == nullptr ? std::string{} : std::string(characters);
+  if (characters != nullptr) {
+    environment->ReleaseStringUTFChars(value, characters);
+  }
+  return result;
+}
+
+jstring NewJavaString(JNIEnv* environment, const std::string& value) {
+  jstring result = environment->NewStringUTF(value.c_str());
+  ThrowIfJavaException(environment, "NewStringUTF");
+  return result;
+}
+
+std::string IntentExtra(
+    JNIEnv* environment,
+    jobject activity,
+    const std::string& name) {
+  jclass activity_class = environment->GetObjectClass(activity);
+  jmethodID get_intent = environment->GetMethodID(
+      activity_class, "getIntent", "()Landroid/content/Intent;");
+  jobject intent = environment->CallObjectMethod(activity, get_intent);
+  ThrowIfJavaException(environment, "Activity.getIntent");
+  jclass intent_class = environment->GetObjectClass(intent);
+  jmethodID get_string_extra = environment->GetMethodID(
+      intent_class,
+      "getStringExtra",
+      "(Ljava/lang/String;)Ljava/lang/String;");
+  jstring key = NewJavaString(environment, name);
+  auto value = static_cast<jstring>(
+      environment->CallObjectMethod(intent, get_string_extra, key));
+  ThrowIfJavaException(environment, "Intent.getStringExtra");
+  const std::string result = JavaString(environment, value);
+  if (value != nullptr) {
+    environment->DeleteLocalRef(value);
+  }
+  environment->DeleteLocalRef(key);
+  environment->DeleteLocalRef(intent_class);
+  environment->DeleteLocalRef(intent);
+  environment->DeleteLocalRef(activity_class);
+  return result;
+}
+
+jobject Preferences(JNIEnv* environment, jobject activity) {
+  jclass activity_class = environment->GetObjectClass(activity);
+  jmethodID get_preferences = environment->GetMethodID(
+      activity_class,
+      "getSharedPreferences",
+      "(Ljava/lang/String;I)Landroid/content/SharedPreferences;");
+  jstring name = NewJavaString(environment, kPreferencesName);
+  jobject preferences = environment->CallObjectMethod(
+      activity, get_preferences, name, 0);
+  ThrowIfJavaException(environment, "Activity.getSharedPreferences");
+  environment->DeleteLocalRef(name);
+  environment->DeleteLocalRef(activity_class);
+  return preferences;
+}
+
+std::string GetPreference(
+    JNIEnv* environment,
+    jobject activity,
+    const std::string& key_name) {
+  jobject preferences = Preferences(environment, activity);
+  jclass preferences_class = environment->GetObjectClass(preferences);
+  jmethodID get_string = environment->GetMethodID(
+      preferences_class,
+      "getString",
+      "(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;");
+  jstring key = NewJavaString(environment, key_name);
+  jstring fallback = NewJavaString(environment, "");
+  auto value = static_cast<jstring>(environment->CallObjectMethod(
+      preferences, get_string, key, fallback));
+  ThrowIfJavaException(environment, "SharedPreferences.getString");
+  const std::string result = JavaString(environment, value);
+  environment->DeleteLocalRef(value);
+  environment->DeleteLocalRef(fallback);
+  environment->DeleteLocalRef(key);
+  environment->DeleteLocalRef(preferences_class);
+  environment->DeleteLocalRef(preferences);
+  return result;
+}
+
+void PutCaptureEnrollment(
+    JNIEnv* environment,
+    jobject activity,
+    const CaptureIdentity& identity,
+    const std::string& websocket_url,
+    const std::string& ca_certificate_pem) {
+  jobject preferences = Preferences(environment, activity);
+  jclass preferences_class = environment->GetObjectClass(preferences);
+  jmethodID edit = environment->GetMethodID(
+      preferences_class, "edit", "()Landroid/content/SharedPreferences$Editor;");
+  jobject editor = environment->CallObjectMethod(preferences, edit);
+  ThrowIfJavaException(environment, "SharedPreferences.edit");
+  jclass editor_class = environment->GetObjectClass(editor);
+  jmethodID put_string = environment->GetMethodID(
+      editor_class,
+      "putString",
+      "(Ljava/lang/String;Ljava/lang/String;)Landroid/content/SharedPreferences$Editor;");
+  jmethodID commit = environment->GetMethodID(editor_class, "commit", "()Z");
+  const auto put = [&](const char* key_text, const std::string& value_text) {
+    jstring key = NewJavaString(environment, key_text);
+    jstring value = NewJavaString(environment, value_text);
+    static_cast<void>(environment->CallObjectMethod(editor, put_string, key, value));
+    ThrowIfJavaException(environment, "SharedPreferences.Editor.putString");
+    environment->DeleteLocalRef(value);
+    environment->DeleteLocalRef(key);
+  };
+  // Commit identity and its pinned transport origin as one editor transaction.
+  // A stored credential is never valid independently of these exact values.
+  put("capture_id", identity.capture_id);
+  put("capture_credential", identity.capture_credential);
+  put("core_wss_url", websocket_url);
+  put("ca_certificate_pem", ca_certificate_pem);
+  const jboolean committed = environment->CallBooleanMethod(editor, commit);
+  ThrowIfJavaException(environment, "SharedPreferences.Editor.commit");
+  if (committed != JNI_TRUE) {
+    throw std::runtime_error("capture preference commit failed");
+  }
+  environment->DeleteLocalRef(editor_class);
+  environment->DeleteLocalRef(editor);
+  environment->DeleteLocalRef(preferences_class);
+  environment->DeleteLocalRef(preferences);
+}
+
+std::string Base64Decode(const std::string& encoded) {
+  static constexpr std::string_view alphabet =
+      "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+  if (encoded.empty() || encoded.size() > 64 * 1024 || encoded.size() % 4 != 0) {
+    throw std::invalid_argument("CA certificate base64 is invalid");
+  }
+  std::string result;
+  result.reserve((encoded.size() / 4) * 3);
+  std::uint32_t accumulator = 0;
+  int bits = 0;
+  bool padding = false;
+  for (const char character : encoded) {
+    if (character == '=') {
+      padding = true;
+      continue;
+    }
+    if (padding) {
+      throw std::invalid_argument("CA certificate base64 padding is invalid");
+    }
+    const auto position = alphabet.find(character);
+    if (position == std::string_view::npos) {
+      throw std::invalid_argument("CA certificate base64 character is invalid");
+    }
+    accumulator = (accumulator << 6U) | static_cast<std::uint32_t>(position);
+    bits += 6;
+    if (bits >= 8) {
+      bits -= 8;
+      result.push_back(static_cast<char>((accumulator >> bits) & 0xffU));
+    }
+  }
+  if (result.find("-----BEGIN CERTIFICATE-----") == std::string::npos ||
+      result.size() > 32 * 1024) {
+    throw std::invalid_argument("CA certificate PEM is invalid");
+  }
+  return result;
+}
+
+CaptureTransportConfiguration LoadConfiguration(
+    JNIEnv* environment,
+    jobject activity) {
+  CaptureTransportConfiguration configuration;
+  configuration.app_version = kAppVersion;
+
+  const auto pairing_id = IntentExtra(environment, activity, "pairing_id");
+  const auto pairing_code = IntentExtra(environment, activity, "pairing_code");
+  const auto launch_websocket_url = IntentExtra(
+      environment, activity, "core_wss_url");
+  const auto launch_ca_base64 = IntentExtra(
+      environment, activity, "ca_certificate_base64");
+  const bool pairing_present = !pairing_id.empty() || !pairing_code.empty();
+  const CaptureLaunchBootstrap launch{
+      .pairing_id = pairing_id,
+      .pairing_code = pairing_code,
+      .websocket_url = launch_websocket_url,
+      .ca_certificate_pem = pairing_present && !launch_ca_base64.empty()
+          ? Base64Decode(launch_ca_base64)
+          : std::string{},
+      .transport_override_present =
+          !launch_websocket_url.empty() || !launch_ca_base64.empty(),
+  };
+  StoredCaptureEnrollment stored;
+  if (!pairing_present) {
+    stored = StoredCaptureEnrollment{
+        .capture_id = GetPreference(environment, activity, "capture_id"),
+        .capture_credential = GetPreference(
+            environment, activity, "capture_credential"),
+        .websocket_url = GetPreference(
+            environment, activity, "core_wss_url"),
+        .ca_certificate_pem = GetPreference(
+            environment, activity, "ca_certificate_pem"),
+    };
+  }
+  auto selected = SelectCaptureEnrollment(stored, launch);
+  configuration.identity = std::move(selected.identity);
+  configuration.pairing = std::move(selected.pairing);
+  configuration.websocket_url = std::move(selected.websocket_url);
+  configuration.ca_certificate_pem =
+      std::move(selected.ca_certificate_pem);
+  return configuration;
+}
+
+void HandleAppCommand(android_app* app, std::int32_t command) {
+  auto* lifecycle = static_cast<AndroidLifecycle*>(app->userData);
+  if (lifecycle == nullptr) {
+    return;
+  }
+  switch (command) {
+    case APP_CMD_RESUME:
+      lifecycle->resumed = true;
+      break;
+    case APP_CMD_PAUSE:
+    case APP_CMD_STOP:
+      lifecycle->resumed = false;
+      break;
+    case APP_CMD_INIT_WINDOW:
+      lifecycle->window_ready = true;
+      break;
+    case APP_CMD_TERM_WINDOW:
+    case APP_CMD_DESTROY:
+      lifecycle->window_ready = false;
+      break;
+    default:
+      break;
+  }
+}
+
+}  // namespace
+}  // namespace motus::quest_capture
+
+void android_main(android_app* app) {
+  using namespace motus::quest_capture;
+  JNIEnv* environment = nullptr;
+  bool attached = false;
+  try {
+    if (app == nullptr || app->activity == nullptr || app->activity->vm == nullptr) {
+      throw std::runtime_error("NativeActivity is unavailable");
+    }
+    const jint environment_result = app->activity->vm->GetEnv(
+        reinterpret_cast<void**>(&environment), JNI_VERSION_1_6);
+    if (environment_result == JNI_EDETACHED) {
+      if (app->activity->vm->AttachCurrentThread(&environment, nullptr) != JNI_OK) {
+        throw std::runtime_error("AttachCurrentThread failed");
+      }
+      attached = true;
+    } else if (environment_result != JNI_OK || environment == nullptr) {
+      throw std::runtime_error("JNI environment unavailable");
+    }
+
+    ANativeActivity_setWindowFlags(
+        app->activity,
+        AWINDOW_FLAG_KEEP_SCREEN_ON,
+        0);
+    AndroidLifecycle lifecycle;
+    app->userData = &lifecycle;
+    app->onAppCmd = HandleAppCommand;
+
+    auto configuration = LoadConfiguration(
+        environment, app->activity->clazz);
+    // Construct the transport after OpenXR so stack unwinding always tears
+    // down WSS/RTC before destroying the runtime and its swapchains.
+    OpenXrCapture xr;
+    xr.Initialize(app);
+    const std::string enrollment_websocket_url = configuration.websocket_url;
+    const std::string enrollment_ca_certificate_pem =
+        configuration.ca_certificate_pem;
+    auto transport = std::make_shared<CaptureTransport>(
+        std::move(configuration),
+        [environment,
+         activity = app->activity->clazz,
+         enrollment_websocket_url,
+         enrollment_ca_certificate_pem](const CaptureIdentity& identity) {
+          PutCaptureEnrollment(
+              environment,
+              activity,
+              identity,
+              enrollment_websocket_url,
+              enrollment_ca_certificate_pem);
+        },
+        [](const std::string& message) { Log(ANDROID_LOG_INFO, message); });
+    transport->Start();
+
+    bool last_focused = false;
+    while (app->destroyRequested == 0 && !xr.exit_requested()) {
+      for (;;) {
+        int events = 0;
+        android_poll_source* source = nullptr;
+        const int timeout_ms = xr.session_running() ? 0 : 50;
+        if (ALooper_pollOnce(
+                timeout_ms,
+                nullptr,
+                &events,
+                reinterpret_cast<void**>(&source)) < 0) {
+          break;
+        }
+        if (source != nullptr) {
+          source->process(app, source);
+        }
+        if (timeout_ms != 0) {
+          break;
+        }
+      }
+
+      xr.PollEvents();
+      const bool focused = lifecycle.resumed && xr.focused();
+      if (focused != last_focused) {
+        transport->SetXrFocused(focused);
+        last_focused = focused;
+      }
+      transport->Tick();
+
+      if (xr.session_running()) {
+        FrameSample sample;
+        if (xr.RenderFrame(&sample) && focused) {
+          transport->SendFrame(sample);
+        }
+      } else {
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+      }
+    }
+    transport->SetXrFocused(false);
+    transport->Shutdown();
+    ANativeActivity_finish(app->activity);
+  } catch (const std::exception& error) {
+    Log(ANDROID_LOG_ERROR, std::string("capture app stopped: ") + error.what());
+    if (app != nullptr && app->activity != nullptr) {
+      ANativeActivity_finish(app->activity);
+    }
+  } catch (...) {
+    Log(ANDROID_LOG_ERROR, "capture app stopped: unknown error");
+    if (app != nullptr && app->activity != nullptr) {
+      ANativeActivity_finish(app->activity);
+    }
+  }
+  if (attached && app != nullptr && app->activity != nullptr &&
+      app->activity->vm != nullptr) {
+    app->activity->vm->DetachCurrentThread();
+  }
+}

--- a/agent-core/clients/quest-capture-native/app/src/main/cpp/capture_transport.cpp
+++ b/agent-core/clients/quest-capture-native/app/src/main/cpp/capture_transport.cpp
@@ -1,0 +1,630 @@
+#include "capture_transport.hpp"
+
+#include <nlohmann/json.hpp>
+
+#include <algorithm>
+#include <stdexcept>
+#include <utility>
+#include <variant>
+
+#include "motus/quest_capture/capture_wire.hpp"
+
+namespace motus::quest_capture {
+namespace {
+
+constexpr std::size_t kPoseBackpressureBytes = 16 * 1024;
+constexpr auto kPeerPingInterval = std::chrono::seconds(1);
+constexpr auto kMaximumReconnectDelay = std::chrono::milliseconds(5'000);
+constexpr auto kRtcNegotiationTimeout = std::chrono::seconds(10);
+
+bool SafeWebSocketUrl(const std::string& value) {
+  return value.size() >= 8 && value.size() <= 2'048 && value.starts_with("wss://") &&
+      value.find('?') == std::string::npos && value.find('#') == std::string::npos &&
+      value.find('@') == std::string::npos &&
+      value.ends_with("/ws/teleop-capture");
+}
+
+}  // namespace
+
+CaptureTransport::CaptureTransport(
+    CaptureTransportConfiguration configuration,
+    IdentitySink identity_sink,
+    LogSink log_sink)
+    : configuration_(std::move(configuration)),
+      identity_sink_(std::move(identity_sink)),
+      log_sink_(std::move(log_sink)) {
+  if (!SafeWebSocketUrl(configuration_.websocket_url) ||
+      configuration_.app_version.empty() ||
+      configuration_.ca_certificate_pem.size() > 32 * 1024 ||
+      configuration_.ca_certificate_pem.find("-----BEGIN CERTIFICATE-----") ==
+          std::string::npos ||
+      (!configuration_.identity && !configuration_.pairing)) {
+    throw std::invalid_argument("capture transport configuration is invalid");
+  }
+  state_.identity = configuration_.identity;
+  state_.pairing = configuration_.pairing;
+}
+
+CaptureTransport::~CaptureTransport() {
+  Shutdown();
+}
+
+void CaptureTransport::Start() {
+  if (started_ || shutting_down_) {
+    return;
+  }
+  if (weak_from_this().expired()) {
+    throw std::logic_error("capture transport must have shared ownership");
+  }
+  started_ = true;
+  rtc::InitLogger(rtc::LogLevel::Warning);
+  ConnectNow();
+}
+
+void CaptureTransport::Shutdown() {
+  if (shutting_down_.exchange(true)) {
+    return;
+  }
+  CloseRtc("capture_shutdown");
+  CloseWebSocket();
+  {
+    std::lock_guard lock(event_mutex_);
+    events_.clear();
+  }
+  static_cast<void>(rtc::Cleanup().wait_for(std::chrono::seconds(5)));
+}
+
+void CaptureTransport::Tick() {
+  if (!started_ || shutting_down_) {
+    return;
+  }
+  std::deque<Event> pending;
+  {
+    std::lock_guard lock(event_mutex_);
+    pending.swap(events_);
+  }
+  for (const auto& event : pending) {
+    HandleEvent(event);
+  }
+
+  const auto now = std::chrono::steady_clock::now();
+  if (state_.link == CaptureLinkState::kOffline && now >= next_reconnect_) {
+    ConnectNow();
+    return;
+  }
+  if (state_.authenticated && now >= next_presence_) {
+    Apply(CapturePresenceTick(state_, state_.connection_epoch));
+    next_presence_ = now + presence_interval_;
+  }
+  if (
+      state_.link == CaptureLinkState::kNegotiating && state_.assignment &&
+      now >= rtc_negotiation_deadline_) {
+    Apply(CaptureRtcFailed(
+        state_,
+        state_.connection_epoch,
+        state_.assignment->id,
+        "rtc_negotiation_timeout"));
+    return;
+  }
+  if (streaming() && now >= next_ping_) {
+    SendPeerPing();
+    next_ping_ = now + kPeerPingInterval;
+  }
+}
+
+void CaptureTransport::SetXrFocused(bool focused) {
+  if (!started_ || shutting_down_ || focused == state_.xr_focused) {
+    return;
+  }
+  if (focused) {
+    Apply(CaptureXrFocused(state_, state_.connection_epoch));
+  } else {
+    Apply(CaptureXrEnded(
+        state_, state_.connection_epoch, "openxr_focus_lost"));
+  }
+}
+
+void CaptureTransport::SendFrame(const FrameSample& sample) {
+  if (!streaming() || !state_.assignment || !pose_ || !pose_->isOpen()) {
+    return;
+  }
+  if (pose_->bufferedAmount() > kPoseBackpressureBytes) {
+    Apply(CaptureRtcFailed(
+        state_,
+        state_.connection_epoch,
+        state_.assignment->id,
+        "pose_backpressure"));
+    return;
+  }
+  try {
+    auto result = BuildFrameV1(
+        state_.frame_state,
+        sample,
+        state_.assignment->frame_configuration);
+    state_.frame_state = result.state;
+    if (!pose_->send(SerializeFrameV1(result.frame))) {
+      Apply(CaptureRtcFailed(
+          state_,
+          state_.connection_epoch,
+          state_.assignment->id,
+          "pose_send_buffered"));
+    }
+  } catch (const std::exception& error) {
+    Apply(CaptureRtcFailed(
+        state_,
+        state_.connection_epoch,
+        state_.assignment->id,
+        std::string("pose_frame_invalid:") + error.what()));
+  }
+}
+
+void CaptureTransport::ConnectNow() {
+  if (shutting_down_) {
+    return;
+  }
+  Apply(BeginCaptureConnection(state_));
+  const auto epoch = state_.connection_epoch;
+  rtc::WebSocket::Configuration websocket_configuration;
+  websocket_configuration.disableTlsVerification = false;
+  websocket_configuration.connectionTimeout = std::chrono::seconds(5);
+  websocket_configuration.pingInterval = std::chrono::seconds(2);
+  websocket_configuration.maxOutstandingPings = 2;
+  websocket_configuration.maxMessageSize = kMaxCaptureWireBytes;
+  // libdatachannel's Mbed TLS backend does not import Android's system trust
+  // store. Pin the deployment CA content explicitly and keep verification on.
+  websocket_configuration.caCertificatePemFile =
+      configuration_.ca_certificate_pem;
+  websocket_ = std::make_shared<rtc::WebSocket>(websocket_configuration);
+  const std::weak_ptr<CaptureTransport> weak_self = weak_from_this();
+  websocket_->onOpen([weak_self, epoch] {
+    const auto self = weak_self.lock();
+    if (!self) {
+      return;
+    }
+    self->Enqueue(Event{
+        .kind = EventKind::kWebSocketOpen,
+        .connection_epoch = epoch,
+    });
+  });
+  websocket_->onMessage([weak_self, epoch](rtc::message_variant message) {
+    const auto self = weak_self.lock();
+    if (!self) {
+      return;
+    }
+    if (!std::holds_alternative<std::string>(message)) {
+      self->Enqueue(Event{
+          .kind = EventKind::kWebSocketError,
+          .connection_epoch = epoch,
+          .value = "capture_binary_message_rejected",
+      });
+      return;
+    }
+    self->Enqueue(Event{
+        .kind = EventKind::kWebSocketMessage,
+        .connection_epoch = epoch,
+        .value = std::get<std::string>(std::move(message)),
+    });
+  });
+  websocket_->onClosed([weak_self, epoch] {
+    const auto self = weak_self.lock();
+    if (!self) {
+      return;
+    }
+    self->Enqueue(Event{
+        .kind = EventKind::kWebSocketClosed,
+        .connection_epoch = epoch,
+        .value = "capture_wss_closed",
+    });
+  });
+  websocket_->onError([weak_self, epoch](std::string error) {
+    const auto self = weak_self.lock();
+    if (!self) {
+      return;
+    }
+    self->Enqueue(Event{
+        .kind = EventKind::kWebSocketError,
+        .connection_epoch = epoch,
+        .value = std::move(error),
+    });
+  });
+  websocket_->open(configuration_.websocket_url);
+}
+
+void CaptureTransport::Enqueue(Event event) {
+  std::lock_guard lock(event_mutex_);
+  if (!shutting_down_) {
+    events_.push_back(std::move(event));
+  }
+}
+
+void CaptureTransport::HandleEvent(const Event& event) {
+  if (event.connection_epoch != state_.connection_epoch) {
+    return;
+  }
+  switch (event.kind) {
+    case EventKind::kWebSocketOpen:
+      if (pending_authentication_) {
+        const auto action = *pending_authentication_;
+        pending_authentication_.reset();
+        ApplyAction(action);
+      }
+      break;
+    case EventKind::kWebSocketMessage:
+      HandleServerMessage(event.value);
+      break;
+    case EventKind::kWebSocketClosed:
+    case EventKind::kWebSocketError:
+      Apply(CaptureTransportLost(
+          state_,
+          state_.connection_epoch,
+          event.value.empty() ? "capture_wss_lost" : event.value));
+      break;
+    case EventKind::kRtcOfferReady:
+      Apply(CaptureOfferCreated(
+          state_,
+          state_.connection_epoch,
+          event.assignment_id,
+          event.value));
+      break;
+    case EventKind::kRtcStateFailed:
+      Apply(CaptureRtcFailed(
+          state_,
+          state_.connection_epoch,
+          event.assignment_id,
+          event.value));
+      break;
+    case EventKind::kControlOpened:
+    case EventKind::kControlClosed:
+    case EventKind::kPoseOpened:
+    case EventKind::kPoseClosed: {
+      const bool control_open = event.kind == EventKind::kControlOpened
+          ? true
+          : event.kind == EventKind::kControlClosed ? false : state_.control_open;
+      const bool pose_open = event.kind == EventKind::kPoseOpened
+          ? true
+          : event.kind == EventKind::kPoseClosed ? false : state_.pose_open;
+      Apply(CaptureChannelState(
+          state_,
+          state_.connection_epoch,
+          event.assignment_id,
+          control_open,
+          pose_open));
+      break;
+    }
+  }
+}
+
+void CaptureTransport::HandleServerMessage(const std::string& payload) {
+  try {
+    const auto message = ParseCaptureServerMessage(payload, state_.identity);
+    std::visit([this](const auto& item) {
+      using Message = std::decay_t<decltype(item)>;
+      if constexpr (std::is_same_v<Message, CaptureAuthenticatedMessage>) {
+        if (item.presence_timeout_ms <= item.presence_interval_ms) {
+          throw std::invalid_argument("presence timeout must exceed interval");
+        }
+        presence_interval_ = std::chrono::milliseconds(item.presence_interval_ms);
+        next_presence_ = std::chrono::steady_clock::now() + presence_interval_;
+        reconnect_delay_ = std::chrono::milliseconds(250);
+        Apply(CaptureAuthenticated(
+            state_,
+            state_.connection_epoch,
+            item.identity,
+            item.fresh_credential));
+      } else if constexpr (std::is_same_v<Message, CaptureAssignmentMessage>) {
+        Apply(CaptureAssigned(
+            state_, state_.connection_epoch, item.assignment));
+      } else if constexpr (std::is_same_v<Message, CaptureSignalingAnswerMessage>) {
+        Apply(CaptureAnswerReceived(
+            state_,
+            state_.connection_epoch,
+            item.assignment_id,
+            item.answer_sdp));
+      } else if constexpr (std::is_same_v<Message, CaptureAssignmentRevokedMessage>) {
+        Apply(CaptureAssignmentRevoked(
+            state_,
+            state_.connection_epoch,
+            item.assignment_id,
+            item.reason));
+      } else if constexpr (std::is_same_v<Message, CaptureTerminalMessage>) {
+        Apply(CaptureTransportLost(
+            state_, state_.connection_epoch, item.reason));
+        if (item.type == "capture_revoked") {
+          next_reconnect_ = std::chrono::steady_clock::time_point::max();
+        }
+      } else if constexpr (std::is_same_v<Message, CapturePresenceAcknowledgedMessage>) {
+        static_cast<void>(item);
+      } else if constexpr (std::is_same_v<Message, CaptureErrorMessage>) {
+        // Core intentionally closes WSS after a capture signaling error. Close
+        // locally now so headset-to-Driver RTC cannot outlive that decision.
+        Apply(CaptureTransportLost(
+            state_, state_.connection_epoch, item.code));
+        if (item.code == "capture_auth_invalid" ||
+            item.code == "capture_pairing_invalid" ||
+            item.code == "capture_protocol_mismatch") {
+          next_reconnect_ = std::chrono::steady_clock::time_point::max();
+        }
+        CloseWebSocket();
+      }
+    }, message);
+  } catch (const std::exception& error) {
+    Apply(CaptureTransportLost(
+        state_,
+        state_.connection_epoch,
+        std::string("capture_wire_rejected:") + error.what()));
+    CloseWebSocket();
+  }
+}
+
+void CaptureTransport::Apply(CaptureTransition transition) {
+  state_ = std::move(transition.state);
+  for (const auto& action : transition.actions) {
+    ApplyAction(action);
+  }
+}
+
+void CaptureTransport::ApplyAction(const CaptureAction& action) {
+  if (action.connection_epoch != state_.connection_epoch &&
+      action.kind != CaptureActionKind::kCloseRtc) {
+    return;
+  }
+  switch (action.kind) {
+    case CaptureActionKind::kSendPairAuthentication:
+    case CaptureActionKind::kSendCredentialAuthentication:
+      if (!websocket_ || !websocket_->isOpen()) {
+        pending_authentication_ = action;
+        return;
+      }
+      if (action.kind == CaptureActionKind::kSendPairAuthentication) {
+        if (!state_.pairing) {
+          throw std::logic_error("pair authentication requested without pairing");
+        }
+        SendWebSocket(SerializePairAuthentication(
+            *state_.pairing, configuration_.app_version));
+      } else {
+        if (!state_.identity) {
+          throw std::logic_error("credential authentication requested without identity");
+        }
+        SendWebSocket(SerializeCredentialAuthentication(
+            *state_.identity, configuration_.app_version));
+      }
+      break;
+    case CaptureActionKind::kPersistCredential:
+      if (state_.identity && identity_sink_) {
+        identity_sink_(*state_.identity);
+        configuration_.identity = state_.identity;
+        configuration_.pairing.reset();
+      }
+      break;
+    case CaptureActionKind::kSendPresence:
+      if (!action.presence) {
+        throw std::logic_error("presence action is missing state");
+      }
+      SendWebSocket(SerializeCapturePresence(
+          *action.presence, action.assignment_id));
+      break;
+    case CaptureActionKind::kCreateRtcOffer:
+      StartRtc(action.assignment_id);
+      break;
+    case CaptureActionKind::kSendSignalingOffer:
+      SendWebSocket(SerializeCaptureSignalingOffer(
+          action.assignment_id, action.value));
+      break;
+    case CaptureActionKind::kApplyRtcAnswer:
+      if (!peer_) {
+        throw std::logic_error("RTC answer received without peer");
+      }
+      peer_->setRemoteDescription(rtc::Description(action.value, "answer"));
+      break;
+    case CaptureActionKind::kCloseRtc:
+      CloseRtc(action.value);
+      break;
+    case CaptureActionKind::kScheduleReconnect:
+      ScheduleReconnect(action.value);
+      break;
+    case CaptureActionKind::kReportFault:
+      Log(std::string("capture fault: ") + action.value);
+      break;
+  }
+}
+
+void CaptureTransport::StartRtc(const std::string& assignment_id) {
+  CloseRtc("rtc_replaced");
+  rtc_negotiation_deadline_ =
+      std::chrono::steady_clock::now() + kRtcNegotiationTimeout;
+  const auto epoch = state_.connection_epoch;
+  rtc::Configuration peer_configuration;
+  peer_configuration.disableAutoNegotiation = true;
+  peer_configuration.disableFingerprintVerification = false;
+  peer_configuration.maxMessageSize = kMaxRtcMessageBytes;
+  peer_ = std::make_shared<rtc::PeerConnection>(peer_configuration);
+  const std::weak_ptr<rtc::PeerConnection> weak_peer = peer_;
+  const std::weak_ptr<CaptureTransport> weak_self = weak_from_this();
+
+  rtc::DataChannelInit control_init;
+  control_init.reliability.unordered = false;
+  control_ = peer_->createDataChannel("teleop-control", control_init);
+  rtc::DataChannelInit pose_init;
+  pose_init.reliability.unordered = true;
+  pose_init.reliability.maxRetransmits = 0;
+  pose_ = peer_->createDataChannel("teleop-pose", pose_init);
+
+  peer_->onGatheringStateChange([weak_self, epoch, assignment_id, weak_peer](
+                                     rtc::PeerConnection::GatheringState state) {
+    const auto self = weak_self.lock();
+    const auto peer = weak_peer.lock();
+    if (state != rtc::PeerConnection::GatheringState::Complete || !self || !peer) {
+      return;
+    }
+    const auto description = peer->localDescription();
+    if (!description || description->type() != rtc::Description::Type::Offer) {
+      self->Enqueue(Event{
+          .kind = EventKind::kRtcStateFailed,
+          .connection_epoch = epoch,
+          .assignment_id = assignment_id,
+          .value = "rtc_local_offer_missing",
+      });
+      return;
+    }
+    self->Enqueue(Event{
+        .kind = EventKind::kRtcOfferReady,
+        .connection_epoch = epoch,
+        .assignment_id = assignment_id,
+        .value = std::string(*description),
+    });
+  });
+  peer_->onStateChange([weak_self, epoch, assignment_id](
+                           rtc::PeerConnection::State state) {
+    if (state == rtc::PeerConnection::State::Disconnected ||
+        state == rtc::PeerConnection::State::Failed ||
+        state == rtc::PeerConnection::State::Closed) {
+      const auto self = weak_self.lock();
+      if (!self) {
+        return;
+      }
+      self->Enqueue(Event{
+          .kind = EventKind::kRtcStateFailed,
+          .connection_epoch = epoch,
+          .assignment_id = assignment_id,
+          .value = "rtc_peer_lost",
+      });
+    }
+  });
+  const auto channel_callbacks = [weak_self, epoch, assignment_id](
+                                     const std::shared_ptr<rtc::DataChannel>& channel,
+                                     EventKind opened,
+                                     EventKind closed) {
+    channel->onOpen([weak_self, epoch, assignment_id, opened] {
+      const auto self = weak_self.lock();
+      if (!self) {
+        return;
+      }
+      self->Enqueue(Event{
+          .kind = opened,
+          .connection_epoch = epoch,
+          .assignment_id = assignment_id,
+      });
+    });
+    channel->onClosed([weak_self, epoch, assignment_id, closed] {
+      const auto self = weak_self.lock();
+      if (!self) {
+        return;
+      }
+      self->Enqueue(Event{
+          .kind = closed,
+          .connection_epoch = epoch,
+          .assignment_id = assignment_id,
+      });
+    });
+    channel->onError([weak_self, epoch, assignment_id, closed](std::string error) {
+      const auto self = weak_self.lock();
+      if (!self) {
+        return;
+      }
+      self->Enqueue(Event{
+          .kind = closed,
+          .connection_epoch = epoch,
+          .assignment_id = assignment_id,
+          .value = std::move(error),
+      });
+    });
+  };
+  channel_callbacks(
+      control_, EventKind::kControlOpened, EventKind::kControlClosed);
+  channel_callbacks(pose_, EventKind::kPoseOpened, EventKind::kPoseClosed);
+  control_->onMessage([weak_self](rtc::message_variant message) {
+    const auto self = weak_self.lock();
+    if (self) {
+      self->HandleControlMessage(message);
+    }
+  });
+  peer_->setLocalDescription(rtc::Description::Type::Offer);
+}
+
+void CaptureTransport::CloseRtc(const std::string& reason) {
+  rtc_negotiation_deadline_ = std::chrono::steady_clock::time_point::max();
+  if (pose_) {
+    pose_->resetCallbacks();
+    pose_->close();
+    pose_.reset();
+  }
+  if (control_) {
+    control_->resetCallbacks();
+    control_->close();
+    control_.reset();
+  }
+  if (peer_) {
+    peer_->resetCallbacks();
+    peer_->close();
+    peer_.reset();
+  }
+  if (!reason.empty()) {
+    Log(std::string("RTC closed: ") + reason);
+  }
+}
+
+void CaptureTransport::CloseWebSocket() {
+  pending_authentication_.reset();
+  if (websocket_) {
+    websocket_->resetCallbacks();
+    websocket_->close();
+    websocket_.reset();
+  }
+}
+
+void CaptureTransport::SendWebSocket(const std::string& payload) {
+  if (!websocket_ || !websocket_->isOpen() || !websocket_->send(payload)) {
+    throw std::runtime_error("capture WSS send failed");
+  }
+}
+
+void CaptureTransport::ScheduleReconnect(const std::string& reason) {
+  CloseWebSocket();
+  const auto now = std::chrono::steady_clock::now();
+  next_reconnect_ = now + reconnect_delay_;
+  reconnect_delay_ = std::min(reconnect_delay_ * 2, kMaximumReconnectDelay);
+  Log(std::string("capture reconnect scheduled: ") + reason);
+}
+
+void CaptureTransport::SendPeerPing() {
+  if (!control_ || !control_->isOpen()) {
+    return;
+  }
+  ++peer_ping_sequence_;
+  const nlohmann::json payload = {
+      {"type", "peer_ping"},
+      {"request_id", "native-" + std::to_string(peer_ping_sequence_)},
+  };
+  if (!control_->send(payload.dump())) {
+    Apply(CaptureRtcFailed(
+        state_,
+        state_.connection_epoch,
+        state_.assignment ? state_.assignment->id : std::string{},
+        "control_ping_buffered"));
+  }
+}
+
+void CaptureTransport::HandleControlMessage(const rtc::message_variant& message) {
+  if (!std::holds_alternative<std::string>(message)) {
+    return;
+  }
+  try {
+    const auto payload = nlohmann::json::parse(std::get<std::string>(message));
+    if (payload.is_object() && payload.value("type", "") == "peer_pong") {
+      return;
+    }
+    if (payload.is_object() && payload.contains("error")) {
+      Log("Driver RTC returned an error");
+    }
+  } catch (const nlohmann::json::exception&) {
+    Log("Driver RTC returned malformed control JSON");
+  }
+}
+
+void CaptureTransport::Log(const std::string& message) const {
+  if (log_sink_) {
+    log_sink_(message);
+  }
+}
+
+}  // namespace motus::quest_capture

--- a/agent-core/clients/quest-capture-native/app/src/main/cpp/capture_transport.hpp
+++ b/agent-core/clients/quest-capture-native/app/src/main/cpp/capture_transport.hpp
@@ -1,0 +1,117 @@
+#pragma once
+
+#include <rtc/rtc.hpp>
+
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <deque>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <string>
+
+#include "motus/quest_capture/capture_session.hpp"
+
+namespace motus::quest_capture {
+
+struct CaptureTransportConfiguration {
+  std::string websocket_url;
+  std::string app_version;
+  std::optional<CaptureIdentity> identity;
+  std::optional<PairingBootstrap> pairing;
+  std::string ca_certificate_pem;
+};
+
+class CaptureTransport final
+    : public std::enable_shared_from_this<CaptureTransport> {
+ public:
+  using IdentitySink = std::function<void(const CaptureIdentity&)>;
+  using LogSink = std::function<void(const std::string&)>;
+
+  CaptureTransport(
+      CaptureTransportConfiguration configuration,
+      IdentitySink identity_sink,
+      LogSink log_sink);
+  ~CaptureTransport();
+
+  CaptureTransport(const CaptureTransport&) = delete;
+  CaptureTransport& operator=(const CaptureTransport&) = delete;
+
+  void Start();
+  void Shutdown();
+  void Tick();
+  void SetXrFocused(bool focused);
+  void SendFrame(const FrameSample& sample);
+
+  [[nodiscard]] CaptureLinkState link_state() const { return state_.link; }
+  [[nodiscard]] bool streaming() const {
+    return state_.link == CaptureLinkState::kStreaming;
+  }
+  [[nodiscard]] const std::optional<CaptureAssignmentV1>& assignment() const {
+    return state_.assignment;
+  }
+
+ private:
+  enum class EventKind {
+    kWebSocketOpen,
+    kWebSocketMessage,
+    kWebSocketClosed,
+    kWebSocketError,
+    kRtcOfferReady,
+    kRtcStateFailed,
+    kControlOpened,
+    kControlClosed,
+    kPoseOpened,
+    kPoseClosed,
+  };
+
+  struct Event {
+    EventKind kind{EventKind::kWebSocketClosed};
+    std::int64_t connection_epoch{0};
+    std::string assignment_id;
+    std::string value;
+  };
+
+  void ConnectNow();
+  void Enqueue(Event event);
+  void HandleEvent(const Event& event);
+  void HandleServerMessage(const std::string& payload);
+  void Apply(CaptureTransition transition);
+  void ApplyAction(const CaptureAction& action);
+  void StartRtc(const std::string& assignment_id);
+  void CloseRtc(const std::string& reason);
+  void CloseWebSocket();
+  void SendWebSocket(const std::string& payload);
+  void ScheduleReconnect(const std::string& reason);
+  void SendPeerPing();
+  void HandleControlMessage(const rtc::message_variant& message);
+  void Log(const std::string& message) const;
+
+  CaptureTransportConfiguration configuration_;
+  IdentitySink identity_sink_;
+  LogSink log_sink_;
+  CaptureSessionState state_;
+
+  mutable std::mutex event_mutex_;
+  std::deque<Event> events_;
+  std::shared_ptr<rtc::WebSocket> websocket_;
+  std::shared_ptr<rtc::PeerConnection> peer_;
+  std::shared_ptr<rtc::DataChannel> control_;
+  std::shared_ptr<rtc::DataChannel> pose_;
+  std::optional<CaptureAction> pending_authentication_;
+
+  bool started_{false};
+  std::atomic_bool shutting_down_{false};
+  std::chrono::steady_clock::time_point next_presence_{};
+  std::chrono::steady_clock::time_point next_reconnect_{};
+  std::chrono::steady_clock::time_point next_ping_{};
+  std::chrono::steady_clock::time_point rtc_negotiation_deadline_{
+      std::chrono::steady_clock::time_point::max()};
+  std::chrono::milliseconds presence_interval_{2'000};
+  std::chrono::milliseconds reconnect_delay_{250};
+  std::uint64_t peer_ping_sequence_{0};
+};
+
+}  // namespace motus::quest_capture

--- a/agent-core/clients/quest-capture-native/app/src/main/cpp/mbedtls_user_config.h
+++ b/agent-core/clients/quest-capture-native/app/src/main/cpp/mbedtls_user_config.h
@@ -1,0 +1,9 @@
+#ifndef MOTUS_QUEST_CAPTURE_MBEDTLS_USER_CONFIG_H_
+#define MOTUS_QUEST_CAPTURE_MBEDTLS_USER_CONFIG_H_
+
+// libdatachannel's WebRTC transport negotiates DTLS-SRTP (RFC 5764).
+// Mbed TLS 3.6 keeps this optional in its default configuration, so the APK
+// enables it explicitly through the supported user-config hook.
+#define MBEDTLS_SSL_DTLS_SRTP
+
+#endif  // MOTUS_QUEST_CAPTURE_MBEDTLS_USER_CONFIG_H_

--- a/agent-core/clients/quest-capture-native/app/src/main/cpp/openxr_capture.cpp
+++ b/agent-core/clients/quest-capture-native/app/src/main/cpp/openxr_capture.cpp
@@ -1,0 +1,793 @@
+// OpenXR Android lifecycle and graphics initialization follow Khronos hello_xr
+// release 1.1.60 (Apache-2.0), reduced here to a capture-only GLES session.
+
+#include "openxr_capture.hpp"
+
+#include <GLES3/gl3.h>
+#include <android_native_app_glue.h>
+#include <openxr/openxr_platform.h>
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstring>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace motus::quest_capture {
+namespace {
+
+constexpr XrViewConfigurationType kViewConfiguration =
+    XR_VIEW_CONFIGURATION_TYPE_PRIMARY_STEREO;
+
+void CopyName(char* target, std::size_t size, std::string_view value) {
+  if (value.size() >= size) {
+    throw std::invalid_argument("OpenXR name is too long");
+  }
+  std::memset(target, 0, size);
+  std::memcpy(target, value.data(), value.size());
+}
+
+bool SupportsExtension(
+    const std::vector<XrExtensionProperties>& properties,
+    const char* extension) {
+  return std::any_of(properties.begin(), properties.end(), [&](const auto& item) {
+    return std::strcmp(item.extensionName, extension) == 0;
+  });
+}
+
+XrPosef IdentityPose() {
+  XrPosef pose{};
+  pose.orientation.w = 1.0F;
+  return pose;
+}
+
+bool FullyTracked(XrSpaceLocationFlags flags) {
+  constexpr XrSpaceLocationFlags required =
+      XR_SPACE_LOCATION_POSITION_VALID_BIT |
+      XR_SPACE_LOCATION_ORIENTATION_VALID_BIT |
+      XR_SPACE_LOCATION_POSITION_TRACKED_BIT |
+      XR_SPACE_LOCATION_ORIENTATION_TRACKED_BIT;
+  return (flags & required) == required;
+}
+
+}  // namespace
+
+OpenXrCapture::~OpenXrCapture() {
+  Destroy();
+}
+
+void OpenXrCapture::Initialize(android_app* app) {
+  if (app == nullptr || app->activity == nullptr) {
+    throw std::invalid_argument("android_app is required");
+  }
+  monotonic_origin_ = std::chrono::steady_clock::now();
+  InitializeLoader(app);
+  CreateInstance(app);
+  CreateEglContext();
+  CreateSession();
+  CreateSpaces();
+  CreateActions();
+  CreateSwapchains();
+}
+
+void OpenXrCapture::InitializeLoader(android_app* app) {
+  PFN_xrInitializeLoaderKHR initialize_loader = nullptr;
+  const XrResult get_result = xrGetInstanceProcAddr(
+      XR_NULL_HANDLE,
+      "xrInitializeLoaderKHR",
+      reinterpret_cast<PFN_xrVoidFunction*>(&initialize_loader));
+  if (XR_FAILED(get_result) || initialize_loader == nullptr) {
+    throw std::runtime_error("xrInitializeLoaderKHR is unavailable");
+  }
+  XrLoaderInitInfoAndroidKHR loader_info{XR_TYPE_LOADER_INIT_INFO_ANDROID_KHR};
+  loader_info.applicationVM = app->activity->vm;
+  loader_info.applicationContext = app->activity->clazz;
+  Check(
+      initialize_loader(
+          reinterpret_cast<const XrLoaderInitInfoBaseHeaderKHR*>(&loader_info)),
+      "xrInitializeLoaderKHR");
+}
+
+void OpenXrCapture::CreateInstance(android_app* app) {
+  std::uint32_t extension_count = 0;
+  Check(xrEnumerateInstanceExtensionProperties(
+            nullptr, 0, &extension_count, nullptr),
+        "xrEnumerateInstanceExtensionProperties(count)");
+  std::vector<XrExtensionProperties> extensions(
+      extension_count, XrExtensionProperties{XR_TYPE_EXTENSION_PROPERTIES});
+  Check(xrEnumerateInstanceExtensionProperties(
+            nullptr, extension_count, &extension_count, extensions.data()),
+        "xrEnumerateInstanceExtensionProperties(values)");
+  const std::array<const char*, 2> required_extensions = {
+      XR_KHR_ANDROID_CREATE_INSTANCE_EXTENSION_NAME,
+      XR_KHR_OPENGL_ES_ENABLE_EXTENSION_NAME,
+  };
+  for (const char* extension : required_extensions) {
+    if (!SupportsExtension(extensions, extension)) {
+      throw std::runtime_error(std::string("required OpenXR extension missing: ") + extension);
+    }
+  }
+  std::vector<std::string_view> available_extensions;
+  available_extensions.reserve(extensions.size());
+  for (const auto& extension : extensions) {
+    available_extensions.emplace_back(extension.extensionName);
+  }
+  runtime_selection_ = SelectRuntime(
+      CompiledRuntimeProfile(), available_extensions);
+  std::vector<const char*> enabled_extensions(
+      required_extensions.begin(), required_extensions.end());
+  enabled_extensions.reserve(
+      required_extensions.size() + runtime_selection_.optional_extensions.size());
+  for (const std::string_view extension :
+       runtime_selection_.optional_extensions) {
+    enabled_extensions.push_back(extension.data());
+  }
+
+  XrInstanceCreateInfoAndroidKHR android_info{
+      XR_TYPE_INSTANCE_CREATE_INFO_ANDROID_KHR};
+  android_info.applicationVM = app->activity->vm;
+  android_info.applicationActivity = app->activity->clazz;
+
+  XrInstanceCreateInfo create_info{XR_TYPE_INSTANCE_CREATE_INFO};
+  create_info.next = &android_info;
+  CopyName(
+      create_info.applicationInfo.applicationName,
+      sizeof(create_info.applicationInfo.applicationName),
+      CompiledRuntimeProfile().application_name);
+  create_info.applicationInfo.applicationVersion = 1;
+  CopyName(
+      create_info.applicationInfo.engineName,
+      sizeof(create_info.applicationInfo.engineName),
+      "phanthymotus-native");
+  create_info.applicationInfo.engineVersion = 1;
+  // This client uses only OpenXR 1.0 core commands plus explicit extensions;
+  // requesting 1.0 keeps it compatible with runtimes that have not promoted
+  // their loader/runtime interface to 1.1.
+  create_info.applicationInfo.apiVersion = XR_API_VERSION_1_0;
+  create_info.enabledExtensionCount = enabled_extensions.size();
+  create_info.enabledExtensionNames = enabled_extensions.data();
+  Check(xrCreateInstance(&create_info, &instance_), "xrCreateInstance");
+
+  XrSystemGetInfo system_info{XR_TYPE_SYSTEM_GET_INFO};
+  system_info.formFactor = XR_FORM_FACTOR_HEAD_MOUNTED_DISPLAY;
+  Check(xrGetSystem(instance_, &system_info, &system_id_), "xrGetSystem");
+}
+
+void OpenXrCapture::CreateEglContext() {
+  PFN_xrGetOpenGLESGraphicsRequirementsKHR get_requirements = nullptr;
+  Check(xrGetInstanceProcAddr(
+            instance_,
+            "xrGetOpenGLESGraphicsRequirementsKHR",
+            reinterpret_cast<PFN_xrVoidFunction*>(&get_requirements)),
+        "xrGetInstanceProcAddr(OpenGLES requirements)");
+  if (get_requirements == nullptr) {
+    throw std::runtime_error("OpenGL ES graphics requirements function is missing");
+  }
+  XrGraphicsRequirementsOpenGLESKHR requirements{
+      XR_TYPE_GRAPHICS_REQUIREMENTS_OPENGL_ES_KHR};
+  Check(get_requirements(instance_, system_id_, &requirements),
+        "xrGetOpenGLESGraphicsRequirementsKHR");
+  constexpr XrVersion requested_gles = XR_MAKE_VERSION(3, 0, 0);
+  if (requested_gles < requirements.minApiVersionSupported ||
+      requested_gles > requirements.maxApiVersionSupported) {
+    throw std::runtime_error("OpenGL ES 3.0 is outside runtime graphics requirements");
+  }
+
+  egl_display_ = eglGetDisplay(EGL_DEFAULT_DISPLAY);
+  if (egl_display_ == EGL_NO_DISPLAY || eglInitialize(egl_display_, nullptr, nullptr) != EGL_TRUE) {
+    throw std::runtime_error("eglInitialize failed");
+  }
+  const EGLint config_attributes[] = {
+      EGL_RENDERABLE_TYPE, EGL_OPENGL_ES3_BIT,
+      EGL_SURFACE_TYPE, EGL_PBUFFER_BIT,
+      EGL_RED_SIZE, 8,
+      EGL_GREEN_SIZE, 8,
+      EGL_BLUE_SIZE, 8,
+      EGL_ALPHA_SIZE, 8,
+      EGL_DEPTH_SIZE, 0,
+      EGL_NONE,
+  };
+  EGLint config_count = 0;
+  if (eglChooseConfig(
+          egl_display_, config_attributes, &egl_config_, 1, &config_count) != EGL_TRUE ||
+      config_count != 1) {
+    throw std::runtime_error("eglChooseConfig failed");
+  }
+  const EGLint context_attributes[] = {
+      EGL_CONTEXT_CLIENT_VERSION, 3,
+      EGL_NONE,
+  };
+  egl_context_ = eglCreateContext(
+      egl_display_, egl_config_, EGL_NO_CONTEXT, context_attributes);
+  const EGLint surface_attributes[] = {
+      EGL_WIDTH, 16,
+      EGL_HEIGHT, 16,
+      EGL_NONE,
+  };
+  egl_surface_ = eglCreatePbufferSurface(
+      egl_display_, egl_config_, surface_attributes);
+  if (egl_context_ == EGL_NO_CONTEXT || egl_surface_ == EGL_NO_SURFACE ||
+      eglMakeCurrent(
+          egl_display_, egl_surface_, egl_surface_, egl_context_) != EGL_TRUE) {
+    throw std::runtime_error("OpenGL ES context creation failed");
+  }
+}
+
+void OpenXrCapture::CreateSession() {
+  XrGraphicsBindingOpenGLESAndroidKHR graphics_binding{
+      XR_TYPE_GRAPHICS_BINDING_OPENGL_ES_ANDROID_KHR};
+  graphics_binding.display = egl_display_;
+  graphics_binding.config = egl_config_;
+  graphics_binding.context = egl_context_;
+  XrSessionCreateInfo create_info{XR_TYPE_SESSION_CREATE_INFO};
+  create_info.next = &graphics_binding;
+  create_info.systemId = system_id_;
+  Check(xrCreateSession(instance_, &create_info, &session_), "xrCreateSession");
+}
+
+void OpenXrCapture::CreateSpaces() {
+  std::uint32_t space_count = 0;
+  Check(xrEnumerateReferenceSpaces(session_, 0, &space_count, nullptr),
+        "xrEnumerateReferenceSpaces(count)");
+  std::vector<XrReferenceSpaceType> spaces(space_count);
+  Check(xrEnumerateReferenceSpaces(
+            session_, space_count, &space_count, spaces.data()),
+        "xrEnumerateReferenceSpaces(values)");
+  const bool local_floor_available = std::find(
+      spaces.begin(), spaces.end(), XR_REFERENCE_SPACE_TYPE_LOCAL_FLOOR_EXT) !=
+      spaces.end();
+  const bool stage_available = std::find(
+      spaces.begin(), spaces.end(), XR_REFERENCE_SPACE_TYPE_STAGE) !=
+      spaces.end();
+  const FloorReferenceSpace selected_space = SelectFloorReferenceSpace(
+      runtime_selection_.local_floor_extension_enabled,
+      local_floor_available,
+      stage_available);
+  const XrReferenceSpaceType floor_space_type =
+      selected_space == FloorReferenceSpace::kLocalFloor
+      ? XR_REFERENCE_SPACE_TYPE_LOCAL_FLOOR_EXT
+      : XR_REFERENCE_SPACE_TYPE_STAGE;
+  XrReferenceSpaceCreateInfo floor_info{XR_TYPE_REFERENCE_SPACE_CREATE_INFO};
+  floor_info.referenceSpaceType = floor_space_type;
+  floor_info.poseInReferenceSpace = IdentityPose();
+  Check(xrCreateReferenceSpace(session_, &floor_info, &floor_space_),
+        selected_space == FloorReferenceSpace::kLocalFloor
+            ? "xrCreateReferenceSpace(local_floor)"
+            : "xrCreateReferenceSpace(stage)");
+
+  XrReferenceSpaceCreateInfo view_info{XR_TYPE_REFERENCE_SPACE_CREATE_INFO};
+  view_info.referenceSpaceType = XR_REFERENCE_SPACE_TYPE_VIEW;
+  view_info.poseInReferenceSpace = IdentityPose();
+  Check(xrCreateReferenceSpace(session_, &view_info, &view_space_),
+        "xrCreateReferenceSpace(view)");
+}
+
+void OpenXrCapture::CreateActions() {
+  Check(xrStringToPath(instance_, "/user/hand/left", &hand_paths_[0]),
+        "xrStringToPath(left hand)");
+  Check(xrStringToPath(instance_, "/user/hand/right", &hand_paths_[1]),
+        "xrStringToPath(right hand)");
+
+  XrActionSetCreateInfo set_info{XR_TYPE_ACTION_SET_CREATE_INFO};
+  CopyName(set_info.actionSetName, sizeof(set_info.actionSetName), "teleop_capture");
+  CopyName(
+      set_info.localizedActionSetName,
+      sizeof(set_info.localizedActionSetName),
+      "Teleoperation capture");
+  set_info.priority = 0;
+  Check(xrCreateActionSet(instance_, &set_info, &action_set_), "xrCreateActionSet");
+
+  const auto create_action = [this](
+                                 XrActionType type,
+                                 std::string_view name,
+                                 std::string_view localized,
+                                 XrAction* action) {
+    XrActionCreateInfo info{XR_TYPE_ACTION_CREATE_INFO};
+    info.actionType = type;
+    CopyName(info.actionName, sizeof(info.actionName), name);
+    CopyName(info.localizedActionName, sizeof(info.localizedActionName), localized);
+    info.countSubactionPaths = hand_paths_.size();
+    info.subactionPaths = hand_paths_.data();
+    Check(xrCreateAction(action_set_, &info, action), "xrCreateAction");
+  };
+  create_action(
+      XR_ACTION_TYPE_POSE_INPUT,
+      "grip_pose",
+      "Grip pose",
+      &grip_pose_action_);
+  create_action(
+      XR_ACTION_TYPE_FLOAT_INPUT,
+      "squeeze_value",
+      "Squeeze value",
+      &squeeze_action_);
+  create_action(
+      XR_ACTION_TYPE_VECTOR2F_INPUT,
+      "thumbstick",
+      "Thumbstick",
+      &thumbstick_action_);
+
+  std::vector<XrActionSuggestedBinding> bindings;
+  bindings.reserve(6);
+  for (std::size_t index = 0; index < hand_paths_.size(); ++index) {
+    const char* hand = index == 0 ? "left" : "right";
+    const auto binding_path = [&](const char* suffix) {
+      XrPath path = XR_NULL_PATH;
+      const std::string value = std::string("/user/hand/") + hand + suffix;
+      Check(xrStringToPath(instance_, value.c_str(), &path), "xrStringToPath(binding)");
+      return path;
+    };
+    bindings.push_back({grip_pose_action_, binding_path("/input/grip/pose")});
+    bindings.push_back({squeeze_action_, binding_path("/input/squeeze/value")});
+    bindings.push_back({thumbstick_action_, binding_path("/input/thumbstick")});
+  }
+  allowed_interaction_profiles_.clear();
+  allowed_interaction_profiles_.reserve(
+      runtime_selection_.interaction_profile_paths.size());
+  for (const std::string_view interaction_profile :
+       runtime_selection_.interaction_profile_paths) {
+    XrPath profile_path = XR_NULL_PATH;
+    Check(xrStringToPath(
+              instance_, interaction_profile.data(), &profile_path),
+          "xrStringToPath(interaction profile)");
+    XrInteractionProfileSuggestedBinding suggested{
+        XR_TYPE_INTERACTION_PROFILE_SUGGESTED_BINDING};
+    suggested.interactionProfile = profile_path;
+    suggested.countSuggestedBindings = bindings.size();
+    suggested.suggestedBindings = bindings.data();
+    Check(xrSuggestInteractionProfileBindings(instance_, &suggested),
+          "xrSuggestInteractionProfileBindings");
+    allowed_interaction_profiles_.push_back(profile_path);
+  }
+
+  XrSessionActionSetsAttachInfo attach_info{
+      XR_TYPE_SESSION_ACTION_SETS_ATTACH_INFO};
+  attach_info.countActionSets = 1;
+  attach_info.actionSets = &action_set_;
+  Check(xrAttachSessionActionSets(session_, &attach_info),
+        "xrAttachSessionActionSets");
+
+  for (std::size_t index = 0; index < grip_spaces_.size(); ++index) {
+    XrActionSpaceCreateInfo space_info{XR_TYPE_ACTION_SPACE_CREATE_INFO};
+    space_info.action = grip_pose_action_;
+    space_info.subactionPath = hand_paths_[index];
+    space_info.poseInActionSpace = IdentityPose();
+    Check(xrCreateActionSpace(session_, &space_info, &grip_spaces_[index]),
+          "xrCreateActionSpace");
+  }
+}
+
+void OpenXrCapture::CreateSwapchains() {
+  std::uint32_t view_count = 0;
+  Check(xrEnumerateViewConfigurationViews(
+            instance_, system_id_, kViewConfiguration, 0, &view_count, nullptr),
+        "xrEnumerateViewConfigurationViews(count)");
+  if (view_count == 0 || view_count > 4) {
+    throw std::runtime_error("unexpected primary stereo view count");
+  }
+  view_configuration_.assign(
+      view_count, XrViewConfigurationView{XR_TYPE_VIEW_CONFIGURATION_VIEW});
+  Check(xrEnumerateViewConfigurationViews(
+            instance_,
+            system_id_,
+            kViewConfiguration,
+            view_count,
+            &view_count,
+            view_configuration_.data()),
+        "xrEnumerateViewConfigurationViews(values)");
+
+  std::uint32_t format_count = 0;
+  Check(xrEnumerateSwapchainFormats(session_, 0, &format_count, nullptr),
+        "xrEnumerateSwapchainFormats(count)");
+  std::vector<std::int64_t> formats(format_count);
+  Check(xrEnumerateSwapchainFormats(
+            session_, format_count, &format_count, formats.data()),
+        "xrEnumerateSwapchainFormats(values)");
+  constexpr std::array<std::int64_t, 2> preferred = {
+      GL_SRGB8_ALPHA8,
+      GL_RGBA8,
+  };
+  for (const auto candidate : preferred) {
+    if (std::find(formats.begin(), formats.end(), candidate) != formats.end()) {
+      color_format_ = candidate;
+      break;
+    }
+  }
+  if (color_format_ == 0) {
+    throw std::runtime_error("no supported RGBA OpenGL ES swapchain format");
+  }
+
+  swapchains_.reserve(view_count);
+  for (const auto& view : view_configuration_) {
+    XrSwapchainCreateInfo create_info{XR_TYPE_SWAPCHAIN_CREATE_INFO};
+    create_info.usageFlags = XR_SWAPCHAIN_USAGE_COLOR_ATTACHMENT_BIT |
+        XR_SWAPCHAIN_USAGE_SAMPLED_BIT;
+    create_info.format = color_format_;
+    // The capture renderer attaches a plain GL_TEXTURE_2D and does not create
+    // a multisample resolve target. Khronos hello_xr's GLES backend likewise
+    // advertises one supported sample for this path.
+    create_info.sampleCount = 1;
+    create_info.width = view.recommendedImageRectWidth;
+    create_info.height = view.recommendedImageRectHeight;
+    create_info.faceCount = 1;
+    create_info.arraySize = 1;
+    create_info.mipCount = 1;
+    Swapchain swapchain;
+    swapchain.width = static_cast<std::int32_t>(create_info.width);
+    swapchain.height = static_cast<std::int32_t>(create_info.height);
+    Check(
+        xrCreateSwapchain(session_, &create_info, &swapchain.handle),
+        "xrCreateSwapchain");
+    std::uint32_t image_count = 0;
+    Check(xrEnumerateSwapchainImages(
+              swapchain.handle, 0, &image_count, nullptr),
+          "xrEnumerateSwapchainImages(count)");
+    swapchain.images.assign(
+        image_count,
+        XrSwapchainImageOpenGLESKHR{XR_TYPE_SWAPCHAIN_IMAGE_OPENGL_ES_KHR});
+    Check(xrEnumerateSwapchainImages(
+              swapchain.handle,
+              image_count,
+              &image_count,
+              reinterpret_cast<XrSwapchainImageBaseHeader*>(swapchain.images.data())),
+          "xrEnumerateSwapchainImages(values)");
+    swapchains_.push_back(std::move(swapchain));
+  }
+}
+
+void OpenXrCapture::PollEvents() {
+  if (instance_ == XR_NULL_HANDLE) {
+    return;
+  }
+  XrEventDataBuffer event{XR_TYPE_EVENT_DATA_BUFFER};
+  for (;;) {
+    const XrResult result = xrPollEvent(instance_, &event);
+    if (result == XR_EVENT_UNAVAILABLE) {
+      break;
+    }
+    Check(result, "xrPollEvent");
+    if (event.type == XR_TYPE_EVENT_DATA_SESSION_STATE_CHANGED) {
+      const auto* changed =
+          reinterpret_cast<const XrEventDataSessionStateChanged*>(&event);
+      if (changed->session == session_) {
+        HandleSessionState(changed->state);
+      }
+    } else if (event.type == XR_TYPE_EVENT_DATA_INSTANCE_LOSS_PENDING) {
+      exit_requested_ = true;
+    } else if (event.type == XR_TYPE_EVENT_DATA_REFERENCE_SPACE_CHANGE_PENDING) {
+      const auto* changed =
+          reinterpret_cast<const XrEventDataReferenceSpaceChangePending*>(&event);
+      if (changed->session == session_) {
+        // A recenter changes the robot-space transform discontinuously. Make
+        // focused() false in this iteration so no post-reset pose is emitted,
+        // then let the Activity close RTC/WSS and require a new PC session.
+        session_state_ = XR_SESSION_STATE_UNKNOWN;
+        exit_requested_ = true;
+      }
+    }
+    event = XrEventDataBuffer{XR_TYPE_EVENT_DATA_BUFFER};
+  }
+}
+
+void OpenXrCapture::HandleSessionState(XrSessionState state) {
+  session_state_ = state;
+  if (state == XR_SESSION_STATE_READY && !session_running_) {
+    XrSessionBeginInfo begin_info{XR_TYPE_SESSION_BEGIN_INFO};
+    begin_info.primaryViewConfigurationType = kViewConfiguration;
+    Check(xrBeginSession(session_, &begin_info), "xrBeginSession");
+    session_running_ = true;
+  } else if (state == XR_SESSION_STATE_STOPPING && session_running_) {
+    session_running_ = false;
+    Check(xrEndSession(session_), "xrEndSession");
+  } else if (state == XR_SESSION_STATE_EXITING ||
+             state == XR_SESSION_STATE_LOSS_PENDING) {
+    exit_requested_ = true;
+  }
+}
+
+bool OpenXrCapture::RenderFrame(FrameSample* sample) {
+  if (!session_running_) {
+    return false;
+  }
+  XrFrameWaitInfo wait_info{XR_TYPE_FRAME_WAIT_INFO};
+  XrFrameState frame_state{XR_TYPE_FRAME_STATE};
+  Check(xrWaitFrame(session_, &wait_info, &frame_state), "xrWaitFrame");
+  XrFrameBeginInfo begin_info{XR_TYPE_FRAME_BEGIN_INFO};
+  Check(xrBeginFrame(session_, &begin_info), "xrBeginFrame");
+
+  std::vector<XrCompositionLayerProjectionView> projection_views;
+  if (frame_state.shouldRender == XR_TRUE) {
+    RenderProjection(frame_state.predictedDisplayTime, &projection_views);
+  }
+
+  const bool sample_ready = focused() && sample != nullptr;
+  if (sample_ready) {
+    SyncActions(frame_state.predictedDisplayTime, sample);
+  }
+
+  XrCompositionLayerProjection projection{XR_TYPE_COMPOSITION_LAYER_PROJECTION};
+  projection.space = floor_space_;
+  projection.viewCount = projection_views.size();
+  projection.views = projection_views.data();
+  const XrCompositionLayerBaseHeader* layer =
+      projection_views.empty()
+      ? nullptr
+      : reinterpret_cast<const XrCompositionLayerBaseHeader*>(&projection);
+  XrFrameEndInfo end_info{XR_TYPE_FRAME_END_INFO};
+  end_info.displayTime = frame_state.predictedDisplayTime;
+  end_info.environmentBlendMode = XR_ENVIRONMENT_BLEND_MODE_OPAQUE;
+  end_info.layerCount = layer == nullptr ? 0 : 1;
+  end_info.layers = layer == nullptr ? nullptr : &layer;
+  Check(xrEndFrame(session_, &end_info), "xrEndFrame");
+  return sample_ready;
+}
+
+void OpenXrCapture::SyncActions(XrTime predicted_display_time, FrameSample* sample) {
+  XrActiveActionSet active{action_set_, XR_NULL_PATH};
+  XrActionsSyncInfo sync_info{XR_TYPE_ACTIONS_SYNC_INFO};
+  sync_info.countActiveActionSets = 1;
+  sync_info.activeActionSets = &active;
+  Check(xrSyncActions(session_, &sync_info), "xrSyncActions");
+
+  sample->head = LocatePose(view_space_, predicted_display_time, true);
+  const auto fill_hand = [&](std::size_t index, PoseSample* pose, ControllerSample* input) {
+    const bool interaction_profile_allowed =
+        HasAllowedInteractionProfile(index);
+    XrActionStateGetInfo get_info{XR_TYPE_ACTION_STATE_GET_INFO};
+    get_info.subactionPath = hand_paths_[index];
+
+    get_info.action = grip_pose_action_;
+    XrActionStatePose pose_state{XR_TYPE_ACTION_STATE_POSE};
+    Check(xrGetActionStatePose(session_, &get_info, &pose_state),
+          "xrGetActionStatePose");
+    *pose = LocatePose(
+        grip_spaces_[index],
+        predicted_display_time,
+        interaction_profile_allowed && pose_state.isActive == XR_TRUE);
+
+    get_info.action = squeeze_action_;
+    XrActionStateFloat squeeze{XR_TYPE_ACTION_STATE_FLOAT};
+    Check(xrGetActionStateFloat(session_, &get_info, &squeeze),
+          "xrGetActionStateFloat");
+    get_info.action = thumbstick_action_;
+    XrActionStateVector2f thumbstick{XR_TYPE_ACTION_STATE_VECTOR2F};
+    Check(xrGetActionStateVector2f(session_, &get_info, &thumbstick),
+          "xrGetActionStateVector2f");
+
+    const double squeeze_value = interaction_profile_allowed &&
+            squeeze.isActive == XR_TRUE
+        ? std::clamp(static_cast<double>(squeeze.currentState), 0.0, 1.0)
+        : 0.0;
+    const double axis_x = interaction_profile_allowed &&
+            thumbstick.isActive == XR_TRUE
+        ? std::clamp(static_cast<double>(thumbstick.currentState.x), -1.0, 1.0)
+        : 0.0;
+    const double axis_y = interaction_profile_allowed &&
+            thumbstick.isActive == XR_TRUE
+        ? std::clamp(static_cast<double>(thumbstick.currentState.y), -1.0, 1.0)
+        : 0.0;
+    *input = ControllerSample{
+        .active = interaction_profile_allowed && pose->valid &&
+            squeeze.isActive == XR_TRUE &&
+            thumbstick.isActive == XR_TRUE,
+        .xr_standard = true,
+        .correct_handedness = interaction_profile_allowed,
+        .tracked_pointer = pose->valid,
+        .has_grip_space = pose->valid,
+        .squeeze_pressed = squeeze_value >= 0.75,
+        .axes = {0.0, 0.0, axis_x, axis_y},
+        .buttons = {0.0, squeeze_value},
+    };
+  };
+  fill_hand(0, &sample->left_controller, &sample->left_input);
+  fill_hand(1, &sample->right_controller, &sample->right_input);
+  sample->distinct_input_sources =
+      sample->left_input.correct_handedness &&
+      sample->right_input.correct_handedness;
+  sample->monotonic_ns = MonotonicNanoseconds();
+}
+
+bool OpenXrCapture::HasAllowedInteractionProfile(
+    std::size_t hand_index) const {
+  if (hand_index >= hand_paths_.size()) {
+    throw std::out_of_range("OpenXR hand index is out of range");
+  }
+  XrInteractionProfileState state{XR_TYPE_INTERACTION_PROFILE_STATE};
+  Check(xrGetCurrentInteractionProfile(
+            session_, hand_paths_[hand_index], &state),
+        "xrGetCurrentInteractionProfile");
+  if (state.interactionProfile == XR_NULL_PATH) {
+    return false;
+  }
+  return std::find(
+             allowed_interaction_profiles_.begin(),
+             allowed_interaction_profiles_.end(),
+             state.interactionProfile) != allowed_interaction_profiles_.end();
+}
+
+PoseSample OpenXrCapture::LocatePose(
+    XrSpace space,
+    XrTime predicted_display_time,
+    bool active) const {
+  if (!active || space == XR_NULL_HANDLE) {
+    return {};
+  }
+  XrSpaceLocation location{XR_TYPE_SPACE_LOCATION};
+  Check(xrLocateSpace(
+            space, floor_space_, predicted_display_time, &location),
+        "xrLocateSpace");
+  if (!FullyTracked(location.locationFlags)) {
+    return {};
+  }
+  return PoseSample{
+      .valid = true,
+      .emulated = false,
+      .position = {
+          location.pose.position.x,
+          location.pose.position.y,
+          location.pose.position.z,
+      },
+      .orientation = {
+          location.pose.orientation.x,
+          location.pose.orientation.y,
+          location.pose.orientation.z,
+          location.pose.orientation.w,
+      },
+  };
+}
+
+void OpenXrCapture::RenderProjection(
+    XrTime predicted_display_time,
+    std::vector<XrCompositionLayerProjectionView>* projection_views) {
+  std::vector<XrView> views(
+      view_configuration_.size(), XrView{XR_TYPE_VIEW});
+  XrViewLocateInfo locate_info{XR_TYPE_VIEW_LOCATE_INFO};
+  locate_info.viewConfigurationType = kViewConfiguration;
+  locate_info.displayTime = predicted_display_time;
+  locate_info.space = floor_space_;
+  XrViewState view_state{XR_TYPE_VIEW_STATE};
+  std::uint32_t view_count = 0;
+  Check(xrLocateViews(
+            session_,
+            &locate_info,
+            &view_state,
+            views.size(),
+            &view_count,
+            views.data()),
+        "xrLocateViews");
+  constexpr XrViewStateFlags required =
+      XR_VIEW_STATE_POSITION_VALID_BIT | XR_VIEW_STATE_ORIENTATION_VALID_BIT;
+  if ((view_state.viewStateFlags & required) != required ||
+      view_count != swapchains_.size()) {
+    return;
+  }
+
+  projection_views->assign(
+      view_count, XrCompositionLayerProjectionView{
+                      XR_TYPE_COMPOSITION_LAYER_PROJECTION_VIEW});
+  for (std::size_t index = 0; index < swapchains_.size(); ++index) {
+    auto& swapchain = swapchains_[index];
+    std::uint32_t image_index = 0;
+    XrSwapchainImageAcquireInfo acquire_info{
+        XR_TYPE_SWAPCHAIN_IMAGE_ACQUIRE_INFO};
+    Check(xrAcquireSwapchainImage(
+              swapchain.handle, &acquire_info, &image_index),
+          "xrAcquireSwapchainImage");
+    XrSwapchainImageWaitInfo wait_info{XR_TYPE_SWAPCHAIN_IMAGE_WAIT_INFO};
+    wait_info.timeout = XR_INFINITE_DURATION;
+    Check(xrWaitSwapchainImage(swapchain.handle, &wait_info),
+          "xrWaitSwapchainImage");
+
+    GLuint framebuffer = 0;
+    glGenFramebuffers(1, &framebuffer);
+    glBindFramebuffer(GL_FRAMEBUFFER, framebuffer);
+    glFramebufferTexture2D(
+        GL_FRAMEBUFFER,
+        GL_COLOR_ATTACHMENT0,
+        GL_TEXTURE_2D,
+        swapchain.images.at(image_index).image,
+        0);
+    if (glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE) {
+      glDeleteFramebuffers(1, &framebuffer);
+      throw std::runtime_error("OpenXR swapchain framebuffer is incomplete");
+    }
+    glViewport(0, 0, swapchain.width, swapchain.height);
+    const float streaming = focused() ? 0.08F : 0.02F;
+    glClearColor(0.01F, streaming, 0.10F, 1.0F);
+    glClear(GL_COLOR_BUFFER_BIT);
+    glBindFramebuffer(GL_FRAMEBUFFER, 0);
+    glDeleteFramebuffers(1, &framebuffer);
+
+    XrSwapchainImageReleaseInfo release_info{
+        XR_TYPE_SWAPCHAIN_IMAGE_RELEASE_INFO};
+    Check(xrReleaseSwapchainImage(swapchain.handle, &release_info),
+          "xrReleaseSwapchainImage");
+    auto& projection_view = projection_views->at(index);
+    projection_view.pose = views[index].pose;
+    projection_view.fov = views[index].fov;
+    projection_view.subImage.swapchain = swapchain.handle;
+    projection_view.subImage.imageRect.offset = {0, 0};
+    projection_view.subImage.imageRect.extent = {
+        swapchain.width,
+        swapchain.height,
+    };
+    projection_view.subImage.imageArrayIndex = 0;
+  }
+}
+
+std::int64_t OpenXrCapture::MonotonicNanoseconds() const {
+  const auto elapsed = std::chrono::duration_cast<std::chrono::nanoseconds>(
+      std::chrono::steady_clock::now() - monotonic_origin_).count();
+  if (elapsed < 0 || elapsed >= kMaxSafeWireInteger) {
+    throw std::range_error("native monotonic clock exhausted wire range");
+  }
+  return elapsed + 1;
+}
+
+void OpenXrCapture::Check(XrResult result, const char* operation) const {
+  if (XR_SUCCEEDED(result)) {
+    return;
+  }
+  char result_name[XR_MAX_RESULT_STRING_SIZE] = {};
+  if (instance_ != XR_NULL_HANDLE) {
+    static_cast<void>(xrResultToString(instance_, result, result_name));
+  }
+  const std::string message = std::string(operation) + " failed: " +
+      (result_name[0] == '\0' ? std::to_string(result) : result_name);
+  throw std::runtime_error(message);
+}
+
+void OpenXrCapture::Destroy() noexcept {
+  const auto destroy_space = [](XrSpace* space) {
+    if (*space != XR_NULL_HANDLE) {
+      static_cast<void>(xrDestroySpace(*space));
+      *space = XR_NULL_HANDLE;
+    }
+  };
+  for (auto& space : grip_spaces_) {
+    destroy_space(&space);
+  }
+  destroy_space(&view_space_);
+  destroy_space(&floor_space_);
+  for (auto& swapchain : swapchains_) {
+    if (swapchain.handle != XR_NULL_HANDLE) {
+      static_cast<void>(xrDestroySwapchain(swapchain.handle));
+      swapchain.handle = XR_NULL_HANDLE;
+    }
+  }
+  swapchains_.clear();
+  if (action_set_ != XR_NULL_HANDLE) {
+    static_cast<void>(xrDestroyActionSet(action_set_));
+    action_set_ = XR_NULL_HANDLE;
+  }
+  if (session_ != XR_NULL_HANDLE) {
+    if (session_running_) {
+      static_cast<void>(xrEndSession(session_));
+    }
+    static_cast<void>(xrDestroySession(session_));
+    session_ = XR_NULL_HANDLE;
+    session_running_ = false;
+  }
+  if (instance_ != XR_NULL_HANDLE) {
+    static_cast<void>(xrDestroyInstance(instance_));
+    instance_ = XR_NULL_HANDLE;
+  }
+  if (egl_display_ != EGL_NO_DISPLAY) {
+    static_cast<void>(eglMakeCurrent(
+        egl_display_, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT));
+    if (egl_surface_ != EGL_NO_SURFACE) {
+      static_cast<void>(eglDestroySurface(egl_display_, egl_surface_));
+      egl_surface_ = EGL_NO_SURFACE;
+    }
+    if (egl_context_ != EGL_NO_CONTEXT) {
+      static_cast<void>(eglDestroyContext(egl_display_, egl_context_));
+      egl_context_ = EGL_NO_CONTEXT;
+    }
+    static_cast<void>(eglTerminate(egl_display_));
+    egl_display_ = EGL_NO_DISPLAY;
+  }
+}
+
+}  // namespace motus::quest_capture

--- a/agent-core/clients/quest-capture-native/app/src/main/cpp/openxr_capture.hpp
+++ b/agent-core/clients/quest-capture-native/app/src/main/cpp/openxr_capture.hpp
@@ -1,0 +1,96 @@
+#pragma once
+
+#include <EGL/egl.h>
+#include <jni.h>
+#include <openxr/openxr_platform.h>
+
+#include <array>
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+#include "motus/quest_capture/frame_v1.hpp"
+#include "runtime_profile.hpp"
+
+struct android_app;
+
+namespace motus::quest_capture {
+
+class OpenXrCapture final {
+ public:
+  OpenXrCapture() = default;
+  ~OpenXrCapture();
+
+  OpenXrCapture(const OpenXrCapture&) = delete;
+  OpenXrCapture& operator=(const OpenXrCapture&) = delete;
+
+  void Initialize(android_app* app);
+  void PollEvents();
+
+  // Drives xrWaitFrame/xrBeginFrame/xrEndFrame and returns a controller sample
+  // only while the runtime grants FOCUSED input ownership.
+  bool RenderFrame(FrameSample* sample);
+
+  [[nodiscard]] bool session_running() const { return session_running_; }
+  [[nodiscard]] bool focused() const { return session_state_ == XR_SESSION_STATE_FOCUSED; }
+  [[nodiscard]] bool exit_requested() const { return exit_requested_; }
+
+ private:
+  struct Swapchain {
+    XrSwapchain handle{XR_NULL_HANDLE};
+    std::int32_t width{0};
+    std::int32_t height{0};
+    std::vector<XrSwapchainImageOpenGLESKHR> images;
+  };
+
+  void InitializeLoader(android_app* app);
+  void CreateInstance(android_app* app);
+  void CreateEglContext();
+  void CreateSession();
+  void CreateSpaces();
+  void CreateActions();
+  void CreateSwapchains();
+  void Destroy() noexcept;
+
+  void HandleSessionState(XrSessionState state);
+  void SyncActions(XrTime predicted_display_time, FrameSample* sample);
+  [[nodiscard]] bool HasAllowedInteractionProfile(std::size_t hand_index) const;
+  PoseSample LocatePose(XrSpace space, XrTime predicted_display_time, bool active) const;
+  void RenderProjection(
+      XrTime predicted_display_time,
+      std::vector<XrCompositionLayerProjectionView>* projection_views);
+  std::int64_t MonotonicNanoseconds() const;
+
+  void Check(XrResult result, const char* operation) const;
+
+  XrInstance instance_{XR_NULL_HANDLE};
+  XrSystemId system_id_{XR_NULL_SYSTEM_ID};
+  XrSession session_{XR_NULL_HANDLE};
+  XrSessionState session_state_{XR_SESSION_STATE_UNKNOWN};
+  bool session_running_{false};
+  bool exit_requested_{false};
+
+  EGLDisplay egl_display_{EGL_NO_DISPLAY};
+  EGLConfig egl_config_{nullptr};
+  EGLContext egl_context_{EGL_NO_CONTEXT};
+  EGLSurface egl_surface_{EGL_NO_SURFACE};
+
+  XrSpace floor_space_{XR_NULL_HANDLE};
+  XrSpace view_space_{XR_NULL_HANDLE};
+  XrActionSet action_set_{XR_NULL_HANDLE};
+  XrAction grip_pose_action_{XR_NULL_HANDLE};
+  XrAction squeeze_action_{XR_NULL_HANDLE};
+  XrAction thumbstick_action_{XR_NULL_HANDLE};
+  std::array<XrPath, 2> hand_paths_{};
+  std::array<XrSpace, 2> grip_spaces_{XR_NULL_HANDLE, XR_NULL_HANDLE};
+  RuntimeSelection runtime_selection_{};
+  std::vector<XrPath> allowed_interaction_profiles_;
+
+  std::vector<XrViewConfigurationView> view_configuration_;
+  std::vector<Swapchain> swapchains_;
+  std::int64_t color_format_{0};
+  std::chrono::steady_clock::time_point monotonic_origin_{};
+};
+
+}  // namespace motus::quest_capture

--- a/agent-core/clients/quest-capture-native/app/src/main/cpp/runtime_profile.cpp
+++ b/agent-core/clients/quest-capture-native/app/src/main/cpp/runtime_profile.cpp
@@ -1,0 +1,136 @@
+#include "runtime_profile.hpp"
+
+#include <algorithm>
+#include <stdexcept>
+
+namespace motus::quest_capture {
+namespace {
+
+constexpr std::string_view kLocalFloorExtension = "XR_EXT_local_floor";
+constexpr std::string_view kPico4ControllerExtension =
+    "XR_BD_controller_interaction";
+constexpr std::string_view kPicoUltraControllerExtension =
+    "XR_BD_ultra_controller_interaction";
+constexpr std::string_view kOculusTouchProfile =
+    "/interaction_profiles/oculus/touch_controller";
+constexpr std::string_view kPico4ControllerProfile =
+    "/interaction_profiles/bytedance/pico4_controller";
+constexpr std::string_view kPicoUltraControllerProfile =
+    "/interaction_profiles/bytedance/pico_ultra_controller_bd";
+
+bool Contains(
+    const std::vector<std::string_view>& values,
+    std::string_view value) {
+  return std::find(values.begin(), values.end(), value) != values.end();
+}
+
+}  // namespace
+
+const RuntimeProfile& MetaRuntimeProfile() {
+  static const RuntimeProfile profile{
+      .target = HeadsetTarget::kMeta,
+      .application_name = "PhanthyMotus Meta Capture",
+      .interaction_profiles = {
+          {
+              .extension_name = {},
+              .interaction_profile_path = kOculusTouchProfile,
+          },
+      },
+      .require_any_interaction_extension = false,
+  };
+  return profile;
+}
+
+const RuntimeProfile& PicoRuntimeProfile() {
+  static const RuntimeProfile profile{
+      .target = HeadsetTarget::kPico,
+      .application_name = "PhanthyMotus PICO Capture",
+      .interaction_profiles = {
+          {
+              .extension_name = kPico4ControllerExtension,
+              .interaction_profile_path = kPico4ControllerProfile,
+          },
+          {
+              .extension_name = kPicoUltraControllerExtension,
+              .interaction_profile_path = kPicoUltraControllerProfile,
+          },
+      },
+      .require_any_interaction_extension = true,
+  };
+  return profile;
+}
+
+const RuntimeProfile& CompiledRuntimeProfile() {
+#if defined(MOTUS_CAPTURE_HEADSET_META) && defined(MOTUS_CAPTURE_HEADSET_PICO)
+#error "Only one MOTUS capture headset target may be compiled"
+#elif defined(MOTUS_CAPTURE_HEADSET_META)
+  return MetaRuntimeProfile();
+#elif defined(MOTUS_CAPTURE_HEADSET_PICO)
+  return PicoRuntimeProfile();
+#else
+#error "MOTUS_CAPTURE_HEADSET_META or MOTUS_CAPTURE_HEADSET_PICO is required"
+#endif
+}
+
+RuntimeSelection SelectRuntime(
+    const RuntimeProfile& profile,
+    const std::vector<std::string_view>& available_extensions) {
+  RuntimeSelection selection{
+      .optional_extensions = {},
+      .interaction_profile_paths = {},
+      .local_floor_extension_enabled =
+          Contains(available_extensions, kLocalFloorExtension),
+  };
+  if (selection.local_floor_extension_enabled) {
+    selection.optional_extensions.push_back(kLocalFloorExtension);
+  }
+
+  bool interaction_extension_enabled = false;
+  for (const auto& candidate : profile.interaction_profiles) {
+    if (candidate.extension_name.empty()) {
+      selection.interaction_profile_paths.push_back(
+          candidate.interaction_profile_path);
+      continue;
+    }
+    if (!Contains(available_extensions, candidate.extension_name)) {
+      continue;
+    }
+    selection.optional_extensions.push_back(candidate.extension_name);
+    selection.interaction_profile_paths.push_back(
+        candidate.interaction_profile_path);
+    interaction_extension_enabled = true;
+  }
+
+  if (profile.require_any_interaction_extension &&
+      !interaction_extension_enabled) {
+    throw std::runtime_error(
+        "no supported PICO controller interaction extension is available");
+  }
+  if (selection.interaction_profile_paths.empty()) {
+    throw std::runtime_error("no allowed controller interaction profile selected");
+  }
+  return selection;
+}
+
+FloorReferenceSpace SelectFloorReferenceSpace(
+    bool local_floor_extension_enabled,
+    bool local_floor_space_available,
+    bool stage_space_available) {
+  if (local_floor_extension_enabled && local_floor_space_available) {
+    return FloorReferenceSpace::kLocalFloor;
+  }
+  if (stage_space_available) {
+    return FloorReferenceSpace::kStage;
+  }
+  throw std::runtime_error(
+      "no floor-relative OpenXR reference space is available");
+}
+
+bool IsInteractionProfileAllowed(
+    const RuntimeSelection& selection,
+    std::string_view interaction_profile_path) {
+  return Contains(
+      selection.interaction_profile_paths, interaction_profile_path);
+}
+
+}  // namespace motus::quest_capture

--- a/agent-core/clients/quest-capture-native/app/src/main/cpp/runtime_profile.hpp
+++ b/agent-core/clients/quest-capture-native/app/src/main/cpp/runtime_profile.hpp
@@ -1,0 +1,61 @@
+#pragma once
+
+#include <string_view>
+#include <vector>
+
+namespace motus::quest_capture {
+
+enum class HeadsetTarget {
+  kMeta,
+  kPico,
+};
+
+struct InteractionProfileRequirement {
+  // Empty for interaction profiles which are part of OpenXR core.
+  std::string_view extension_name;
+  std::string_view interaction_profile_path;
+};
+
+struct RuntimeProfile {
+  HeadsetTarget target;
+  std::string_view application_name;
+  std::vector<InteractionProfileRequirement> interaction_profiles;
+  bool require_any_interaction_extension;
+};
+
+struct RuntimeSelection {
+  // Optional extensions are enabled only when the runtime enumerates them.
+  std::vector<std::string_view> optional_extensions;
+  std::vector<std::string_view> interaction_profile_paths;
+  bool local_floor_extension_enabled;
+};
+
+enum class FloorReferenceSpace {
+  kLocalFloor,
+  kStage,
+};
+
+[[nodiscard]] const RuntimeProfile& MetaRuntimeProfile();
+[[nodiscard]] const RuntimeProfile& PicoRuntimeProfile();
+[[nodiscard]] const RuntimeProfile& CompiledRuntimeProfile();
+
+// Selects the optional extensions and interaction profiles which this build may
+// use. PICO builds fail closed unless at least one supported PICO controller
+// extension is present. Meta builds accept only the core Oculus Touch profile.
+[[nodiscard]] RuntimeSelection SelectRuntime(
+    const RuntimeProfile& profile,
+    const std::vector<std::string_view>& available_extensions);
+
+// Robot poses must always be expressed in a floor-relative reference space.
+// LOCAL is deliberately not an accepted fallback because its origin is tied to
+// the headset start/recenter pose rather than the physical floor.
+[[nodiscard]] FloorReferenceSpace SelectFloorReferenceSpace(
+    bool local_floor_extension_enabled,
+    bool local_floor_space_available,
+    bool stage_space_available);
+
+[[nodiscard]] bool IsInteractionProfileAllowed(
+    const RuntimeSelection& selection,
+    std::string_view interaction_profile_path);
+
+}  // namespace motus::quest_capture

--- a/agent-core/clients/quest-capture-native/app/src/main/res/values/strings.xml
+++ b/agent-core/clients/quest-capture-native/app/src/main/res/values/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="app_name">PhanthyMotus OpenXR Capture</string>
+</resources>

--- a/agent-core/clients/quest-capture-native/app/src/meta/res/values/strings.xml
+++ b/agent-core/clients/quest-capture-native/app/src/meta/res/values/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="app_name">PhanthyMotus Meta Capture</string>
+</resources>

--- a/agent-core/clients/quest-capture-native/app/src/pico/AndroidManifest.xml
+++ b/agent-core/clients/quest-capture-native/app/src/pico/AndroidManifest.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <application>
+        <meta-data
+            android:name="pvr.app.type"
+            android:value="vr" />
+    </application>
+</manifest>

--- a/agent-core/clients/quest-capture-native/app/src/pico/res/values/strings.xml
+++ b/agent-core/clients/quest-capture-native/app/src/pico/res/values/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="app_name">PhanthyMotus PICO Capture</string>
+</resources>

--- a/agent-core/clients/quest-capture-native/build.gradle.kts
+++ b/agent-core/clients/quest-capture-native/build.gradle.kts
@@ -1,0 +1,3 @@
+plugins {
+    id("com.android.application") version "8.7.3" apply false
+}

--- a/agent-core/clients/quest-capture-native/gradle.properties
+++ b/agent-core/clients/quest-capture-native/gradle.properties
@@ -1,0 +1,5 @@
+org.gradle.jvmargs=-Xmx4g -Dfile.encoding=UTF-8
+org.gradle.parallel=true
+org.gradle.caching=true
+android.useAndroidX=false
+android.nonTransitiveRClass=true

--- a/agent-core/clients/quest-capture-native/include/motus/quest_capture/capture_session.hpp
+++ b/agent-core/clients/quest-capture-native/include/motus/quest_capture/capture_session.hpp
@@ -1,0 +1,171 @@
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "motus/quest_capture/frame_v1.hpp"
+
+namespace motus::quest_capture {
+
+inline constexpr char kCaptureProtocol[] = "motus.teleop.capture.v1";
+inline constexpr char kFrameProtocol[] = "motus.teleop.rtc-frame.v1";
+inline constexpr char kNativeClientKind[] = "native_openxr";
+
+enum class CaptureLinkState {
+  kOffline,
+  kAuthenticating,
+  kStandby,
+  kNegotiating,
+  kStreaming,
+  kFaulted,
+};
+
+enum class PresenceState {
+  kBrowserReady,
+  kError,
+  kRtcConnecting,
+  kStreaming,
+  kXrEnded,
+  kXrStandby,
+};
+
+enum class CaptureActionKind {
+  kSendPairAuthentication,
+  kSendCredentialAuthentication,
+  kPersistCredential,
+  kSendPresence,
+  kCreateRtcOffer,
+  kSendSignalingOffer,
+  kApplyRtcAnswer,
+  kCloseRtc,
+  kScheduleReconnect,
+  kReportFault,
+};
+
+struct CaptureIdentity {
+  std::string capture_id;
+  std::string capture_credential;
+};
+
+struct PairingBootstrap {
+  std::string pairing_id;
+  std::string pairing_code;
+};
+
+struct CaptureAssignmentV1 {
+  std::string id;
+  std::int64_t generation{0};
+  std::string session_id;
+  FrameMode mode{FrameMode::kShadow};
+  std::string profile_id;
+  std::string capability_digest;
+  FrameConfiguration frame_configuration;
+};
+
+struct CaptureAction {
+  CaptureActionKind kind{CaptureActionKind::kReportFault};
+  std::int64_t connection_epoch{0};
+  std::optional<PresenceState> presence;
+  std::string assignment_id;
+  std::string value;
+};
+
+struct CaptureSessionState {
+  CaptureLinkState link{CaptureLinkState::kOffline};
+  std::int64_t connection_epoch{0};
+  std::optional<CaptureIdentity> identity;
+  std::optional<PairingBootstrap> pairing;
+  std::optional<CaptureAssignmentV1> assignment;
+  std::int64_t highest_assignment_generation{0};
+  bool authenticated{false};
+  bool xr_focused{false};
+  bool control_open{false};
+  bool pose_open{false};
+  bool offer_sent{false};
+  bool answer_applied{false};
+  std::string frame_session_id;
+  FrameState frame_state;
+};
+
+struct CaptureTransition {
+  CaptureSessionState state;
+  std::vector<CaptureAction> actions;
+};
+
+// Start one WSS connection. Authentication is always sent in-band and the
+// returned epoch must be supplied to all callbacks so stale sockets are inert.
+CaptureTransition BeginCaptureConnection(const CaptureSessionState& previous);
+
+// Apply the exact paired/connected server acknowledgement. A freshly paired
+// credential is persisted before it can be used for a later reconnect.
+CaptureTransition CaptureAuthenticated(
+    const CaptureSessionState& previous,
+    std::int64_t connection_epoch,
+    const CaptureIdentity& identity,
+    bool persist_credential);
+
+// The native Activity calls this from the OpenXR session state machine. Merely
+// becoming focused never creates robot authority; it only advertises standby.
+CaptureTransition CaptureXrFocused(
+    const CaptureSessionState& previous,
+    std::int64_t connection_epoch);
+
+// A PC-authorized assignment is the only event that may start RTC signaling.
+// In particular there is no native action for Acquire or confirm-live.
+CaptureTransition CaptureAssigned(
+    const CaptureSessionState& previous,
+    std::int64_t connection_epoch,
+    const CaptureAssignmentV1& assignment);
+
+CaptureTransition CaptureOfferCreated(
+    const CaptureSessionState& previous,
+    std::int64_t connection_epoch,
+    const std::string& assignment_id,
+    const std::string& offer_sdp);
+
+CaptureTransition CaptureAnswerReceived(
+    const CaptureSessionState& previous,
+    std::int64_t connection_epoch,
+    const std::string& assignment_id,
+    const std::string& answer_sdp);
+
+CaptureTransition CaptureChannelState(
+    const CaptureSessionState& previous,
+    std::int64_t connection_epoch,
+    const std::string& assignment_id,
+    bool control_open,
+    bool pose_open);
+
+// Presence timers use this to renew only capture presence. This is not and
+// must never become the Core robot-session heartbeat.
+CaptureTransition CapturePresenceTick(
+    const CaptureSessionState& previous,
+    std::int64_t connection_epoch);
+
+// These loss paths close the Quest-to-Driver peer locally before reconnecting
+// or notifying Core. The frame deadman is relatched immediately.
+CaptureTransition CaptureTransportLost(
+    const CaptureSessionState& previous,
+    std::int64_t connection_epoch,
+    const std::string& reason);
+
+CaptureTransition CaptureRtcFailed(
+    const CaptureSessionState& previous,
+    std::int64_t connection_epoch,
+    const std::string& assignment_id,
+    const std::string& reason);
+
+CaptureTransition CaptureXrEnded(
+    const CaptureSessionState& previous,
+    std::int64_t connection_epoch,
+    const std::string& reason);
+
+CaptureTransition CaptureAssignmentRevoked(
+    const CaptureSessionState& previous,
+    std::int64_t connection_epoch,
+    const std::string& assignment_id,
+    const std::string& reason);
+
+}  // namespace motus::quest_capture

--- a/agent-core/clients/quest-capture-native/include/motus/quest_capture/capture_wire.hpp
+++ b/agent-core/clients/quest-capture-native/include/motus/quest_capture/capture_wire.hpp
@@ -1,0 +1,81 @@
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <variant>
+
+#include "motus/quest_capture/capture_session.hpp"
+
+namespace motus::quest_capture {
+
+inline constexpr std::size_t kMaxCaptureWireBytes = 128 * 1024;
+inline constexpr std::size_t kMaxSignalingSdpBytes = 120 * 1024;
+inline constexpr std::size_t kMaxRtcMessageBytes = 64 * 1024;
+
+struct CaptureAuthenticatedMessage {
+  CaptureIdentity identity;
+  bool fresh_credential{false};
+  std::int64_t presence_interval_ms{0};
+  std::int64_t presence_timeout_ms{0};
+};
+
+struct CaptureAssignmentMessage {
+  CaptureAssignmentV1 assignment;
+};
+
+struct CaptureSignalingAnswerMessage {
+  std::string assignment_id;
+  std::string answer_sdp;
+};
+
+struct CaptureAssignmentRevokedMessage {
+  std::string assignment_id;
+  std::string reason;
+};
+
+struct CaptureTerminalMessage {
+  std::string type;
+  std::string reason;
+};
+
+struct CapturePresenceAcknowledgedMessage {
+  PresenceState state{PresenceState::kXrStandby};
+};
+
+struct CaptureErrorMessage {
+  std::string code;
+};
+
+using CaptureServerMessage = std::variant<
+    CaptureAuthenticatedMessage,
+    CaptureAssignmentMessage,
+    CaptureSignalingAnswerMessage,
+    CaptureAssignmentRevokedMessage,
+    CaptureTerminalMessage,
+    CapturePresenceAcknowledgedMessage,
+    CaptureErrorMessage>;
+
+std::string SerializePairAuthentication(
+    const PairingBootstrap& pairing,
+    const std::string& app_version);
+
+std::string SerializeCredentialAuthentication(
+    const CaptureIdentity& identity,
+    const std::string& app_version);
+
+std::string SerializeCapturePresence(
+    PresenceState state,
+    const std::string& assignment_id);
+
+std::string SerializeCaptureSignalingOffer(
+    const std::string& assignment_id,
+    const std::string& offer_sdp);
+
+// existing_identity is required for the credential reconnect acknowledgement,
+// because Core deliberately does not echo the long-lived credential.
+CaptureServerMessage ParseCaptureServerMessage(
+    const std::string& payload,
+    const std::optional<CaptureIdentity>& existing_identity = std::nullopt);
+
+}  // namespace motus::quest_capture

--- a/agent-core/clients/quest-capture-native/include/motus/quest_capture/enrollment.hpp
+++ b/agent-core/clients/quest-capture-native/include/motus/quest_capture/enrollment.hpp
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <optional>
+#include <string>
+
+#include "motus/quest_capture/capture_session.hpp"
+
+namespace motus::quest_capture {
+
+struct StoredCaptureEnrollment {
+  std::string capture_id;
+  std::string capture_credential;
+  std::string websocket_url;
+  std::string ca_certificate_pem;
+};
+
+struct CaptureLaunchBootstrap {
+  std::string pairing_id;
+  std::string pairing_code;
+  std::string websocket_url;
+  std::string ca_certificate_pem;
+  bool transport_override_present{false};
+};
+
+struct CaptureEnrollmentSelection {
+  std::optional<CaptureIdentity> identity;
+  std::optional<PairingBootstrap> pairing;
+  std::string websocket_url;
+  std::string ca_certificate_pem;
+};
+
+// An exported NativeActivity may receive Intents from any local application.
+// Existing bearer credentials are therefore inseparable from the WSS origin
+// and trust material stored in the same successful pairing transaction.
+CaptureEnrollmentSelection SelectCaptureEnrollment(
+    const StoredCaptureEnrollment& stored,
+    const CaptureLaunchBootstrap& launch);
+
+}  // namespace motus::quest_capture

--- a/agent-core/clients/quest-capture-native/include/motus/quest_capture/frame_v1.hpp
+++ b/agent-core/clients/quest-capture-native/include/motus/quest_capture/frame_v1.hpp
@@ -1,0 +1,134 @@
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace motus::quest_capture {
+
+inline constexpr std::int64_t kMaxSafeWireInteger = 9'007'199'254'740'991LL;
+
+enum class FrameMode {
+  kShadow,
+  kLive,
+};
+
+struct PoseSample {
+  bool valid{false};
+  bool emulated{false};
+  std::array<double, 3> position{};
+  std::array<double, 4> orientation{0.0, 0.0, 0.0, 1.0};
+};
+
+struct ControllerSample {
+  bool active{false};
+  bool xr_standard{false};
+  bool correct_handedness{false};
+  bool tracked_pointer{false};
+  bool has_grip_space{false};
+  bool squeeze_pressed{false};
+  std::vector<double> axes;
+  std::vector<double> buttons;
+};
+
+struct AxisBinding {
+  enum class Hand {
+    kLeft,
+    kRight,
+  };
+
+  Hand hand{Hand::kLeft};
+  std::size_t axis{0};
+  double scale{0.0};
+  double deadzone{0.0};
+  int direction{1};
+};
+
+struct BaseTwistBinding {
+  AxisBinding linear_x;
+  AxisBinding linear_y;
+  AxisBinding angular_z;
+};
+
+struct FrameConfiguration {
+  FrameMode mode{FrameMode::kShadow};
+  std::optional<BaseTwistBinding> base_twist;
+};
+
+struct FrameSample {
+  PoseSample head;
+  PoseSample left_controller;
+  PoseSample right_controller;
+  ControllerSample left_input;
+  ControllerSample right_input;
+  bool distinct_input_sources{true};
+  std::optional<std::int64_t> monotonic_ns;
+};
+
+struct FrameState {
+  std::int64_t next_sequence{0};
+  std::int64_t clutch_sequence{0};
+  bool deadman_active{false};
+  bool rearm_required{true};
+  std::int64_t last_monotonic_ns{0};
+};
+
+struct WirePose {
+  std::array<double, 3> position{};
+  std::array<double, 4> orientation{};
+};
+
+struct WireController {
+  std::vector<double> axes;
+  std::vector<double> buttons;
+};
+
+struct TrackingState {
+  bool head{false};
+  bool left_controller{false};
+  bool right_controller{false};
+};
+
+struct BaseTwist {
+  std::array<double, 3> linear{};
+  std::array<double, 3> angular{};
+};
+
+struct FrameV1 {
+  std::int64_t sequence{0};
+  std::int64_t client_monotonic_ns{0};
+  FrameMode mode{FrameMode::kShadow};
+  bool deadman{false};
+  std::int64_t clutch_sequence{0};
+  TrackingState tracking;
+  std::optional<WirePose> head;
+  std::optional<WirePose> left_controller;
+  std::optional<WirePose> right_controller;
+  WireController left_input;
+  WireController right_input;
+  std::optional<BaseTwist> base_twist;
+};
+
+struct FrameResult {
+  FrameV1 frame;
+  FrameState state;
+};
+
+// Validate and reduce one native OpenXR sample into the public
+// motus.teleop.rtc-frame.v1 contract. Session authority is deliberately absent.
+FrameResult BuildFrameV1(
+    const FrameState& previous,
+    const FrameSample& sample,
+    const FrameConfiguration& configuration);
+
+// Preserve sequence/clutch watermarks across RTC reconnects while forcing a
+// physical release-neutral-regrip before motion can resume.
+FrameState MarkDeadmanReleased(const FrameState& previous);
+
+// Compact JSON suitable for the unordered teleop-pose DataChannel.
+std::string SerializeFrameV1(const FrameV1& frame);
+
+}  // namespace motus::quest_capture

--- a/agent-core/clients/quest-capture-native/scripts/build_android.sh
+++ b/agent-core/clients/quest-capture-native/scripts/build_android.sh
@@ -1,0 +1,116 @@
+#!/bin/sh
+set -eu
+
+usage() {
+  cat >&2 <<'EOF'
+Usage: build_android.sh [--platform meta|pico|all]
+
+Builds both Android OpenXR APKs by default. Select one platform to shorten an
+incremental build.
+EOF
+}
+
+platform=all
+platform_seen=false
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --platform)
+      if [ "$platform_seen" = true ] || [ "$#" -lt 2 ]; then
+        usage
+        exit 2
+      fi
+      platform=$2
+      platform_seen=true
+      shift 2
+      ;;
+    --platform=*)
+      if [ "$platform_seen" = true ]; then
+        usage
+        exit 2
+      fi
+      platform=${1#--platform=}
+      platform_seen=true
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+case "$platform" in
+  meta|pico|all) ;;
+  *)
+    echo "Unsupported platform: $platform (expected meta, pico, or all)" >&2
+    exit 2
+    ;;
+esac
+
+project_dir=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+android_sdk_root=${ANDROID_SDK_ROOT:-${ANDROID_HOME:-}}
+if [ -z "$android_sdk_root" ]; then
+  echo "ANDROID_SDK_ROOT is required" >&2
+  exit 2
+fi
+if [ -z "${JAVA_HOME:-}" ] || [ ! -x "$JAVA_HOME/bin/java" ]; then
+  echo "JAVA_HOME must point to JDK 17" >&2
+  exit 2
+fi
+
+for required in \
+  "$android_sdk_root/platforms/android-35/android.jar" \
+  "$android_sdk_root/build-tools/35.0.1/aapt2" \
+  "$android_sdk_root/ndk/27.0.12077973/build/cmake/android.toolchain.cmake" \
+  "$android_sdk_root/cmake/3.22.1/bin/cmake"
+do
+  if [ ! -e "$required" ]; then
+    echo "Android build dependency missing: $required" >&2
+    exit 2
+  fi
+done
+
+gradle_version=8.9
+gradle_sha256=d725d707bfabd4dfdc958c624003b3c80accc03f7037b5122c4b1d0ef15cecab
+tool_cache=${MOTUS_ANDROID_TOOL_CACHE:-${TMPDIR:-/tmp}/motus-android-tools}
+gradle_home="$tool_cache/gradle-$gradle_version"
+if [ ! -x "$gradle_home/bin/gradle" ]; then
+  mkdir -p "$tool_cache"
+  archive="$tool_cache/gradle-$gradle_version-bin.zip"
+  curl --fail --location --silent --show-error \
+    "https://services.gradle.org/distributions/gradle-$gradle_version-bin.zip" \
+    --output "$archive"
+  actual=$(shasum -a 256 "$archive" | awk '{print $1}')
+  if [ "$actual" != "$gradle_sha256" ]; then
+    echo "Gradle checksum mismatch: $actual" >&2
+    exit 3
+  fi
+  unzip -q -o "$archive" -d "$tool_cache"
+fi
+
+case "$platform" in
+  meta)
+    exec "$gradle_home/bin/gradle" \
+      --no-daemon \
+      --project-dir "$project_dir" \
+      :app:assembleMetaDebug
+    ;;
+  pico)
+    exec "$gradle_home/bin/gradle" \
+      --no-daemon \
+      --project-dir "$project_dir" \
+      :app:assemblePicoDebug
+    ;;
+  all)
+    exec "$gradle_home/bin/gradle" \
+      --no-daemon \
+      --project-dir "$project_dir" \
+      :app:assembleMetaDebug \
+      :app:assemblePicoDebug
+    ;;
+esac

--- a/agent-core/clients/quest-capture-native/scripts/launch_capture.sh
+++ b/agent-core/clients/quest-capture-native/scripts/launch_capture.sh
@@ -1,0 +1,143 @@
+#!/bin/sh
+set -eu
+
+usage() {
+  cat >&2 <<'EOF'
+Usage: launch_capture.sh --platform meta|pico [--resume]
+
+Set ADB_SERIAL when more than one Android device is connected. First pairing
+also requires CORE_WSS_URL, PAIRING_ID, and CA_CERT_BASE64 or CA_CERT_FILE.
+EOF
+}
+
+platform=
+resume=false
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --platform)
+      if [ -n "$platform" ] || [ "$#" -lt 2 ]; then
+        usage
+        exit 2
+      fi
+      platform=$2
+      shift 2
+      ;;
+    --platform=*)
+      if [ -n "$platform" ]; then
+        usage
+        exit 2
+      fi
+      platform=${1#--platform=}
+      shift
+      ;;
+    --resume)
+      if [ "$resume" = true ]; then
+        usage
+        exit 2
+      fi
+      resume=true
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+case "$platform" in
+  meta)
+    package_activity=com.phanthymotus.questcapture/android.app.NativeActivity
+    ;;
+  pico)
+    package_activity=com.phanthymotus.picocapture/android.app.NativeActivity
+    ;;
+  '')
+    echo "--platform meta|pico is required" >&2
+    usage
+    exit 2
+    ;;
+  *)
+    echo "Unsupported platform: $platform (expected meta or pico)" >&2
+    exit 2
+    ;;
+esac
+
+adb_bin=${ADB:-}
+if [ -z "$adb_bin" ]; then
+  adb_bin=$(command -v adb || true)
+elif [ "${adb_bin#*/}" = "$adb_bin" ]; then
+  adb_bin=$(command -v "$adb_bin" || true)
+fi
+if [ -z "$adb_bin" ] && [ -n "${ANDROID_SDK_ROOT:-}" ]; then
+  adb_bin="$ANDROID_SDK_ROOT/platform-tools/adb"
+fi
+if [ -z "$adb_bin" ] || [ ! -x "$adb_bin" ]; then
+  echo "adb is required; set ADB or ANDROID_SDK_ROOT" >&2
+  exit 2
+fi
+
+set -- "$adb_bin"
+if [ -n "${ADB_SERIAL:-}" ]; then
+  set -- "$@" -s "$ADB_SERIAL"
+fi
+
+if [ "$resume" = true ]; then
+  exec "$@" shell am start -S -n "$package_activity"
+fi
+
+if [ -z "${CORE_WSS_URL:-}" ] || [ -z "${PAIRING_ID:-}" ] || \
+   { [ -z "${CA_CERT_BASE64:-}" ] && [ -z "${CA_CERT_FILE:-}" ]; }; then
+  echo "CORE_WSS_URL, PAIRING_ID and CA_CERT_BASE64 (or CA_CERT_FILE) are required for first pairing" >&2
+  exit 2
+fi
+if [ -n "${CA_CERT_FILE:-}" ] && [ ! -f "$CA_CERT_FILE" ]; then
+  echo "CA_CERT_FILE must be a readable PEM file" >&2
+  exit 2
+fi
+
+if [ -z "${PAIRING_CODE:-}" ]; then
+  if [ ! -t 0 ]; then
+    echo "PAIRING_CODE is required when stdin is not a terminal" >&2
+    exit 2
+  fi
+  printf "One-time pairing code: " >&2
+  restore_echo() {
+    stty echo 2>/dev/null || true
+  }
+  trap restore_echo EXIT HUP INT TERM
+  stty -echo
+  IFS= read -r PAIRING_CODE
+  stty echo
+  trap - EXIT HUP INT TERM
+  printf "\n" >&2
+fi
+if [ -n "${CA_CERT_BASE64:-}" ]; then
+  ca_base64=$CA_CERT_BASE64
+else
+  ca_base64=$(base64 < "$CA_CERT_FILE" | tr -d '\r\n')
+fi
+case "$ca_base64" in
+  ''|*[!A-Za-z0-9+/=]*)
+    echo "CA certificate base64 is invalid" >&2
+    exit 2
+    ;;
+esac
+if [ $((${#ca_base64} % 4)) -ne 0 ] || [ ${#ca_base64} -gt 49152 ]; then
+  echo "CA certificate base64 has an invalid size" >&2
+  exit 2
+fi
+
+# The pairing code is a 60-second, one-use secret. It is supplied only as an
+# Activity extra and is never placed in the WSS URL or Android log output.
+exec "$@" shell am start -S \
+  -n "$package_activity" \
+  --es core_wss_url "$CORE_WSS_URL" \
+  --es pairing_id "$PAIRING_ID" \
+  --es pairing_code "$PAIRING_CODE" \
+  --es ca_certificate_base64 "$ca_base64"

--- a/agent-core/clients/quest-capture-native/settings.gradle.kts
+++ b/agent-core/clients/quest-capture-native/settings.gradle.kts
@@ -1,0 +1,18 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+rootProject.name = "MotusQuestCapture"
+include(":app")

--- a/agent-core/clients/quest-capture-native/src/capture_session.cpp
+++ b/agent-core/clients/quest-capture-native/src/capture_session.cpp
@@ -1,0 +1,420 @@
+#include "motus/quest_capture/capture_session.hpp"
+
+#include <stdexcept>
+#include <utility>
+
+namespace motus::quest_capture {
+namespace {
+
+bool CurrentEpoch(const CaptureSessionState& state, std::int64_t epoch) {
+  return epoch > 0 && epoch == state.connection_epoch;
+}
+
+void RequireText(const std::string& value, const char* name) {
+  if (value.empty()) {
+    throw std::invalid_argument(std::string(name) + " is required");
+  }
+}
+
+CaptureTransition Unchanged(const CaptureSessionState& previous) {
+  return CaptureTransition{.state = previous};
+}
+
+CaptureAction Action(
+    CaptureActionKind kind,
+    std::int64_t epoch,
+    std::string assignment_id = {},
+    std::string value = {}) {
+  return CaptureAction{
+      .kind = kind,
+      .connection_epoch = epoch,
+      .assignment_id = std::move(assignment_id),
+      .value = std::move(value),
+  };
+}
+
+CaptureAction Presence(
+    std::int64_t epoch,
+    PresenceState presence,
+    std::string assignment_id = {}) {
+  return CaptureAction{
+      .kind = CaptureActionKind::kSendPresence,
+      .connection_epoch = epoch,
+      .presence = presence,
+      .assignment_id = std::move(assignment_id),
+  };
+}
+
+void ReleaseLocalMotion(CaptureSessionState& state) {
+  state.frame_state = MarkDeadmanReleased(state.frame_state);
+  state.control_open = false;
+  state.pose_open = false;
+  state.offer_sent = false;
+  state.answer_applied = false;
+}
+
+void ClearAssignment(CaptureSessionState& state) {
+  state.assignment.reset();
+  ReleaseLocalMotion(state);
+}
+
+bool AssignmentMatches(
+    const CaptureSessionState& state,
+    const std::string& assignment_id) {
+  return state.assignment && state.assignment->id == assignment_id;
+}
+
+CaptureTransition Faulted(
+    const CaptureSessionState& previous,
+    const std::string& code) {
+  CaptureTransition transition{.state = previous};
+  ReleaseLocalMotion(transition.state);
+  transition.state.link = CaptureLinkState::kFaulted;
+  transition.actions.push_back(Action(
+      CaptureActionKind::kReportFault,
+      previous.connection_epoch,
+      previous.assignment ? previous.assignment->id : std::string{},
+      code));
+  return transition;
+}
+
+}  // namespace
+
+CaptureTransition BeginCaptureConnection(const CaptureSessionState& previous) {
+  CaptureTransition transition{.state = previous};
+  if (previous.connection_epoch >= kMaxSafeWireInteger) {
+    throw std::range_error("connection_epoch exhausted the safe wire integer range");
+  }
+  if (!previous.identity && !previous.pairing) {
+    return Faulted(previous, "capture_enrollment_missing");
+  }
+  if (previous.link != CaptureLinkState::kOffline &&
+      previous.link != CaptureLinkState::kFaulted) {
+    transition.actions.push_back(Action(
+        CaptureActionKind::kCloseRtc,
+        previous.connection_epoch,
+        previous.assignment ? previous.assignment->id : std::string{},
+        "connection_replaced"));
+  }
+  ClearAssignment(transition.state);
+  ++transition.state.connection_epoch;
+  transition.state.authenticated = false;
+  transition.state.link = CaptureLinkState::kAuthenticating;
+  const auto kind = transition.state.identity
+      ? CaptureActionKind::kSendCredentialAuthentication
+      : CaptureActionKind::kSendPairAuthentication;
+  transition.actions.push_back(Action(kind, transition.state.connection_epoch));
+  return transition;
+}
+
+CaptureTransition CaptureAuthenticated(
+    const CaptureSessionState& previous,
+    std::int64_t connection_epoch,
+    const CaptureIdentity& identity,
+    bool persist_credential) {
+  if (!CurrentEpoch(previous, connection_epoch) ||
+      previous.link != CaptureLinkState::kAuthenticating) {
+    return Unchanged(previous);
+  }
+  RequireText(identity.capture_id, "capture_id");
+  RequireText(identity.capture_credential, "capture_credential");
+  if (previous.identity && previous.identity->capture_id != identity.capture_id) {
+    return Faulted(previous, "capture_identity_mismatch");
+  }
+
+  CaptureTransition transition{.state = previous};
+  transition.state.identity = identity;
+  transition.state.pairing.reset();
+  transition.state.authenticated = true;
+  transition.state.link = CaptureLinkState::kStandby;
+  if (persist_credential) {
+    transition.actions.push_back(Action(
+        CaptureActionKind::kPersistCredential,
+        connection_epoch,
+        {},
+        identity.capture_id));
+  }
+  transition.actions.push_back(Presence(
+      connection_epoch,
+      transition.state.xr_focused
+          ? PresenceState::kXrStandby
+          : PresenceState::kBrowserReady));
+  return transition;
+}
+
+CaptureTransition CaptureXrFocused(
+    const CaptureSessionState& previous,
+    std::int64_t connection_epoch) {
+  if (!CurrentEpoch(previous, connection_epoch)) {
+    return Unchanged(previous);
+  }
+  CaptureTransition transition{.state = previous};
+  transition.state.xr_focused = true;
+  if (previous.authenticated && previous.link == CaptureLinkState::kStandby) {
+    transition.actions.push_back(Presence(
+        connection_epoch,
+        PresenceState::kXrStandby));
+  }
+  return transition;
+}
+
+CaptureTransition CaptureAssigned(
+    const CaptureSessionState& previous,
+    std::int64_t connection_epoch,
+    const CaptureAssignmentV1& assignment) {
+  if (!CurrentEpoch(previous, connection_epoch) || !previous.authenticated) {
+    return Unchanged(previous);
+  }
+  RequireText(assignment.id, "assignment.id");
+  RequireText(assignment.session_id, "assignment.session_id");
+  RequireText(assignment.profile_id, "assignment.profile_id");
+  RequireText(assignment.capability_digest, "assignment.capability_digest");
+  if (assignment.generation <= previous.highest_assignment_generation) {
+    return Faulted(previous, "capture_assignment_stale");
+  }
+  if (previous.link != CaptureLinkState::kStandby || !previous.xr_focused ||
+      previous.assignment) {
+    return Faulted(previous, "capture_assignment_unexpected");
+  }
+  if (assignment.frame_configuration.mode != assignment.mode) {
+    return Faulted(previous, "capture_assignment_mode_mismatch");
+  }
+
+  CaptureTransition transition{.state = previous};
+  transition.state.assignment = assignment;
+  transition.state.highest_assignment_generation = assignment.generation;
+  transition.state.link = CaptureLinkState::kNegotiating;
+  ReleaseLocalMotion(transition.state);
+  if (transition.state.frame_session_id != assignment.session_id) {
+    transition.state.frame_session_id = assignment.session_id;
+    transition.state.frame_state = FrameState{};
+  }
+  transition.actions.push_back(Presence(
+      connection_epoch,
+      PresenceState::kRtcConnecting,
+      assignment.id));
+  transition.actions.push_back(Action(
+      CaptureActionKind::kCreateRtcOffer,
+      connection_epoch,
+      assignment.id));
+  return transition;
+}
+
+CaptureTransition CaptureOfferCreated(
+    const CaptureSessionState& previous,
+    std::int64_t connection_epoch,
+    const std::string& assignment_id,
+    const std::string& offer_sdp) {
+  if (!CurrentEpoch(previous, connection_epoch) ||
+      previous.link != CaptureLinkState::kNegotiating ||
+      !AssignmentMatches(previous, assignment_id) || previous.offer_sent) {
+    return Unchanged(previous);
+  }
+  RequireText(offer_sdp, "offer_sdp");
+  CaptureTransition transition{.state = previous};
+  transition.state.offer_sent = true;
+  transition.actions.push_back(Action(
+      CaptureActionKind::kSendSignalingOffer,
+      connection_epoch,
+      assignment_id,
+      offer_sdp));
+  return transition;
+}
+
+CaptureTransition CaptureAnswerReceived(
+    const CaptureSessionState& previous,
+    std::int64_t connection_epoch,
+    const std::string& assignment_id,
+    const std::string& answer_sdp) {
+  if (!CurrentEpoch(previous, connection_epoch) ||
+      previous.link != CaptureLinkState::kNegotiating ||
+      !AssignmentMatches(previous, assignment_id) || !previous.offer_sent ||
+      previous.answer_applied) {
+    return Unchanged(previous);
+  }
+  RequireText(answer_sdp, "answer_sdp");
+  CaptureTransition transition{.state = previous};
+  transition.state.answer_applied = true;
+  transition.actions.push_back(Action(
+      CaptureActionKind::kApplyRtcAnswer,
+      connection_epoch,
+      assignment_id,
+      answer_sdp));
+  return transition;
+}
+
+CaptureTransition CaptureChannelState(
+    const CaptureSessionState& previous,
+    std::int64_t connection_epoch,
+    const std::string& assignment_id,
+    bool control_open,
+    bool pose_open) {
+  if (!CurrentEpoch(previous, connection_epoch) ||
+      !AssignmentMatches(previous, assignment_id) ||
+      (previous.link != CaptureLinkState::kNegotiating &&
+       previous.link != CaptureLinkState::kStreaming)) {
+    return Unchanged(previous);
+  }
+  CaptureTransition transition{.state = previous};
+  transition.state.control_open = control_open;
+  transition.state.pose_open = pose_open;
+  if (control_open && pose_open && previous.answer_applied) {
+    transition.state.link = CaptureLinkState::kStreaming;
+    transition.actions.push_back(Presence(
+        connection_epoch,
+        PresenceState::kStreaming,
+        assignment_id));
+  } else if (previous.link == CaptureLinkState::kStreaming) {
+    return CaptureRtcFailed(
+        previous,
+        connection_epoch,
+        assignment_id,
+        "capture_data_channel_lost");
+  }
+  return transition;
+}
+
+CaptureTransition CapturePresenceTick(
+    const CaptureSessionState& previous,
+    std::int64_t connection_epoch) {
+  if (!CurrentEpoch(previous, connection_epoch) || !previous.authenticated) {
+    return Unchanged(previous);
+  }
+  CaptureTransition transition{.state = previous};
+  if (previous.link == CaptureLinkState::kStreaming && previous.assignment) {
+    transition.actions.push_back(Presence(
+        connection_epoch,
+        PresenceState::kStreaming,
+        previous.assignment->id));
+  } else if (previous.link == CaptureLinkState::kNegotiating && previous.assignment) {
+    transition.actions.push_back(Presence(
+        connection_epoch,
+        PresenceState::kRtcConnecting,
+        previous.assignment->id));
+  } else if (previous.link == CaptureLinkState::kStandby) {
+    transition.actions.push_back(Presence(
+        connection_epoch,
+        previous.xr_focused
+            ? PresenceState::kXrStandby
+            : PresenceState::kBrowserReady));
+  }
+  return transition;
+}
+
+CaptureTransition CaptureTransportLost(
+    const CaptureSessionState& previous,
+    std::int64_t connection_epoch,
+    const std::string& reason) {
+  if (!CurrentEpoch(previous, connection_epoch)) {
+    return Unchanged(previous);
+  }
+  RequireText(reason, "reason");
+  CaptureTransition transition{.state = previous};
+  const std::string assignment_id = previous.assignment
+      ? previous.assignment->id
+      : std::string{};
+  ClearAssignment(transition.state);
+  transition.state.authenticated = false;
+  transition.state.link = CaptureLinkState::kOffline;
+  transition.actions.push_back(Action(
+      CaptureActionKind::kCloseRtc,
+      connection_epoch,
+      assignment_id,
+      reason));
+  transition.actions.push_back(Action(
+      CaptureActionKind::kScheduleReconnect,
+      connection_epoch,
+      {},
+      reason));
+  return transition;
+}
+
+CaptureTransition CaptureRtcFailed(
+    const CaptureSessionState& previous,
+    std::int64_t connection_epoch,
+    const std::string& assignment_id,
+    const std::string& reason) {
+  if (!CurrentEpoch(previous, connection_epoch) ||
+      !AssignmentMatches(previous, assignment_id)) {
+    return Unchanged(previous);
+  }
+  RequireText(reason, "reason");
+  CaptureTransition transition{.state = previous};
+  ReleaseLocalMotion(transition.state);
+  transition.state.link = CaptureLinkState::kFaulted;
+  transition.actions.push_back(Action(
+      CaptureActionKind::kCloseRtc,
+      connection_epoch,
+      assignment_id,
+      reason));
+  transition.actions.push_back(Presence(
+      connection_epoch,
+      PresenceState::kError,
+      assignment_id));
+  transition.actions.push_back(Action(
+      CaptureActionKind::kReportFault,
+      connection_epoch,
+      assignment_id,
+      reason));
+  return transition;
+}
+
+CaptureTransition CaptureXrEnded(
+    const CaptureSessionState& previous,
+    std::int64_t connection_epoch,
+    const std::string& reason) {
+  if (!CurrentEpoch(previous, connection_epoch)) {
+    return Unchanged(previous);
+  }
+  RequireText(reason, "reason");
+  CaptureTransition transition{.state = previous};
+  const std::string assignment_id = previous.assignment
+      ? previous.assignment->id
+      : std::string{};
+  ClearAssignment(transition.state);
+  transition.state.xr_focused = false;
+  transition.state.link = previous.authenticated
+      ? CaptureLinkState::kStandby
+      : CaptureLinkState::kOffline;
+  transition.actions.push_back(Action(
+      CaptureActionKind::kCloseRtc,
+      connection_epoch,
+      assignment_id,
+      reason));
+  if (previous.authenticated) {
+    transition.actions.push_back(Presence(
+        connection_epoch,
+        PresenceState::kXrEnded));
+  }
+  return transition;
+}
+
+CaptureTransition CaptureAssignmentRevoked(
+    const CaptureSessionState& previous,
+    std::int64_t connection_epoch,
+    const std::string& assignment_id,
+    const std::string& reason) {
+  if (!CurrentEpoch(previous, connection_epoch) ||
+      !AssignmentMatches(previous, assignment_id)) {
+    return Unchanged(previous);
+  }
+  RequireText(reason, "reason");
+  CaptureTransition transition{.state = previous};
+  ClearAssignment(transition.state);
+  transition.state.link = previous.authenticated
+      ? CaptureLinkState::kStandby
+      : CaptureLinkState::kOffline;
+  transition.actions.push_back(Action(
+      CaptureActionKind::kCloseRtc,
+      connection_epoch,
+      assignment_id,
+      reason));
+  if (previous.authenticated && previous.xr_focused) {
+    transition.actions.push_back(Presence(
+        connection_epoch,
+        PresenceState::kXrStandby));
+  }
+  return transition;
+}
+
+}  // namespace motus::quest_capture

--- a/agent-core/clients/quest-capture-native/src/capture_wire.cpp
+++ b/agent-core/clients/quest-capture-native/src/capture_wire.cpp
@@ -1,0 +1,537 @@
+#include "motus/quest_capture/capture_wire.hpp"
+
+#include <cmath>
+#include <regex>
+#include <set>
+#include <stdexcept>
+#include <string_view>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include <nlohmann/json.hpp>
+
+namespace motus::quest_capture {
+namespace {
+
+using Json = nlohmann::json;
+
+const std::regex kUuidV4(
+    "^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$");
+const std::regex kSafeId("^[A-Za-z0-9][A-Za-z0-9_.:-]{0,127}$");
+const std::regex kAppVersion("^[A-Za-z0-9][A-Za-z0-9_.+-]{0,31}$");
+const std::regex kDigest("^[0-9a-f]{64}$");
+
+[[noreturn]] void Invalid(const std::string& field) {
+  throw std::invalid_argument("invalid capture wire field: " + field);
+}
+
+void ExactKeys(
+    const Json& value,
+    std::initializer_list<std::string_view> expected,
+    const std::string& field) {
+  if (!value.is_object() || value.size() != expected.size()) {
+    Invalid(field);
+  }
+  for (const auto key : expected) {
+    if (!value.contains(std::string(key))) {
+      Invalid(field);
+    }
+  }
+}
+
+std::string StringMatching(
+    const Json& value,
+    const std::regex& pattern,
+    const std::string& field) {
+  if (!value.is_string()) {
+    Invalid(field);
+  }
+  const auto result = value.get<std::string>();
+  if (!std::regex_match(result, pattern)) {
+    Invalid(field);
+  }
+  return result;
+}
+
+std::string BoundedString(
+    const Json& value,
+    std::size_t minimum,
+    std::size_t maximum,
+    const std::string& field) {
+  if (!value.is_string()) {
+    Invalid(field);
+  }
+  auto result = value.get<std::string>();
+  if (result.size() < minimum || result.size() > maximum ||
+      result.find('\0') != std::string::npos) {
+    Invalid(field);
+  }
+  return result;
+}
+
+std::int64_t SafeInteger(
+    const Json& value,
+    std::int64_t minimum,
+    std::int64_t maximum,
+    const std::string& field) {
+  if (!value.is_number_integer()) {
+    Invalid(field);
+  }
+  const auto result = value.get<std::int64_t>();
+  if (result < minimum || result > maximum) {
+    Invalid(field);
+  }
+  return result;
+}
+
+double FiniteNumber(
+    const Json& value,
+    double minimum,
+    double maximum,
+    const std::string& field) {
+  if (!value.is_number()) {
+    Invalid(field);
+  }
+  const auto result = value.get<double>();
+  if (!std::isfinite(result) || result < minimum || result > maximum) {
+    Invalid(field);
+  }
+  return result;
+}
+
+bool StrictBoolean(const Json& value, const std::string& field) {
+  if (!value.is_boolean()) {
+    Invalid(field);
+  }
+  return value.get<bool>();
+}
+
+Json ParseStrict(const std::string& payload) {
+  if (payload.empty() || payload.size() > kMaxCaptureWireBytes ||
+      payload.find('\0') != std::string::npos) {
+    Invalid("message");
+  }
+  bool duplicate = false;
+  std::vector<std::unordered_set<std::string>> object_keys;
+  const auto callback = [&duplicate, &object_keys](
+                            int,
+                            Json::parse_event_t event,
+                            Json& parsed) {
+    if (event == Json::parse_event_t::object_start) {
+      object_keys.emplace_back();
+    } else if (event == Json::parse_event_t::key) {
+      if (object_keys.empty() ||
+          !object_keys.back().insert(parsed.get<std::string>()).second) {
+        duplicate = true;
+      }
+    } else if (event == Json::parse_event_t::object_end) {
+      if (object_keys.empty()) {
+        duplicate = true;
+      } else {
+        object_keys.pop_back();
+      }
+    }
+    return true;
+  };
+  Json result;
+  try {
+    result = Json::parse(payload, callback, true, true);
+  } catch (const Json::exception&) {
+    Invalid("message");
+  }
+  if (duplicate || !object_keys.empty() || !result.is_object()) {
+    Invalid("message");
+  }
+  return result;
+}
+
+std::string PresenceName(PresenceState state) {
+  switch (state) {
+    case PresenceState::kBrowserReady:
+      return "browser_ready";
+    case PresenceState::kError:
+      return "error";
+    case PresenceState::kRtcConnecting:
+      return "rtc_connecting";
+    case PresenceState::kStreaming:
+      return "streaming";
+    case PresenceState::kXrEnded:
+      return "xr_ended";
+    case PresenceState::kXrStandby:
+      return "xr_standby";
+  }
+  Invalid("presence.state");
+}
+
+PresenceState ParsePresence(const Json& value) {
+  if (!value.is_string()) {
+    Invalid("presence.state");
+  }
+  const auto state = value.get<std::string>();
+  if (state == "browser_ready") {
+    return PresenceState::kBrowserReady;
+  }
+  if (state == "error") {
+    return PresenceState::kError;
+  }
+  if (state == "rtc_connecting") {
+    return PresenceState::kRtcConnecting;
+  }
+  if (state == "streaming") {
+    return PresenceState::kStreaming;
+  }
+  if (state == "xr_ended") {
+    return PresenceState::kXrEnded;
+  }
+  if (state == "xr_standby") {
+    return PresenceState::kXrStandby;
+  }
+  Invalid("presence.state");
+}
+
+AxisBinding ParseAxisBinding(const Json& value, const std::string& field) {
+  ExactKeys(value, {"hand", "axis", "scale", "deadzone", "direction"}, field);
+  AxisBinding binding;
+  const auto hand = BoundedString(value.at("hand"), 4, 5, field + ".hand");
+  if (hand == "left") {
+    binding.hand = AxisBinding::Hand::kLeft;
+  } else if (hand == "right") {
+    binding.hand = AxisBinding::Hand::kRight;
+  } else {
+    Invalid(field + ".hand");
+  }
+  binding.axis = static_cast<std::size_t>(SafeInteger(
+      value.at("axis"), 0, 7, field + ".axis"));
+  binding.scale = FiniteNumber(value.at("scale"), 0.0, 10.0, field + ".scale");
+  binding.deadzone = FiniteNumber(
+      value.at("deadzone"), 0.0, 0.95, field + ".deadzone");
+  binding.direction = static_cast<int>(SafeInteger(
+      value.at("direction"), -1, 1, field + ".direction"));
+  if (binding.direction == 0) {
+    Invalid(field + ".direction");
+  }
+  return binding;
+}
+
+FrameConfiguration ParseCapabilities(
+    const Json& value,
+    const std::string& profile_id,
+    FrameMode mode,
+    const Json& top_effectors) {
+  ExactKeys(
+      value,
+      {"profile_id", "input_bindings", "outputs", "effectors"},
+      "assignment.capabilities");
+  if (StringMatching(value.at("profile_id"), kSafeId, "capabilities.profile_id") !=
+      profile_id) {
+    Invalid("capabilities.profile_id");
+  }
+  const auto& inputs = value.at("input_bindings");
+  const auto& outputs = value.at("outputs");
+  const auto& effectors = value.at("effectors");
+  if (!inputs.is_object() || inputs.size() > 16 || !outputs.is_object() ||
+      outputs.empty() || outputs.size() > 16 || !effectors.is_array() ||
+      effectors.size() > 16 || effectors != top_effectors) {
+    Invalid("capabilities");
+  }
+
+  std::set<std::string> enabled_outputs;
+  for (const auto& [name, output] : outputs.items()) {
+    if (!std::regex_match(name, kSafeId) || !output.is_object() ||
+        output.empty() || output.size() > 2 || !output.contains("enabled")) {
+      Invalid("capabilities.outputs");
+    }
+    for (const auto& [key, ignored] : output.items()) {
+      static_cast<void>(ignored);
+      if (key != "enabled" && key != "joint_count") {
+        Invalid("capabilities.outputs");
+      }
+    }
+    if (output.contains("joint_count")) {
+      static_cast<void>(SafeInteger(
+          output.at("joint_count"), 0, 128, "capabilities.outputs.joint_count"));
+    }
+    if (StrictBoolean(output.at("enabled"), "capabilities.outputs.enabled")) {
+      enabled_outputs.insert(name);
+    }
+  }
+
+  std::set<std::string> declared_effectors;
+  for (const auto& effector : effectors) {
+    declared_effectors.insert(StringMatching(
+        effector, kSafeId, "capabilities.effectors"));
+  }
+  if (declared_effectors.size() != effectors.size() ||
+      declared_effectors != enabled_outputs) {
+    Invalid("capabilities.effectors");
+  }
+
+  for (const auto& [name, binding] : inputs.items()) {
+    if (!std::regex_match(name, kSafeId)) {
+      Invalid("capabilities.input_bindings");
+    }
+    if (name == "base_twist") {
+      continue;
+    }
+    ExactKeys(binding, {"required", "role"}, "capabilities.input_bindings.role");
+    static_cast<void>(StrictBoolean(
+        binding.at("required"), "capabilities.input_bindings.required"));
+    static_cast<void>(StringMatching(
+        binding.at("role"), kSafeId, "capabilities.input_bindings.role"));
+  }
+
+  const bool base_enabled = enabled_outputs.contains("base");
+  const bool has_base_binding = inputs.contains("base_twist");
+  if (base_enabled != has_base_binding) {
+    Invalid("capabilities.input_bindings.base_twist");
+  }
+  FrameConfiguration configuration{.mode = mode};
+  if (has_base_binding) {
+    const auto& base = inputs.at("base_twist");
+    ExactKeys(base, {"linear_x", "linear_y", "angular_z"}, "base_twist");
+    configuration.base_twist = BaseTwistBinding{
+        .linear_x = ParseAxisBinding(base.at("linear_x"), "base_twist.linear_x"),
+        .linear_y = ParseAxisBinding(base.at("linear_y"), "base_twist.linear_y"),
+        .angular_z = ParseAxisBinding(base.at("angular_z"), "base_twist.angular_z"),
+    };
+  }
+  return configuration;
+}
+
+CaptureAssignmentV1 ParseAssignment(const Json& value) {
+  ExactKeys(
+      value,
+      {"id", "generation", "session_id", "mode", "profile_id",
+       "capability_digest", "capabilities", "effectors", "state",
+       "created_at", "updated_at", "failure_code"},
+      "assignment");
+  if (value.at("state") != "issued" || !value.at("failure_code").is_null()) {
+    Invalid("assignment.state");
+  }
+  static_cast<void>(FiniteNumber(
+      value.at("created_at"), 0.0, 1.0e13, "assignment.created_at"));
+  static_cast<void>(FiniteNumber(
+      value.at("updated_at"), 0.0, 1.0e13, "assignment.updated_at"));
+  const auto mode_name = BoundedString(value.at("mode"), 4, 6, "assignment.mode");
+  FrameMode mode;
+  if (mode_name == "shadow") {
+    mode = FrameMode::kShadow;
+  } else if (mode_name == "live") {
+    mode = FrameMode::kLive;
+  } else {
+    Invalid("assignment.mode");
+  }
+  const auto profile_id = StringMatching(
+      value.at("profile_id"), kSafeId, "assignment.profile_id");
+  if (!value.at("effectors").is_array()) {
+    Invalid("assignment.effectors");
+  }
+  const auto configuration = ParseCapabilities(
+      value.at("capabilities"), profile_id, mode, value.at("effectors"));
+  return CaptureAssignmentV1{
+      .id = StringMatching(value.at("id"), kUuidV4, "assignment.id"),
+      .generation = SafeInteger(
+          value.at("generation"), 1, kMaxSafeWireInteger, "assignment.generation"),
+      .session_id = StringMatching(
+          value.at("session_id"), kUuidV4, "assignment.session_id"),
+      .mode = mode,
+      .profile_id = profile_id,
+      .capability_digest = StringMatching(
+          value.at("capability_digest"), kDigest, "assignment.capability_digest"),
+      .frame_configuration = configuration,
+  };
+}
+
+void ValidateAuthenticationInputs(
+    const std::string& app_version,
+    const std::string& id,
+    const std::string& secret,
+    const std::string& id_field) {
+  if (!std::regex_match(app_version, kAppVersion) ||
+      !std::regex_match(id, kUuidV4) || secret.size() < 32 || secret.size() > 128 ||
+      secret.find('\0') != std::string::npos) {
+    Invalid(id_field);
+  }
+}
+
+}  // namespace
+
+std::string SerializePairAuthentication(
+    const PairingBootstrap& pairing,
+    const std::string& app_version) {
+  ValidateAuthenticationInputs(
+      app_version, pairing.pairing_id, pairing.pairing_code, "pairing");
+  return Json{
+      {"type", "pair"},
+      {"pairing_id", pairing.pairing_id},
+      {"pairing_code", pairing.pairing_code},
+      {"capture_protocol", kCaptureProtocol},
+      {"frame_protocol", kFrameProtocol},
+      {"client_kind", kNativeClientKind},
+      {"app_version", app_version},
+  }.dump();
+}
+
+std::string SerializeCredentialAuthentication(
+    const CaptureIdentity& identity,
+    const std::string& app_version) {
+  ValidateAuthenticationInputs(
+      app_version,
+      identity.capture_id,
+      identity.capture_credential,
+      "capture_identity");
+  return Json{
+      {"type", "credential"},
+      {"capture_id", identity.capture_id},
+      {"capture_credential", identity.capture_credential},
+      {"capture_protocol", kCaptureProtocol},
+      {"frame_protocol", kFrameProtocol},
+      {"client_kind", kNativeClientKind},
+      {"app_version", app_version},
+  }.dump();
+}
+
+std::string SerializeCapturePresence(
+    PresenceState state,
+    const std::string& assignment_id) {
+  const bool assignment_bound = state == PresenceState::kError ||
+      state == PresenceState::kRtcConnecting || state == PresenceState::kStreaming;
+  if (assignment_bound != !assignment_id.empty() ||
+      (!assignment_id.empty() && !std::regex_match(assignment_id, kUuidV4))) {
+    Invalid("presence.assignment_id");
+  }
+  return Json{
+      {"type", "presence"},
+      {"state", PresenceName(state)},
+      {"assignment_id", assignment_id.empty() ? Json(nullptr) : Json(assignment_id)},
+  }.dump();
+}
+
+std::string SerializeCaptureSignalingOffer(
+    const std::string& assignment_id,
+    const std::string& offer_sdp) {
+  if (!std::regex_match(assignment_id, kUuidV4) || offer_sdp.empty() ||
+      offer_sdp.size() > kMaxSignalingSdpBytes ||
+      offer_sdp.find('\0') != std::string::npos) {
+    Invalid("signaling_offer");
+  }
+  const auto payload = Json{
+      {"type", "signaling_offer"},
+      {"assignment_id", assignment_id},
+      {"offer", {{"type", "offer"}, {"sdp", offer_sdp}}},
+  }.dump();
+  if (payload.size() > kMaxCaptureWireBytes) {
+    Invalid("signaling_offer");
+  }
+  return payload;
+}
+
+CaptureServerMessage ParseCaptureServerMessage(
+    const std::string& payload,
+    const std::optional<CaptureIdentity>& existing_identity) {
+  const auto message = ParseStrict(payload);
+  if (!message.contains("type") || !message.at("type").is_string()) {
+    Invalid("type");
+  }
+  const auto type = message.at("type").get<std::string>();
+  if (type == "paired") {
+    ExactKeys(
+        message,
+        {"type", "capture_id", "capture_credential", "capture_protocol",
+         "frame_protocol", "presence_interval_ms", "presence_timeout_ms"},
+        "paired");
+    if (message.at("capture_protocol") != kCaptureProtocol ||
+        message.at("frame_protocol") != kFrameProtocol) {
+      Invalid("paired.protocol");
+    }
+    return CaptureAuthenticatedMessage{
+        .identity = CaptureIdentity{
+            .capture_id = StringMatching(
+                message.at("capture_id"), kUuidV4, "paired.capture_id"),
+            .capture_credential = BoundedString(
+                message.at("capture_credential"), 32, 128, "paired.credential"),
+        },
+        .fresh_credential = true,
+        .presence_interval_ms = SafeInteger(
+            message.at("presence_interval_ms"), 250, 10'000, "presence_interval_ms"),
+        .presence_timeout_ms = SafeInteger(
+            message.at("presence_timeout_ms"), 1'000, 30'000, "presence_timeout_ms"),
+    };
+  }
+  if (type == "connected") {
+    ExactKeys(
+        message,
+        {"type", "capture_id", "capture_protocol", "frame_protocol",
+         "presence_interval_ms", "presence_timeout_ms"},
+        "connected");
+    if (!existing_identity || message.at("capture_protocol") != kCaptureProtocol ||
+        message.at("frame_protocol") != kFrameProtocol ||
+        StringMatching(message.at("capture_id"), kUuidV4, "connected.capture_id") !=
+            existing_identity->capture_id) {
+      Invalid("connected.identity");
+    }
+    return CaptureAuthenticatedMessage{
+        .identity = *existing_identity,
+        .fresh_credential = false,
+        .presence_interval_ms = SafeInteger(
+            message.at("presence_interval_ms"), 250, 10'000, "presence_interval_ms"),
+        .presence_timeout_ms = SafeInteger(
+            message.at("presence_timeout_ms"), 1'000, 30'000, "presence_timeout_ms"),
+    };
+  }
+  if (type == "assignment") {
+    ExactKeys(message, {"type", "assignment"}, "assignment_message");
+    return CaptureAssignmentMessage{.assignment = ParseAssignment(message.at("assignment"))};
+  }
+  if (type == "signaling_answer") {
+    ExactKeys(
+        message,
+        {"type", "assignment_id", "answer"},
+        "signaling_answer");
+    const auto& answer = message.at("answer");
+    ExactKeys(answer, {"type", "sdp"}, "signaling_answer.answer");
+    if (answer.at("type") != "answer") {
+      Invalid("signaling_answer.answer.type");
+    }
+    return CaptureSignalingAnswerMessage{
+        .assignment_id = StringMatching(
+            message.at("assignment_id"), kUuidV4, "signaling_answer.assignment_id"),
+        .answer_sdp = BoundedString(
+            answer.at("sdp"), 1, kMaxSignalingSdpBytes, "signaling_answer.sdp"),
+    };
+  }
+  if (type == "assignment_revoked") {
+    ExactKeys(
+        message,
+        {"type", "assignment_id", "reason"},
+        "assignment_revoked");
+    return CaptureAssignmentRevokedMessage{
+        .assignment_id = StringMatching(
+            message.at("assignment_id"), kUuidV4, "assignment_revoked.assignment_id"),
+        .reason = BoundedString(message.at("reason"), 1, 128, "assignment_revoked.reason"),
+    };
+  }
+  if (type == "capture_revoked" || type == "capture_stale") {
+    ExactKeys(message, {"type", "reason"}, type);
+    return CaptureTerminalMessage{
+        .type = type,
+        .reason = BoundedString(message.at("reason"), 1, 128, type + ".reason"),
+    };
+  }
+  if (type == "presence_ack") {
+    ExactKeys(message, {"type", "state"}, "presence_ack");
+    return CapturePresenceAcknowledgedMessage{
+        .state = ParsePresence(message.at("state")),
+    };
+  }
+  if (type == "error") {
+    ExactKeys(message, {"type", "code"}, "error");
+    return CaptureErrorMessage{
+        .code = StringMatching(message.at("code"), kSafeId, "error.code"),
+    };
+  }
+  Invalid("type");
+}
+
+}  // namespace motus::quest_capture

--- a/agent-core/clients/quest-capture-native/src/enrollment.cpp
+++ b/agent-core/clients/quest-capture-native/src/enrollment.cpp
@@ -1,0 +1,48 @@
+#include "motus/quest_capture/enrollment.hpp"
+
+#include <stdexcept>
+
+namespace motus::quest_capture {
+
+CaptureEnrollmentSelection SelectCaptureEnrollment(
+    const StoredCaptureEnrollment& stored,
+    const CaptureLaunchBootstrap& launch) {
+  const bool pairing_present =
+      !launch.pairing_id.empty() || !launch.pairing_code.empty();
+  if (pairing_present) {
+    if (
+        launch.pairing_id.empty() || launch.pairing_code.empty() ||
+        launch.websocket_url.empty() || launch.ca_certificate_pem.empty()) {
+      throw std::invalid_argument("capture pairing bootstrap is incomplete");
+    }
+    return CaptureEnrollmentSelection{
+        .identity = std::nullopt,
+        .pairing = PairingBootstrap{
+            .pairing_id = launch.pairing_id,
+            .pairing_code = launch.pairing_code,
+        },
+        .websocket_url = launch.websocket_url,
+        .ca_certificate_pem = launch.ca_certificate_pem,
+    };
+  }
+
+  if (launch.transport_override_present) {
+    throw std::invalid_argument("stored capture transport cannot be overridden");
+  }
+  if (
+      stored.capture_id.empty() || stored.capture_credential.empty() ||
+      stored.websocket_url.empty() || stored.ca_certificate_pem.empty()) {
+    throw std::invalid_argument("stored capture enrollment is incomplete");
+  }
+  return CaptureEnrollmentSelection{
+      .identity = CaptureIdentity{
+          .capture_id = stored.capture_id,
+          .capture_credential = stored.capture_credential,
+      },
+      .pairing = std::nullopt,
+      .websocket_url = stored.websocket_url,
+      .ca_certificate_pem = stored.ca_certificate_pem,
+  };
+}
+
+}  // namespace motus::quest_capture

--- a/agent-core/clients/quest-capture-native/src/frame_v1.cpp
+++ b/agent-core/clients/quest-capture-native/src/frame_v1.cpp
@@ -1,0 +1,447 @@
+#include "motus/quest_capture/frame_v1.hpp"
+
+#include <algorithm>
+#include <charconv>
+#include <cmath>
+#include <stdexcept>
+#include <string_view>
+
+namespace motus::quest_capture {
+namespace {
+
+constexpr std::size_t kMaxAxes = 8;
+constexpr std::size_t kMaxButtons = 16;
+constexpr double kMaxPositionMetres = 100.0;
+constexpr double kQuaternionNormMin = 0.5;
+constexpr double kQuaternionNormMax = 1.5;
+constexpr double kQuaternionComponentLimit = 1.000001;
+
+enum class SqueezeState {
+  kInvalid,
+  kReleased,
+  kTransition,
+  kPressed,
+};
+
+struct NormalizedController {
+  WireController wire;
+  bool valid{false};
+  SqueezeState squeeze{SqueezeState::kInvalid};
+};
+
+void RequireCounter(std::int64_t value, std::string_view name, bool allow_maximum = true) {
+  const auto maximum = allow_maximum ? kMaxSafeWireInteger : kMaxSafeWireInteger - 1;
+  if (value < 0 || value > maximum) {
+    throw std::range_error(std::string(name) + " is outside the safe wire integer range");
+  }
+}
+
+bool IsFinite(double value) {
+  return std::isfinite(value);
+}
+
+double Clamp(double value, double minimum, double maximum) {
+  return std::min(maximum, std::max(minimum, value));
+}
+
+std::optional<WirePose> NormalizePose(const PoseSample& sample) {
+  if (!sample.valid || sample.emulated) {
+    return std::nullopt;
+  }
+  for (double value : sample.position) {
+    if (!IsFinite(value) || std::abs(value) > kMaxPositionMetres) {
+      return std::nullopt;
+    }
+  }
+  double norm_squared = 0.0;
+  for (double value : sample.orientation) {
+    if (!IsFinite(value) || std::abs(value) > kQuaternionComponentLimit) {
+      return std::nullopt;
+    }
+    norm_squared += value * value;
+  }
+  const double norm = std::sqrt(norm_squared);
+  if (!IsFinite(norm) || norm < kQuaternionNormMin || norm > kQuaternionNormMax) {
+    return std::nullopt;
+  }
+
+  WirePose pose;
+  pose.position = sample.position;
+  double normalized_norm_squared = 0.0;
+  for (std::size_t index = 0; index < pose.orientation.size(); ++index) {
+    pose.orientation[index] = sample.orientation[index] / norm;
+    normalized_norm_squared += pose.orientation[index] * pose.orientation[index];
+  }
+  const double normalized_norm = std::sqrt(normalized_norm_squared);
+  if (!IsFinite(normalized_norm) || normalized_norm == 0.0) {
+    return std::nullopt;
+  }
+  for (double& value : pose.orientation) {
+    value = Clamp(value / normalized_norm, -1.0, 1.0);
+    if (!IsFinite(value)) {
+      return std::nullopt;
+    }
+  }
+  return pose;
+}
+
+NormalizedController NormalizeController(const ControllerSample& sample) {
+  NormalizedController result;
+  result.valid = sample.active && sample.xr_standard && sample.correct_handedness &&
+      sample.tracked_pointer && sample.has_grip_space && sample.axes.size() <= kMaxAxes &&
+      sample.buttons.size() >= 2 && sample.buttons.size() <= kMaxButtons;
+
+  const auto axis_count = std::min(sample.axes.size(), kMaxAxes);
+  result.wire.axes.reserve(axis_count);
+  for (std::size_t index = 0; index < axis_count; ++index) {
+    const double raw = sample.axes[index];
+    result.wire.axes.push_back(IsFinite(raw) ? Clamp(raw, -1.0, 1.0) : 0.0);
+    result.valid = result.valid && IsFinite(raw) && raw >= -1.0 && raw <= 1.0;
+  }
+
+  const auto button_count = std::min(sample.buttons.size(), kMaxButtons);
+  result.wire.buttons.reserve(button_count);
+  for (std::size_t index = 0; index < button_count; ++index) {
+    const double raw = sample.buttons[index];
+    result.wire.buttons.push_back(IsFinite(raw) ? Clamp(raw, 0.0, 1.0) : 0.0);
+    result.valid = result.valid && IsFinite(raw) && raw >= 0.0 && raw <= 1.0;
+  }
+
+  if (sample.buttons.size() < 2 || !IsFinite(sample.buttons[1]) || sample.buttons[1] < 0.0 ||
+      sample.buttons[1] > 1.0) {
+    result.squeeze = SqueezeState::kInvalid;
+  } else if (sample.squeeze_pressed && sample.buttons[1] >= 0.75) {
+    result.squeeze = SqueezeState::kPressed;
+  } else if (!sample.squeeze_pressed && sample.buttons[1] < 0.75) {
+    result.squeeze = SqueezeState::kReleased;
+  } else {
+    result.squeeze = SqueezeState::kTransition;
+  }
+  return result;
+}
+
+void ValidateBinding(const AxisBinding& binding) {
+  if (binding.axis >= kMaxAxes || !IsFinite(binding.scale) || binding.scale < 0.0 ||
+      binding.scale > 10.0 || !IsFinite(binding.deadzone) || binding.deadzone < 0.0 ||
+      binding.deadzone > 0.95 || (binding.direction != -1 && binding.direction != 1)) {
+    throw std::invalid_argument("base_twist axis binding is invalid");
+  }
+}
+
+const std::vector<double>& AxesFor(
+    const AxisBinding& binding,
+    const NormalizedController& left,
+    const NormalizedController& right) {
+  return binding.hand == AxisBinding::Hand::kLeft ? left.wire.axes : right.wire.axes;
+}
+
+std::optional<double> BoundAxis(
+    const AxisBinding& binding,
+    const NormalizedController& left,
+    const NormalizedController& right) {
+  const auto& axes = AxesFor(binding, left, right);
+  if (binding.axis >= axes.size()) {
+    return std::nullopt;
+  }
+  return axes[binding.axis];
+}
+
+std::optional<double> RemapAxis(double value, double deadzone) {
+  if (!IsFinite(value) || value < -1.0 || value > 1.0) {
+    return std::nullopt;
+  }
+  const double magnitude = std::abs(value);
+  if (magnitude <= deadzone) {
+    return 0.0;
+  }
+  return std::copysign((magnitude - deadzone) / (1.0 - deadzone), value);
+}
+
+bool BoundInputsAvailable(
+    const BaseTwistBinding& binding,
+    const NormalizedController& left,
+    const NormalizedController& right) {
+  return BoundAxis(binding.linear_x, left, right).has_value() &&
+      BoundAxis(binding.linear_y, left, right).has_value() &&
+      BoundAxis(binding.angular_z, left, right).has_value();
+}
+
+bool BoundInputsNeutral(
+    const BaseTwistBinding& binding,
+    const NormalizedController& left,
+    const NormalizedController& right) {
+  const auto neutral = [&](const AxisBinding& axis) {
+    const auto value = BoundAxis(axis, left, right);
+    const auto remapped = value ? RemapAxis(*value, axis.deadzone) : std::nullopt;
+    return remapped.has_value() && *remapped == 0.0;
+  };
+  return neutral(binding.linear_x) && neutral(binding.linear_y) && neutral(binding.angular_z);
+}
+
+double ScaledAxis(
+    const AxisBinding& binding,
+    const NormalizedController& left,
+    const NormalizedController& right) {
+  const auto value = BoundAxis(binding, left, right);
+  const auto remapped = value ? RemapAxis(*value, binding.deadzone) : std::nullopt;
+  if (!remapped || *remapped == 0.0) {
+    return 0.0;
+  }
+  return *remapped * binding.scale * static_cast<double>(binding.direction);
+}
+
+BaseTwist BuildBaseTwist(
+    bool deadman,
+    bool inputs_valid,
+    const BaseTwistBinding& binding,
+    const NormalizedController& left,
+    const NormalizedController& right) {
+  BaseTwist twist;
+  if (!deadman || !inputs_valid) {
+    return twist;
+  }
+  twist.linear = {
+      ScaledAxis(binding.linear_x, left, right),
+      ScaledAxis(binding.linear_y, left, right),
+      0.0,
+  };
+  twist.angular = {0.0, 0.0, ScaledAxis(binding.angular_z, left, right)};
+  return twist;
+}
+
+std::int64_t NextMonotonicNanoseconds(std::int64_t previous, std::optional<std::int64_t> value) {
+  if (value && *value >= 0 && *value <= kMaxSafeWireInteger && *value > previous) {
+    return *value;
+  }
+  if (previous >= kMaxSafeWireInteger) {
+    throw std::range_error("client_monotonic_ns exhausted the safe wire integer range");
+  }
+  return previous + 1;
+}
+
+std::string_view ModeName(FrameMode mode) {
+  switch (mode) {
+    case FrameMode::kShadow:
+      return "shadow";
+    case FrameMode::kLive:
+      return "live";
+  }
+  throw std::invalid_argument("unknown frame mode");
+}
+
+void AppendInteger(std::string& output, std::int64_t value) {
+  std::array<char, 32> buffer{};
+  const auto result = std::to_chars(buffer.data(), buffer.data() + buffer.size(), value);
+  if (result.ec != std::errc{}) {
+    throw std::runtime_error("failed to serialize integer");
+  }
+  output.append(buffer.data(), result.ptr);
+}
+
+void AppendNumber(std::string& output, double value) {
+  if (!IsFinite(value)) {
+    throw std::runtime_error("refusing to serialize a non-finite number");
+  }
+  if (value == 0.0) {
+    output.push_back('0');
+    return;
+  }
+  std::array<char, 64> buffer{};
+  const auto result = std::to_chars(
+      buffer.data(),
+      buffer.data() + buffer.size(),
+      value,
+      std::chars_format::general);
+  if (result.ec != std::errc{}) {
+    throw std::runtime_error("failed to serialize number");
+  }
+  output.append(buffer.data(), result.ptr);
+}
+
+template <std::size_t Size>
+void AppendArray(std::string& output, const std::array<double, Size>& values) {
+  output.push_back('[');
+  for (std::size_t index = 0; index < values.size(); ++index) {
+    if (index != 0) {
+      output.push_back(',');
+    }
+    AppendNumber(output, values[index]);
+  }
+  output.push_back(']');
+}
+
+void AppendVector(std::string& output, const std::vector<double>& values) {
+  output.push_back('[');
+  for (std::size_t index = 0; index < values.size(); ++index) {
+    if (index != 0) {
+      output.push_back(',');
+    }
+    AppendNumber(output, values[index]);
+  }
+  output.push_back(']');
+}
+
+void AppendPose(std::string& output, const std::optional<WirePose>& pose) {
+  if (!pose) {
+    output.append("null");
+    return;
+  }
+  output.append("{\"position\":");
+  AppendArray(output, pose->position);
+  output.append(",\"orientation\":");
+  AppendArray(output, pose->orientation);
+  output.push_back('}');
+}
+
+void AppendController(std::string& output, const WireController& controller) {
+  output.append("{\"axes\":");
+  AppendVector(output, controller.axes);
+  output.append(",\"buttons\":");
+  AppendVector(output, controller.buttons);
+  output.push_back('}');
+}
+
+}  // namespace
+
+FrameResult BuildFrameV1(
+    const FrameState& previous,
+    const FrameSample& sample,
+    const FrameConfiguration& configuration) {
+  RequireCounter(previous.next_sequence, "next_sequence", false);
+  RequireCounter(previous.clutch_sequence, "clutch_sequence");
+  RequireCounter(previous.last_monotonic_ns, "last_monotonic_ns");
+  if (configuration.base_twist) {
+    ValidateBinding(configuration.base_twist->linear_x);
+    ValidateBinding(configuration.base_twist->linear_y);
+    ValidateBinding(configuration.base_twist->angular_z);
+  }
+
+  FrameResult result;
+  result.frame.sequence = previous.next_sequence;
+  result.frame.client_monotonic_ns =
+      NextMonotonicNanoseconds(previous.last_monotonic_ns, sample.monotonic_ns);
+  result.frame.mode = configuration.mode;
+  result.frame.head = NormalizePose(sample.head);
+  result.frame.left_controller = NormalizePose(sample.left_controller);
+  result.frame.right_controller = NormalizePose(sample.right_controller);
+  result.frame.tracking = {
+      result.frame.head.has_value(),
+      result.frame.left_controller.has_value(),
+      result.frame.right_controller.has_value(),
+  };
+
+  const auto left = NormalizeController(sample.left_input);
+  const auto right = NormalizeController(sample.right_input);
+  result.frame.left_input = left.wire;
+  result.frame.right_input = right.wire;
+
+  const bool all_tracked = result.frame.tracking.head &&
+      result.frame.tracking.left_controller && result.frame.tracking.right_controller;
+  const bool squeeze_requested = sample.distinct_input_sources &&
+      left.squeeze == SqueezeState::kPressed && right.squeeze == SqueezeState::kPressed;
+  const bool base_inputs_available = !configuration.base_twist ||
+      BoundInputsAvailable(*configuration.base_twist, left, right);
+  const bool inputs_valid = left.valid && right.valid && sample.distinct_input_sources &&
+      base_inputs_available;
+  const bool explicit_release_observed = inputs_valid &&
+      left.squeeze != SqueezeState::kInvalid && right.squeeze != SqueezeState::kInvalid &&
+      (left.squeeze == SqueezeState::kReleased || right.squeeze == SqueezeState::kReleased);
+  const bool motion_inputs_neutral = !configuration.base_twist ||
+      BoundInputsNeutral(*configuration.base_twist, left, right);
+  const bool non_neutral_engagement_attempt =
+      !previous.deadman_active && squeeze_requested && !motion_inputs_neutral;
+
+  bool rearm_required = previous.rearm_required;
+  if (!all_tracked || !inputs_valid) {
+    rearm_required = true;
+  } else if (explicit_release_observed) {
+    rearm_required = !motion_inputs_neutral;
+  } else if ((previous.deadman_active && !squeeze_requested) ||
+             non_neutral_engagement_attempt) {
+    rearm_required = true;
+  }
+
+  result.frame.deadman =
+      all_tracked && inputs_valid && squeeze_requested && !rearm_required;
+  result.frame.clutch_sequence = previous.clutch_sequence;
+  if (result.frame.deadman && !previous.deadman_active) {
+    if (result.frame.clutch_sequence >= kMaxSafeWireInteger) {
+      throw std::range_error("clutch_sequence exhausted the safe wire integer range");
+    }
+    ++result.frame.clutch_sequence;
+  }
+  if (configuration.base_twist) {
+    result.frame.base_twist = BuildBaseTwist(
+        result.frame.deadman,
+        inputs_valid,
+        *configuration.base_twist,
+        left,
+        right);
+  }
+
+  result.state = {
+      previous.next_sequence + 1,
+      result.frame.clutch_sequence,
+      result.frame.deadman,
+      rearm_required,
+      result.frame.client_monotonic_ns,
+  };
+  return result;
+}
+
+FrameState MarkDeadmanReleased(const FrameState& previous) {
+  RequireCounter(previous.next_sequence, "next_sequence");
+  RequireCounter(previous.clutch_sequence, "clutch_sequence");
+  RequireCounter(previous.last_monotonic_ns, "last_monotonic_ns");
+  FrameState released = previous;
+  released.deadman_active = false;
+  released.rearm_required = true;
+  return released;
+}
+
+std::string SerializeFrameV1(const FrameV1& frame) {
+  RequireCounter(frame.sequence, "sequence");
+  RequireCounter(frame.client_monotonic_ns, "client_monotonic_ns");
+  RequireCounter(frame.clutch_sequence, "clutch_sequence");
+
+  std::string output;
+  output.reserve(1024);
+  output.append("{\"schema_version\":1,\"sequence\":");
+  AppendInteger(output, frame.sequence);
+  output.append(",\"client_monotonic_ns\":");
+  AppendInteger(output, frame.client_monotonic_ns);
+  output.append(",\"mode\":\"");
+  output.append(ModeName(frame.mode));
+  output.append("\",\"deadman\":");
+  output.append(frame.deadman ? "true" : "false");
+  output.append(",\"clutch_sequence\":");
+  AppendInteger(output, frame.clutch_sequence);
+  output.append(",\"tracking\":{\"head\":");
+  output.append(frame.tracking.head ? "true" : "false");
+  output.append(",\"left_controller\":");
+  output.append(frame.tracking.left_controller ? "true" : "false");
+  output.append(",\"right_controller\":");
+  output.append(frame.tracking.right_controller ? "true" : "false");
+  output.append("},\"head\":");
+  AppendPose(output, frame.head);
+  output.append(",\"left_controller\":");
+  AppendPose(output, frame.left_controller);
+  output.append(",\"right_controller\":");
+  AppendPose(output, frame.right_controller);
+  output.append(",\"controllers\":{\"left\":");
+  AppendController(output, frame.left_input);
+  output.append(",\"right\":");
+  AppendController(output, frame.right_input);
+  output.push_back('}');
+  if (frame.base_twist) {
+    output.append(",\"base_twist\":{\"linear\":");
+    AppendArray(output, frame.base_twist->linear);
+    output.append(",\"angular\":");
+    AppendArray(output, frame.base_twist->angular);
+    output.push_back('}');
+  }
+  output.push_back('}');
+  return output;
+}
+
+}  // namespace motus::quest_capture

--- a/agent-core/clients/quest-capture-native/tests/capture_session_test.cpp
+++ b/agent-core/clients/quest-capture-native/tests/capture_session_test.cpp
@@ -1,0 +1,279 @@
+#include "motus/quest_capture/capture_session.hpp"
+
+#include <cstdlib>
+#include <iostream>
+#include <string>
+
+namespace {
+
+using motus::quest_capture::BeginCaptureConnection;
+using motus::quest_capture::CaptureActionKind;
+using motus::quest_capture::CaptureAnswerReceived;
+using motus::quest_capture::CaptureAssigned;
+using motus::quest_capture::CaptureAssignmentRevoked;
+using motus::quest_capture::CaptureAssignmentV1;
+using motus::quest_capture::CaptureAuthenticated;
+using motus::quest_capture::CaptureChannelState;
+using motus::quest_capture::CaptureIdentity;
+using motus::quest_capture::CaptureLinkState;
+using motus::quest_capture::CaptureOfferCreated;
+using motus::quest_capture::CapturePresenceTick;
+using motus::quest_capture::CaptureRtcFailed;
+using motus::quest_capture::CaptureSessionState;
+using motus::quest_capture::CaptureTransportLost;
+using motus::quest_capture::CaptureXrEnded;
+using motus::quest_capture::CaptureXrFocused;
+using motus::quest_capture::FrameConfiguration;
+using motus::quest_capture::FrameMode;
+using motus::quest_capture::PairingBootstrap;
+using motus::quest_capture::PresenceState;
+
+[[noreturn]] void Fail(const std::string& message) {
+  std::cerr << "capture_session_test: " << message << '\n';
+  std::exit(1);
+}
+
+void Check(bool condition, const std::string& message) {
+  if (!condition) {
+    Fail(message);
+  }
+}
+
+CaptureAssignmentV1 Assignment(
+    std::int64_t generation = 1,
+    std::string session_id = "session-a") {
+  return CaptureAssignmentV1{
+      .id = "assignment-a",
+      .generation = generation,
+      .session_id = std::move(session_id),
+      .mode = FrameMode::kLive,
+      .profile_id = "unitree_g1_23_dual_arm_controller_v1",
+      .capability_digest = std::string(64, 'a'),
+      .frame_configuration = FrameConfiguration{
+          .mode = FrameMode::kLive,
+          .base_twist = std::nullopt,
+      },
+  };
+}
+
+CaptureSessionState PairedStandby() {
+  CaptureSessionState initial{
+      .pairing = PairingBootstrap{
+          .pairing_id = "pairing-a",
+          .pairing_code = std::string(43, 'p'),
+      },
+  };
+  auto begun = BeginCaptureConnection(initial);
+  Check(begun.actions.size() == 1 &&
+            begun.actions[0].kind == CaptureActionKind::kSendPairAuthentication,
+        "first connection must authenticate with the one-time pairing code");
+  auto paired = CaptureAuthenticated(
+      begun.state,
+      begun.state.connection_epoch,
+      CaptureIdentity{
+          .capture_id = "capture-a",
+          .capture_credential = std::string(43, 'c'),
+      },
+      true);
+  Check(paired.state.identity.has_value() && !paired.state.pairing.has_value(),
+        "pairing must become a persistent capture identity");
+  Check(paired.actions.size() == 2 &&
+            paired.actions[0].kind == CaptureActionKind::kPersistCredential &&
+            paired.actions[1].presence == PresenceState::kBrowserReady,
+        "fresh credential must persist and immediately start unbound presence");
+  return CaptureXrFocused(paired.state, paired.state.connection_epoch).state;
+}
+
+CaptureSessionState Streaming() {
+  auto standby = PairedStandby();
+  auto assigned = CaptureAssigned(
+      standby,
+      standby.connection_epoch,
+      Assignment());
+  Check(assigned.state.link == CaptureLinkState::kNegotiating,
+        "PC assignment must start negotiation");
+  Check(assigned.actions.size() == 2 &&
+            assigned.actions[0].presence == PresenceState::kRtcConnecting &&
+            assigned.actions[1].kind == CaptureActionKind::kCreateRtcOffer,
+        "assignment must emit connecting presence and exactly one RTC start action");
+  const auto offered = CaptureOfferCreated(
+      assigned.state,
+      assigned.state.connection_epoch,
+      "assignment-a",
+      "v=0\r\na=offer");
+  Check(offered.actions.size() == 1 &&
+            offered.actions[0].kind == CaptureActionKind::kSendSignalingOffer,
+        "gathered SDP must be sent exactly once over capture WSS");
+  const auto duplicate_offer = CaptureOfferCreated(
+      offered.state,
+      offered.state.connection_epoch,
+      "assignment-a",
+      "v=0\r\na=duplicate");
+  Check(duplicate_offer.actions.empty(),
+        "duplicate gathering callback must not consume the one-shot Core offer twice");
+  auto answered = CaptureAnswerReceived(
+      offered.state,
+      offered.state.connection_epoch,
+      "assignment-a",
+      "v=0\r\na=answer");
+  Check(answered.state.answer_applied &&
+            answered.actions[0].kind == CaptureActionKind::kApplyRtcAnswer,
+        "matching answer must be applied");
+  auto streaming = CaptureChannelState(
+      answered.state,
+      answered.state.connection_epoch,
+      "assignment-a",
+      true,
+      true);
+  Check(streaming.state.link == CaptureLinkState::kStreaming,
+        "both exact data channels must enter streaming");
+  Check(streaming.actions.size() == 1 &&
+            streaming.actions[0].presence == PresenceState::kStreaming,
+        "streaming presence must bind the active assignment");
+  return streaming.state;
+}
+
+void PcAssignmentIsTheOnlyRtcAuthorityTrigger() {
+  const auto standby = PairedStandby();
+  Check(standby.link == CaptureLinkState::kStandby && standby.xr_focused,
+        "focused native OpenXR must settle in standby");
+  const auto tick = CapturePresenceTick(standby, standby.connection_epoch);
+  Check(tick.actions.size() == 1 &&
+            tick.actions[0].presence == PresenceState::kXrStandby,
+        "standby heartbeat must not create RTC or robot authority");
+  for (const auto& action : tick.actions) {
+    Check(action.kind != CaptureActionKind::kCreateRtcOffer,
+          "presence alone must never start Driver RTC");
+  }
+
+  auto not_focused = standby;
+  not_focused.xr_focused = false;
+  const auto background_tick = CapturePresenceTick(
+      not_focused, not_focused.connection_epoch);
+  Check(background_tick.actions.size() == 1 &&
+            background_tick.actions[0].presence == PresenceState::kBrowserReady,
+        "authenticated native app must remain observable while XR is not focused");
+}
+
+void SocketLossClosesRtcLocallyAndStaleCallbacksAreInert() {
+  auto streaming = Streaming();
+  streaming.frame_state.deadman_active = true;
+  streaming.frame_state.rearm_required = false;
+  const auto old_epoch = streaming.connection_epoch;
+  const auto lost = CaptureTransportLost(streaming, old_epoch, "wss_disconnected");
+  Check(lost.state.link == CaptureLinkState::kOffline && !lost.state.assignment,
+        "WSS loss must synchronously discard the local assignment");
+  Check(!lost.state.frame_state.deadman_active && lost.state.frame_state.rearm_required,
+        "WSS loss must relatch physical deadman before reconnect");
+  Check(lost.actions.size() == 2 &&
+            lost.actions[0].kind == CaptureActionKind::kCloseRtc &&
+            lost.actions[1].kind == CaptureActionKind::kScheduleReconnect,
+        "WSS loss must close Driver RTC before reconnecting");
+
+  auto reconnecting = BeginCaptureConnection(lost.state);
+  Check(reconnecting.actions[0].kind ==
+            CaptureActionKind::kSendCredentialAuthentication,
+        "reconnect must use persisted credential, never replay pairing");
+  const auto stale = CaptureAnswerReceived(
+      reconnecting.state,
+      old_epoch,
+      "assignment-a",
+      "stale-answer");
+  Check(stale.actions.empty() &&
+            stale.state.connection_epoch == reconnecting.state.connection_epoch,
+        "events from an old socket epoch must be ignored");
+}
+
+void RtcAndXrLossFailClosed() {
+  auto streaming = Streaming();
+  const auto failed = CaptureRtcFailed(
+      streaming,
+      streaming.connection_epoch,
+      "assignment-a",
+      "pose_channel_closed");
+  Check(failed.state.link == CaptureLinkState::kFaulted,
+        "RTC failure must latch a local fault");
+  Check(failed.actions.size() == 3 &&
+            failed.actions[0].kind == CaptureActionKind::kCloseRtc &&
+            failed.actions[1].presence == PresenceState::kError,
+        "RTC failure must close peer before reporting assignment-bound error");
+
+  streaming = Streaming();
+  const auto ended = CaptureXrEnded(
+      streaming,
+      streaming.connection_epoch,
+      "openxr_not_focused");
+  Check(!ended.state.assignment && !ended.state.xr_focused,
+        "OpenXR focus loss must revoke local streaming state");
+  Check(ended.actions.size() == 2 &&
+            ended.actions[0].kind == CaptureActionKind::kCloseRtc &&
+            ended.actions[1].presence == PresenceState::kXrEnded &&
+            ended.actions[1].assignment_id.empty(),
+        "XR end must close RTC and use terminal unbound presence contract");
+}
+
+void GenerationAndSessionWatermarksPreventReplay() {
+  auto streaming = Streaming();
+  streaming.frame_state = {
+      .next_sequence = 41,
+      .clutch_sequence = 3,
+      .deadman_active = true,
+      .rearm_required = false,
+      .last_monotonic_ns = 99,
+  };
+  const auto revoked = CaptureAssignmentRevoked(
+      streaming,
+      streaming.connection_epoch,
+      "assignment-a",
+      "operator_pause");
+  Check(revoked.state.frame_state.next_sequence == 41 &&
+            revoked.state.frame_state.clutch_sequence == 3 &&
+            revoked.state.frame_state.rearm_required,
+        "same-session retry must retain sequence watermarks and require regrip");
+
+  auto retry = Assignment(2);
+  retry.id = "assignment-b";
+  const auto retried = CaptureAssigned(
+      revoked.state,
+      revoked.state.connection_epoch,
+      retry);
+  Check(retried.state.frame_state.next_sequence == 41 &&
+            retried.state.frame_state.clutch_sequence == 3,
+        "same session must not rewind Driver sequence");
+
+  const auto stale = CaptureAssignmentRevoked(
+      retried.state,
+      retried.state.connection_epoch,
+      "assignment-b",
+      "retry_failed");
+  auto replay = Assignment(1);
+  replay.id = "assignment-replay";
+  const auto rejected = CaptureAssigned(
+      stale.state,
+      stale.state.connection_epoch,
+      replay);
+  Check(rejected.state.link == CaptureLinkState::kFaulted,
+        "old assignment generation must fail closed");
+
+  auto next_session_state = stale.state;
+  auto next = Assignment(3, "session-b");
+  next.id = "assignment-c";
+  const auto next_session = CaptureAssigned(
+      next_session_state,
+      next_session_state.connection_epoch,
+      next);
+  Check(next_session.state.frame_state.next_sequence == 0 &&
+            next_session.state.frame_state.clutch_sequence == 0,
+        "a new Core session gets fresh RTC sequence watermarks");
+}
+
+}  // namespace
+
+int main() {
+  PcAssignmentIsTheOnlyRtcAuthorityTrigger();
+  SocketLossClosesRtcLocallyAndStaleCallbacksAreInert();
+  RtcAndXrLossFailClosed();
+  GenerationAndSessionWatermarksPreventReplay();
+  std::cout << "quest-capture session: all host tests passed\n";
+  return 0;
+}

--- a/agent-core/clients/quest-capture-native/tests/capture_wire_test.cpp
+++ b/agent-core/clients/quest-capture-native/tests/capture_wire_test.cpp
@@ -1,0 +1,176 @@
+#include "motus/quest_capture/capture_wire.hpp"
+
+#include <cstdlib>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <variant>
+
+namespace {
+
+using motus::quest_capture::CaptureAssignmentMessage;
+using motus::quest_capture::CaptureAuthenticatedMessage;
+using motus::quest_capture::CaptureIdentity;
+using motus::quest_capture::CaptureSignalingAnswerMessage;
+using motus::quest_capture::FrameMode;
+using motus::quest_capture::PairingBootstrap;
+using motus::quest_capture::ParseCaptureServerMessage;
+using motus::quest_capture::PresenceState;
+using motus::quest_capture::SerializeCapturePresence;
+using motus::quest_capture::SerializeCaptureSignalingOffer;
+using motus::quest_capture::SerializeCredentialAuthentication;
+using motus::quest_capture::SerializePairAuthentication;
+
+constexpr char kCaptureId[] = "3f32ff2f-ed55-44d1-8ee3-87f3576c1a6f";
+constexpr char kAssignmentId[] = "441b5d6c-ee37-419c-bd00-c4ed0c1962a8";
+constexpr char kSessionId[] = "7ad3de66-64f2-4d47-89a2-c8da2940eb97";
+
+[[noreturn]] void Fail(const std::string& message) {
+  std::cerr << "capture_wire_test: " << message << '\n';
+  std::exit(1);
+}
+
+void Check(bool condition, const std::string& message) {
+  if (!condition) {
+    Fail(message);
+  }
+}
+
+template <typename Callback>
+void CheckInvalid(Callback callback, const std::string& message) {
+  try {
+    callback();
+  } catch (const std::invalid_argument&) {
+    return;
+  }
+  Fail(message);
+}
+
+std::string AssignmentMessage(bool base = false) {
+  const std::string input_bindings = base
+      ? R"({"base_twist":{"linear_x":{"hand":"left","axis":3,"scale":0.5,"deadzone":0.2,"direction":-1},"linear_y":{"hand":"left","axis":2,"scale":0.3,"deadzone":0.2,"direction":-1},"angular_z":{"hand":"right","axis":2,"scale":0.6,"deadzone":0.2,"direction":-1}}})"
+      : "{}";
+  const std::string outputs = base
+      ? R"({"dual_arm":{"enabled":true,"joint_count":10},"base":{"enabled":true}})"
+      : R"({"dual_arm":{"enabled":true,"joint_count":10}})";
+  const std::string effectors = base ? R"(["dual_arm","base"])" : R"(["dual_arm"])";
+  return std::string(R"({"type":"assignment","assignment":{"id":")") +
+      kAssignmentId + R"(","generation":1,"session_id":")" + kSessionId +
+      R"(","mode":"live","profile_id":"unitree_g1_23_dual_arm_controller_v1","capability_digest":")" +
+      std::string(64, 'a') + R"(","capabilities":{"profile_id":"unitree_g1_23_dual_arm_controller_v1","input_bindings":)" +
+      input_bindings + R"(,"outputs":)" + outputs + R"(,"effectors":)" + effectors +
+      R"(},"effectors":)" + effectors +
+      R"(,"state":"issued","created_at":1000,"updated_at":1001,"failure_code":null}})";
+}
+
+void AuthenticationNeverMovesSecretsIntoUrls() {
+  const PairingBootstrap pairing{
+      .pairing_id = "f922333d-88f7-42a9-b140-56fbf7f670f3",
+      .pairing_code = std::string(43, 'p'),
+  };
+  const auto pair = SerializePairAuthentication(pairing, "0.1.0");
+  Check(pair.find("motus.teleop.capture.v1") != std::string::npos,
+        "pair auth must bind capture protocol");
+  Check(pair.find("native_openxr") != std::string::npos,
+        "pair auth must identify native OpenXR client");
+
+  const CaptureIdentity identity{
+      .capture_id = kCaptureId,
+      .capture_credential = std::string(43, 'c'),
+  };
+  const auto credential = SerializeCredentialAuthentication(identity, "0.1.0");
+  Check(credential.find(identity.capture_credential) != std::string::npos,
+        "credential belongs only in the in-band first message");
+}
+
+void AuthAndAssignmentAreStrictlyProjected() {
+  const auto paired = ParseCaptureServerMessage(
+      std::string(R"({"type":"paired","capture_id":")") + kCaptureId +
+      R"(","capture_credential":")" + std::string(43, 'c') +
+      R"(","capture_protocol":"motus.teleop.capture.v1","frame_protocol":"motus.teleop.rtc-frame.v1","presence_interval_ms":2000,"presence_timeout_ms":5000})");
+  const auto& authenticated = std::get<CaptureAuthenticatedMessage>(paired);
+  Check(authenticated.fresh_credential &&
+            authenticated.identity.capture_id == kCaptureId &&
+            authenticated.presence_interval_ms == 2000,
+        "paired response must expose exact persisted identity and timers");
+
+  const auto connected = ParseCaptureServerMessage(
+      std::string(R"({"type":"connected","capture_id":")") + kCaptureId +
+      R"(","capture_protocol":"motus.teleop.capture.v1","frame_protocol":"motus.teleop.rtc-frame.v1","presence_interval_ms":2000,"presence_timeout_ms":5000})",
+      authenticated.identity);
+  Check(!std::get<CaptureAuthenticatedMessage>(connected).fresh_credential,
+        "reconnect acknowledgement must reuse rather than echo credential");
+
+  const auto assignment = std::get<CaptureAssignmentMessage>(
+      ParseCaptureServerMessage(AssignmentMessage())).assignment;
+  Check(assignment.id == kAssignmentId && assignment.session_id == kSessionId &&
+            assignment.mode == FrameMode::kLive &&
+            !assignment.frame_configuration.base_twist.has_value(),
+        "arm-only assignment must map to exact native frame configuration");
+
+  const auto base_assignment = std::get<CaptureAssignmentMessage>(
+      ParseCaptureServerMessage(AssignmentMessage(true))).assignment;
+  Check(base_assignment.frame_configuration.base_twist.has_value() &&
+            base_assignment.frame_configuration.base_twist->linear_x.axis == 3,
+        "descriptor-provided base mapping must survive strict projection");
+}
+
+void SignalingAndPresenceUseExactPublicEnvelopes() {
+  const auto standby = SerializeCapturePresence(PresenceState::kXrStandby, {});
+  Check(standby == R"({"assignment_id":null,"state":"xr_standby","type":"presence"})",
+        "standby presence must be explicitly unbound");
+  const auto streaming = SerializeCapturePresence(
+      PresenceState::kStreaming, kAssignmentId);
+  Check(streaming.find(kAssignmentId) != std::string::npos,
+        "streaming presence must bind assignment");
+  CheckInvalid(
+      [] { static_cast<void>(SerializeCapturePresence(PresenceState::kStreaming, {})); },
+      "assignment-bound presence without id must fail closed");
+
+  const auto offer = SerializeCaptureSignalingOffer(kAssignmentId, "v=0\r\na=offer");
+  Check(offer.find("signaling_offer") != std::string::npos &&
+            offer.find("pairing") == std::string::npos,
+        "SDP message must not contain enrollment authority");
+  const auto answer = ParseCaptureServerMessage(
+      std::string(R"({"type":"signaling_answer","assignment_id":")") +
+      kAssignmentId + R"(","answer":{"type":"answer","sdp":"v=0\r\na=answer"}})");
+  Check(std::get<CaptureSignalingAnswerMessage>(answer).answer_sdp == "v=0\r\na=answer",
+        "answer SDP must parse for matching state-machine binding");
+}
+
+void AmbiguousOrContradictoryJsonFailsClosed() {
+  CheckInvalid(
+      [] {
+        static_cast<void>(ParseCaptureServerMessage(
+            R"({"type":"error","type":"presence_ack","code":"bad"})"));
+      },
+      "duplicate JSON keys must be rejected");
+  CheckInvalid(
+      [] {
+        static_cast<void>(ParseCaptureServerMessage(
+            R"({"type":"error","code":"bad","extra":true})"));
+      },
+      "unknown fields must be rejected");
+
+  auto contradictory = AssignmentMessage();
+  const auto marker = contradictory.find(R"("effectors":["dual_arm"],"state")");
+  Check(marker != std::string::npos, "test fixture marker missing");
+  contradictory.replace(
+      marker,
+      std::string(R"("effectors":["dual_arm"])" ).size(),
+      R"("effectors":[])" );
+  CheckInvalid(
+      [&contradictory] { static_cast<void>(ParseCaptureServerMessage(contradictory)); },
+      "top-level and capability effectors must agree");
+}
+
+}  // namespace
+
+int main() {
+  AuthenticationNeverMovesSecretsIntoUrls();
+  AuthAndAssignmentAreStrictlyProjected();
+  SignalingAndPresenceUseExactPublicEnvelopes();
+  AmbiguousOrContradictoryJsonFailsClosed();
+  std::cout << "quest-capture wire: all host tests passed\n";
+  return 0;
+}

--- a/agent-core/clients/quest-capture-native/tests/emit_frame_fixture.cpp
+++ b/agent-core/clients/quest-capture-native/tests/emit_frame_fixture.cpp
@@ -1,0 +1,61 @@
+#include "motus/quest_capture/frame_v1.hpp"
+
+#include <iostream>
+
+namespace {
+
+using motus::quest_capture::BuildFrameV1;
+using motus::quest_capture::ControllerSample;
+using motus::quest_capture::FrameConfiguration;
+using motus::quest_capture::FrameMode;
+using motus::quest_capture::FrameSample;
+using motus::quest_capture::FrameState;
+using motus::quest_capture::PoseSample;
+using motus::quest_capture::SerializeFrameV1;
+
+PoseSample Pose(double x, double y, double z) {
+  return PoseSample{
+      .valid = true,
+      .emulated = false,
+      .position = {x, y, z},
+      .orientation = {0.0, 0.0, 0.0, 1.0},
+  };
+}
+
+ControllerSample Controller(bool pressed) {
+  return ControllerSample{
+      .active = true,
+      .xr_standard = true,
+      .correct_handedness = true,
+      .tracked_pointer = true,
+      .has_grip_space = true,
+      .squeeze_pressed = pressed,
+      .axes = {0.0, 0.0, 0.0, 0.0},
+      .buttons = {0.0, pressed ? 1.0 : 0.0},
+  };
+}
+
+FrameSample Sample(bool pressed, std::int64_t monotonic_ns) {
+  return FrameSample{
+      .head = Pose(0.0, 1.6, 0.0),
+      .left_controller = Pose(-0.2, 1.2, -0.3),
+      .right_controller = Pose(0.2, 1.2, -0.3),
+      .left_input = Controller(pressed),
+      .right_input = Controller(pressed),
+      .distinct_input_sources = true,
+      .monotonic_ns = monotonic_ns,
+  };
+}
+
+}  // namespace
+
+int main() {
+  const FrameConfiguration configuration{
+      .mode = FrameMode::kLive,
+      .base_twist = std::nullopt,
+  };
+  const auto released = BuildFrameV1(FrameState{}, Sample(false, 1'000'000), configuration);
+  const auto active = BuildFrameV1(released.state, Sample(true, 2'000'000), configuration);
+  std::cout << SerializeFrameV1(active.frame) << '\n';
+  return 0;
+}

--- a/agent-core/clients/quest-capture-native/tests/enrollment_test.cpp
+++ b/agent-core/clients/quest-capture-native/tests/enrollment_test.cpp
@@ -1,0 +1,113 @@
+#include "motus/quest_capture/enrollment.hpp"
+
+#include <cstdlib>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+
+namespace {
+
+using motus::quest_capture::CaptureLaunchBootstrap;
+using motus::quest_capture::SelectCaptureEnrollment;
+using motus::quest_capture::StoredCaptureEnrollment;
+
+[[noreturn]] void Fail(const std::string& message) {
+  std::cerr << "enrollment_test: " << message << '\n';
+  std::exit(1);
+}
+
+void Check(bool condition, const std::string& message) {
+  if (!condition) {
+    Fail(message);
+  }
+}
+
+template <typename Callback>
+void CheckRejected(Callback callback, const std::string& message) {
+  try {
+    callback();
+  } catch (const std::invalid_argument&) {
+    return;
+  }
+  Fail(message);
+}
+
+StoredCaptureEnrollment Stored() {
+  return StoredCaptureEnrollment{
+      .capture_id = "capture-a",
+      .capture_credential = "credential-a",
+      .websocket_url = "wss://trusted.example/ws/teleop-capture",
+      .ca_certificate_pem = "trusted-ca",
+  };
+}
+
+void ResumeIsPinnedToTheStoredOrigin() {
+  const auto selected = SelectCaptureEnrollment(Stored(), {});
+  Check(selected.identity.has_value() && !selected.pairing.has_value(),
+        "resume must select the stored identity");
+  Check(selected.websocket_url == "wss://trusted.example/ws/teleop-capture" &&
+            selected.ca_certificate_pem == "trusted-ca",
+        "resume must atomically reuse the stored WSS origin and CA");
+
+  CheckRejected(
+      [] {
+        static_cast<void>(SelectCaptureEnrollment(
+            Stored(),
+            CaptureLaunchBootstrap{
+                .websocket_url = "wss://attacker.example/ws/teleop-capture",
+                .ca_certificate_pem = "attacker-ca",
+                .transport_override_present = true,
+            }));
+      },
+      "an exported Activity must reject transport injection on resume");
+}
+
+void ExplicitCompletePairingMayReplaceTheEnrollment() {
+  const auto selected = SelectCaptureEnrollment(
+      Stored(),
+      CaptureLaunchBootstrap{
+          .pairing_id = "pairing-b",
+          .pairing_code = "pairing-secret-b",
+          .websocket_url = "wss://replacement.example/ws/teleop-capture",
+          .ca_certificate_pem = "replacement-ca",
+          .transport_override_present = true,
+      });
+  Check(!selected.identity.has_value() && selected.pairing.has_value(),
+        "a complete new pairing must not send the old credential");
+  Check(selected.websocket_url ==
+            "wss://replacement.example/ws/teleop-capture",
+        "a complete new pairing may bind a replacement origin");
+
+  CheckRejected(
+      [] {
+        static_cast<void>(SelectCaptureEnrollment(
+            Stored(),
+            CaptureLaunchBootstrap{
+                .pairing_id = "pairing-only",
+                .websocket_url = "wss://replacement.example/ws/teleop-capture",
+                .ca_certificate_pem = "replacement-ca",
+                .transport_override_present = true,
+            }));
+      },
+      "partial pairing bootstrap must fail closed");
+}
+
+void IncompleteStoredEnrollmentFailsClosed() {
+  auto stored = Stored();
+  stored.capture_credential.clear();
+  CheckRejected(
+      [&stored] {
+        static_cast<void>(SelectCaptureEnrollment(stored, {}));
+      },
+      "identity without its credential and transport binding must be unusable");
+}
+
+}  // namespace
+
+int main() {
+  ResumeIsPinnedToTheStoredOrigin();
+  ExplicitCompletePairingMayReplaceTheEnrollment();
+  IncompleteStoredEnrollmentFailsClosed();
+  std::cout << "quest-capture enrollment: all host tests passed\n";
+  return 0;
+}

--- a/agent-core/clients/quest-capture-native/tests/frame_v1_test.cpp
+++ b/agent-core/clients/quest-capture-native/tests/frame_v1_test.cpp
@@ -1,0 +1,237 @@
+#include "motus/quest_capture/frame_v1.hpp"
+
+#include <cmath>
+#include <cstdlib>
+#include <iostream>
+#include <limits>
+#include <stdexcept>
+#include <string>
+
+namespace {
+
+using motus::quest_capture::AxisBinding;
+using motus::quest_capture::BaseTwistBinding;
+using motus::quest_capture::BuildFrameV1;
+using motus::quest_capture::ControllerSample;
+using motus::quest_capture::FrameConfiguration;
+using motus::quest_capture::FrameMode;
+using motus::quest_capture::FrameSample;
+using motus::quest_capture::FrameState;
+using motus::quest_capture::MarkDeadmanReleased;
+using motus::quest_capture::PoseSample;
+using motus::quest_capture::SerializeFrameV1;
+
+[[noreturn]] void Fail(const std::string& message) {
+  std::cerr << "frame_v1_test: " << message << '\n';
+  std::exit(1);
+}
+
+void Check(bool condition, const std::string& message) {
+  if (!condition) {
+    Fail(message);
+  }
+}
+
+void CheckNear(double actual, double expected, const std::string& message) {
+  if (std::abs(actual - expected) > 1e-12) {
+    Fail(message);
+  }
+}
+
+PoseSample TrackedPose(double x = 0.0, double y = 1.5, double z = 0.0) {
+  return PoseSample{
+      .valid = true,
+      .emulated = false,
+      .position = {x, y, z},
+      .orientation = {0.0, 0.0, 0.0, 1.0},
+  };
+}
+
+ControllerSample Controller(bool pressed, double squeeze_value, double x = 0.0, double y = 0.0) {
+  return ControllerSample{
+      .active = true,
+      .xr_standard = true,
+      .correct_handedness = true,
+      .tracked_pointer = true,
+      .has_grip_space = true,
+      .squeeze_pressed = pressed,
+      .axes = {0.0, 0.0, x, y},
+      .buttons = {0.0, squeeze_value},
+  };
+}
+
+FrameSample Sample(bool pressed, double squeeze_value) {
+  return FrameSample{
+      .head = TrackedPose(0.0, 1.6, 0.0),
+      .left_controller = TrackedPose(-0.2, 1.2, -0.3),
+      .right_controller = TrackedPose(0.2, 1.2, -0.3),
+      .left_input = Controller(pressed, squeeze_value),
+      .right_input = Controller(pressed, squeeze_value),
+      .distinct_input_sources = true,
+      .monotonic_ns = 1'000'000,
+  };
+}
+
+FrameConfiguration ArmOnly(FrameMode mode = FrameMode::kLive) {
+  return FrameConfiguration{.mode = mode, .base_twist = std::nullopt};
+}
+
+FrameConfiguration WithBase() {
+  return FrameConfiguration{
+      .mode = FrameMode::kLive,
+      .base_twist = BaseTwistBinding{
+          .linear_x = AxisBinding{
+              .hand = AxisBinding::Hand::kLeft,
+              .axis = 3,
+              .scale = 0.5,
+              .deadzone = 0.2,
+              .direction = -1,
+          },
+          .linear_y = AxisBinding{
+              .hand = AxisBinding::Hand::kLeft,
+              .axis = 2,
+              .scale = 0.3,
+              .deadzone = 0.2,
+              .direction = -1,
+          },
+          .angular_z = AxisBinding{
+              .hand = AxisBinding::Hand::kRight,
+              .axis = 2,
+              .scale = 0.6,
+              .deadzone = 0.2,
+              .direction = -1,
+          },
+      },
+  };
+}
+
+void InitialHeldGripCannotArm() {
+  const auto held = BuildFrameV1(FrameState{}, Sample(true, 1.0), ArmOnly());
+  Check(!held.frame.deadman, "initial held squeeze must not arm");
+  Check(held.state.rearm_required, "initial held squeeze must retain rearm latch");
+  Check(held.frame.clutch_sequence == 0, "initial held squeeze must not advance clutch");
+  Check(held.frame.sequence == 0 && held.state.next_sequence == 1, "sequence must advance once");
+}
+
+void ReleaseNeutralRegripArmsAndMapsXrStandardAxes() {
+  FrameState state;
+  auto released_sample = Sample(false, 0.0);
+  const auto released = BuildFrameV1(state, released_sample, WithBase());
+  Check(!released.frame.deadman, "release frame must be inactive");
+  Check(!released.state.rearm_required, "neutral explicit release must clear rearm latch");
+
+  auto pressed_sample = Sample(true, 1.0);
+  pressed_sample.monotonic_ns = 2'000'000;
+  const auto pressed = BuildFrameV1(released.state, pressed_sample, WithBase());
+  Check(pressed.frame.deadman, "release-neutral-regrip must arm");
+  Check(pressed.frame.clutch_sequence == 1, "first deliberate grip must increment clutch");
+  Check(pressed.frame.base_twist.has_value(), "base-enabled frame must include base_twist");
+
+  auto motion_sample = Sample(true, 1.0);
+  motion_sample.monotonic_ns = 3'000'000;
+  motion_sample.left_input.axes = {0.7, -0.6, -1.0, -1.0};
+  motion_sample.right_input.axes = {-0.8, 0.9, -1.0, 0.5};
+  const auto motion = BuildFrameV1(pressed.state, motion_sample, WithBase());
+  Check(motion.frame.deadman, "motion after neutral engagement must remain armed");
+  CheckNear(motion.frame.base_twist->linear[0], 0.5, "left axes[3] must drive linear_x");
+  CheckNear(motion.frame.base_twist->linear[1], 0.3, "left axes[2] must drive linear_y");
+  CheckNear(motion.frame.base_twist->angular[2], 0.6, "right axes[2] must drive angular_z");
+}
+
+void ReconnectAndTrackingLossRequireHigherClutch() {
+  auto released = BuildFrameV1(FrameState{}, Sample(false, 0.0), ArmOnly());
+  auto active_sample = Sample(true, 1.0);
+  active_sample.monotonic_ns = 2'000'000;
+  auto active = BuildFrameV1(released.state, active_sample, ArmOnly());
+  Check(active.frame.deadman && active.frame.clutch_sequence == 1, "test precondition failed");
+
+  const auto reconnect_state = MarkDeadmanReleased(active.state);
+  auto held_sample = Sample(true, 1.0);
+  held_sample.monotonic_ns = 3'000'000;
+  auto held = BuildFrameV1(reconnect_state, held_sample, ArmOnly());
+  Check(!held.frame.deadman && held.frame.clutch_sequence == 1,
+        "holding squeeze across reconnect must stay inhibited");
+
+  auto second_release_sample = Sample(false, 0.0);
+  second_release_sample.monotonic_ns = 4'000'000;
+  auto second_release = BuildFrameV1(held.state, second_release_sample, ArmOnly());
+  auto second_grip_sample = Sample(true, 1.0);
+  second_grip_sample.monotonic_ns = 5'000'000;
+  auto second_grip = BuildFrameV1(second_release.state, second_grip_sample, ArmOnly());
+  Check(second_grip.frame.deadman && second_grip.frame.clutch_sequence == 2,
+        "reconnect must require and prove a higher clutch sequence");
+
+  auto lost_tracking_sample = Sample(true, 1.0);
+  lost_tracking_sample.left_controller.valid = false;
+  lost_tracking_sample.monotonic_ns = 6'000'000;
+  auto lost = BuildFrameV1(second_grip.state, lost_tracking_sample, ArmOnly());
+  Check(!lost.frame.deadman && lost.state.rearm_required,
+        "tracking loss must release deadman and relatch rearm");
+}
+
+void MalformedInputFailsClosedAndMonotonicNeverRegresses() {
+  auto malformed = Sample(false, 0.0);
+  malformed.left_input.buttons = {0.0};
+  malformed.head.orientation = {0.0, 0.0, 0.0, 2.0};
+  malformed.monotonic_ns = -4;
+  const auto result = BuildFrameV1(
+      FrameState{.last_monotonic_ns = 41}, malformed, ArmOnly(FrameMode::kShadow));
+  Check(!result.frame.deadman && result.state.rearm_required,
+        "malformed input must fail closed");
+  Check(!result.frame.head.has_value() && !result.frame.tracking.head,
+        "invalid pose must be projected as null and untracked");
+  Check(result.frame.client_monotonic_ns == 42,
+        "invalid or regressing monotonic sample must advance from watermark");
+}
+
+void JsonHasExactPublicEnvelopeAndNoAuthority() {
+  auto released = BuildFrameV1(FrameState{}, Sample(false, 0.0), ArmOnly(FrameMode::kShadow));
+  const std::string json = SerializeFrameV1(released.frame);
+  Check(json.find("\"schema_version\":1") != std::string::npos, "schema_version missing");
+  Check(json.find("\"mode\":\"shadow\"") != std::string::npos, "mode missing");
+  Check(json.find("\"controllers\":{\"left\":{\"axes\":[0,0,0,0],\"buttons\":[0,0]}") !=
+            std::string::npos,
+        "xr-standard controller slots must be serialized exactly");
+  Check(json.find("session_id") == std::string::npos, "frame must not contain session authority");
+  Check(json.find("fence") == std::string::npos, "frame must not contain fence authority");
+  Check(json.find("token") == std::string::npos, "frame must not contain credentials");
+  Check(json.find("base_twist") == std::string::npos,
+        "arm-only capabilities must omit base_twist");
+}
+
+void SafeIntegerExhaustionThrows() {
+  bool sequence_threw = false;
+  try {
+    static_cast<void>(BuildFrameV1(
+        FrameState{.next_sequence = motus::quest_capture::kMaxSafeWireInteger},
+        Sample(false, 0.0),
+        ArmOnly()));
+  } catch (const std::range_error&) {
+    sequence_threw = true;
+  }
+  Check(sequence_threw, "exhausted sequence must throw instead of wrapping");
+
+  bool monotonic_threw = false;
+  try {
+    static_cast<void>(BuildFrameV1(
+        FrameState{.last_monotonic_ns = motus::quest_capture::kMaxSafeWireInteger},
+        Sample(false, 0.0),
+        ArmOnly()));
+  } catch (const std::range_error&) {
+    monotonic_threw = true;
+  }
+  Check(monotonic_threw, "exhausted monotonic watermark must throw instead of wrapping");
+}
+
+}  // namespace
+
+int main() {
+  InitialHeldGripCannotArm();
+  ReleaseNeutralRegripArmsAndMapsXrStandardAxes();
+  ReconnectAndTrackingLossRequireHigherClutch();
+  MalformedInputFailsClosedAndMonotonicNeverRegresses();
+  JsonHasExactPublicEnvelopeAndNoAuthority();
+  SafeIntegerExhaustionThrows();
+  std::cout << "quest-capture frame_v1: all host tests passed\n";
+  return 0;
+}

--- a/agent-core/clients/quest-capture-native/tests/launch_capture_test.sh
+++ b/agent-core/clients/quest-capture-native/tests/launch_capture_test.sh
@@ -1,0 +1,109 @@
+#!/bin/sh
+set -eu
+
+if [ "${MOTUS_FAKE_ADB:-}" = 1 ]; then
+  : "${MOTUS_FAKE_ADB_CAPTURE:?}"
+  umask 077
+  : > "$MOTUS_FAKE_ADB_CAPTURE"
+  for argument in "$@"; do
+    printf '%s\n' "$argument" >> "$MOTUS_FAKE_ADB_CAPTURE"
+  done
+  exit 0
+fi
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+project_dir=$(CDPATH= cd -- "$script_dir/.." && pwd)
+launch_script="$project_dir/scripts/launch_capture.sh"
+test_dir=$(mktemp -d "${TMPDIR:-/tmp}/motus-launch-capture.XXXXXX")
+trap 'rm -rf "$test_dir"' EXIT HUP INT TERM
+
+fail() {
+  echo "launch_capture_test: $*" >&2
+  exit 1
+}
+
+assert_line() {
+  capture=$1
+  line_number=$2
+  expected=$3
+  actual=$(sed -n "${line_number}p" "$capture")
+  [ "$actual" = "$expected" ] || \
+    fail "line $line_number: expected '$expected', got '$actual'"
+}
+
+run_fake() {
+  capture=$1
+  shift
+  MOTUS_FAKE_ADB=1 \
+  MOTUS_FAKE_ADB_CAPTURE="$capture" \
+  ADB="$0" \
+  "$launch_script" "$@"
+}
+
+meta_resume="$test_dir/meta-resume.args"
+ADB_SERIAL='quest-serial' run_fake "$meta_resume" --platform meta --resume
+assert_line "$meta_resume" 1 -s
+assert_line "$meta_resume" 2 quest-serial
+assert_line "$meta_resume" 3 shell
+assert_line "$meta_resume" 6 -S
+assert_line "$meta_resume" 7 -n
+assert_line "$meta_resume" 8 \
+  com.phanthymotus.questcapture/android.app.NativeActivity
+
+pico_resume="$test_dir/pico-resume.args"
+ADB_SERIAL= run_fake "$pico_resume" --resume --platform=pico
+assert_line "$pico_resume" 1 shell
+assert_line "$pico_resume" 4 -S
+assert_line "$pico_resume" 5 -n
+assert_line "$pico_resume" 6 \
+  com.phanthymotus.picocapture/android.app.NativeActivity
+
+pico_pair="$test_dir/pico-pair.args"
+pico_output="$test_dir/pico-pair.output"
+MOTUS_FAKE_ADB=1 \
+MOTUS_FAKE_ADB_CAPTURE="$pico_pair" \
+ADB="$0" \
+ADB_SERIAL='pico-serial' \
+CORE_WSS_URL='wss://core.example/ws/teleop-capture' \
+PAIRING_ID='pairing-id' \
+PAIRING_CODE='one-time-secret' \
+CA_CERT_BASE64='VEVTVA==' \
+  "$launch_script" --platform pico > "$pico_output" 2>&1
+[ ! -s "$pico_output" ] || fail "launch output must not disclose bootstrap values"
+assert_line "$pico_pair" 1 -s
+assert_line "$pico_pair" 2 pico-serial
+assert_line "$pico_pair" 7 -n
+assert_line "$pico_pair" 8 \
+  com.phanthymotus.picocapture/android.app.NativeActivity
+grep -Fx -- one-time-secret "$pico_pair" >/dev/null || \
+  fail "pairing code was not passed as an Activity extra"
+grep -Fx -- wss://core.example/ws/teleop-capture "$pico_pair" >/dev/null || \
+  fail "Core URL was not passed as an Activity extra"
+
+meta_pair="$test_dir/meta-pair.args"
+MOTUS_FAKE_ADB=1 \
+MOTUS_FAKE_ADB_CAPTURE="$meta_pair" \
+ADB="$0" \
+CORE_WSS_URL='wss://core.example/ws/teleop-capture' \
+PAIRING_ID='pairing-id' \
+PAIRING_CODE='meta-secret' \
+CA_CERT_BASE64='VEVTVA==' \
+  "$launch_script" --platform=meta
+assert_line "$meta_pair" 6 \
+  com.phanthymotus.questcapture/android.app.NativeActivity
+
+for invalid in \
+  '' \
+  '--platform unknown' \
+  '--platform meta extra' \
+  '--platform meta --platform pico'
+do
+  set +e
+  # Intentional word splitting exercises the CLI parser with each invalid form.
+  ADB="$0" "$launch_script" $invalid > "$test_dir/invalid.output" 2>&1
+  status=$?
+  set -e
+  [ "$status" -eq 2 ] || fail "invalid arguments '$invalid' returned $status"
+done
+
+echo "launch_capture_test: Meta/PICO CLI contract passed"

--- a/agent-core/clients/quest-capture-native/tests/run_host_tests.sh
+++ b/agent-core/clients/quest-capture-native/tests/run_host_tests.sh
@@ -1,0 +1,114 @@
+#!/bin/sh
+set -eu
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+project_dir=$(CDPATH= cd -- "$script_dir/.." && pwd)
+build_dir=$(mktemp -d /tmp/motus-quest-capture-host.XXXXXX)
+trap 'rm -r "$build_dir"' EXIT HUP INT TERM
+
+"$project_dir/tests/launch_capture_test.sh"
+
+for headset in meta pico; do
+  case "$headset" in
+    meta)
+      headset_definition=-DMOTUS_CAPTURE_HEADSET_META=1
+      test_definition=-DTEST_EXPECT_META=1
+      ;;
+    pico)
+      headset_definition=-DMOTUS_CAPTURE_HEADSET_PICO=1
+      test_definition=-DTEST_EXPECT_PICO=1
+      ;;
+  esac
+  "${CXX:-clang++}" \
+    -std=c++20 \
+    -Wall \
+    -Wextra \
+    -Werror \
+    -pedantic \
+    "$headset_definition" \
+    "$test_definition" \
+    -I"$project_dir/app/src/main/cpp" \
+    "$project_dir/app/src/main/cpp/runtime_profile.cpp" \
+    "$project_dir/tests/runtime_profile_test.cpp" \
+    -o "$build_dir/runtime_profile_test_$headset"
+
+  "$build_dir/runtime_profile_test_$headset"
+done
+
+"${CXX:-clang++}" \
+  -std=c++20 \
+  -Wall \
+  -Wextra \
+  -Werror \
+  -pedantic \
+  -I"$project_dir/include" \
+  "$project_dir/src/frame_v1.cpp" \
+  "$project_dir/tests/frame_v1_test.cpp" \
+  -o "$build_dir/frame_v1_test"
+
+"$build_dir/frame_v1_test"
+
+"${CXX:-clang++}" \
+  -std=c++20 \
+  -Wall \
+  -Wextra \
+  -Werror \
+  -pedantic \
+  -I"$project_dir/include" \
+  "$project_dir/src/frame_v1.cpp" \
+  "$project_dir/src/capture_session.cpp" \
+  "$project_dir/tests/capture_session_test.cpp" \
+  -o "$build_dir/capture_session_test"
+
+"$build_dir/capture_session_test"
+
+"${CXX:-clang++}" \
+  -std=c++20 \
+  -Wall \
+  -Wextra \
+  -Werror \
+  -pedantic \
+  -I"$project_dir/include" \
+  "$project_dir/src/enrollment.cpp" \
+  "$project_dir/tests/enrollment_test.cpp" \
+  -o "$build_dir/enrollment_test"
+
+"$build_dir/enrollment_test"
+
+if [ -n "${NLOHMANN_JSON_INCLUDE:-}" ]; then
+  "${CXX:-clang++}" \
+    -std=c++20 \
+    -Wall \
+    -Wextra \
+    -Werror \
+    -pedantic \
+    -I"$project_dir/include" \
+    -I"$NLOHMANN_JSON_INCLUDE" \
+    "$project_dir/src/frame_v1.cpp" \
+    "$project_dir/src/capture_session.cpp" \
+    "$project_dir/src/capture_wire.cpp" \
+    "$project_dir/tests/capture_wire_test.cpp" \
+    -o "$build_dir/capture_wire_test"
+
+  "$build_dir/capture_wire_test"
+fi
+
+"${CXX:-clang++}" \
+  -std=c++20 \
+  -Wall \
+  -Wextra \
+  -Werror \
+  -pedantic \
+  -I"$project_dir/include" \
+  "$project_dir/src/frame_v1.cpp" \
+  "$project_dir/tests/emit_frame_fixture.cpp" \
+  -o "$build_dir/emit_frame_fixture"
+
+"$build_dir/emit_frame_fixture" > "$build_dir/frame_v1.json"
+python3 "$project_dir/tests/verify_frame_fixture.py" "$build_dir/frame_v1.json"
+
+if [ -n "${PHANTHYMOTUS_DRIVER_G1_ROOT:-}" ]; then
+  python3 "$project_dir/tests/verify_frame_fixture.py" \
+    "$build_dir/frame_v1.json" \
+    --driver-root "$PHANTHYMOTUS_DRIVER_G1_ROOT"
+fi

--- a/agent-core/clients/quest-capture-native/tests/runtime_profile_test.cpp
+++ b/agent-core/clients/quest-capture-native/tests/runtime_profile_test.cpp
@@ -1,0 +1,153 @@
+#include "runtime_profile.hpp"
+
+#include <cstdlib>
+#include <exception>
+#include <iostream>
+#include <string_view>
+#include <vector>
+
+namespace {
+
+using motus::quest_capture::FloorReferenceSpace;
+using motus::quest_capture::HeadsetTarget;
+using motus::quest_capture::IsInteractionProfileAllowed;
+using motus::quest_capture::SelectFloorReferenceSpace;
+using motus::quest_capture::SelectRuntime;
+
+constexpr std::string_view kLocalFloorExtension = "XR_EXT_local_floor";
+constexpr std::string_view kPico4Extension = "XR_BD_controller_interaction";
+constexpr std::string_view kPicoUltraExtension =
+    "XR_BD_ultra_controller_interaction";
+constexpr std::string_view kOculusTouchProfile =
+    "/interaction_profiles/oculus/touch_controller";
+constexpr std::string_view kPico4Profile =
+    "/interaction_profiles/bytedance/pico4_controller";
+constexpr std::string_view kPicoUltraProfile =
+    "/interaction_profiles/bytedance/pico_ultra_controller_bd";
+
+[[noreturn]] void Fail(std::string_view message) {
+  std::cerr << "FAIL: " << message << '\n';
+  std::exit(1);
+}
+
+void Check(bool condition, std::string_view message) {
+  if (!condition) {
+    Fail(message);
+  }
+}
+
+template <typename Function>
+void CheckThrows(Function&& function, std::string_view message) {
+  try {
+    function();
+  } catch (const std::exception&) {
+    return;
+  }
+  Fail(message);
+}
+
+void TestMetaSelection() {
+  const auto selection = SelectRuntime(
+      motus::quest_capture::MetaRuntimeProfile(),
+      {kLocalFloorExtension, kPico4Extension, kPicoUltraExtension});
+  Check(selection.local_floor_extension_enabled,
+        "Meta selection should enable available local-floor support");
+  Check(selection.optional_extensions.size() == 1,
+        "Meta selection must not enable PICO controller extensions");
+  Check(IsInteractionProfileAllowed(selection, kOculusTouchProfile),
+        "Meta selection should allow Oculus Touch");
+  Check(!IsInteractionProfileAllowed(selection, kPico4Profile),
+        "Meta selection must reject PICO 4 controllers");
+  Check(!IsInteractionProfileAllowed(selection, kPicoUltraProfile),
+        "Meta selection must reject PICO Ultra controllers");
+}
+
+void TestPicoSelection() {
+  const auto both = SelectRuntime(
+      motus::quest_capture::PicoRuntimeProfile(),
+      {kLocalFloorExtension, kPico4Extension, kPicoUltraExtension});
+  Check(both.local_floor_extension_enabled,
+        "PICO selection should enable available local-floor support");
+  Check(both.optional_extensions.size() == 3,
+        "PICO selection should enable both available controller extensions");
+  Check(IsInteractionProfileAllowed(both, kPico4Profile),
+        "PICO selection should allow PICO 4 when its extension is enabled");
+  Check(IsInteractionProfileAllowed(both, kPicoUltraProfile),
+        "PICO selection should allow PICO Ultra when its extension is enabled");
+  Check(!IsInteractionProfileAllowed(both, kOculusTouchProfile),
+        "PICO selection must reject Oculus Touch");
+
+  const auto pico4_only = SelectRuntime(
+      motus::quest_capture::PicoRuntimeProfile(), {kPico4Extension});
+  Check(IsInteractionProfileAllowed(pico4_only, kPico4Profile),
+        "PICO 4-only runtime should select PICO 4");
+  Check(!IsInteractionProfileAllowed(pico4_only, kPicoUltraProfile),
+        "PICO 4-only runtime must not allow PICO Ultra");
+
+  const auto ultra_only = SelectRuntime(
+      motus::quest_capture::PicoRuntimeProfile(), {kPicoUltraExtension});
+  Check(!IsInteractionProfileAllowed(ultra_only, kPico4Profile),
+        "PICO Ultra-only runtime must not allow PICO 4");
+  Check(IsInteractionProfileAllowed(ultra_only, kPicoUltraProfile),
+        "PICO Ultra-only runtime should select PICO Ultra");
+
+  CheckThrows(
+      [] {
+        static_cast<void>(SelectRuntime(
+            motus::quest_capture::PicoRuntimeProfile(),
+            {kLocalFloorExtension}));
+      },
+      "PICO runtime without either controller extension must fail closed");
+}
+
+void TestFloorSelection() {
+  Check(
+      SelectFloorReferenceSpace(true, true, true) ==
+          FloorReferenceSpace::kLocalFloor,
+      "local-floor should take priority over stage");
+  Check(
+      SelectFloorReferenceSpace(false, true, true) ==
+          FloorReferenceSpace::kStage,
+      "an unenabled local-floor extension must not be used");
+  Check(
+      SelectFloorReferenceSpace(true, false, true) ==
+          FloorReferenceSpace::kStage,
+      "stage should be the floor-relative fallback");
+  CheckThrows(
+      [] {
+        static_cast<void>(SelectFloorReferenceSpace(false, false, false));
+      },
+      "absence of local-floor and stage must fail closed");
+  CheckThrows(
+      [] {
+        static_cast<void>(SelectFloorReferenceSpace(true, false, false));
+      },
+      "enumerated local-floor space is required before use");
+}
+
+void TestCompiledTarget() {
+#if defined(TEST_EXPECT_META)
+  Check(
+      motus::quest_capture::CompiledRuntimeProfile().target ==
+          HeadsetTarget::kMeta,
+      "Meta compile macro should select the Meta runtime profile");
+#elif defined(TEST_EXPECT_PICO)
+  Check(
+      motus::quest_capture::CompiledRuntimeProfile().target ==
+          HeadsetTarget::kPico,
+      "PICO compile macro should select the PICO runtime profile");
+#else
+#error "runtime_profile_test requires TEST_EXPECT_META or TEST_EXPECT_PICO"
+#endif
+}
+
+}  // namespace
+
+int main() {
+  TestMetaSelection();
+  TestPicoSelection();
+  TestFloorSelection();
+  TestCompiledTarget();
+  std::cout << "runtime_profile_test: PASS\n";
+  return 0;
+}

--- a/agent-core/clients/quest-capture-native/tests/verify_android_apks.py
+++ b/agent-core/clients/quest-capture-native/tests/verify_android_apks.py
@@ -1,0 +1,188 @@
+"""Verify both Android OpenXR Capture APKs without installing a headset."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import subprocess
+import tempfile
+import zipfile
+from pathlib import Path
+
+PROJECT = Path(__file__).resolve().parents[1]
+EXPECTED_PERMISSIONS = {
+    "android.permission.ACCESS_NETWORK_STATE",
+    "android.permission.INTERNET",
+    "android.permission.WAKE_LOCK",
+    "org.khronos.openxr.permission.OPENXR",
+    "org.khronos.openxr.permission.OPENXR_SYSTEM",
+}
+EXPECTED_LIBRARIES = {
+    "lib/arm64-v8a/libc++_shared.so",
+    "lib/arm64-v8a/libmotus_quest_capture.so",
+    "lib/arm64-v8a/libopenxr_loader.so",
+}
+ANDROID_LIBRARIES = {
+    "libandroid.so",
+    "libc.so",
+    "libdl.so",
+    "libEGL.so",
+    "libGLESv3.so",
+    "liblog.so",
+    "libm.so",
+}
+FLAVORS = {
+    "meta": {
+        "package": "com.phanthymotus.questcapture",
+        "label": "PhanthyMotus Meta Capture",
+        "pico_metadata": False,
+    },
+    "pico": {
+        "package": "com.phanthymotus.picocapture",
+        "label": "PhanthyMotus PICO Capture",
+        "pico_metadata": True,
+    },
+}
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise RuntimeError(message)
+
+
+def run(*arguments: str) -> str:
+    completed = subprocess.run(
+        arguments,
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    return completed.stdout
+
+
+def android_tools() -> tuple[Path, Path]:
+    sdk = Path(os.environ.get("ANDROID_SDK_ROOT", ""))
+    require(sdk.is_dir(), "ANDROID_SDK_ROOT must point to the pinned Android SDK")
+    build_tools = sdk / "build-tools" / "35.0.1"
+    prebuilt = (
+        sdk
+        / "ndk"
+        / "27.0.12077973"
+        / "toolchains"
+        / "llvm"
+        / "prebuilt"
+    )
+    readelf_candidates = list(prebuilt.glob("*/bin/llvm-readelf"))
+    for tool in ("aapt2", "apksigner", "zipalign"):
+        require((build_tools / tool).is_file(), f"missing Android tool: {tool}")
+    require(len(readelf_candidates) == 1, "missing or ambiguous NDK llvm-readelf")
+    return build_tools, readelf_candidates[0]
+
+
+def verify_elf(readelf: Path, library: Path, packaged_names: set[str]) -> None:
+    header = run(str(readelf), "-h", str(library))
+    require("Class:                             ELF64" in header, f"{library.name} is not ELF64")
+    require("Machine:                           AArch64" in header, f"{library.name} is not AArch64")
+    dynamic = run(str(readelf), "-d", str(library))
+    needed = set(re.findall(r"Shared library: \[([^]]+)]", dynamic))
+    unexpected = needed - packaged_names - ANDROID_LIBRARIES
+    require(not unexpected, f"{library.name} has unbundled dependencies: {sorted(unexpected)}")
+
+
+def verify_apk(
+    flavor: str,
+    expected: dict[str, object],
+    build_tools: Path,
+    readelf: Path,
+) -> dict[str, object]:
+    apk = PROJECT / "app" / "build" / "outputs" / "apk" / flavor / "debug" / f"app-{flavor}-debug.apk"
+    require(apk.is_file(), f"missing {flavor} APK: {apk}")
+
+    badging = run(str(build_tools / "aapt2"), "dump", "badging", str(apk))
+    for fragment in (
+        f"package: name='{expected['package']}'",
+        "versionCode='2'",
+        "versionName='0.2.0'",
+        "minSdkVersion:'29'",
+        "targetSdkVersion:'35'",
+        f"application-label:'{expected['label']}'",
+        "native-code: 'arm64-v8a'",
+    ):
+        require(fragment in badging, f"{flavor} badging is missing {fragment!r}")
+
+    permissions = run(str(build_tools / "aapt2"), "dump", "permissions", str(apk))
+    actual_permissions = set(re.findall(r"uses-permission: name='([^']+)'", permissions))
+    require(
+        actual_permissions == EXPECTED_PERMISSIONS,
+        f"{flavor} permission mismatch: {sorted(actual_permissions)}",
+    )
+
+    manifest = run(
+        str(build_tools / "aapt2"),
+        "dump",
+        "xmltree",
+        "--file",
+        "AndroidManifest.xml",
+        str(apk),
+    )
+    require('="android.app.lib_name"' in manifest, f"{flavor} lacks NativeActivity library metadata")
+    require('="org.khronos.openxr.intent.category.IMMERSIVE_HMD"' in manifest, f"{flavor} lacks OpenXR launch category")
+    pico_metadata = re.search(
+        r'="pvr\.app\.type".*\n\s+A: .*="vr"',
+        manifest,
+    ) is not None
+    require(
+        pico_metadata == expected["pico_metadata"],
+        f"{flavor} pvr.app.type presence is incorrect",
+    )
+
+    run(str(build_tools / "zipalign"), "-c", "-P", "16", "-v", "4", str(apk))
+    signature = run(
+        str(build_tools / "apksigner"),
+        "verify",
+        "--verbose",
+        "--print-certs",
+        str(apk),
+    )
+    require(
+        "Verified using v2 scheme (APK Signature Scheme v2): true" in signature,
+        f"{flavor} APK lacks a valid v2 signature",
+    )
+
+    with zipfile.ZipFile(apk) as archive:
+        libraries = {name for name in archive.namelist() if name.startswith("lib/")}
+        require(libraries == EXPECTED_LIBRARIES, f"{flavor} native library set mismatch: {sorted(libraries)}")
+        with tempfile.TemporaryDirectory(prefix=f"motus-{flavor}-apk-") as directory:
+            extracted = Path(directory)
+            packaged_names = {Path(name).name for name in libraries}
+            for name in libraries:
+                archive.extract(name, extracted)
+                verify_elf(readelf, extracted / name, packaged_names)
+
+    digest = hashlib.sha256(apk.read_bytes()).hexdigest()
+    return {
+        "bytes": apk.stat().st_size,
+        "package": expected["package"],
+        "pvr_app_type": pico_metadata,
+        "sha256": digest,
+    }
+
+
+def main() -> None:
+    build_tools, readelf = android_tools()
+    results = {
+        flavor: verify_apk(flavor, expected, build_tools, readelf)
+        for flavor, expected in FLAVORS.items()
+    }
+    require(
+        results["meta"]["sha256"] != results["pico"]["sha256"],
+        "Meta and PICO APKs must be distinct artifacts",
+    )
+    print(json.dumps({"artifacts": results, "result": "PASS"}, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/agent-core/clients/quest-capture-native/tests/verify_frame_fixture.py
+++ b/agent-core/clients/quest-capture-native/tests/verify_frame_fixture.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import sys
+import uuid
+
+
+def _arguments() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument('fixture', type=pathlib.Path)
+    parser.add_argument('--driver-root', type=pathlib.Path)
+    return parser.parse_args()
+
+
+def main() -> None:
+    arguments = _arguments()
+    frame = json.loads(arguments.fixture.read_text(encoding='utf-8'))
+    assert set(frame) == {
+        'schema_version',
+        'sequence',
+        'client_monotonic_ns',
+        'mode',
+        'deadman',
+        'clutch_sequence',
+        'tracking',
+        'head',
+        'left_controller',
+        'right_controller',
+        'controllers',
+    }
+    assert frame['schema_version'] == 1
+    assert frame['mode'] == 'live'
+    assert frame['deadman'] is True
+    assert frame['clutch_sequence'] == 1
+    assert frame['tracking'] == {
+        'head': True,
+        'left_controller': True,
+        'right_controller': True,
+    }
+    assert frame['controllers']['left'] == {
+        'axes': [0, 0, 0, 0],
+        'buttons': [0, 1],
+    }
+    assert frame['controllers']['right'] == frame['controllers']['left']
+
+    if arguments.driver_root is None:
+        print('quest-capture fixture: public JSON contract passed')
+        return
+
+    driver_root = arguments.driver_root.resolve()
+    if not (driver_root / 'teleop' / 'protocol.py').is_file():
+        raise SystemExit(f'G1 Driver root is invalid: {driver_root}')
+    sys.path.insert(0, str(driver_root))
+    from teleop.protocol import bind_rtc_frame_v1  # noqa: PLC0415
+
+    session_id = str(uuid.UUID('d097eb8f-b386-455f-9e2b-23f1ad6a1ee3'))
+    bound = bind_rtc_frame_v1(
+        frame,
+        authority={
+            'boot_id': str(uuid.UUID('6e6973a9-5b32-4d10-b1b8-c0331800a4aa')),
+            'session_id': session_id,
+            'epoch': 1,
+            'fence': 'f' * 32,
+        },
+        expected_mode='live',
+    )
+    assert bound['session_id'] == session_id
+    assert bound['deadman'] is True
+    assert bound['clutch_sequence'] == 1
+    print('quest-capture fixture: G1 Driver strict contract passed')
+
+
+if __name__ == '__main__':
+    main()

--- a/agent-core/deploy/docker-compose.yml
+++ b/agent-core/deploy/docker-compose.yml
@@ -14,6 +14,8 @@ services:
       - DB_PATH=/work/resource/data.db
       - COMPOSE_DIR=/opt/phanthy-motus
       - CONTAINER_NAME=phanthy-motus-agent-core-1
+      - MOTUS_TLS_CERT_FILE=${MOTUS_TLS_CERT_FILE:-}
+      - MOTUS_TLS_KEY_FILE=${MOTUS_TLS_KEY_FILE:-}
       - ROS_DOMAIN_ID=42
       - RMW_IMPLEMENTATION=rmw_fastrtps_cpp
       - FASTDDS_BUILTIN_TRANSPORTS=DEFAULT

--- a/agent-core/src/api/canvas.py
+++ b/agent-core/src/api/canvas.py
@@ -7,7 +7,6 @@ configuration in the SQLite config table.
 Includes editor lock: only one session can edit at a time.
 """
 
-import asyncio
 import json
 import time
 import fastapi
@@ -19,6 +18,82 @@ import config
 router = fastapi.APIRouter(prefix='/canvas', tags=['canvas'])
 
 _TOOL_CONFIG_PREFIX = 'tool_config:'
+_RESERVED_TOOL_CONFIG_KEYS = frozenset({'action', 'instance_id'})
+
+
+def _validated_tool_config(body: Any) -> dict:
+    """Return a safe persisted config object or reject protocol-owned keys."""
+
+    if not isinstance(body, dict):
+        raise fastapi.HTTPException(
+            status_code=422,
+            detail='Tool config must be a JSON object',
+        )
+    reserved = sorted(_RESERVED_TOOL_CONFIG_KEYS.intersection(body))
+    if reserved:
+        raise fastapi.HTTPException(
+            status_code=422,
+            detail={
+                'code': 'tool_config_reserved_key',
+                'keys': reserved,
+            },
+        )
+    return dict(body)
+
+
+async def _apply_saved_tool_config(mcp_id: str, request):
+    """Apply a persisted config through the broker-protected MCP path."""
+
+    from api.mcp_manage import mcp_call_tool
+
+    try:
+        result = await mcp_call_tool(mcp_id, request)
+    except fastapi.HTTPException as error:
+        detail = error.detail if isinstance(error.detail, dict) else {}
+        if error.status_code == 409 and detail.get('code') == 'teleop_command_blocked':
+            return fastapi.responses.JSONResponse(
+                status_code=202,
+                content={
+                    'code': 202,
+                    'data': {
+                        'saved': True,
+                        'applied': False,
+                        'deferred': True,
+                        'reason': 'teleop_session_active',
+                    },
+                },
+            )
+        return fastapi.responses.JSONResponse(
+            status_code=502,
+            content={
+                'code': 502,
+                'message': 'Config was saved but could not be applied',
+                'data': {
+                    'saved': True,
+                    'applied': False,
+                    'deferred': False,
+                    'reason': detail.get('code', 'driver_apply_failed'),
+                },
+            },
+        )
+    if isinstance(result, dict) and result.get('code') == 200:
+        return {
+            'code': 200,
+            'data': {'saved': True, 'applied': True, 'deferred': False},
+        }
+    return fastapi.responses.JSONResponse(
+        status_code=502,
+        content={
+            'code': 502,
+            'message': 'Config was saved but Driver apply failed',
+            'data': {
+                'saved': True,
+                'applied': False,
+                'deferred': False,
+                'reason': 'driver_apply_failed',
+            },
+        },
+    )
 
 # ── Editor Lock State (in-memory, resets on restart) ─────────────────────────
 
@@ -41,6 +116,49 @@ class CanvasLayout(BaseModel):
     execConnections: list  = []
     transform:       dict  = {}
     session_id:      Optional[str] = None
+    revision:        Optional[int] = None
+
+
+def _current_layout_revision() -> int:
+    layout = config.main.get('canvas_layout', {})
+    revision = layout.get('revision', 0) if isinstance(layout, dict) else 0
+    return revision if type(revision) is int and revision >= 0 else 0
+
+
+def validate_project_start_snapshot(
+    session_id: str,
+    expected_revision: int,
+) -> Optional[dict]:
+    """Validate that Start targets the layout visible to the current editor.
+
+    The caller must hold the project transition lock.  Canvas saves reject while
+    that lock is held, so a successful validation pins the revision until the
+    start transaction has taken its own layout snapshot.
+    """
+
+    _check_editor_expired()
+    if not session_id or _editor_session != session_id:
+        return {
+            'status_code': 409,
+            'detail': {
+                'code': 'project_editor_required',
+                'reason': 'only_the_current_canvas_editor_can_start',
+            },
+            'errors': [],
+        }
+
+    current_revision = _current_layout_revision()
+    if expected_revision != current_revision:
+        return {
+            'status_code': 409,
+            'detail': {
+                'code': 'project_layout_revision_conflict',
+                'expected_revision': expected_revision,
+                'current_revision': current_revision,
+            },
+            'errors': [],
+        }
+    return None
 
 
 # ── Editor Lock Endpoints ────────────────────────────────────────────────────
@@ -91,6 +209,8 @@ async def get_layout():
     """Return the saved canvas layout + current editor info."""
     _check_editor_expired()
     data = config.main.get('canvas_layout', {'cards': []})
+    data = dict(data) if isinstance(data, dict) else {'cards': []}
+    data['revision'] = _current_layout_revision()
     return {'code': 200, 'data': data, 'editor': _editor_session}
 
 
@@ -113,10 +233,39 @@ async def save_layout(layout: CanvasLayout):
     if session_id == _editor_session:
         _editor_last_seen = time.monotonic()
 
-    save_data = layout.dict()
+    core = config.main.get('core', {})
+    from api import config as config_api
+    if core.get('project_running', False) or config_api._project_transition_lock.locked():
+        return fastapi.responses.JSONResponse(
+            status_code=409,
+            content={
+                'code': 409,
+                'detail': {
+                    'code': 'project_topology_locked',
+                    'project_state': core.get('project_state', 'transitioning'),
+                },
+            },
+        )
+
+    current_revision = _current_layout_revision()
+    if layout.revision is not None and layout.revision != current_revision:
+        return fastapi.responses.JSONResponse(
+            status_code=409,
+            content={
+                'code': 409,
+                'detail': {
+                    'code': 'canvas_revision_conflict',
+                    'expected_revision': layout.revision,
+                    'current_revision': current_revision,
+                },
+            },
+        )
+
+    save_data = layout.model_dump()
     save_data.pop('session_id', None)
+    save_data['revision'] = current_revision + 1
     config.main['canvas_layout'] = save_data
-    return {'code': 200}
+    return {'code': 200, 'data': {'revision': save_data['revision']}}
 
 
 # ── Per-tool config CRUD ─────────────────────────────────────────────────────
@@ -149,19 +298,15 @@ async def get_all_tool_configs():
 @router.put('/tool-config/{mcp_id}/{tool_name}')
 async def save_tool_config(mcp_id: str, tool_name: str, body: Any = fastapi.Body(...)):
     """Save config for a tool and apply it to the MCP plugin."""
-    config.main[f'{_TOOL_CONFIG_PREFIX}{mcp_id}:{tool_name}'] = body
+    safe_body = _validated_tool_config(body)
+    config.main[f'{_TOOL_CONFIG_PREFIX}{mcp_id}:{tool_name}'] = safe_body
 
-    # Apply config to the MCP plugin (fire-and-forget, don't block response)
-    from api.mcp_manage import mcp_call_tool, MCPCallRequest
-    async def _apply():
-        try:
-            req = MCPCallRequest(tool=tool_name, arguments={'action': 'config', **body})
-            await mcp_call_tool(mcp_id, req)
-        except Exception:
-            pass
-    asyncio.create_task(_apply())
-
-    return {'code': 200}
+    from api.mcp_manage import MCPCallRequest
+    req = MCPCallRequest(
+        tool=tool_name,
+        arguments={**safe_body, 'action': 'config'},
+    )
+    return await _apply_saved_tool_config(mcp_id, req)
 
 
 @router.delete('/tool-config/{mcp_id}/{tool_name}')
@@ -189,18 +334,19 @@ async def get_instance_config(mcp_id: str, tool_name: str, instance_id: str):
 @router.put('/tool-config/{mcp_id}/{tool_name}/{instance_id}')
 async def save_instance_config(mcp_id: str, tool_name: str, instance_id: str, body: Any = fastapi.Body(...)):
     """Save config for a specific tool instance and apply it."""
-    config.main[f'{_TOOL_CONFIG_PREFIX}{mcp_id}:{tool_name}:{instance_id}'] = body
+    safe_body = _validated_tool_config(body)
+    config.main[f'{_TOOL_CONFIG_PREFIX}{mcp_id}:{tool_name}:{instance_id}'] = safe_body
 
-    # Apply instance config to the MCP plugin (fire-and-forget)
-    from api.mcp_manage import mcp_call_tool, MCPCallRequest
-    async def _apply():
-        try:
-            req = MCPCallRequest(tool=tool_name, arguments={'action': 'config', 'instance_id': instance_id, **body})
-            await mcp_call_tool(mcp_id, req)
-        except Exception:
-            pass
-    asyncio.create_task(_apply())
-    return {'code': 200}
+    from api.mcp_manage import MCPCallRequest
+    req = MCPCallRequest(
+        tool=tool_name,
+        arguments={
+            **safe_body,
+            'action': 'config',
+            'instance_id': instance_id,
+        },
+    )
+    return await _apply_saved_tool_config(mcp_id, req)
 
 
 @router.delete('/tool-config/{mcp_id}/{tool_name}/{instance_id}')

--- a/agent-core/src/api/config.py
+++ b/agent-core/src/api/config.py
@@ -1,15 +1,338 @@
+import asyncio
+import json
 import time
-from urllib.parse import urlparse
 from typing import List
+from urllib.parse import urlparse
 
+import aiohttp
 import fastapi
+import openai as openai_lib
 from pydantic import BaseModel
 
 import config
-import aiohttp
-import openai as openai_lib
+from teleop import authority_guard
 
 router = fastapi.APIRouter(prefix='/config', tags=['config'])
+_project_transition_lock = asyncio.Lock()
+_project_residual_latched = False
+_project_residual_cards: list[dict] = []
+
+
+def _project_transition_conflict() -> dict:
+    return {
+        'status_code': 409,
+        'detail': {
+            'code': 'project_transition_in_progress',
+            'reason': 'another_start_or_stop_is_running',
+        },
+        'errors': [],
+    }
+
+
+def _project_card_snapshot(cards) -> list[dict]:
+    if not isinstance(cards, list):
+        return []
+    return [
+        {
+            'id': card.get('id', ''),
+            'mcpId': card.get('mcpId', ''),
+            'toolName': card.get('toolName', ''),
+        }
+        for card in cards
+        if isinstance(card, dict)
+        and card.get('id')
+        and card.get('mcpId')
+        and card.get('toolName')
+    ]
+
+
+def _latch_project_residual(cards) -> None:
+    """Keep residual-control state fail-closed if durable state cannot be written."""
+
+    global _project_residual_latched, _project_residual_cards
+    snapshot = _project_card_snapshot(cards)
+    if snapshot:
+        _project_residual_cards = snapshot
+    _project_residual_latched = True
+
+
+def _clear_project_residual() -> None:
+    global _project_residual_latched, _project_residual_cards
+    _project_residual_latched = False
+    _project_residual_cards = []
+
+
+def _effective_project_cards(core: dict) -> list[dict]:
+    if _project_residual_latched:
+        return _project_card_snapshot(_project_residual_cards)
+    active = core.get('active_project_cards')
+    if isinstance(active, list) and active:
+        return _project_card_snapshot(active)
+    layout = config.main.get('canvas_layout', {})
+    cards = layout.get('cards', []) if isinstance(layout, dict) else []
+    return _project_card_snapshot(cards)
+
+
+def _reject_non_finite_json(value: str):
+    raise ValueError(f'non-finite JSON constant: {value}')
+
+
+def _project_tool_ack_error(result: object) -> str | None:
+    """Require a structured, non-failing acknowledgement for lifecycle calls."""
+
+    if not isinstance(result, dict) or result.get('code') != 200:
+        if isinstance(result, dict):
+            message = result.get('message') or result.get('detail')
+            if message:
+                return str(message)[:200]
+        return 'Driver lifecycle call failed'
+
+    data = result.get('data')
+    acknowledgements = []
+    if isinstance(data, dict):
+        acknowledgements.append(data)
+    elif isinstance(data, list):
+        for item in data:
+            if not isinstance(item, dict) or item.get('type') != 'text':
+                continue
+            text = item.get('text')
+            if not isinstance(text, str):
+                continue
+            try:
+                parsed = json.loads(
+                    text,
+                    parse_constant=_reject_non_finite_json,
+                )
+            except (json.JSONDecodeError, ValueError):
+                continue
+            if isinstance(parsed, dict):
+                acknowledgements.append(parsed)
+    if not acknowledgements:
+        return 'Driver did not return a structured lifecycle acknowledgement'
+
+    for acknowledgement in acknowledgements:
+        explicit_error = acknowledgement.get('error')
+        if explicit_error not in (None, '', False):
+            return (
+                str(explicit_error)[:200]
+                if isinstance(explicit_error, str)
+                else 'Driver returned an explicit error'
+            )
+        if acknowledgement.get('adapter_ok') is False:
+            message = acknowledgement.get('message')
+            return str(message)[:200] if message else 'Driver rejected the lifecycle call'
+        if acknowledgement.get('state') == 'error':
+            message = acknowledgement.get('message')
+            return str(message)[:200] if message else 'Driver reported an error state'
+        status = acknowledgement.get('status')
+        if (
+            acknowledgement.get('ok') is False
+            or acknowledgement.get('success') is False
+            or acknowledgement.get('configured') is False
+            or (isinstance(status, str) and status in {'error', 'failed', 'failure'})
+        ):
+            message = acknowledgement.get('message')
+            return str(message)[:200] if message else 'Driver rejected the operation'
+    return None
+
+
+def _set_project_state(state: str, *, cards=None) -> None:
+    core = config.main.get('core', {})
+    core['project_state'] = state
+    core['project_running'] = state in {'running', 'degraded'}
+    if state in {'running', 'degraded'}:
+        if cards is not None:
+            core['active_project_cards'] = _project_card_snapshot(cards)
+    else:
+        core.pop('active_project_cards', None)
+    config.main['core'] = core
+
+
+def _set_project_state_safely(state: str, *, cards=None) -> bool:
+    try:
+        _set_project_state(state, cards=cards)
+        return True
+    except Exception as error:
+        print(f'[project-state] failed to persist {state}: {type(error).__name__}')
+        return False
+
+
+async def _await_project_cleanup(task: asyncio.Task):
+    """Wait for a project rollback even if the initiating request is recancelled."""
+
+    while True:
+        try:
+            return await asyncio.shield(task)
+        except asyncio.CancelledError:
+            if task.done():
+                return task.result()
+
+
+def _authority_roots(record: dict) -> tuple[str, ...]:
+    roots = []
+    for key in ('authority_domain', 'pending_authority_domain'):
+        root_id = record.get(key)
+        if isinstance(root_id, str) and root_id and root_id not in roots:
+            roots.append(root_id)
+    return tuple(roots)
+
+
+def _project_target_signature(record: object) -> tuple:
+    """Fields that must remain stable until every active card is stopped."""
+
+    target = record if isinstance(record, dict) else {}
+    try:
+        tools = json.dumps(
+            target.get('tools', []),
+            sort_keys=True,
+            separators=(',', ':'),
+            ensure_ascii=False,
+            allow_nan=False,
+        )
+    except (TypeError, ValueError, RecursionError):
+        tools = repr(target.get('tools', []))
+    return (
+        target.get('id'),
+        target.get('url', ''),
+        target.get('transport', 'http'),
+        target.get('trust_state', ''),
+        target.get('category', ''),
+        target.get('authority_domain', ''),
+        target.get('pending_authority_domain', ''),
+        target.get('authority_binding_error', ''),
+        bool(target.get('authority_binding_required', False)),
+        bool(target.get('capability_refresh_required', False)),
+        target.get('reported_robot_id', ''),
+        tools,
+    )
+
+
+def _project_locked_target_ids(targets: list[dict]) -> tuple[bool, set[str]]:
+    """Return whether a transition is active and the targets needed for Stop."""
+
+    transitioning = _project_transition_lock.locked()
+    if transitioning:
+        return True, {
+            target.get('id')
+            for target in targets
+            if isinstance(target, dict) and isinstance(target.get('id'), str)
+        }
+
+    core = config.main.get('core', {})
+    state = core.get('project_state')
+    if (
+        not _project_residual_latched
+        and not core.get('project_running', False)
+        and state not in {'running', 'degraded'}
+    ):
+        return False, set()
+
+    cards = _effective_project_cards(core)
+    by_id = {
+        target.get('id'): target
+        for target in targets
+        if isinstance(target, dict) and isinstance(target.get('id'), str)
+    }
+    locked_ids: set[str] = set()
+    for card in cards:
+        if not isinstance(card, dict):
+            continue
+        mcp_id = card.get('mcpId')
+        if not isinstance(mcp_id, str) or not mcp_id:
+            continue
+        locked_ids.add(mcp_id)
+        target = by_id.get(mcp_id, {})
+        authority_root = target.get('authority_domain')
+        if isinstance(authority_root, str) and authority_root:
+            locked_ids.add(authority_root)
+    return False, locked_ids
+
+
+async def _project_target_mutation_error(
+    current_targets: list[dict],
+    proposed_targets: list[dict],
+) -> dict | None:
+    """Reject target changes that could invalidate Stop or recovery authority."""
+
+    transitioning, locked_ids = _project_locked_target_ids(current_targets)
+    guard_store_failed = False
+    try:
+        guards = await asyncio.to_thread(authority_guard.list_guards)
+    except Exception:  # noqa: BLE001 -- unreadable deny state locks all mutations
+        guard_store_failed = True
+        locked_ids.update(
+            target.get('id')
+            for target in current_targets
+            if isinstance(target, dict) and isinstance(target.get('id'), str)
+        )
+    else:
+        for guard in guards:
+            locked_ids.update({guard.driver_id, guard.robot_id})
+    if not transitioning and not locked_ids and not guard_store_failed:
+        return None
+
+    current_by_id: dict[str, list[dict]] = {}
+    proposed_by_id: dict[str, list[dict]] = {}
+    for target in current_targets:
+        if isinstance(target, dict) and isinstance(target.get('id'), str):
+            current_by_id.setdefault(target['id'], []).append(target)
+    for target in proposed_targets:
+        if isinstance(target, dict) and isinstance(target.get('id'), str):
+            proposed_by_id.setdefault(target['id'], []).append(target)
+
+    changed_ids: set[str] = set()
+    if (transitioning or guard_store_failed) and set(current_by_id) != set(proposed_by_id):
+        changed_ids.update(set(current_by_id) ^ set(proposed_by_id))
+    if guard_store_failed:
+        for mcp_id in set(current_by_id) & set(proposed_by_id):
+            if current_by_id[mcp_id] != proposed_by_id[mcp_id]:
+                changed_ids.add(mcp_id)
+    for mcp_id in locked_ids:
+        current_matches = current_by_id.get(mcp_id, [])
+        proposed_matches = proposed_by_id.get(mcp_id, [])
+        if (
+            len(current_matches) != 1
+            or len(proposed_matches) != 1
+            or _project_target_signature(current_matches[0])
+            != _project_target_signature(proposed_matches[0])
+        ):
+            changed_ids.add(mcp_id)
+    if not changed_ids:
+        return None
+
+    core = config.main.get('core', {})
+    return {
+        'code': (
+            'authority_guard_persistence_error'
+            if guard_store_failed
+            else 'authority_target_locked'
+            if any(
+                guard.driver_id in changed_ids or guard.robot_id in changed_ids
+                for guard in guards
+            )
+            else 'project_target_locked'
+        ),
+        'reason': (
+            'authority_guard_store_unavailable'
+            if guard_store_failed
+            else 'persistent_authority_guard_requires_stable_target'
+            if any(
+                guard.driver_id in changed_ids or guard.robot_id in changed_ids
+                for guard in guards
+            )
+            else 'project_transition_in_progress'
+            if transitioning
+            else 'active_project_requires_stable_stop_targets'
+        ),
+        'project_state': (
+            'transitioning'
+            if transitioning
+            else 'degraded'
+            if _project_residual_latched
+            else core.get('project_state', 'running')
+        ),
+        'mcp_ids': sorted(changed_ids),
+    }
 
 
 # ── Models ──────────────────────────────────────────────────────────────────
@@ -119,12 +442,27 @@ async def config_status():
 @router.get('/project-running')
 async def get_project_running():
     core = config.main.get('core', {})
-    return {'running': bool(core.get('project_running', False))}
+    running = _project_residual_latched or bool(core.get('project_running', False))
+    state = (
+        'degraded'
+        if _project_residual_latched
+        else core.get('project_state', 'running' if running else 'stopped')
+    )
+    return {
+        'running': running,
+        'state': state,
+        'transitioning': _project_transition_lock.locked(),
+    }
 
 
 # ── Start / Stop Project (统一入口) ─────────────────────────────────────────────
 
-async def _do_start_project():
+async def _do_start_project(
+    *,
+    _transition_locked: bool = False,
+    editor_session_id: str | None = None,
+    expected_layout_revision: int | None = None,
+):
     """启动所有 canvas cards — 前端按钮和 auto-start 共用此函数。
 
     Topic resolution strategy:
@@ -133,6 +471,54 @@ async def _do_start_project():
       3. When starting processor cards, look up source card's topic_out via connections
       4. Fallback: use connection's persisted fromTopic if info() didn't return topic_out
     """
+    if not _transition_locked:
+        if _project_transition_lock.locked():
+            return _project_transition_conflict()
+        async with _project_transition_lock:
+            return await _do_start_project(
+                _transition_locked=True,
+                editor_session_id=editor_session_id,
+                expected_layout_revision=expected_layout_revision,
+            )
+
+    core = config.main.get('core', {})
+    if _project_residual_latched or core.get('project_running', False):
+        project_state = (
+            'degraded'
+            if _project_residual_latched
+            else core.get('project_state', 'running')
+        )
+        if project_state == 'running':
+            return True
+        return {
+            'status_code': 409,
+            'detail': {
+                'code': 'project_degraded_requires_stop',
+                'reason': 'residual_control_must_be_stopped_before_start',
+                'project_state': 'degraded',
+            },
+            'errors': [],
+        }
+
+    if editor_session_id is not None or expected_layout_revision is not None:
+        from api.canvas import validate_project_start_snapshot
+
+        if editor_session_id is None or expected_layout_revision is None:
+            return {
+                'status_code': 422,
+                'detail': {
+                    'code': 'project_start_snapshot_required',
+                    'reason': 'editor_session_and_layout_revision_are_required',
+                },
+                'errors': [],
+            }
+        snapshot_error = validate_project_start_snapshot(
+            editor_session_id,
+            expected_layout_revision,
+        )
+        if snapshot_error is not None:
+            return snapshot_error
+
     from api.mcp_manage import mcp_call_tool, MCPCallRequest
     from api.motus_stream import push_event
     import json as _json
@@ -141,16 +527,64 @@ async def _do_start_project():
     cards = layout.get('cards', [])
     connections = layout.get('connections', [])
 
-    if not cards:
-        return
+    if not isinstance(cards, list) or not cards:
+        return {
+            'status_code': 409,
+            'detail': {
+                'code': 'project_empty',
+                'reason': 'no_canvas_cards',
+            },
+            'errors': [],
+        }
+
+    card_ids = set()
+    layout_errors = []
+    for index, card in enumerate(cards):
+        if not isinstance(card, dict):
+            layout_errors.append(f'cards[{index}] must be an object')
+            continue
+        card_id = card.get('id')
+        if not card_id or not card.get('mcpId') or not card.get('toolName'):
+            layout_errors.append(f'cards[{index}] is missing id, mcpId, or toolName')
+            continue
+        if card_id in card_ids:
+            layout_errors.append(f'duplicate card id: {card_id}')
+        card_ids.add(card_id)
+    if not isinstance(connections, list):
+        layout_errors.append('connections must be an array')
+    else:
+        for index, connection in enumerate(connections):
+            if not isinstance(connection, dict):
+                layout_errors.append(f'connections[{index}] must be an object')
+                continue
+            if (
+                connection.get('fromCardId') not in card_ids
+                or connection.get('toCardId') not in card_ids
+            ):
+                layout_errors.append(f'connections[{index}] references an unknown card')
+            try:
+                port_index = int(connection.get('fromPortIdx', 0))
+                if port_index < 0:
+                    raise ValueError
+            except (TypeError, ValueError):
+                layout_errors.append(f'connections[{index}].fromPortIdx is invalid')
+    if layout_errors:
+        return {
+            'status_code': 422,
+            'detail': {
+                'code': 'project_layout_invalid',
+                'errors': layout_errors,
+            },
+            'errors': layout_errors,
+        }
 
     # 分类：sources (无入连接) 和 processors (有入连接)
     cards_with_inbound = set()
     for conn in connections:
         cards_with_inbound.add(conn.get('toCardId'))
 
-    sources = [c for c in cards if c['id'] not in cards_with_inbound]
-    processors = [c for c in cards if c['id'] in cards_with_inbound]
+    sources = [c for c in cards if c.get('id') not in cards_with_inbound]
+    processors = [c for c in cards if c.get('id') in cards_with_inbound]
     all_ordered = sources + processors
 
     # 广播启动开始
@@ -159,6 +593,9 @@ async def _do_start_project():
     }})
 
     errors = []
+    teleop_conflicts: list[dict] = []
+    started_cards: list[dict] = []
+    attempted_cards: list[dict] = []
     # Resolved topic_out per card (populated after starting sources)
     resolved_topics: dict[str, list] = {}
 
@@ -168,6 +605,14 @@ async def _do_start_project():
         tool_name = card.get('toolName', '')
         card_id = card.get('id', '')
         if not mcp_id or not tool_name:
+            item_name = tool_name or card_id or '<invalid-card>'
+            errors.append(item_name)
+            await push_event({'type': 'project_start_item', 'payload': {
+                'tool': tool_name,
+                'mcp_id': mcp_id,
+                'status': 'error',
+                'message': 'card is missing mcpId or toolName',
+            }})
             return
 
         await push_event({'type': 'project_start_item', 'payload': {
@@ -182,70 +627,99 @@ async def _do_start_project():
 
         try:
             req = MCPCallRequest(tool=tool_name, arguments=args)
+            attempted_cards.append(card)
             result = await mcp_call_tool(mcp_id, req)
-            if result.get('code') == 200:
-                # Check if tool reported an error state in its response
-                resp_data = result.get('data')
-                tool_state = None
-                tool_message = ''
-                if isinstance(resp_data, dict):
-                    tool_state = resp_data.get('state')
-                    tool_message = resp_data.get('message', '')
-                elif isinstance(resp_data, list) and resp_data:
-                    try:
-                        parsed = _json.loads(resp_data[0].get('text', '{}')) if isinstance(resp_data[0], dict) else {}
-                        tool_state = parsed.get('state')
-                        tool_message = parsed.get('message', '')
-                    except Exception:
-                        pass
-
-                if tool_state == 'error':
-                    print(f'[start-project] {tool_name} ({mcp_id}) self-check failed: {tool_message}')
-                    await push_event({'type': 'project_start_item', 'payload': {
-                        'tool': tool_name, 'mcp_id': mcp_id, 'status': 'error', 'message': tool_message,
-                    }})
-                    errors.append(tool_name)
-                else:
-                    print(f'[start-project] started {tool_name} ({mcp_id})')
-                    await push_event({'type': 'project_start_item', 'payload': {
-                        'tool': tool_name, 'mcp_id': mcp_id, 'status': 'ready',
-                    }})
-                # After successful start, query info() to get resolved topic_out
-                try:
-                    info_req = MCPCallRequest(tool=tool_name, arguments={'action': 'info', 'instance_id': card_id})
-                    info_result = await mcp_call_tool(mcp_id, info_req)
-                    if info_result.get('code') == 200:
-                        data = info_result.get('data')
-                        # Parse MCP JSON-RPC content format: [{"type":"text","text":"..."}]
-                        if isinstance(data, list) and data:
-                            text = data[0].get('text', '{}') if isinstance(data[0], dict) else '{}'
-                            try:
-                                data = _json.loads(text)
-                            except Exception:
-                                data = {}
-                        elif isinstance(data, str):
-                            try:
-                                data = _json.loads(data)
-                            except Exception:
-                                data = {}
-                        if isinstance(data, dict):
-                            topic_out = data.get('topic_out', [])
-                            if topic_out:
-                                resolved_topics[card_id] = topic_out
-                                # Register resolved topics so WebSocket relay works
-                                from api.inspection import register_topic_internal
-                                for tp in topic_out:
-                                    if tp.get('topic') and tp.get('format'):
-                                        await register_topic_internal(tp['topic'], tp['format'], mcp_id)
-                except Exception:
-                    pass  # info() failure is non-fatal
-            else:
-                msg = str(result.get('detail', result.get('data', '')))[:100]
+            ack_error = _project_tool_ack_error(result)
+            if ack_error:
+                msg = ack_error[:100]
                 print(f'[start-project] {tool_name} error: {result}')
                 await push_event({'type': 'project_start_item', 'payload': {
                     'tool': tool_name, 'mcp_id': mcp_id, 'status': 'error', 'message': msg,
                 }})
                 errors.append(tool_name)
+                return
+
+            # Check if a legacy/internal tool reported an error state in a 200.
+            resp_data = result.get('data')
+            tool_state = None
+            tool_message = ''
+            if isinstance(resp_data, dict):
+                tool_state = resp_data.get('state')
+                tool_message = resp_data.get('message', '')
+            elif isinstance(resp_data, list) and resp_data:
+                try:
+                    parsed = _json.loads(resp_data[0].get('text', '{}')) if isinstance(resp_data[0], dict) else {}
+                    tool_state = parsed.get('state')
+                    tool_message = parsed.get('message', '')
+                except Exception:
+                    pass
+
+            if tool_state == 'error':
+                print(f'[start-project] {tool_name} ({mcp_id}) self-check failed: {tool_message}')
+                await push_event({'type': 'project_start_item', 'payload': {
+                    'tool': tool_name, 'mcp_id': mcp_id, 'status': 'error', 'message': tool_message,
+                }})
+                errors.append(tool_name)
+                return
+
+            started_cards.append(card)
+            print(f'[start-project] started {tool_name} ({mcp_id})')
+            await push_event({'type': 'project_start_item', 'payload': {
+                'tool': tool_name, 'mcp_id': mcp_id, 'status': 'ready',
+            }})
+
+            # After successful start, query info() to get resolved topic_out.
+            try:
+                info_req = MCPCallRequest(tool=tool_name, arguments={'action': 'info', 'instance_id': card_id})
+                info_result = await mcp_call_tool(mcp_id, info_req)
+                if info_result.get('code') == 200:
+                    data = info_result.get('data')
+                    # Parse MCP JSON-RPC content format: [{"type":"text","text":"..."}]
+                    if isinstance(data, list) and data:
+                        text = data[0].get('text', '{}') if isinstance(data[0], dict) else '{}'
+                        try:
+                            data = _json.loads(text)
+                        except Exception:
+                            data = {}
+                    elif isinstance(data, str):
+                        try:
+                            data = _json.loads(data)
+                        except Exception:
+                            data = {}
+                    if isinstance(data, dict):
+                        topic_out = data.get('topic_out', [])
+                        if (
+                            isinstance(topic_out, list)
+                            and topic_out
+                            and all(isinstance(topic, dict) for topic in topic_out)
+                        ):
+                            resolved_topics[card_id] = topic_out
+                            # Register resolved topics so WebSocket relay works
+                            from api.inspection import register_topic_internal
+                            for tp in topic_out:
+                                if tp.get('topic') and tp.get('format'):
+                                    await register_topic_internal(tp['topic'], tp['format'], mcp_id)
+            except Exception:
+                pass  # info() failure is non-fatal
+        except fastapi.HTTPException as error:
+            # HTTPException paths are rejected by Core before a Driver call.
+            if card in attempted_cards:
+                attempted_cards.remove(card)
+            detail = error.detail if isinstance(error.detail, dict) else {}
+            if (
+                error.status_code == 409
+                and detail.get('code') == 'teleop_command_blocked'
+            ):
+                teleop_conflicts.append(detail)
+            message = detail.get('code') or str(error.detail)[:100]
+            print(f'[start-project] failed {tool_name}: {message}')
+            await push_event({'type': 'project_start_item', 'payload': {
+                'tool': tool_name,
+                'mcp_id': mcp_id,
+                'status': 'error',
+                'message': message,
+            }})
+            errors.append(tool_name)
         except Exception as e:
             print(f'[start-project] failed {tool_name}: {e}')
             await push_event({'type': 'project_start_item', 'payload': {
@@ -286,54 +760,220 @@ async def _do_start_project():
             return topics[0], []
         return '', []
 
-    # Phase 1: start sources (no input_topic needed) and collect their topic_out
-    for card in sources:
-        await _start_and_resolve(card)
+    cancellation: asyncio.CancelledError | None = None
+    try:
+        # Phase 1: start sources (no input_topic needed) and collect their topic_out
+        for card in sources:
+            await _start_and_resolve(card)
 
-    # Phase 2: start processors with resolved input_topic from sources
-    for card in processors:
-        input_topic, input_topics = _resolve_input_topic(card['id'])
-        await _start_and_resolve(card, input_topic=input_topic, input_topics=input_topics)
+        # Phase 2: start processors with resolved input_topic from sources
+        for card in processors:
+            input_topic, input_topics = _resolve_input_topic(card['id'])
+            await _start_and_resolve(card, input_topic=input_topic, input_topics=input_topics)
+    except asyncio.CancelledError as error:
+        cancellation = error
+        errors.append('project_start_cancelled')
+    except Exception as error:
+        print(f'[start-project] orchestration failed: {error}')
+        errors.append('project_orchestration')
 
     # 有 card 失败 → 全部回滚，不标记 running
     if errors:
         print(f'[start-project] {len(errors)} cards failed ({", ".join(errors)}), rolling back')
-        await push_event({'type': 'project_start_done', 'payload': {'has_error': True, 'errors': errors}})
-        await _do_stop_project()
-        return False
-
-    # 全部成功 → 标记 running
-    core = config.main.get('core', {})
-    core['project_running'] = True
-    config.main['core'] = core
+        rollback_task = asyncio.create_task(
+            _do_stop_project(
+                cards=attempted_cards,
+                _transition_locked=True,
+            ),
+            name='project-start-rollback',
+        )
+        try:
+            rollback = await _await_project_cleanup(rollback_task)
+        except Exception as error:
+            print(
+                '[start-project] rollback failed: '
+                f'{type(error).__name__}'
+            )
+            rollback = {
+                'errors': ['project_rollback_failed'],
+            }
+        rollback_incomplete = rollback is not True
+        rollback_errors = rollback.get('errors', []) if isinstance(rollback, dict) else []
+        if cancellation is not None:
+            raise cancellation
+        await push_event({'type': 'project_start_done', 'payload': {
+            'has_error': True,
+            'errors': errors,
+            'rollback_incomplete': rollback_incomplete,
+            'rollback_errors': rollback_errors,
+        }})
+        detail = (
+            dict(teleop_conflicts[0])
+            if teleop_conflicts
+            else {'code': 'project_start_failed', 'reason': 'driver_start_failed'}
+        )
+        detail.update({
+            'rollback_incomplete': rollback_incomplete,
+            'project_state': 'degraded' if rollback_incomplete else 'stopped',
+            'started_card_ids': [card.get('id', '') for card in started_cards],
+            'attempted_card_ids': [card.get('id', '') for card in attempted_cards],
+            'rollback_errors': rollback_errors,
+        })
+        return {
+            'status_code': 409 if teleop_conflicts else 500,
+            'detail': detail,
+            'errors': errors,
+        }
 
     # 确保 channel adapters 已连接（restart 断开的 adapter）
     from channel.manager import manager as channel_mgr, _get_channel_configs
-    channel_mgr.sync_from_canvas()
-    for ch_cfg in _get_channel_configs():
-        ch_id = ch_cfg.get('id', '')
-        if ch_cfg.get('enabled') and ch_id not in channel_mgr._adapters:
-            try:
+    cancellation = None
+    try:
+        channel_mgr.sync_from_canvas()
+        for ch_cfg in _get_channel_configs():
+            ch_id = ch_cfg.get('id', '')
+            if ch_cfg.get('enabled') and ch_id not in channel_mgr._adapters:
                 await channel_mgr.restart_adapter(ch_id)
-            except Exception as e:
-                print(f'[start-project] channel {ch_id} restart failed: {e}')
+    except asyncio.CancelledError as error:
+        cancellation = error
+        errors.append('project_start_cancelled')
+        print('[start-project] channel synchronization cancelled; rolling back')
+    except Exception as error:
+        print(f'[start-project] channel synchronization failed: {error}')
+        errors.append('channel_sync')
+    if errors:
+        rollback_task = asyncio.create_task(
+            _do_stop_project(
+                cards=attempted_cards,
+                _transition_locked=True,
+            ),
+            name='project-channel-rollback',
+        )
+        try:
+            rollback = await _await_project_cleanup(rollback_task)
+        except Exception as error:
+            print(
+                '[start-project] channel rollback failed: '
+                f'{type(error).__name__}'
+            )
+            rollback = {'errors': ['project_channel_rollback_failed']}
+        rollback_incomplete = rollback is not True
+        rollback_errors = rollback.get('errors', []) if isinstance(rollback, dict) else []
+        if cancellation is not None:
+            raise cancellation
+        await push_event({'type': 'project_start_done', 'payload': {
+            'has_error': True,
+            'errors': errors,
+            'rollback_incomplete': rollback_incomplete,
+            'rollback_errors': rollback_errors,
+        }})
+        return {
+            'status_code': 500,
+            'detail': {
+                'code': 'project_start_failed',
+                'reason': 'channel_sync_failed',
+                'rollback_incomplete': rollback_incomplete,
+                'project_state': 'degraded' if rollback_incomplete else 'stopped',
+                'started_card_ids': [card.get('id', '') for card in started_cards],
+                'attempted_card_ids': [card.get('id', '') for card in attempted_cards],
+                'rollback_errors': rollback_errors,
+            },
+            'errors': errors,
+        }
+
+    # 全部成功 → 标记 running
+    if not _set_project_state_safely('running', cards=attempted_cards):
+        rollback_task = asyncio.create_task(
+            _do_stop_project(
+                cards=attempted_cards,
+                _transition_locked=True,
+            ),
+            name='project-state-commit-rollback',
+        )
+        try:
+            rollback = await _await_project_cleanup(rollback_task)
+        except Exception as error:
+            print(
+                '[start-project] state-commit rollback failed: '
+                f'{type(error).__name__}'
+            )
+            rollback = {
+                'errors': ['project_state_commit_rollback_failed'],
+            }
+        rollback_incomplete = rollback is not True
+        rollback_errors = (
+            rollback.get('errors', [])
+            if isinstance(rollback, dict)
+            else []
+        )
+        await push_event({'type': 'project_start_done', 'payload': {
+            'has_error': True,
+            'errors': ['project_state_commit_failed'],
+            'rollback_incomplete': rollback_incomplete,
+            'rollback_errors': rollback_errors,
+        }})
+        return {
+            'status_code': 500,
+            'detail': {
+                'code': 'project_state_commit_failed',
+                'reason': 'running_state_not_persisted',
+                'rollback_incomplete': rollback_incomplete,
+                'project_state': 'degraded' if rollback_incomplete else 'stopped',
+                'attempted_card_ids': [
+                    card.get('id', '') for card in attempted_cards
+                ],
+                'rollback_errors': rollback_errors,
+            },
+            'errors': ['project_state_commit_failed'],
+        }
 
     # 广播启动完成
     await push_event({'type': 'project_start_done', 'payload': {'has_error': False}})
-    await push_event({'type': 'project_state', 'payload': {'running': True}})
+    await push_event({'type': 'project_state', 'payload': {
+        'running': True,
+        'state': 'running',
+    }})
     print(f'[start-project] done ({len(cards)} cards, all succeeded)')
     return True
 
 
-async def _do_stop_project():
+async def _do_stop_project(*, cards=None, _transition_locked: bool = False):
     """停止所有 canvas cards。"""
+    if not _transition_locked:
+        if _project_transition_lock.locked():
+            return _project_transition_conflict()
+        async with _project_transition_lock:
+            stop_task = asyncio.create_task(
+                _do_stop_project(
+                    cards=cards,
+                    _transition_locked=True,
+                ),
+                name='project-stop-transition',
+            )
+            try:
+                return await asyncio.shield(stop_task)
+            except asyncio.CancelledError as cancellation:
+                await _await_project_cleanup(stop_task)
+                raise cancellation
+
     from api.mcp_manage import mcp_call_tool, MCPCallRequest
     from api.motus_stream import push_event
 
-    layout = config.main.get('canvas_layout', {})
-    cards = layout.get('cards', [])
+    core = config.main.get('core', {})
+    if (
+        cards is None
+        and not _project_residual_latched
+        and not core.get('project_running', False)
+    ):
+        return True
+    if cards is None:
+        target_cards = _effective_project_cards(core)
+    else:
+        target_cards = cards
+    errors = []
+    teleop_conflicts: list[dict] = []
 
-    for card in cards:
+    for card in target_cards:
         mcp_id = card.get('mcpId', '')
         tool_name = card.get('toolName', '')
         card_id = card.get('id', '')
@@ -341,21 +981,101 @@ async def _do_stop_project():
             continue
         try:
             req = MCPCallRequest(tool=tool_name, arguments={'action': 'stop', 'instance_id': card_id})
-            await mcp_call_tool(mcp_id, req)
+            result = await mcp_call_tool(mcp_id, req)
+            if _project_tool_ack_error(result):
+                errors.append(tool_name)
+        except fastapi.HTTPException as error:
+            detail = error.detail if isinstance(error.detail, dict) else {}
+            if (
+                error.status_code == 409
+                and detail.get('code') == 'teleop_command_blocked'
+            ):
+                teleop_conflicts.append(detail)
+            errors.append(tool_name)
         except Exception:
-            pass
+            errors.append(tool_name)
 
-    core = config.main.get('core', {})
-    core['project_running'] = False
-    config.main['core'] = core
-    await push_event({'type': 'project_state', 'payload': {'running': False}})
+    if teleop_conflicts:
+        _latch_project_residual(target_cards)
+        state_persisted = _set_project_state_safely(
+            'degraded',
+            cards=target_cards,
+        )
+        await push_event({'type': 'project_state', 'payload': {
+            'running': True,
+            'state': 'degraded',
+        }})
+        detail = dict(teleop_conflicts[0])
+        detail['project_state'] = 'degraded'
+        detail['state_persisted'] = state_persisted
+        return {
+            'status_code': 409,
+            'detail': detail,
+            'errors': errors,
+        }
+    if errors:
+        _latch_project_residual(target_cards)
+        state_persisted = _set_project_state_safely(
+            'degraded',
+            cards=target_cards,
+        )
+        await push_event({'type': 'project_state', 'payload': {
+            'running': True,
+            'state': 'degraded',
+        }})
+        return {
+            'status_code': 500,
+            'detail': {
+                'code': 'project_stop_failed',
+                'reason': 'driver_stop_failed',
+                'project_state': 'degraded',
+                'state_persisted': state_persisted,
+            },
+            'errors': errors,
+        }
+
+    if not _set_project_state_safely('stopped'):
+        _latch_project_residual(target_cards)
+        return {
+            'status_code': 500,
+            'detail': {
+                'code': 'project_state_persist_failed',
+                'reason': 'drivers_stopped_but_state_not_persisted',
+                'project_state': 'unknown',
+                'state_persisted': False,
+            },
+            'errors': ['project_state_persist_failed'],
+        }
+    _clear_project_residual()
+    await push_event({'type': 'project_state', 'payload': {
+        'running': False,
+        'state': 'stopped',
+    }})
     print('[stop-project] done')
+    return True
+
+
+class ProjectStartRequest(BaseModel):
+    session_id: str
+    layout_revision: int
 
 
 @router.post('/start-project')
-async def api_start_project():
-    success = await _do_start_project()
-    if success is False:
+async def api_start_project(req: ProjectStartRequest):
+    success = await _do_start_project(
+        editor_session_id=req.session_id,
+        expected_layout_revision=req.layout_revision,
+    )
+    if isinstance(success, dict):
+        return fastapi.responses.JSONResponse(
+            status_code=success.get('status_code', 500),
+            content={
+                'ok': False,
+                'detail': success.get('detail', 'Project start failed'),
+                'errors': success.get('errors', []),
+            },
+        )
+    if success is not True:
         return fastapi.responses.JSONResponse(
             status_code=500,
             content={'ok': False, 'detail': '部分设备启动失败，已回滚'}
@@ -365,7 +1085,21 @@ async def api_start_project():
 
 @router.post('/stop-project')
 async def api_stop_project():
-    await _do_stop_project()
+    success = await _do_stop_project()
+    if isinstance(success, dict):
+        return fastapi.responses.JSONResponse(
+            status_code=success.get('status_code', 500),
+            content={
+                'ok': False,
+                'detail': success.get('detail', 'Project stop failed'),
+                'errors': success.get('errors', []),
+            },
+        )
+    if success is not True:
+        return fastapi.responses.JSONResponse(
+            status_code=500,
+            content={'ok': False, 'detail': '部分设备停止失败'},
+        )
     return {'ok': True}
 
 
@@ -376,10 +1110,13 @@ class ProjectRunningRequest(BaseModel):
 
 @router.put('/project-running')
 async def set_project_running(req: ProjectRunningRequest):
-    core = config.main.get('core', {})
-    core['project_running'] = req.running
-    config.main['core'] = core
-    return {'ok': True}
+    raise fastapi.HTTPException(
+        status_code=409,
+        detail={
+            'code': 'project_state_write_forbidden',
+            'reason': 'use start-project or stop-project',
+        },
+    )
 
 
 @router.get('/auto-start')
@@ -478,7 +1215,116 @@ async def config_get():
 
 @router.post('')
 async def config_save(req: ConfigSaveRequest):
+    async with authority_guard.target_mutation_lock:
+        return await _config_save_locked(req)
+
+
+async def _config_save_locked(req: ConfigSaveRequest):
     services = config.main.get('services', {})
+
+    # Build and validate the complete MCP proposal before writing any config or
+    # replacing the live LLM client.  A rejected save must be a true zero-write.
+    current_mcp_list = services.get('mcp', [])
+    current_mcp_list = current_mcp_list if isinstance(current_mcp_list, list) else []
+    existing_mcps = {
+        m.get('id'): m for m in current_mcp_list if isinstance(m, dict)
+    }
+    new_mcps = [
+        {
+            'id':          m.id or f'mcp-{int(time.time())}',
+            'name':        m.name,
+            'transport':   m.transport,
+            'url':         m.url,
+            'render_hint': m.render_hint,
+            'depends_on':  m.depends_on,
+            'topic_in':    m.topic_in if m.topic_in else existing_mcps.get(m.id, {}).get('topic_in', []),
+            'topic_out':   m.topic_out if m.topic_out else existing_mcps.get(m.id, {}).get('topic_out', []),
+            **({
+                key: existing_mcps[m.id][key]
+                for key in (
+                    'authority_binding_error', 'authority_binding_required',
+                    'authority_domain', 'category', 'credential_binding',
+                    'pending_authority_domain',
+                    'reported_robot_id', 'resources', 'server_name', 'tools',
+                    'trust_state',
+                )
+                if m.id in existing_mcps and key in existing_mcps[m.id]
+            }),
+        }
+        for m in req.mcp_list
+    ]
+    new_ids = [m.get('id', '') for m in new_mcps]
+    if len(new_ids) != len(set(new_ids)):
+        raise fastapi.HTTPException(status_code=409, detail='Duplicate MCP id')
+
+    # A target change invalidates the old capability snapshot immediately.
+    # Apply this before binding validation so a retargeted authority root cannot
+    # retain an actuator proof that belongs to its previous endpoint.
+    changed_targets = []
+    for target in new_mcps:
+        previous = existing_mcps.get(target.get('id'))
+        if previous and (
+            previous.get('url') != target.get('url')
+            or previous.get('transport', 'http') != target.get('transport', 'http')
+        ):
+            target['tools'] = []
+            target['resources'] = []
+            target['server_name'] = ''
+            target['capability_refresh_required'] = True
+            changed_targets.append(target.get('id', ''))
+
+    mutation_error = await _project_target_mutation_error(
+        current_mcp_list,
+        new_mcps,
+    )
+    if mutation_error is not None:
+        raise fastapi.HTTPException(status_code=409, detail=mutation_error)
+
+    missing_roots = [
+        {
+            'mcp_id': m.get('id', ''),
+            'root_mcp_id': root_id,
+        }
+        for m in new_mcps
+        for root_id in _authority_roots(m)
+        if root_id and root_id != m.get('id') and root_id not in new_ids
+    ]
+    if missing_roots:
+        raise fastapi.HTTPException(
+            status_code=409,
+            detail={
+                'code': 'authority_binding_invalid',
+                'reason': 'authority_root_would_be_removed',
+                'bindings': missing_roots,
+            },
+        )
+    from api.mcp_manage import _authority_binding_problem
+    binding_problems = []
+    for target in new_mcps:
+        for root_id in _authority_roots(target):
+            if root_id == target.get('id'):
+                continue
+            roots = [root for root in new_mcps if root.get('id') == root_id]
+            problem = (
+                'authority_root_not_unique'
+                if len(roots) != 1
+                else _authority_binding_problem(target, roots[0], root_id)
+            )
+            if problem is not None:
+                binding_problems.append({
+                    'mcp_id': target.get('id', ''),
+                    'root_mcp_id': root_id,
+                    'reason': problem,
+                })
+    if binding_problems:
+        raise fastapi.HTTPException(
+            status_code=409,
+            detail={
+                'code': 'authority_binding_invalid',
+                'reason': 'authority_binding_would_be_invalidated',
+                'bindings': binding_problems,
+            },
+        )
 
     # LLM
     existing_key = services.get('llm', {}).get('key', '')
@@ -490,7 +1336,8 @@ async def config_save(req: ConfigSaveRequest):
         'think_mode': req.services.llm.think_mode,
     }
 
-    # Sync to client.llm (operational LLM config)
+    # Stage client.llm; persistence and the runtime swap happen only after all
+    # MCP/authority/project validation above has succeeded.
     client_cfg = config.main.get('client', {})
     client_cfg['llm'] = [{
         'url':   services['llm']['url'],
@@ -498,11 +1345,6 @@ async def config_save(req: ConfigSaveRequest):
         'model': services['llm']['model'],
         'think_mode': services['llm']['think_mode'],
     }]
-    config.main['client'] = client_cfg
-    # Reinitialize the LLM client with new config
-    import client as client_mod
-    client_mod.llm = client_mod.llm.__class__()
-
     # TTS / VAD / ASR
     existing_tts_key = services.get('tts', {}).get('api_key', '')
     new_tts_key = req.services.tts.api_key if (req.services.tts.api_key and req.services.tts.api_key != '****') else existing_tts_key
@@ -527,31 +1369,11 @@ async def config_save(req: ConfigSaveRequest):
         'language':   asr.language,
     }
 
-    # MCP — topic_in/topic_out from request take priority (user may have updated them via dep selection);
-    # server_name/tools/resources fall back to DB-persisted values.
-    existing_mcps = {m.get('id'): m for m in services.get('mcp', [])}
-    services['mcp'] = [
-        {
-            'id':          m.id or f'mcp-{int(time.time())}',
-            'name':        m.name,
-            'transport':   m.transport,
-            'url':         m.url,
-            'render_hint': m.render_hint,
-            'depends_on':  m.depends_on,
-            'topic_in':    m.topic_in  if m.topic_in  else existing_mcps.get(m.id, {}).get('topic_in',  []),
-            'topic_out':   m.topic_out if m.topic_out else existing_mcps.get(m.id, {}).get('topic_out', []),
-            **({k: existing_mcps[m.id][k]
-                for k in ('server_name', 'tools', 'resources')
-                if m.id in existing_mcps and k in existing_mcps[m.id]}),
-        }
-        for m in req.mcp_list
-    ]
+    services['mcp'] = new_mcps
 
     # Inspector — only persist if non-empty (URL is auto-detected from running container)
     if req.services.inspector.url:
         services['inspector'] = {'url': req.services.inspector.url}
-
-    config.main['services'] = services
 
     # Search config → desktop_tools section
     dt = config.main.get('desktop_tools', {})
@@ -563,12 +1385,31 @@ async def config_save(req: ConfigSaveRequest):
         'base_url': req.services.search.base_url,
         'api_key':  new_search_key,
     }
-    config.main['desktop_tools'] = dt
-
     # Mark configured
     core = config.main.get('core', {})
     core['configured'] = True
-    config.main['core'] = core
+    import client as client_mod
+
+    # Validate and fully construct the next runtime before durable commit.  An
+    # invalid URL/credential must leave both DB and the live route untouched.
+    candidate_llm = client_mod.llm.__class__(configs=client_cfg['llm'])
+    try:
+        config.main.set_many({
+            'services': services,
+            'client': client_cfg,
+            'desktop_tools': dt,
+            'core': core,
+        })
+    except Exception:
+        await candidate_llm.aclose()
+        raise
+    client_mod.llm = candidate_llm
+
+    if changed_targets:
+        import mcp_client
+
+        for mcp_id in changed_targets:
+            mcp_client.registry.pop(mcp_id, None)
 
     return {'code': 200, 'message': 'saved'}
 
@@ -703,7 +1544,7 @@ async def config_test_asr_audio(
 
 
 def _asr_transcribe_sync(cfg: dict, wav_bytes: bytes) -> str:
-    import requests, base64, json as _json, time as _time
+    import requests, base64, json as _json
     provider = cfg.get('provider', 'openai')
 
     if provider in ('openai', 'openai_omni'):
@@ -957,5 +1798,3 @@ async def reset_config(req: ResetRequest):
             )
 
     return {'ok': True, 'reset': reset_items}
-
-

--- a/agent-core/src/api/inspection.py
+++ b/agent-core/src/api/inspection.py
@@ -210,6 +210,10 @@ async def topics_subscriptions():
 
 @ws_router.websocket('/ws/bus/{topic:path}')
 async def bus_ws(websocket: fastapi.WebSocket, topic: str):
+    import auth
+    if not auth.check_ws_token(websocket):
+        await websocket.close(code=4003, reason='Owner role required')
+        return
     await websocket.accept()
 
     topic = '/' + topic  # restore leading /

--- a/agent-core/src/api/mcp_manage.py
+++ b/agent-core/src/api/mcp_manage.py
@@ -1,18 +1,31 @@
 import asyncio
 import json
-import time
-from typing import Optional
+import re
+import uuid
 
 import aiohttp
 import fastapi
 from pydantic import BaseModel
 
+import auth
 import config
 import mcp_client
+from mcp_protocol import (
+    rpc_response_error as _rpc_response_error,
+    tool_result_error as _tool_result_error,
+)
+from teleop import audit, authority_guard
+from teleop.command_broker import (
+    InvalidAuthorityBinding,
+    TeleopCommandBlocked,
+    authority_domain_for_target,
+    classify_tool_access,
+)
 
 router = fastapi.APIRouter(prefix='/mcp', tags=['mcp'])
 
-_mcp_write_lock = asyncio.Lock()  # 防止并发 ping 的 read-modify-write race condition
+_mcp_write_lock = authority_guard.target_mutation_lock
+_RESERVED_CONFIG_ARGUMENTS = frozenset({'action', 'instance_id'})
 
 
 def _get_inspector_url() -> str:
@@ -43,25 +56,219 @@ def _save_mcp_list(mcp_list: list):
     config.main['services'] = services
 
 
+def _effective_trust_state(mcp: dict) -> str:
+    state = mcp.get('trust_state')
+    if (
+        state == 'trusted'
+        and not auth.driver_record_credential_available(
+            mcp.get('id', ''),
+            mcp.get('credential_binding'),
+        )
+    ):
+        return 'quarantined'
+    if state:
+        return state
+    # Records created before C1 are legacy-untrusted.  Once a deployment opts
+    # into driver authentication they are quarantined until re-registration.
+    return 'quarantined' if auth.is_driver_auth_enforced() else 'untrusted'
+
+
+def _runtime_registration_allowed(mcp: dict) -> bool:
+    if mcp.get('transport') == 'internal':
+        return True
+    state = _effective_trust_state(mcp)
+    return state == 'trusted' or (state == 'untrusted' and not auth.is_driver_auth_enforced())
+
+
+def _is_reserved_teleop_tool(tool) -> bool:
+    return (
+        isinstance(tool, dict)
+        and (tool.get('name') == 'teleop_session' or 'x-teleop' in tool)
+    )
+
+
+def _ordinary_tools(tools: list) -> list:
+    """Hide teleop-only tools from Canvas, LLM, and generic MCP callers."""
+    return [tool for tool in (tools or []) if not _is_reserved_teleop_tool(tool)]
+
+
+def _descriptor_action_declared(tool: object, arguments: object) -> bool:
+    descriptor = tool if isinstance(tool, dict) else {}
+    safe_arguments = arguments if isinstance(arguments, dict) else {}
+    action = safe_arguments.get('action')
+    input_schema = descriptor.get('inputSchema')
+    input_schema = input_schema if isinstance(input_schema, dict) else {}
+    properties = input_schema.get('properties')
+    properties = properties if isinstance(properties, dict) else {}
+    action_schema = properties.get('action')
+    action_schema = action_schema if isinstance(action_schema, dict) else {}
+    action_enum = action_schema.get('enum')
+    return isinstance(action_enum, list) and action in action_enum
+
+
+def _descriptor_tool_access(tool: object, arguments: object):
+    descriptor = tool if isinstance(tool, dict) else {}
+    safe_arguments = arguments if isinstance(arguments, dict) else {}
+    action = safe_arguments.get('action')
+
+    return classify_tool_access(
+        tool_type=descriptor.get('type'),
+        annotations=descriptor.get('annotations'),
+        action=action,
+        action_declared=_descriptor_action_declared(descriptor, safe_arguments),
+    )
+
+
+def _safe_saved_config(value: object) -> dict:
+    if not isinstance(value, dict):
+        return {}
+    return {
+        key: item
+        for key, item in value.items()
+        if key not in _RESERVED_CONFIG_ARGUMENTS
+    }
+
+
+def _outbound_headers(target: dict) -> dict[str, str]:
+    headers = {'Content-Type': 'application/json'}
+    if _effective_trust_state(target) == 'trusted':
+        driver_headers = auth.driver_request_headers(target.get('id', ''))
+        if not driver_headers:
+            raise PermissionError('trusted Driver credential is unavailable')
+        headers.update(driver_headers)
+    return headers
+
+
 # Cache of last-seen tool names per mcp_id (for change detection)
 _last_tool_names: dict[str, list[str]] = {}
+_ping_generations: dict[str, int] = {}
+
+
+def _capability_fingerprint(value: object) -> str:
+    """Return a conservative, deterministic snapshot for persisted capabilities."""
+
+    try:
+        return json.dumps(
+            value,
+            sort_keys=True,
+            separators=(',', ':'),
+            ensure_ascii=False,
+            allow_nan=False,
+        )
+    except (TypeError, ValueError, RecursionError):
+        # Invalid/non-JSON persisted data must not make two distinct snapshots
+        # look equal.  repr is intentionally conservative for this corrupt case.
+        return repr(value)
+
+
+def _ping_target_fingerprint(target: dict) -> tuple:
+    """Fields that must remain unchanged while a capability ping is in flight."""
+
+    return (
+        target.get('id'),
+        target.get('url', ''),
+        target.get('transport', 'http'),
+        _effective_trust_state(target),
+        target.get('name', ''),
+        target.get('depends_on', ''),
+        target.get('authority_domain', ''),
+        target.get('pending_authority_domain', ''),
+        bool(target.get('authority_binding_required', False)),
+        target.get('authority_binding_error', ''),
+        target.get('reported_robot_id', ''),
+        bool(target.get('capability_refresh_required', False)),
+        _capability_fingerprint(target.get('tools', [])),
+    )
+
+
+def _stale_ping_result(mcp_id: str) -> dict:
+    return {
+        'online': False,
+        'error': 'ping target changed; stale result discarded',
+        'tools': [],
+        'resources': [],
+        'mcp_id': mcp_id,
+    }
+
+
+async def _project_target_mutation_error(
+    current_targets: list[dict],
+    proposed_targets: list[dict],
+) -> dict | None:
+    from api import config as config_api
+
+    return await config_api._project_target_mutation_error(
+        current_targets,
+        proposed_targets,
+    )
+
+
+def _project_target_locked_response(error: dict):
+    return fastapi.responses.JSONResponse(
+        status_code=409,
+        content={
+            'code': 409,
+            'message': 'Execution target is locked until safe Stop or recovery completes',
+            'data': error,
+        },
+    )
+
+
+def _project_target_locked_ping_result(
+    mcp_id: str,
+    target: dict,
+    error: dict,
+) -> dict:
+    return {
+        'online': bool(mcp_client.registry.get(mcp_id, {}).get('online', False)),
+        'error': 'project execution target is locked until Stop completes',
+        'detail': error,
+        'tools': target.get('tools', []),
+        'resources': target.get('resources', []),
+        'render_hint': target.get('render_hint', ''),
+        'server_name': target.get('server_name', ''),
+        'topic_out': target.get('topic_out', []),
+        'topic_in': target.get('topic_in', []),
+    }
 
 
 # ── Models ───────────────────────────────────────────────────────────────────
 
 class MCPAddRequest(BaseModel):
+    id:        str = ''
     name:      str
     transport: str = 'http'
     url:       str = ''
     render_hint: str = ''
     category:  str = ''
+    robot_id: str = ''
+
+    model_config = {'extra': 'forbid'}
+
+
+class MCPAuthorityBindingRequest(BaseModel):
+    root_mcp_id: str
+
+    model_config = {'extra': 'forbid'}
 
 
 # ── Helpers ──────────────────────────────────────────────────────────────────
 
-async def _ping_mcp_http(url: str) -> dict:
+async def _ping_mcp_http(
+    url: str,
+    *,
+    trusted: bool = False,
+    driver_id: str | None = None,
+) -> dict:
     """Connect to an MCP HTTP server, initialize, list tools and resources."""
     headers = {'Content-Type': 'application/json'}
+    if trusted:
+        driver_headers = auth.driver_request_headers(driver_id)
+        if not driver_headers:
+            raise PermissionError(
+                f'trusted Driver request requires an exact credential: {driver_id!r}'
+            )
+        headers.update(driver_headers)
     timeout = aiohttp.ClientTimeout(total=5)
     tools = []
     resources = []
@@ -82,33 +289,87 @@ async def _ping_mcp_http(url: str) -> dict:
                 'clientInfo': {'name': 'phanthy-motus', 'version': '1.0'},
             }
         }
-        async with session.post(url, json=init_payload, headers=headers) as resp:
-            if resp.status >= 400:
-                raise ConnectionError(f'MCP initialize failed: HTTP {resp.status}')
+        async with session.post(
+            url,
+            json=init_payload,
+            headers=headers,
+            allow_redirects=False,
+        ) as resp:
             init_data = await resp.json(content_type=None)
-            server_name = init_data.get('result', {}).get('serverInfo', {}).get('name', '')
+            init_error = _rpc_response_error(
+                init_data,
+                request_id=1,
+                http_status=resp.status,
+            )
+            if init_error:
+                raise ConnectionError(f'MCP initialize failed: {init_error}')
+            init_result = init_data['result']
+            if not isinstance(init_result, dict):
+                raise ConnectionError('MCP initialize returned an invalid result')
+            server_info = init_result.get('serverInfo')
+            server_name = (
+                server_info.get('name', '')
+                if isinstance(server_info, dict)
+                else ''
+            )
 
         # List tools
-        try:
-            tools_payload = {'jsonrpc': '2.0', 'id': 2, 'method': 'tools/list', 'params': {}}
-            async with session.post(url, json=tools_payload, headers=headers) as resp:
-                data = await resp.json(content_type=None)
-                tools = [
-                    {k: v for k, v in t.items() if k in ('name', 'description', 'type', 'multiInstance', 'inputSchema', 'configSchema', 'topic_out', 'topic_in')}
-                    for t in data.get('result', {}).get('tools', [])
-                ]
-        except Exception as e:
-            print(f'[mcp/tools] error: {e}')
-            pass
+        tools_payload = {'jsonrpc': '2.0', 'id': 2, 'method': 'tools/list', 'params': {}}
+        async with session.post(
+            url,
+            json=tools_payload,
+            headers=headers,
+            allow_redirects=False,
+        ) as resp:
+            data = await resp.json(content_type=None)
+            tools_error = _rpc_response_error(
+                data,
+                request_id=2,
+                http_status=resp.status,
+            )
+            if tools_error:
+                raise ConnectionError(f'MCP tools/list failed: {tools_error}')
+            tools_result = data['result']
+            raw_tools = (
+                tools_result.get('tools')
+                if isinstance(tools_result, dict)
+                else None
+            )
+            if not isinstance(raw_tools, list) or any(
+                not isinstance(tool, dict) for tool in raw_tools
+            ):
+                raise ConnectionError('MCP tools/list returned an invalid result')
+            tools = [
+                {k: v for k, v in tool.items() if k in (
+                    'name', 'description', 'type', 'multiInstance',
+                    'inputSchema', 'configSchema', 'topic_out', 'topic_in',
+                    'annotations', 'x-teleop',
+                )}
+                for tool in raw_tools
+            ]
 
         # Call all *_info / info tools in parallel — device self-reports type and topics.
         # Bundles expose per-plugin tools like mic_info, loco_info; single devices use bare 'info'.
         # Tools with action enum containing 'info' are called with {action: "info"}.
-        tool_names = [t.get('name', '') if isinstance(t, dict) else t for t in tools]
-        info_tools = [n for n in tool_names if n == 'info' or n.endswith('_info')]
+        # Reserved teleop descriptors are discovery metadata only.  They must
+        # never enter auto-info, even if named ``*_info`` or if their action
+        # enum advertises ``info``.
+        info_candidates = _ordinary_tools(tools)
+        info_tools = [
+            tool.get('name', '')
+            for tool in info_candidates
+            if (
+                isinstance(tool, dict)
+                and (
+                    tool.get('name') == 'info'
+                    or tool.get('name', '').endswith('_info')
+                )
+                and _descriptor_tool_access(tool, {}).read_only
+            )
+        ]
         # Also detect tools with action schema containing 'info'
         action_info_tools = []
-        for t in tools:
+        for t in info_candidates:
             if not isinstance(t, dict): continue
             name = t.get('name', '')
             if name in info_tools: continue
@@ -127,9 +388,24 @@ async def _ping_mcp_http(url: str) -> dict:
                 'params': {'name': tool_name, 'arguments': arguments},
             }
             try:
-                async with session.post(url, json=payload, headers=headers) as resp:
+                async with session.post(
+                    url,
+                    json=payload,
+                    headers=headers,
+                    allow_redirects=False,
+                ) as resp:
                     data = await resp.json(content_type=None)
-                    content = data.get('result', {}).get('content', [])
+                    response_error = _rpc_response_error(
+                        data,
+                        request_id=rid,
+                        http_status=resp.status,
+                    )
+                    if response_error:
+                        return None
+                    result = data['result']
+                    if _tool_result_error(result):
+                        return None
+                    content = result['content']
                     for item in content:
                         text = item.get('text', '')
                         if text:
@@ -207,9 +483,33 @@ async def _ping_mcp_http(url: str) -> dict:
         # List resources
         try:
             res_payload = {'jsonrpc': '2.0', 'id': 3, 'method': 'resources/list', 'params': {}}
-            async with session.post(url, json=res_payload, headers=headers) as resp:
+            async with session.post(
+                url,
+                json=res_payload,
+                headers=headers,
+                allow_redirects=False,
+            ) as resp:
                 data = await resp.json(content_type=None)
-                resources = [r.get('name') for r in data.get('result', {}).get('resources', [])]
+                resources_error = _rpc_response_error(
+                    data,
+                    request_id=3,
+                    http_status=resp.status,
+                )
+                if resources_error:
+                    raise ConnectionError(resources_error)
+                resources_result = data['result']
+                raw_resources = (
+                    resources_result.get('resources')
+                    if isinstance(resources_result, dict)
+                    else None
+                )
+                if not isinstance(raw_resources, list):
+                    raise ConnectionError('invalid resources/list result')
+                resources = [
+                    resource.get('name')
+                    for resource in raw_resources
+                    if isinstance(resource, dict)
+                ]
         except Exception:
             pass
 
@@ -294,11 +594,20 @@ async def mcp_list():
             'url':         m.get('url', ''),
             'render_hint': m.get('render_hint', ''),
             'server_name': m.get('server_name', ''),
-            'tools':       m.get('tools', []),
+            'tools':       _ordinary_tools(m.get('tools', [])),
             'resources':   m.get('resources', []),
             'topic_out':   m.get('topic_out', []),
             'topic_in':    m.get('topic_in',  []),
             'category':    m.get('category', ''),
+            'reported_robot_id': m.get('reported_robot_id', ''),
+            'authority_domain': m.get('authority_domain', m.get('id', '')),
+            'pending_authority_domain': m.get('pending_authority_domain', ''),
+            'authority_binding_error': m.get('authority_binding_error', ''),
+            'restart_required': 'pending_authority_domain' in m,
+            'trust_state': (
+                'internal' if m.get('transport') == 'internal'
+                else _effective_trust_state(m)
+            ),
             'depends_on':  m.get('depends_on', ''),
             'ws_path':     ('/ws/bus' + (m.get('topic_out') or [{}])[0].get('topic', '')) if m.get('topic_out') else '',
             'online':      None,
@@ -308,76 +617,736 @@ async def mcp_list():
     return {'code': 200, 'data': items}
 
 
+_MCP_ID_RE = re.compile(r'^[A-Za-z0-9][A-Za-z0-9_.:-]{0,63}$')
+_RESERVED_INTERNAL_MCP_IDS = frozenset({'agentcore', 'channel'})
+
+
 @router.post('')
-async def mcp_add(req: MCPAddRequest):
+async def mcp_add(req: MCPAddRequest, request: fastapi.Request):
+    """Register or heartbeat an MCP service.
+
+    Legacy services remain discoverable, but only callers presenting the
+    credential selected for their exact stable id receive
+    ``trust_state=trusted``.  An untrusted heartbeat is never allowed to mutate
+    a trusted record, and a dedicated credential cannot claim another id.
+    """
+    requested_id = req.id.strip()
+    presented_token = auth.extract_driver_token(request)
+    dedicated_identity = auth.driver_token_identity(presented_token)
+    if (
+        auth.is_known_driver_token(presented_token)
+        and not _MCP_ID_RE.fullmatch(requested_id)
+    ):
+        raise fastapi.HTTPException(
+            status_code=422,
+            detail='trusted Driver registration requires a valid stable MCP id',
+        )
+    if dedicated_identity is not None and dedicated_identity != requested_id:
+        return fastapi.responses.JSONResponse(
+            status_code=403,
+            content={
+                'code': 403,
+                'message': 'Driver credential is bound to a different stable MCP id',
+                'data': {'id': requested_id, 'trust_state': 'quarantined'},
+            },
+        )
+    if (
+        auth.has_dedicated_driver_token(requested_id)
+        and not auth.verify_driver_token(presented_token, requested_id)
+    ):
+        return fastapi.responses.JSONResponse(
+            status_code=401,
+            content={
+                'code': 401,
+                'message': 'Dedicated Driver credential required for this stable MCP id',
+                'data': {'id': requested_id, 'trust_state': 'quarantined'},
+            },
+        )
+    trusted = auth.verify_driver_token(presented_token, requested_id)
+    credential_binding = (
+        auth.driver_credential_binding(requested_id) if trusted else ''
+    )
+    trust_state = (
+        'trusted' if trusted
+        else 'quarantined' if auth.is_driver_auth_enforced()
+        else 'untrusted'
+    )
+
+    requested_robot_id = req.robot_id.strip()
+    if trusted and not requested_id:
+        raise fastapi.HTTPException(
+            status_code=422,
+            detail='trusted driver registration requires a stable MCP id',
+        )
+    if requested_id and trusted and not _MCP_ID_RE.fullmatch(requested_id):
+        raise fastapi.HTTPException(status_code=422, detail='invalid MCP id')
+    if requested_robot_id and trusted and not _MCP_ID_RE.fullmatch(requested_robot_id):
+        raise fastapi.HTTPException(status_code=422, detail='invalid robot id')
+
     async with _mcp_write_lock:
         mcps = _get_mcp_list()
-        # Upsert: match by URL, name, or server_name (prevents duplicate device bundles)
-        existing = next(
-            (m for m in mcps if (m.get('url') == req.url and req.url)
-             or (m.get('name') == req.name and req.name)
-             or (m.get('server_name') and m.get('server_name') == req.name)),
+        internal_collision = next(
+            (
+                m for m in mcps
+                if m.get('transport') == 'internal'
+                and (
+                    (requested_id and m.get('id') == requested_id)
+                    or (req.url and m.get('url') == req.url)
+                    or (req.name and m.get('name') == req.name)
+                    or (req.name and m.get('server_name') == req.name)
+                )
+            ),
             None,
         )
+        if requested_id in _RESERVED_INTERNAL_MCP_IDS or internal_collision:
+            conflict_id = (
+                internal_collision.get('id', '')
+                if internal_collision else requested_id
+            )
+            return fastapi.responses.JSONResponse(
+                status_code=409,
+                content={
+                    'code': 409,
+                    'message': 'MCP identity is reserved for an internal service',
+                    'data': {'id': conflict_id, 'trust_state': 'internal'},
+                },
+            )
+
+        # A trusted service's stable configured id is its authority key.  Name,
+        # URL, and initialize.serverInfo.name are descriptive and may be shared
+        # by multiple robots, so they must never merge two trusted identities.
+        if trusted and requested_id:
+            existing = next((m for m in mcps if m.get('id') == requested_id), None)
+        else:
+            # Preserve legacy upsert behavior only for callers without a stable
+            # trusted identity.  Any collision with a trusted record is rejected
+            # below before the record can be mutated.
+            existing = next(
+                (m for m in mcps if (m.get('url') == req.url and req.url)
+                 or (m.get('name') == req.name and req.name)
+                 or (m.get('server_name') and m.get('server_name') == req.name)),
+                None,
+            )
+
+        if existing and existing.get('trust_state') == 'trusted' and not trusted:
+            return fastapi.responses.JSONResponse(
+                status_code=403,
+                content={
+                    'code': 403,
+                    'message': 'Untrusted registration cannot replace a trusted service',
+                    'data': {'id': existing.get('id', ''), 'trust_state': 'trusted'},
+                },
+            )
+
+        if (
+            trusted
+            and existing
+            and existing.get('trust_state') == 'trusted'
+            and existing.get('url')
+            and req.url != existing.get('url')
+        ):
+            return fastapi.responses.JSONResponse(
+                status_code=409,
+                content={
+                    'code': 409,
+                    'message': 'Trusted Driver target URL is owner-controlled',
+                    'data': {'id': existing.get('id', '')},
+                },
+            )
+
+        expected_reported_robot_id = (
+            existing.get('authority_domain')
+            or existing.get('reported_robot_id')
+            if existing else ''
+        )
+        if trusted and expected_reported_robot_id and not requested_robot_id:
+            return fastapi.responses.JSONResponse(
+                status_code=409,
+                content={
+                    'code': 409,
+                    'message': 'Trusted Driver registration must echo its robot identity',
+                    'data': {'id': existing.get('id', '')},
+                },
+            )
+
+        existing_robot_id = existing.get('reported_robot_id', '') if existing else ''
+        if (
+            trusted
+            and requested_robot_id
+            and existing_robot_id
+            and existing_robot_id != requested_robot_id
+        ):
+            return fastapi.responses.JSONResponse(
+                status_code=409,
+                content={
+                    'code': 409,
+                    'message': 'Trusted Driver-reported robot identity is immutable',
+                    'data': {
+                        'id': existing.get('id', ''),
+                        'robot_id': existing_robot_id,
+                    },
+                },
+            )
+        if (
+            trusted
+            and requested_robot_id
+            and existing
+            and existing.get('authority_domain')
+            and existing.get('authority_domain') != requested_robot_id
+        ):
+            return fastapi.responses.JSONResponse(
+                status_code=409,
+                content={
+                    'code': 409,
+                    'message': 'Driver-reported robot identity conflicts with owner binding',
+                    'data': {
+                        'id': existing.get('id', ''),
+                        'authority_domain': existing.get('authority_domain'),
+                    },
+                },
+            )
+
         if existing:
-            existing['name']        = req.name
-            existing['transport']   = req.transport
-            existing['url']         = req.url
-            existing['render_hint'] = req.render_hint
+            prospective = dict(existing)
+            prospective['name'] = req.name
+            prospective['transport'] = req.transport
+            prospective['url'] = req.url
+            prospective['render_hint'] = req.render_hint
+            if trusted:
+                prospective['trust_state'] = 'trusted'
+                if credential_binding:
+                    prospective['credential_binding'] = credential_binding
+                else:
+                    prospective.pop('credential_binding', None)
+            else:
+                prospective['trust_state'] = trust_state
             if req.category:
-                existing['category'] = req.category
+                prospective['category'] = req.category
+            if trusted and requested_robot_id:
+                prospective['reported_robot_id'] = requested_robot_id
+            proposed_mcps = [
+                prospective if target is existing else target
+                for target in mcps
+            ]
+            mutation_error = await _project_target_mutation_error(
+                mcps,
+                proposed_mcps,
+            )
+            if mutation_error is not None:
+                return _project_target_locked_response(mutation_error)
+            if trusted and not credential_binding:
+                existing.pop('credential_binding', None)
+            existing.update(prospective)
             _save_mcp_list(mcps)
             mcp_id = existing['id']
         else:
-            mcp_id = f'mcp-{int(time.time())}'
-            mcps.append({
+            mcp_id = requested_id if trusted and requested_id else f'mcp-{uuid.uuid4().hex[:12]}'
+            record = {
                 'id':          mcp_id,
                 'name':        req.name,
                 'transport':   req.transport,
                 'url':         req.url,
                 'render_hint': req.render_hint,
                 'category':    req.category,
-            })
+                'trust_state': trust_state,
+            }
+            if credential_binding:
+                record['credential_binding'] = credential_binding
+            if trusted and requested_robot_id:
+                record['reported_robot_id'] = requested_robot_id
+            mutation_error = await _project_target_mutation_error(
+                mcps,
+                [*mcps, record],
+            )
+            if mutation_error is not None:
+                return _project_target_locked_response(mutation_error)
+            mcps.append(record)
             _save_mcp_list(mcps)
-    # Auto-ping to discover tools
-    asyncio.create_task(_do_ping(mcp_id))
-    return {'code': 200, 'data': {'id': mcp_id}}
+    if trust_state == 'quarantined':
+        # Discovery-only record: it must not contribute LLM schemas, restored
+        # configuration, or runtime authority.
+        mcp_client.registry.pop(mcp_id, None)
+    else:
+        asyncio.create_task(_do_ping(mcp_id))
+    return {'code': 200, 'data': {'id': mcp_id, 'trust_state': trust_state}}
 
 
 @router.delete('/{mcp_id}')
 async def mcp_delete(mcp_id: str):
-    mcps = [m for m in _get_mcp_list() if m.get('id') != mcp_id]
-    _save_mcp_list(mcps)
+    async with _mcp_write_lock:
+        current = _get_mcp_list()
+        mcps = [m for m in current if m.get('id') != mcp_id]
+        mutation_error = await _project_target_mutation_error(current, mcps)
+        if mutation_error is not None:
+            return _project_target_locked_response(mutation_error)
+        dependants = [
+            m.get('id', '') for m in current
+            if (
+                m.get('authority_domain') == mcp_id
+                or m.get('pending_authority_domain') == mcp_id
+            )
+            and m.get('id') != mcp_id
+        ]
+        if dependants:
+            return fastapi.responses.JSONResponse(
+                status_code=409,
+                content={
+                    'code': 409,
+                    'message': 'MCP is an active authority root',
+                    'data': {'dependants': dependants},
+                },
+            )
+        _save_mcp_list(mcps)
+    mcp_client.registry.pop(mcp_id, None)
     return {'code': 200}
 
 
-async def _restore_saved_configs(mcp_id: str, url: str, tools: list) -> None:
+def _authority_binding_problem(target: dict, root: dict, root_mcp_id: str) -> str | None:
+    if (
+        _effective_trust_state(target) != 'trusted'
+        or _effective_trust_state(root) != 'trusted'
+        or target.get('transport') != 'http'
+        or root.get('transport') != 'http'
+        or target.get('category') != 'driver'
+        or root.get('category') != 'driver'
+    ):
+        return 'binding_requires_trusted_http_drivers'
+    if root.get('authority_domain') not in (None, '', root_mcp_id):
+        return 'authority_root_is_alias'
+    session_tools = [
+        tool for tool in target.get('tools', [])
+        if isinstance(tool, dict) and tool.get('name') == 'teleop_session'
+    ]
+    if len(session_tools) != 1 or not isinstance(session_tools[0].get('x-teleop'), dict):
+        return 'source_missing_teleop_descriptor'
+    ordinary_actuator = any(
+        isinstance(tool, dict)
+        and tool.get('type') == 'actuator'
+        and not _is_reserved_teleop_tool(tool)
+        for tool in root.get('tools', [])
+    )
+    if not ordinary_actuator:
+        return 'root_missing_ordinary_actuator'
+    reported_robot_id = target.get('reported_robot_id')
+    descriptor_robot_id = session_tools[0]['x-teleop'].get('robot_id')
+    if reported_robot_id and reported_robot_id != root_mcp_id:
+        return 'reported_robot_id_mismatch'
+    if descriptor_robot_id != root_mcp_id:
+        return 'descriptor_robot_id_mismatch'
+    return None
+
+
+def _require_binding_owner(request: fastapi.Request) -> auth.Principal:
+    if not auth.is_enabled():
+        raise fastapi.HTTPException(
+            status_code=503,
+            detail='Owner authentication must be configured for authority binding',
+        )
+    return auth.require_role(request, 'owner')
+
+
+async def activate_pending_authority_bindings() -> None:
+    """Freeze validated owner bindings before the application accepts traffic."""
+
+    audit_events = []
+    async with _mcp_write_lock:
+        try:
+            persisted_guards = await asyncio.to_thread(authority_guard.list_guards)
+        except Exception:  # noqa: BLE001 -- leave every pending binding untouched
+            print('[teleop] authority guard store unavailable; pending bindings deferred')
+            return
+        guard_locked_ids = {
+            guarded_id
+            for guard in persisted_guards
+            for guarded_id in (guard.driver_id, guard.robot_id)
+        }
+        mcps = _get_mcp_list()
+        changed = False
+        for target in mcps:
+            if not isinstance(target, dict):
+                continue
+            mcp_id = target.get('id')
+            if not isinstance(mcp_id, str):
+                continue
+            pending = target.get('pending_authority_domain')
+            active = target.get('authority_domain')
+            has_pending = 'pending_authority_domain' in target
+            desired = pending if isinstance(pending, str) else active
+            if not isinstance(desired, str) or not desired:
+                continue
+            old_root = active or mcp_id
+            if has_pending and {mcp_id, old_root, desired} & guard_locked_ids:
+                audit_events.append({
+                    'mcp_id': mcp_id,
+                    'old_root': old_root,
+                    'new_root': desired,
+                    'decision': 'deferred',
+                    'reason': 'persistent_authority_guard_requires_stable_target',
+                })
+                continue
+            changed = True
+            if desired == mcp_id:
+                target.pop('authority_domain', None)
+                target.pop('pending_authority_domain', None)
+                target.pop('authority_binding_error', None)
+                target.pop('authority_binding_required', None)
+                if has_pending:
+                    audit_events.append({
+                        'mcp_id': mcp_id,
+                        'old_root': active or mcp_id,
+                        'new_root': mcp_id,
+                        'decision': 'activated',
+                        'reason': 'owner_unbind_activated',
+                    })
+                continue
+            roots = [
+                root for root in mcps
+                if isinstance(root, dict) and root.get('id') == desired
+            ]
+            problem = (
+                'authority_root_not_unique'
+                if len(roots) != 1
+                else _authority_binding_problem(target, roots[0], desired)
+            )
+            if problem is not None:
+                target.pop('authority_domain', None)
+                target.pop('pending_authority_domain', None)
+                target['authority_binding_required'] = True
+                target['authority_binding_error'] = problem
+                mcp_client.registry.pop(mcp_id, None)
+                if has_pending:
+                    audit_events.append({
+                        'mcp_id': mcp_id,
+                        'old_root': active or mcp_id,
+                        'new_root': desired,
+                        'decision': 'rejected',
+                        'reason': problem,
+                    })
+                continue
+            target['authority_domain'] = desired
+            target['authority_binding_required'] = True
+            target.pop('pending_authority_domain', None)
+            target.pop('authority_binding_error', None)
+            runtime = mcp_client.registry.get(mcp_id)
+            if runtime is not None:
+                runtime['authority_domain'] = desired
+            if has_pending:
+                audit_events.append({
+                    'mcp_id': mcp_id,
+                    'old_root': active or mcp_id,
+                    'new_root': desired,
+                    'decision': 'activated',
+                    'reason': 'owner_binding_activated',
+                })
+        if changed:
+            _save_mcp_list(mcps)
+    for event in audit_events:
+        await audit.emit(
+            'teleop.authority_binding',
+            robot_id=event['new_root'],
+            principal_id='core:startup',
+            source='core',
+            decision=event['decision'],
+            reason=event['reason'],
+            details={
+                'mcp_id': event['mcp_id'],
+                'old_root': event['old_root'],
+                'new_root': event['new_root'],
+            },
+        )
+
+
+@router.put('/{mcp_id}/authority-domain')
+async def mcp_bind_authority_domain(
+    mcp_id: str,
+    req: MCPAuthorityBindingRequest,
+    request: fastapi.Request,
+):
+    """Stage an owner-approved alias for activation on the next Core start."""
+
+    principal = _require_binding_owner(request)
+    root_mcp_id = req.root_mcp_id.strip()
+    if not _MCP_ID_RE.fullmatch(mcp_id) or not _MCP_ID_RE.fullmatch(root_mcp_id):
+        raise fastapi.HTTPException(status_code=422, detail='invalid MCP id')
+    if root_mcp_id == mcp_id:
+        raise fastapi.HTTPException(
+            status_code=422,
+            detail='Use DELETE to remove an authority alias',
+        )
+
+    async with _mcp_write_lock:
+        mcps = _get_mcp_list()
+        targets = [m for m in mcps if m.get('id') == mcp_id]
+        roots = [m for m in mcps if m.get('id') == root_mcp_id]
+        if len(targets) != 1 or len(roots) != 1:
+            raise fastapi.HTTPException(status_code=404, detail='MCP not found')
+        problem = _authority_binding_problem(targets[0], roots[0], root_mcp_id)
+        if problem is not None:
+            await audit.emit(
+                'teleop.authority_binding',
+                robot_id=root_mcp_id,
+                principal_id=principal.id,
+                source='api',
+                decision='rejected',
+                reason=problem,
+                details={'mcp_id': mcp_id, 'new_root': root_mcp_id},
+            )
+            raise fastapi.HTTPException(
+                status_code=409,
+                detail={'code': 'authority_binding_invalid', 'reason': problem},
+            )
+        old_root = targets[0].get('authority_domain') or mcp_id
+        prospective = dict(targets[0])
+        prospective['pending_authority_domain'] = root_mcp_id
+        proposed_mcps = [
+            prospective if target is targets[0] else target
+            for target in mcps
+        ]
+        mutation_error = await _project_target_mutation_error(mcps, proposed_mcps)
+        if mutation_error is not None:
+            return _project_target_locked_response(mutation_error)
+        targets[0]['pending_authority_domain'] = root_mcp_id
+        _save_mcp_list(mcps)
+
+    await audit.emit(
+        'teleop.authority_binding',
+        robot_id=root_mcp_id,
+        principal_id=principal.id,
+        source='api',
+        decision='staged',
+        reason='owner_binding_staged',
+        details={
+            'mcp_id': mcp_id,
+            'old_root': old_root,
+            'new_root': root_mcp_id,
+            'restart_required': True,
+        },
+    )
+
+    return fastapi.responses.JSONResponse(
+        status_code=202,
+        content={
+            'code': 202,
+            'data': {
+                'mcp_id': mcp_id,
+                'authority_domain': root_mcp_id,
+                'restart_required': True,
+            },
+        },
+    )
+
+
+@router.delete('/{mcp_id}/authority-domain')
+async def mcp_unbind_authority_domain(
+    mcp_id: str,
+    request: fastapi.Request,
+):
+    """Stage removal of an authority alias for the next Core start."""
+
+    principal = _require_binding_owner(request)
+    async with _mcp_write_lock:
+        mcps = _get_mcp_list()
+        targets = [m for m in mcps if m.get('id') == mcp_id]
+        if len(targets) != 1:
+            raise fastapi.HTTPException(status_code=404, detail='MCP not found')
+        old_root = targets[0].get('authority_domain') or mcp_id
+        prospective = dict(targets[0])
+        prospective['pending_authority_domain'] = mcp_id
+        proposed_mcps = [
+            prospective if target is targets[0] else target
+            for target in mcps
+        ]
+        mutation_error = await _project_target_mutation_error(mcps, proposed_mcps)
+        if mutation_error is not None:
+            return _project_target_locked_response(mutation_error)
+        targets[0]['pending_authority_domain'] = mcp_id
+        _save_mcp_list(mcps)
+    await audit.emit(
+        'teleop.authority_binding',
+        robot_id=old_root,
+        principal_id=principal.id,
+        source='api',
+        decision='staged',
+        reason='owner_unbind_staged',
+        details={
+            'mcp_id': mcp_id,
+            'old_root': old_root,
+            'new_root': mcp_id,
+            'restart_required': True,
+        },
+    )
+    return fastapi.responses.JSONResponse(
+        status_code=202,
+        content={
+            'code': 202,
+            'data': {
+                'mcp_id': mcp_id,
+                'authority_domain': mcp_id,
+                'restart_required': True,
+            },
+        },
+    )
+
+
+async def _restore_saved_configs(
+    mcp_id: str,
+    url: str,
+    tools: list,
+    *,
+    trusted: bool = False,
+    authority_domain: str | None = None,
+    target_fingerprint: tuple | None = None,
+    ping_generation: int | None = None,
+) -> None:
     """Re-send saved tool configs to a device that just came online.
 
     Only sends shared (non-instance) configs for tools that have configSchema.
     Called once when a device transitions from offline → online.
     """
     headers = {'Content-Type': 'application/json'}
+    if trusted:
+        driver_headers = auth.driver_request_headers(mcp_id)
+        if not driver_headers:
+            return
+        headers.update(driver_headers)
     timeout = aiohttp.ClientTimeout(total=5)
     sent = []
+    from teleop.service import coordinator
+
+    def current_target() -> dict | None:
+        records = _get_mcp_list()
+        targets = [record for record in records if record.get('id') == mcp_id]
+        if len(targets) != 1:
+            return None
+        current = targets[0]
+        if (
+            (
+                ping_generation is not None
+                and _ping_generations.get(mcp_id) != ping_generation
+            )
+            or current.get('url', '') != url
+            or current.get('transport', 'http') != 'http'
+            or not _runtime_registration_allowed(current)
+            or (
+                target_fingerprint is not None
+                and _ping_target_fingerprint(current) != target_fingerprint
+            )
+        ):
+            return None
+        return current
+
+    def current_configurable_tool(target: dict, tool_name: str) -> dict | None:
+        matches = [
+            tool
+            for tool in (target.get('tools') or [])
+            if isinstance(tool, dict) and tool.get('name') == tool_name
+        ]
+        if len(matches) != 1:
+            return None
+        tool = matches[0]
+        config_schema = tool.get('configSchema')
+        if _is_reserved_teleop_tool(tool) or not (
+            isinstance(config_schema, dict) and config_schema
+        ):
+            return None
+        return tool
+
+    initial_target = current_target()
+    if initial_target is None:
+        return
+    if target_fingerprint is None:
+        target_fingerprint = _ping_target_fingerprint(initial_target)
+    if authority_domain is None:
+        records = _get_mcp_list()
+        try:
+            authority_domain = authority_domain_for_target(
+                mcp_id,
+                initial_target,
+                targets=records,
+            )
+        except InvalidAuthorityBinding:
+            return
 
     try:
         async with aiohttp.ClientSession(timeout=timeout) as session:
-            for tool in tools:
-                if not isinstance(tool, dict):
+            seen_tool_names = set()
+            for discovered_tool in tools:
+                if not isinstance(discovered_tool, dict):
                     continue
-                tool_name = tool.get('name', '')
-                if not tool.get('configSchema'):
+                if _is_reserved_teleop_tool(discovered_tool):
                     continue
-                saved_cfg = config.main.get(f'tool_config:{mcp_id}:{tool_name}', None)
+                tool_name = discovered_tool.get('name', '')
+                if not isinstance(tool_name, str) or not tool_name:
+                    continue
+                if tool_name in seen_tool_names:
+                    continue
+                seen_tool_names.add(tool_name)
+                target_snapshot = current_target()
+                if target_snapshot is None:
+                    return
+                tool = current_configurable_tool(target_snapshot, tool_name)
+                if tool is None:
+                    continue
+                saved_cfg = _safe_saved_config(
+                    config.main.get(f'tool_config:{mcp_id}:{tool_name}', None)
+                )
                 if not saved_cfg:
                     continue
                 cfg_payload = {
                     'jsonrpc': '2.0', 'id': 99,
                     'method': 'tools/call',
-                    'params': {'name': tool_name, 'arguments': {'action': 'config', **saved_cfg}},
+                    'params': {
+                        'name': tool_name,
+                        'arguments': {**saved_cfg, 'action': 'config'},
+                    },
                 }
-                await session.post(url, json=cfg_payload, headers=headers)
+                access = _descriptor_tool_access(tool, cfg_payload['params']['arguments'])
+                try:
+                    async with coordinator.command_broker.ordinary_command(
+                        authority_domain,
+                        read_only=access.read_only,
+                        source='config_restore',
+                        tool=tool_name,
+                        action='config',
+                        tool_verified=True,
+                        action_verified=_descriptor_action_declared(
+                            tool,
+                            cfg_payload['params']['arguments'],
+                        ),
+                    ):
+                        latest_target = current_target()
+                        if latest_target is None:
+                            return
+                        latest_tool = current_configurable_tool(
+                            latest_target,
+                            tool_name,
+                        )
+                        if latest_tool is None:
+                            continue
+                        try:
+                            latest_authority = authority_domain_for_target(
+                                mcp_id,
+                                latest_target,
+                                targets=_get_mcp_list(),
+                            )
+                        except InvalidAuthorityBinding:
+                            return
+                        if latest_authority != authority_domain:
+                            return
+                        latest_access = _descriptor_tool_access(
+                            latest_tool,
+                            cfg_payload['params']['arguments'],
+                        )
+                        if latest_access.read_only != access.read_only:
+                            continue
+                        await session.post(
+                            url,
+                            json=cfg_payload,
+                            headers=headers,
+                            allow_redirects=False,
+                        )
+                except TeleopCommandBlocked:
+                    continue
                 sent.append(tool_name)
     except Exception as e:
         print(f'[mcp/config-restore] {mcp_id} error: {e}')
@@ -395,6 +1364,34 @@ async def _do_ping(mcp_id: str) -> dict:
     target = next((m for m in mcps if m.get('id') == mcp_id), None)
     if not target:
         raise fastapi.HTTPException(status_code=404, detail='MCP not found')
+
+    if not _runtime_registration_allowed(target):
+        mcp_client.registry.pop(mcp_id, None)
+        return {
+            'online': False,
+            'error': 'registration quarantined: valid Driver credential required',
+            'tools': [],
+            'resources': [],
+            'render_hint': target.get('render_hint', ''),
+            'server_name': target.get('server_name', ''),
+            'topic_out': [],
+            'topic_in': [],
+        }
+
+    try:
+        authority_domain = authority_domain_for_target(
+            mcp_id,
+            target,
+            targets=mcps,
+        )
+    except InvalidAuthorityBinding:
+        mcp_client.registry.pop(mcp_id, None)
+        return {
+            'online': False,
+            'error': 'authority_binding_invalid',
+            'tools': [],
+            'resources': [],
+        }
 
     transport = target.get('transport', 'http')
     url       = target.get('url', '')
@@ -416,25 +1413,57 @@ async def _do_ping(mcp_id: str) -> dict:
             'topic_in':    target.get('topic_in', []),
         }
 
+    target_fingerprint = _ping_target_fingerprint(target)
+    ping_generation = _ping_generations.get(mcp_id, 0) + 1
+    _ping_generations[mcp_id] = ping_generation
+
     # 记录 ping 前的 online 状态，用于判断是否需要重新下发 config
     was_online = mcp_client.registry.get(mcp_id, {}).get('online', False)
 
     try:
-        caps = await _ping_mcp_http(url)
+        caps = await _ping_mcp_http(
+            url,
+            trusted=_effective_trust_state(target) == 'trusted',
+            driver_id=mcp_id,
+        )
     except Exception as e:
-        # 标记 registry 中该设备离线
-        if mcp_id in mcp_client.registry:
-            mcp_client.registry[mcp_id]['online'] = False
-        # Dedup: if this offline MCP has same server_name as another entry, remove it
+        # Legacy duplicate cleanup is intentionally limited to two untrusted
+        # identities.  A descriptive server_name must never merge or delete a
+        # stable trusted identity, even while it is offline.
         async with _mcp_write_lock:
             mcps = _get_mcp_list()
             this_entry = next((m for m in mcps if m.get('id') == mcp_id), None)
-            if this_entry and this_entry.get('server_name'):
-                dup = next((m for m in mcps if m.get('server_name') == this_entry['server_name'] and m.get('id') != mcp_id), None)
+            if (
+                _ping_generations.get(mcp_id) != ping_generation
+                or this_entry is None
+                or _ping_target_fingerprint(this_entry) != target_fingerprint
+            ):
+                return _stale_ping_result(mcp_id)
+            if mcp_id in mcp_client.registry:
+                mcp_client.registry[mcp_id]['online'] = False
+            if (
+                this_entry
+                and this_entry.get('server_name')
+                and _effective_trust_state(this_entry) != 'trusted'
+            ):
+                dup = next(
+                    (m for m in mcps if m.get('server_name') == this_entry['server_name'] and m.get('id') != mcp_id),
+                    None,
+                )
                 if dup:
-                    mcps = [m for m in mcps if m.get('id') != mcp_id]
-                    _save_mcp_list(mcps)
-                    print(f'[mcp/ping] dedup: removed offline {mcp_id} (same server_name as {dup["id"]})')
+                    proposed_mcps = [
+                        m for m in mcps if m.get('id') != mcp_id
+                    ]
+                    mutation_error = await _project_target_mutation_error(
+                        mcps,
+                        proposed_mcps,
+                    )
+                    if mutation_error is None:
+                        _save_mcp_list(proposed_mcps)
+                        print(
+                            f'[mcp/ping] dedup: removed offline {mcp_id} '
+                            '(same legacy server_name)'
+                        )
         return {'online': False, 'error': str(e), 'tools': [], 'resources': []}
 
     # render_hint priority:
@@ -464,36 +1493,149 @@ async def _do_ping(mcp_id: str) -> dict:
             if not t.get('topic'):
                 t['topic'] = upstream_topic
 
-    # Log only when tools change (first ping or tool list updated)
+    # Prepare change logging only after the target snapshot is revalidated.
     current_tool_names = [t.get('name', '') if isinstance(t, dict) else t for t in caps['tools']]
-    prev_tool_names = _last_tool_names.get(mcp_id)
-    if prev_tool_names != current_tool_names:
-        _last_tool_names[mcp_id] = current_tool_names
-        print(f'[mcp/ping] {mcp_id}: server={caps.get("server_name", "?")} tools={current_tool_names}')
 
-    # Persist on every successful ping; server_name only set once (not overwritten)
-    # Also deduplicate: if another MCP with the same server_name exists, remove this one (keep the earlier entry)
+    # Persist on every successful ping; server_name only set once (not overwritten).
+    # server_name is never an authority key for trusted services.  Legacy
+    # untrusted registrations retain historical same-name de-duplication.
     async with _mcp_write_lock:
         mcps = _get_mcp_list()  # re-read under lock to avoid race condition
         new_server_name = caps.get('server_name', '')
+        current = next((m for m in mcps if m.get('id') == mcp_id), None)
+        if (
+            _ping_generations.get(mcp_id) != ping_generation
+            or current is None
+            or _ping_target_fingerprint(current) != target_fingerprint
+        ):
+            return _stale_ping_result(mcp_id)
+        published_target = dict(current)
 
-        # Check for duplicate server_name — keep the first registered entry, remove this one
-        if new_server_name:
-            existing_with_same_name = next(
-                (m for m in mcps if m.get('server_name') == new_server_name and m.get('id') != mcp_id),
+        proposed_capabilities = []
+        for record in mcps:
+            if record is current:
+                updated = dict(record)
+                updated['tools'] = caps['tools']
+                updated.pop('capability_refresh_required', None)
+                proposed_capabilities.append(updated)
+            else:
+                proposed_capabilities.append(record)
+        mutation_error = await _project_target_mutation_error(
+            mcps,
+            proposed_capabilities,
+        )
+        if mutation_error is not None:
+            return _project_target_locked_ping_result(
+                mcp_id,
+                current,
+                mutation_error,
+            )
+
+        internal_collision = next(
+            (
+                m for m in mcps
+                if m.get('transport') == 'internal'
+                and m.get('server_name') == new_server_name
+                and m.get('id') != mcp_id
+            ),
+            None,
+        ) if new_server_name else None
+        if current and current.get('transport') != 'internal' and internal_collision:
+            proposed_mcps = [m for m in mcps if m.get('id') != mcp_id]
+            mutation_error = await _project_target_mutation_error(
+                mcps,
+                proposed_mcps,
+            )
+            if mutation_error is not None:
+                return _project_target_locked_ping_result(
+                    mcp_id,
+                    current,
+                    mutation_error,
+                )
+            _save_mcp_list(proposed_mcps)
+            mcp_client.registry.pop(mcp_id, None)
+            print(f'[mcp/ping] rejected external duplicate {mcp_id} of internal {internal_collision["id"]}')
+            return {
+                'online': False,
+                'error': 'external duplicate of internal service',
+                'tools': [],
+                'resources': [],
+                'render_hint': '',
+                'server_name': new_server_name,
+                'topic_out': [],
+                'topic_in': [],
+            }
+
+        if new_server_name and current and _effective_trust_state(current) != 'trusted':
+            same_name = [
+                m for m in mcps
+                if m.get('server_name') == new_server_name and m.get('id') != mcp_id
+            ]
+            trusted_collision = next(
+                (m for m in same_name if _effective_trust_state(m) == 'trusted'),
                 None,
             )
-            if existing_with_same_name:
-                # This is a duplicate — remove current entry, update existing one's URL
-                target = next((m for m in mcps if m.get('id') == mcp_id), None)
-                if target:
-                    existing_with_same_name['url'] = target.get('url', existing_with_same_name.get('url', ''))
-                    mcps = [m for m in mcps if m.get('id') != mcp_id]
-                    print(f'[mcp/ping] dedup: removed {mcp_id}, merged into {existing_with_same_name["id"]} (server_name={new_server_name})')
-                    _save_mcp_list(mcps)
-                    return {'online': True, 'tools': caps['tools'], 'resources': caps['resources'],
-                            'render_hint': render_hint, 'server_name': new_server_name,
-                            'topic_out': topic_out, 'topic_in': topic_in}
+            if trusted_collision:
+                proposed_mcps = [m for m in mcps if m.get('id') != mcp_id]
+                mutation_error = await _project_target_mutation_error(
+                    mcps,
+                    proposed_mcps,
+                )
+                if mutation_error is not None:
+                    return _project_target_locked_ping_result(
+                        mcp_id,
+                        current,
+                        mutation_error,
+                    )
+                # A legacy endpoint spoofing a trusted server name loses without
+                # touching that trusted record or its runtime identity.
+                _save_mcp_list(proposed_mcps)
+                mcp_client.registry.pop(mcp_id, None)
+                print(f'[mcp/ping] rejected untrusted duplicate {mcp_id} of trusted {trusted_collision["id"]}')
+                return {
+                    'online': False,
+                    'error': 'untrusted duplicate of trusted service',
+                    'tools': [],
+                    'resources': [],
+                    'render_hint': '',
+                    'server_name': new_server_name,
+                    'topic_out': [],
+                    'topic_in': [],
+                }
+
+            legacy_duplicate = next(
+                (m for m in same_name if _effective_trust_state(m) != 'trusted'),
+                None,
+            )
+            if legacy_duplicate:
+                proposed_mcps = []
+                for record in mcps:
+                    if record is current:
+                        continue
+                    if record is legacy_duplicate:
+                        updated_duplicate = dict(record)
+                        updated_duplicate['url'] = current.get(
+                            'url',
+                            record.get('url', ''),
+                        )
+                        proposed_mcps.append(updated_duplicate)
+                    else:
+                        proposed_mcps.append(record)
+                mutation_error = await _project_target_mutation_error(
+                    mcps,
+                    proposed_mcps,
+                )
+                if mutation_error is not None:
+                    return _project_target_locked_ping_result(
+                        mcp_id,
+                        current,
+                        mutation_error,
+                    )
+                print(f'[mcp/ping] dedup: removed {mcp_id}, merged into {legacy_duplicate["id"]} (server_name={new_server_name})')
+                _save_mcp_list(proposed_mcps)
+                return {'online': True, 'tools': caps['tools'], 'resources': caps['resources'],
+                        'render_hint': render_hint, 'server_name': new_server_name,
+                        'topic_out': topic_out, 'topic_in': topic_in}
 
         for m in mcps:
             if m.get('id') == mcp_id:
@@ -502,17 +1644,25 @@ async def _do_ping(mcp_id: str) -> dict:
                 m['resources']   = caps['resources']
                 m['topic_out']   = topic_out
                 m['topic_in']    = topic_in
+                m.pop('capability_refresh_required', None)
                 if not m.get('server_name'):
                     m['server_name'] = new_server_name
+                published_target = dict(m)
                 break
         _save_mcp_list(mcps)
+
+    prev_tool_names = _last_tool_names.get(mcp_id)
+    if prev_tool_names != current_tool_names:
+        _last_tool_names[mcp_id] = current_tool_names
+        print(f'[mcp/ping] {mcp_id}: server={caps.get("server_name", "?")} tools={current_tool_names}')
 
     # 同步更新内存中的 mcp_client.registry（LLM 决策依赖此数据）
     schemas = {}
     tool_meta_map = {}
     split_map = {}
     tool_groups = {}
-    for tool in caps['tools']:
+    ordinary_tools = _ordinary_tools(caps['tools'])
+    for tool in ordinary_tools:
         tool_schemas = mcp_client._to_openai_schema(mcp_id, tool)
 
         if len(tool_schemas) == 1:
@@ -525,6 +1675,8 @@ async def _do_ping(mcp_id: str) -> dict:
                 'action_enum': action_enum,
                 'has_config_schema': bool(tool.get('configSchema')),
                 'completion': raw_input_schema.get('x-completion'),
+                'annotations': tool.get('annotations') or {},
+                'x_teleop': tool.get('x-teleop'),
             }
         else:
             group = []
@@ -535,6 +1687,8 @@ async def _do_ping(mcp_id: str) -> dict:
                     'action_enum': None,
                     'has_config_schema': bool(tool.get('configSchema')),
                     'completion': (tool.get('inputSchema') or {}).get('x-completion'),
+                    'annotations': tool.get('annotations') or {},
+                    'x_teleop': tool.get('x-teleop'),
                 }
                 action_name = schema['name'].split('__')[-1]
                 split_map[schema['name']] = {
@@ -547,15 +1701,18 @@ async def _do_ping(mcp_id: str) -> dict:
                 tool_groups[tool_name] = group
 
     mcp_client.registry[mcp_id] = {
-        'name':        target.get('name', mcp_id),
+        'name':        published_target.get('name', mcp_id),
         'url':         url,
         'online':      True,
-        'tools':       [t.get('name', '') if isinstance(t, dict) else t for t in caps['tools']],
+        'tools':       [t.get('name', '') if isinstance(t, dict) else t for t in ordinary_tools],
         'render_hint': render_hint,
         'schemas':     schemas,
         'tool_meta':   tool_meta_map,
         'split_map':   split_map,
         'tool_groups': tool_groups,
+        'trusted':     _effective_trust_state(published_target) == 'trusted',
+        'authority_domain': authority_domain,
+        'teleop_fingerprint': mcp_client.teleop_tools_fingerprint(caps['tools']),
     }
 
     # Register system hooks from x-hooks declarations
@@ -570,7 +1727,15 @@ async def _do_ping(mcp_id: str) -> dict:
 
     # Auto-restore saved configs when device comes online (first ping or after offline)
     if not was_online:
-        asyncio.create_task(_restore_saved_configs(mcp_id, url, caps['tools']))
+        asyncio.create_task(_restore_saved_configs(
+            mcp_id,
+            url,
+            ordinary_tools,
+            trusted=_effective_trust_state(published_target) == 'trusted',
+            authority_domain=authority_domain,
+            target_fingerprint=_ping_target_fingerprint(published_target),
+            ping_generation=ping_generation,
+        ))
 
     ws_path = ('/ws/bus' + topic_out[0].get('topic', '')) if topic_out else ''
     return {
@@ -599,11 +1764,14 @@ async def mcp_get_tools(mcp_id: str):
     if not target:
         raise fastapi.HTTPException(status_code=404, detail='MCP not found')
 
+    if not _runtime_registration_allowed(target):
+        return {'code': 200, 'data': _ordinary_tools(target.get('tools', []))}
+
     url = target.get('url', '')
     if not url or target.get('transport', 'http') != 'http':
-        return {'code': 200, 'data': target.get('tools', [])}
+        return {'code': 200, 'data': _ordinary_tools(target.get('tools', []))}
 
-    headers = {'Content-Type': 'application/json'}
+    headers = _outbound_headers(target)
     timeout = aiohttp.ClientTimeout(total=5)
     try:
         async with aiohttp.ClientSession(timeout=timeout) as session:
@@ -614,14 +1782,54 @@ async def mcp_get_tools(mcp_id: str):
                     'clientInfo': {'name': 'phanthy-motus', 'version': '1.0'},
                 }
             }
-            await session.post(url, json=init_payload, headers=headers)
+            async with session.post(
+                url,
+                json=init_payload,
+                headers=headers,
+                allow_redirects=False,
+            ) as resp:
+                init_data = await resp.json(content_type=None)
+                init_error = _rpc_response_error(
+                    init_data,
+                    request_id=1,
+                    http_status=resp.status,
+                )
+                if init_error:
+                    return {'code': 502, 'message': init_error, 'data': None}
+                if not isinstance(init_data.get('result'), dict):
+                    return {
+                        'code': 502,
+                        'message': 'Driver returned an invalid initialize result',
+                        'data': None,
+                    }
             tools_payload = {'jsonrpc': '2.0', 'id': 2, 'method': 'tools/list', 'params': {}}
-            async with session.post(url, json=tools_payload, headers=headers) as resp:
+            async with session.post(
+                url,
+                json=tools_payload,
+                headers=headers,
+                allow_redirects=False,
+            ) as resp:
                 data = await resp.json(content_type=None)
-                tools = data.get('result', {}).get('tools', [])
-        return {'code': 200, 'data': tools}
+                tools_error = _rpc_response_error(
+                    data,
+                    request_id=2,
+                    http_status=resp.status,
+                )
+                if tools_error:
+                    return {'code': 502, 'message': tools_error, 'data': None}
+                result = data['result']
+                tools = result.get('tools') if isinstance(result, dict) else None
+                if not isinstance(tools, list) or any(
+                    not isinstance(tool, dict) for tool in tools
+                ):
+                    return {
+                        'code': 502,
+                        'message': 'Driver returned an invalid tools/list result',
+                        'data': None,
+                    }
+        return {'code': 200, 'data': _ordinary_tools(tools)}
     except Exception:
-        return {'code': 200, 'data': target.get('tools', [])}
+        return {'code': 200, 'data': _ordinary_tools(target.get('tools', []))}
 
 
 class MCPCallRequest(BaseModel):
@@ -643,10 +1851,12 @@ async def _handle_agentcore_call(req: MCPCallRequest):
 
     if action == 'start':
         # Auto-apply saved config before start (same pattern as HTTP MCPs)
-        saved_cfg = config.main.get(f'tool_config:agentcore:{req.tool}', None)
+        saved_cfg = _safe_saved_config(
+            config.main.get(f'tool_config:agentcore:{req.tool}', None)
+        )
         if saved_cfg:
             await _handle_agentcore_call(MCPCallRequest(
-                tool=req.tool, arguments={'action': 'config', **saved_cfg}
+                tool=req.tool, arguments={**saved_cfg, 'action': 'config'}
             ))
 
         # Subscribe to requested topics (additive — cleanup is done by prior 'stop' call)
@@ -660,7 +1870,13 @@ async def _handle_agentcore_call(req: MCPCallRequest):
             config.main['event'] = event_cfg
             for t in all_topics:
                 topic_subscriber.subscribe(t)
-        return {'code': 200, 'data': f'subscribed to {all_topics}' if all_topics else 'started'}
+        return {
+            'code': 200,
+            'data': {
+                'state': 'running',
+                'subscribed_topics': all_topics,
+            },
+        }
 
     elif action == 'stop':
         event_cfg = config.main.get('event', {})
@@ -674,14 +1890,26 @@ async def _handle_agentcore_call(req: MCPCallRequest):
                 topic_subscriber.unsubscribe(t)
             event_cfg['subscribe_topics'] = topics
             config.main['event'] = event_cfg
-            return {'code': 200, 'data': f'unsubscribed from {all_topics}'}
+            return {
+                'code': 200,
+                'data': {
+                    'state': 'idle',
+                    'unsubscribed_topics': all_topics,
+                },
+            }
         else:
             # 未指定 topic：退订全部（项目停止时的清理）
             for t in list(topics):
                 topic_subscriber.unsubscribe(t)
             event_cfg['subscribe_topics'] = []
             config.main['event'] = event_cfg
-            return {'code': 200, 'data': 'unsubscribed all topics'}
+            return {
+                'code': 200,
+                'data': {
+                    'state': 'idle',
+                    'unsubscribed_topics': list(topics),
+                },
+            }
 
     elif action == 'info':
         event_cfg = config.main.get('event', {})
@@ -697,18 +1925,28 @@ async def _handle_agentcore_call(req: MCPCallRequest):
         }}
 
     elif action == 'config':
-        # Save LLM config to client.llm (list format used by client/llm.py)
+        changes = {}
+        candidate_llm = None
+        client_mod = None
+
+        # Stage and validate the LLM runtime before any durable write.
         llm_url = req.arguments.get('llm_url', '')
         llm_key = req.arguments.get('llm_key', '')
         llm_model = req.arguments.get('llm_model', '')
         think_mode = req.arguments.get('think_mode', False)
         if llm_url and llm_key:
             client_cfg = config.main.get('client', {})
-            client_cfg['llm'] = [{'url': llm_url, 'key': llm_key, 'model': llm_model, 'think_mode': think_mode}]
-            config.main['client'] = client_cfg
-            # Reinitialize the LLM client with new config
+            client_cfg['llm'] = [{
+                'url': llm_url,
+                'key': llm_key,
+                'model': llm_model,
+                'think_mode': think_mode,
+            }]
             import client as client_mod
-            client_mod.llm = client_mod.llm.__class__()
+
+            candidate_llm = client_mod.llm.__class__(configs=client_cfg['llm'])
+            changes['client'] = client_cfg
+
         # Save trigger_interval_ms to event.llm config
         trigger_interval = req.arguments.get('trigger_interval_ms')
         if trigger_interval is not None:
@@ -716,7 +1954,8 @@ async def _handle_agentcore_call(req: MCPCallRequest):
             llm_cfg = event_cfg.get('llm', {})
             llm_cfg['trigger_interval_ms'] = int(trigger_interval)
             event_cfg['llm'] = llm_cfg
-            config.main['event'] = event_cfg
+            changes['event'] = event_cfg
+
         # Save search config to desktop_tools.search
         search_type = req.arguments.get('search_type')
         if search_type is not None:
@@ -730,8 +1969,18 @@ async def _handle_agentcore_call(req: MCPCallRequest):
             if search_key and search_key != '****':
                 search_cfg['api_key'] = search_key
             dt['search'] = search_cfg
-            config.main['desktop_tools'] = dt
-        return {'code': 200, 'data': 'config saved'}
+            changes['desktop_tools'] = dt
+
+        try:
+            if changes:
+                config.main.set_many(changes)
+        except Exception:
+            if candidate_llm is not None:
+                await candidate_llm.aclose()
+            raise
+        if candidate_llm is not None and client_mod is not None:
+            client_mod.llm = candidate_llm
+        return {'code': 200, 'data': {'configured': True}}
 
     return {'code': 200, 'data': None}
 
@@ -879,12 +2128,70 @@ async def mcp_call_tool(mcp_id: str, req: MCPCallRequest):
     if not target:
         raise fastapi.HTTPException(status_code=404, detail='MCP not found')
 
+    if not _runtime_registration_allowed(target):
+        raise fastapi.HTTPException(status_code=403, detail='MCP registration is quarantined')
+
+    if req.tool == 'teleop_session':
+        raise fastapi.HTTPException(
+            status_code=403,
+            detail='Teleop tools are reserved for the dedicated teleop API',
+        )
+
+    tool_descriptor = next(
+        (
+            tool for tool in target.get('tools', [])
+            if isinstance(tool, dict) and tool.get('name') == req.tool
+        ),
+        None,
+    )
+    if tool_descriptor is None:
+        raise fastapi.HTTPException(status_code=404, detail='MCP tool not found')
+    if _is_reserved_teleop_tool(tool_descriptor):
+        raise fastapi.HTTPException(
+            status_code=403,
+            detail='Teleop tools are reserved for the dedicated teleop API',
+        )
+
     url = target.get('url', '')
     if not url or target.get('transport', 'http') != 'http':
         raise fastapi.HTTPException(status_code=400, detail='MCP not reachable via HTTP')
 
-    headers = {'Content-Type': 'application/json'}
-    timeout = aiohttp.ClientTimeout(total=None)
+    headers = _outbound_headers(target)
+    timeout = aiohttp.ClientTimeout(total=30)
+    access = _descriptor_tool_access(tool_descriptor, req.arguments)
+    action = req.arguments.get('action')
+    from teleop.service import coordinator
+    try:
+        authority_domain = authority_domain_for_target(
+            mcp_id,
+            target,
+            targets=mcps,
+        )
+    except InvalidAuthorityBinding:
+        raise fastapi.HTTPException(
+            status_code=409,
+            detail={
+                'code': 'authority_binding_invalid',
+                'reason': 'core_authority_binding_invalid',
+                'robot_id': mcp_id,
+            },
+        ) from None
+    admission = coordinator.command_broker.ordinary_command(
+        authority_domain,
+        read_only=access.read_only,
+        source='mcp_api',
+        tool=req.tool,
+        action=action if isinstance(action, str) else '',
+        tool_verified=True,
+        action_verified=_descriptor_action_declared(tool_descriptor, req.arguments),
+    )
+    try:
+        await admission.__aenter__()
+    except TeleopCommandBlocked as error:
+        raise fastapi.HTTPException(
+            status_code=409,
+            detail=error.public_detail(),
+        ) from None
     try:
         async with aiohttp.ClientSession(timeout=timeout) as session:
             # Initialize first (required by MCP protocol)
@@ -895,27 +2202,57 @@ async def mcp_call_tool(mcp_id: str, req: MCPCallRequest):
                     'clientInfo': {'name': 'phanthy-motus', 'version': '1.0'},
                 }
             }
-            await session.post(url, json=init_payload, headers=headers)
+            async with session.post(
+                url,
+                json=init_payload,
+                headers=headers,
+                allow_redirects=False,
+            ) as resp:
+                init_data = await resp.json(content_type=None)
+                init_error = _rpc_response_error(
+                    init_data,
+                    request_id=1,
+                    http_status=resp.status,
+                )
+                if init_error:
+                    return {'code': 502, 'message': init_error, 'data': None}
+                if not isinstance(init_data.get('result'), dict):
+                    return {
+                        'code': 502,
+                        'message': 'Driver returned an invalid initialize result',
+                        'data': None,
+                    }
 
             # Auto-config: start 前自动 apply 已保存的 config (shared + instance merged)
             # Also send config for non-system actions (set_*/get_*) so driver can resolve device_path after restart
             action = req.arguments.get('action')
             _SYSTEM_ACTIONS_NO_CONFIG = {'info', 'stop', 'config'}
-            if action and action not in _SYSTEM_ACTIONS_NO_CONFIG:
+            if (
+                not access.read_only
+                and action
+                and action not in _SYSTEM_ACTIONS_NO_CONFIG
+            ):
                 # Check if this tool has configSchema (requires config before start)
                 tools = target.get('tools') or []
                 tool_obj = next((t for t in tools if isinstance(t, dict) and t.get('name') == req.tool), None)
                 has_config_schema = bool(tool_obj and tool_obj.get('configSchema'))
 
                 instance_id = req.arguments.get('instance_id', '')
-                shared_cfg = config.main.get(f'tool_config:{mcp_id}:{req.tool}', None) or {}
+                shared_cfg = _safe_saved_config(
+                    config.main.get(f'tool_config:{mcp_id}:{req.tool}', None)
+                )
                 instance_cfg = {}
                 if instance_id:
-                    instance_cfg = config.main.get(f'tool_config:{mcp_id}:{req.tool}:{instance_id}', None) or {}
+                    instance_cfg = _safe_saved_config(
+                        config.main.get(
+                            f'tool_config:{mcp_id}:{req.tool}:{instance_id}',
+                            None,
+                        )
+                    )
                 merged_cfg = {**shared_cfg, **instance_cfg}
 
                 if merged_cfg:
-                    cfg_args = {'action': 'config', **merged_cfg}
+                    cfg_args = {**merged_cfg, 'action': 'config'}
                     if instance_id:
                         cfg_args['instance_id'] = instance_id
                     cfg_payload = {
@@ -923,16 +2260,35 @@ async def mcp_call_tool(mcp_id: str, req: MCPCallRequest):
                         'method': 'tools/call',
                         'params': {'name': req.tool, 'arguments': cfg_args},
                     }
-                    async with session.post(url, json=cfg_payload, headers=headers) as resp:
+                    async with session.post(
+                        url,
+                        json=cfg_payload,
+                        headers=headers,
+                        allow_redirects=False,
+                    ) as resp:
                         cfg_data = await resp.json(content_type=None)
-                        cfg_result = cfg_data.get('result', {})
-                        cfg_content = (cfg_result.get('content') or [{}])[0].get('text', '{}')
-                        try:
-                            parsed = json.loads(cfg_content)
-                            if not parsed.get('adapter_ok', True):
-                                return {'code': 400, 'message': f'[{req.tool}] 配置无效（缺少 url/key），请检查配置。', 'data': None}
-                        except (json.JSONDecodeError, IndexError):
-                            pass
+                        cfg_rpc_error = _rpc_response_error(
+                            cfg_data,
+                            request_id=2,
+                            http_status=resp.status,
+                        )
+                        if cfg_rpc_error:
+                            return {
+                                'code': 502,
+                                'message': cfg_rpc_error,
+                                'data': None,
+                            }
+                        cfg_result = cfg_data['result']
+                        cfg_result_error = _tool_result_error(
+                            cfg_result,
+                            require_structured_ack=True,
+                        )
+                        if cfg_result_error:
+                            return {
+                                'code': 502,
+                                'message': f'[{req.tool}] {cfg_result_error}',
+                                'data': None,
+                            }
                 elif has_config_schema:
                     return {'code': 400, 'message': f'[{req.tool}] 尚未配置，请先完成配置后再启动。', 'data': None}
 
@@ -941,12 +2297,30 @@ async def mcp_call_tool(mcp_id: str, req: MCPCallRequest):
                 'method': 'tools/call',
                 'params': {'name': req.tool, 'arguments': req.arguments},
             }
-            async with session.post(url, json=call_payload, headers=headers) as resp:
+            async with session.post(
+                url,
+                json=call_payload,
+                headers=headers,
+                allow_redirects=False,
+            ) as resp:
                 data = await resp.json(content_type=None)
-                result = data.get('result', {})
-                error  = data.get('error')
-                if error:
-                    return {'code': 500, 'message': error.get('message', 'Tool call error'), 'data': None}
+                rpc_error = _rpc_response_error(
+                    data,
+                    request_id=3,
+                    http_status=resp.status,
+                )
+                if rpc_error:
+                    return {'code': 502, 'message': rpc_error, 'data': None}
+                result = data['result']
+                result_error = _tool_result_error(
+                    result,
+                    require_structured_ack=(
+                        isinstance(action, str)
+                        and action in {'config', 'start', 'stop'}
+                    ),
+                )
+                if result_error:
+                    return {'code': 502, 'message': result_error, 'data': None}
                 # Auto-register any instance-specific topics returned by the tool
                 content_items = result.get('content') or []
                 if isinstance(content_items, list):
@@ -963,3 +2337,5 @@ async def mcp_call_tool(mcp_id: str, req: MCPCallRequest):
                 return {'code': 200, 'data': result.get('content', result)}
     except Exception as e:
         return {'code': 500, 'message': str(e), 'data': None}
+    finally:
+        await admission.__aexit__(None, None, None)

--- a/agent-core/src/api/teleop.py
+++ b/agent-core/src/api/teleop.py
@@ -1,0 +1,1191 @@
+"""Dedicated teleoperation identity, session, and signaling API."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import math
+import uuid
+from typing import Literal
+
+import fastapi
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
+
+import auth
+import config
+import mcp_client
+from teleop import audit
+from teleop.capture_manager import CaptureError
+from teleop.command_broker import (
+    InvalidAuthorityBinding,
+    authority_domain_for_target,
+)
+from teleop.contracts import (
+    SHADOW_MODE,
+    TeleopContractError,
+    project_teleop_descriptor,
+)
+from teleop.service import TeleopServiceError, coordinator
+from teleop.session_manager import (
+    SessionClientMismatch,
+    SessionConflict,
+    SessionForbidden,
+    SessionNotFound,
+    SessionStateConflict,
+)
+from tls_config import TLSConfigurationError, project_public_certificate_chain
+
+router = fastapi.APIRouter(prefix='/teleop', tags=['teleop'])
+ws_router = fastapi.APIRouter(tags=['teleop-capture'])
+
+_SENSITIVE_KEY_PARTS = (
+    'apikey',
+    'credential',
+    'fence',
+    'password',
+    'privatekey',
+    'secret',
+    'token',
+)
+_SIGNALING_OFFER_BODY_LIMIT = 128 * 1024
+_SIGNALING_OFFER_SDP_LIMIT = 120 * 1024
+_CAPTURE_WS_AUTH_TIMEOUT_SECONDS = 5.0
+_CAPTURE_WS_HEALTH_TICK_SECONDS = 1.0
+_CAPTURE_WS_MESSAGE_LIMIT = 128 * 1024
+
+
+class SessionCreateRequest(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+
+    driver_id: str = Field(min_length=1, max_length=128, pattern=r'^[A-Za-z0-9][A-Za-z0-9_.:-]*$')
+    mode: Literal['shadow', 'live'] = SHADOW_MODE
+
+
+class LiveConfirmationRequest(BaseModel):
+    model_config = ConfigDict(extra='forbid', strict=True)
+
+    confirm_live_actuation: Literal[True]
+    profile_id: str = Field(
+        min_length=1,
+        max_length=128,
+        pattern=r'^[A-Za-z0-9][A-Za-z0-9_.:-]*$',
+    )
+
+    @field_validator('confirm_live_actuation', mode='before')
+    @classmethod
+    def _require_exact_true(cls, value):
+        if value is not True:
+            raise ValueError('confirm_live_actuation must be the boolean true')
+        return value
+
+
+class SignalingOfferRequest(BaseModel):
+    model_config = ConfigDict(extra='forbid', strict=True)
+
+    type: Literal['offer']
+    sdp: str = Field(min_length=1, max_length=_SIGNALING_OFFER_SDP_LIMIT)
+
+
+class CapturePairingRequest(BaseModel):
+    model_config = ConfigDict(extra='forbid', strict=True)
+
+    label: str = Field(min_length=1, max_length=64)
+
+
+class CaptureAttachmentRequest(BaseModel):
+    model_config = ConfigDict(extra='forbid', strict=True)
+
+    capture_id: str = Field(
+        min_length=36,
+        max_length=36,
+        pattern=r'^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$',
+    )
+    mode: Literal['shadow', 'live']
+    profile_id: str = Field(
+        min_length=1,
+        max_length=128,
+        pattern=r'^[A-Za-z0-9][A-Za-z0-9_.:-]*$',
+    )
+    capability_digest: str = Field(pattern=r'^[0-9a-f]{64}$')
+
+
+class CapturePairMessage(BaseModel):
+    model_config = ConfigDict(extra='forbid', strict=True)
+
+    type: Literal['pair']
+    pairing_id: str = Field(
+        min_length=36,
+        max_length=36,
+        pattern=r'^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$',
+    )
+    pairing_code: str = Field(min_length=32, max_length=128, repr=False)
+    capture_protocol: Literal['motus.teleop.capture.v1']
+    frame_protocol: Literal['motus.teleop.rtc-frame.v1']
+    client_kind: Literal['browser_webxr', 'native_openxr']
+    app_version: str = Field(
+        min_length=1,
+        max_length=32,
+        pattern=r'^[A-Za-z0-9][A-Za-z0-9_.+-]*$',
+    )
+
+
+class CaptureCredentialMessage(BaseModel):
+    model_config = ConfigDict(extra='forbid', strict=True)
+
+    type: Literal['credential']
+    capture_id: str = Field(
+        min_length=36,
+        max_length=36,
+        pattern=r'^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$',
+    )
+    capture_credential: str = Field(min_length=32, max_length=128, repr=False)
+    capture_protocol: Literal['motus.teleop.capture.v1']
+    frame_protocol: Literal['motus.teleop.rtc-frame.v1']
+    client_kind: Literal['browser_webxr', 'native_openxr']
+    app_version: str = Field(
+        min_length=1,
+        max_length=32,
+        pattern=r'^[A-Za-z0-9][A-Za-z0-9_.+-]*$',
+    )
+
+
+class CapturePresenceMessage(BaseModel):
+    model_config = ConfigDict(extra='forbid', strict=True)
+
+    type: Literal['presence']
+    state: Literal[
+        'browser_ready',
+        'error',
+        'rtc_connecting',
+        'streaming',
+        'xr_ended',
+        'xr_standby',
+    ]
+    assignment_id: str | None = Field(
+        default=None,
+        min_length=36,
+        max_length=36,
+        pattern=r'^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$',
+    )
+
+
+class CaptureSignalingOfferMessage(BaseModel):
+    model_config = ConfigDict(extra='forbid', strict=True)
+
+    type: Literal['signaling_offer']
+    assignment_id: str = Field(
+        min_length=36,
+        max_length=36,
+        pattern=r'^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$',
+    )
+    offer: SignalingOfferRequest
+
+
+class _DuplicateJsonField(ValueError):
+    pass
+
+
+def _reject_duplicate_json_fields(pairs):
+    value = {}
+    for key, item in pairs:
+        if key in value:
+            raise _DuplicateJsonField(key)
+        value[key] = item
+    return value
+
+
+def _reject_non_finite_json(_value: str):
+    raise ValueError('non-finite JSON is not allowed')
+
+
+async def _signaling_offer_request(request: fastapi.Request) -> SignalingOfferRequest:
+    media_type = request.headers.get('content-type', '').split(';', 1)[0].strip().lower()
+    if media_type != 'application/json':
+        raise fastapi.HTTPException(
+            status_code=415,
+            detail={'code': 'signaling_content_type_required'},
+        )
+    content_length = request.headers.get('content-length')
+    if content_length:
+        try:
+            declared_length = int(content_length)
+        except ValueError:
+            declared_length = -1
+        if declared_length < 0:
+            raise fastapi.HTTPException(
+                status_code=400,
+                detail={'code': 'invalid_signaling_offer'},
+            )
+        if declared_length > _SIGNALING_OFFER_BODY_LIMIT:
+            raise fastapi.HTTPException(
+                status_code=413,
+                detail={'code': 'signaling_offer_too_large'},
+            )
+
+    raw = bytearray()
+    async for chunk in request.stream():
+        if len(raw) + len(chunk) > _SIGNALING_OFFER_BODY_LIMIT:
+            raise fastapi.HTTPException(
+                status_code=413,
+                detail={'code': 'signaling_offer_too_large'},
+            )
+        raw.extend(chunk)
+    try:
+        payload = json.loads(
+            raw.decode('utf-8'),
+            object_pairs_hook=_reject_duplicate_json_fields,
+            parse_constant=_reject_non_finite_json,
+        )
+        body = SignalingOfferRequest.model_validate(payload)
+        if len(body.sdp.encode('utf-8')) > _SIGNALING_OFFER_SDP_LIMIT:
+            raise ValueError('SDP exceeds byte limit')
+    except (
+        UnicodeDecodeError,
+        UnicodeEncodeError,
+        json.JSONDecodeError,
+        ValidationError,
+        TypeError,
+        ValueError,
+        RecursionError,
+    ):
+        raise fastapi.HTTPException(
+            status_code=400,
+            detail={'code': 'invalid_signaling_offer'},
+        ) from None
+    return body
+
+
+def _capture_ws_payload(
+    raw: str,
+    *,
+    first_message: bool,
+) -> BaseModel:
+    try:
+        if len(raw.encode('utf-8')) > _CAPTURE_WS_MESSAGE_LIMIT:
+            raise ValueError('capture message too large')
+        payload = json.loads(
+            raw,
+            object_pairs_hook=_reject_duplicate_json_fields,
+            parse_constant=_reject_non_finite_json,
+        )
+        if not isinstance(payload, dict):
+            raise TypeError('capture message must be an object')
+        message_type = payload.get('type')
+        if first_message:
+            model = {
+                'credential': CaptureCredentialMessage,
+                'pair': CapturePairMessage,
+            }.get(message_type)
+        else:
+            model = {
+                'presence': CapturePresenceMessage,
+                'signaling_offer': CaptureSignalingOfferMessage,
+            }.get(message_type)
+        if model is None:
+            raise ValueError('capture message type is not supported')
+        return model.model_validate(payload)
+    except (
+        UnicodeEncodeError,
+        json.JSONDecodeError,
+        ValidationError,
+        TypeError,
+        ValueError,
+        RecursionError,
+    ):
+        raise CaptureError('capture_message_invalid', 400) from None
+
+
+async def _capture_ws_text(websocket: fastapi.WebSocket) -> str:
+    message = await websocket.receive()
+    if message.get('type') == 'websocket.disconnect':
+        raise fastapi.WebSocketDisconnect(message.get('code', 1000))
+    raw = message.get('text')
+    if not isinstance(raw, str):
+        raise CaptureError('capture_message_invalid', 400)
+    return raw
+
+
+def _capture_ws_error_code(error: BaseException) -> str:
+    if isinstance(error, (CaptureError, TeleopServiceError)):
+        return error.code
+    if isinstance(error, SessionClientMismatch):
+        return 'session_client_mismatch'
+    if isinstance(error, SessionForbidden):
+        return 'session_forbidden'
+    if isinstance(error, SessionNotFound):
+        return 'session_not_found'
+    if isinstance(error, SessionStateConflict):
+        return 'session_state_conflict'
+    if isinstance(error, asyncio.TimeoutError):
+        return 'capture_auth_timeout'
+    return 'capture_internal_error'
+
+
+async def _close_capture_ws(
+    websocket: fastapi.WebSocket,
+    *,
+    code: int,
+    reason: str,
+) -> None:
+    try:
+        await websocket.close(code=code, reason=reason)
+    except Exception:  # noqa: BLE001, S110 -- the peer may already be gone
+        pass
+
+
+def _client_id(request: fastapi.Request) -> str:
+    value = request.headers.get('x-motus-teleop-client', '')
+    try:
+        parsed = uuid.UUID(value)
+    except (ValueError, TypeError, AttributeError):
+        raise fastapi.HTTPException(
+            status_code=400,
+            detail={'code': 'teleop_client_required'},
+        ) from None
+    if str(parsed) != value.lower():
+        raise fastapi.HTTPException(
+            status_code=400,
+            detail={'code': 'teleop_client_required'},
+        )
+    return str(parsed)
+
+
+def _safe_metadata(value, depth: int = 0):
+    """Bound untrusted descriptor metadata and strip credential-like fields."""
+    if depth > 5:
+        return None
+    if value is None or isinstance(value, (bool, int)):
+        return value
+    if isinstance(value, float):
+        return value if math.isfinite(value) else None
+    if isinstance(value, str):
+        return value[:1000]
+    if isinstance(value, list):
+        return [_safe_metadata(item, depth + 1) for item in value[:50]]
+    if isinstance(value, dict):
+        safe = {}
+        for raw_key, item in list(value.items())[:100]:
+            key = str(raw_key)[:100]
+            normalized = ''.join(
+                character for character in key.lower()
+                if character.isalnum()
+            )
+            if any(part in normalized for part in _SENSITIVE_KEY_PARTS):
+                continue
+            safe[key] = _safe_metadata(item, depth + 1)
+        return safe
+    return str(value)[:1000]
+
+
+def _tool_name(tool) -> str:
+    return tool.get('name', '') if isinstance(tool, dict) else str(tool)
+
+
+def _project_descriptor(
+    tool: dict | None,
+    expected_driver_id: str | None = None,
+) -> dict | None:
+    try:
+        return project_teleop_descriptor(
+            tool,
+            expected_driver_id=expected_driver_id,
+        )
+    except TeleopContractError:
+        return None
+
+
+def _valid_teleop_descriptor(
+    tool: dict | None,
+    expected_driver_id: str | None = None,
+) -> bool:
+    return _project_descriptor(tool, expected_driver_id) is not None
+
+
+def _valid_shadow_descriptor(
+    tool: dict | None,
+    expected_driver_id: str | None = None,
+) -> bool:
+    """Compatibility predicate retained for callers that require Shadow."""
+
+    descriptor = _project_descriptor(tool, expected_driver_id)
+    return descriptor is not None and descriptor['mode'] == SHADOW_MODE
+
+
+def _robot_view(mcp: dict, mcps: list | None = None) -> dict:
+    tools = mcp.get('tools') or []
+    session_tool = next(
+        (
+            tool for tool in tools
+            if isinstance(tool, dict) and tool.get('name') == 'teleop_session'
+        ),
+        None,
+    )
+    explicitly_declared = bool(session_tool and 'x-teleop' in session_tool)
+    projected_descriptor = _project_descriptor(session_tool, mcp.get('id', ''))
+    descriptor_valid = projected_descriptor is not None
+    try:
+        robot_id = authority_domain_for_target(
+            mcp.get('id', ''),
+            mcp,
+            targets=mcps,
+        )
+        binding_valid = True
+    except InvalidAuthorityBinding:
+        robot_id = ''
+        binding_valid = False
+    descriptor = session_tool.get('x-teleop') if isinstance(session_tool, dict) else {}
+    descriptor_robot_id = (
+        descriptor.get('robot_id') if isinstance(descriptor, dict) else None
+    )
+    reported_robot_id = mcp.get('reported_robot_id')
+    robot_identity_matches = binding_valid and (
+        descriptor_robot_id in (None, robot_id)
+        and reported_robot_id in (None, '', robot_id)
+        and (robot_id == mcp.get('id') or descriptor_robot_id == robot_id)
+    )
+    trust_state = mcp.get('trust_state') or (
+        'quarantined' if auth.is_driver_auth_enforced() else 'untrusted'
+    )
+    credential_missing = (
+        trust_state == 'trusted'
+        and not auth.driver_record_credential_available(
+            mcp.get('id', ''),
+            mcp.get('credential_binding'),
+        )
+    )
+    if credential_missing:
+        trust_state = 'quarantined'
+    signaling_missing = not auth.teleop_ticket_credential_available(
+        mcp.get('id', '')
+    )
+    registry_entry = mcp_client.registry.get(mcp.get('id', ''), {})
+    online = bool(registry_entry.get('online', False))
+    runtime_trusted = registry_entry.get('trusted') is True
+    target_matches = registry_entry.get('url') == mcp.get('url')
+    descriptor_matches = (
+        registry_entry.get('teleop_fingerprint')
+        == mcp_client.teleop_tool_fingerprint(session_tool)
+    )
+
+    if credential_missing:
+        reason = 'driver_credential_unavailable'
+    elif trust_state != 'trusted':
+        reason = 'driver_registration_not_trusted'
+    elif not binding_valid:
+        reason = 'authority_binding_invalid'
+    elif not explicitly_declared:
+        reason = 'teleop_session_not_declared'
+    elif not descriptor_valid:
+        reason = 'teleop_descriptor_invalid'
+    elif signaling_missing:
+        reason = 'teleop_signaling_unavailable'
+    elif not robot_identity_matches:
+        reason = 'authority_binding_required'
+    elif (
+        mcp.get('transport') != 'http'
+        or mcp_client.teleop_url_safety_code(mcp.get('url')) is not None
+    ):
+        reason = 'driver_transport_invalid'
+    elif not runtime_trusted:
+        reason = 'driver_runtime_not_trusted'
+    elif not target_matches or not descriptor_matches:
+        reason = 'driver_runtime_target_mismatch'
+    elif not online:
+        reason = 'driver_offline'
+    else:
+        reason = 'ready'
+
+    return {
+        'id': mcp.get('id', ''),
+        'driver_id': mcp.get('id', ''),
+        'robot_id': robot_id,
+        'name': mcp.get('name', '') or mcp.get('server_name', ''),
+        'server_name': mcp.get('server_name', ''),
+        'online': online,
+        'trust_state': trust_state,
+        'teleop_declared': explicitly_declared,
+        'descriptor_valid': descriptor_valid,
+        'teleop_ready': reason == 'ready',
+        'reason': reason,
+        'teleop': _safe_metadata(session_tool.get('x-teleop')) if session_tool else None,
+        'annotations': _safe_metadata(session_tool.get('annotations') or {}) if session_tool else {},
+        'tools': sorted({_tool_name(tool) for tool in tools if _tool_name(tool)}),
+    }
+
+
+@router.get('/me')
+async def teleop_me(request: fastapi.Request):
+    principal = auth.require_role(request, 'viewer')
+    return {
+        'code': 200,
+        'data': {
+            'principal': principal.as_dict(),
+            'permissions': {
+                'view_devices': True,
+                'control': principal.role in ('operator', 'owner'),
+            },
+        },
+    }
+
+
+@router.get('/robots')
+async def teleop_robots(request: fastapi.Request):
+    principal = auth.require_role(request, 'viewer')
+    client_id = request.headers.get('x-motus-teleop-client', '')
+    mcps = await asyncio.to_thread(
+        lambda: config.main.get('services', {}).get('mcp', []),
+    )
+    robots = []
+    represented_guard_ids: set[str] = set()
+    for mcp in mcps:
+        if mcp.get('category') != 'driver':
+            continue
+        robot = _robot_view(mcp, mcps)
+        session = (
+            await coordinator.manager.active_for_robot(robot['robot_id'])
+            if robot['robot_id'] else None
+        )
+        authority_guard = (
+            coordinator.authority_guard_for_robot(robot['robot_id'])
+            if robot['robot_id'] else None
+        )
+        if authority_guard is not None:
+            represented_guard_ids.add(authority_guard['robot_id'])
+            robot['teleop_ready'] = False
+            robot['reason'] = 'authority_recovery_required'
+            robot['authority_guard'] = authority_guard
+            robot['session'] = {
+                'busy': True,
+                'owned_by_me': False,
+                'owned_by_client': False,
+                'state': 'recovery_required',
+            }
+        elif session is None:
+            robot['session'] = {
+                'busy': False,
+                'owned_by_me': False,
+                'owned_by_client': False,
+            }
+        else:
+            owned_by_me = session.principal_id == principal.id
+            owned_by_client = owned_by_me and session.client_id == client_id
+            session_view = coordinator.manager.public_dict(session)
+            robot['session'] = {
+                'busy': True,
+                'owned_by_me': owned_by_me,
+                'owned_by_client': owned_by_client,
+                'state': session.state,
+                'remaining_seconds': session_view['remaining_seconds'],
+            }
+            if owned_by_me or principal.role == 'owner':
+                robot['session'].update({
+                    'id': session.id,
+                    'principal_id': session.principal_id,
+                })
+        robots.append(robot)
+    for authority_guard in coordinator.list_authority_guards():
+        robot_id = authority_guard['robot_id']
+        if robot_id in represented_guard_ids:
+            continue
+        robots.append({
+            'id': f'recovery:{robot_id}',
+            'driver_id': authority_guard['driver_id'],
+            'robot_id': robot_id,
+            'name': f'{robot_id} · recovery',
+            'server_name': '',
+            'online': False,
+            'trust_state': 'unknown',
+            'teleop_declared': False,
+            'descriptor_valid': False,
+            'teleop_ready': False,
+            'reason': 'authority_recovery_required',
+            'teleop': None,
+            'annotations': {},
+            'tools': [],
+            'authority_guard': authority_guard,
+            'session': {
+                'busy': True,
+                'owned_by_me': False,
+                'owned_by_client': False,
+                'state': 'recovery_required',
+            },
+        })
+    robots.sort(key=lambda item: (not item['teleop_ready'], item['name'], item['id']))
+    return {'code': 200, 'data': robots}
+
+
+def _owner(principal: auth.Principal) -> bool:
+    return principal.role == 'owner'
+
+
+def _capture_ca_certificate_pem(request: fastapi.Request) -> str:
+    raw_pem = getattr(
+        request.app.state,
+        'teleop_capture_ca_certificate_pem',
+        None,
+    )
+    try:
+        return project_public_certificate_chain(raw_pem)
+    except TLSConfigurationError as exc:
+        raise fastapi.HTTPException(
+            status_code=503,
+            detail={'code': 'capture_tls_bootstrap_unavailable'},
+            headers={'Cache-Control': 'no-store'},
+        ) from exc
+
+
+@router.post('/authority-guards/{robot_id}/reconcile')
+async def reconcile_authority_guard(robot_id: str, request: fastapi.Request):
+    principal = auth.require_role(request, 'owner')
+    try:
+        result = await coordinator.reconcile_authority_guard(
+            robot_id,
+            principal_id=principal.id,
+        )
+    except Exception as error:
+        await _raise_session_error(error)
+        raise
+    return {'code': 200, 'data': result}
+
+
+@router.post('/capture-pairings')
+async def create_capture_pairing(
+    body: CapturePairingRequest,
+    request: fastapi.Request,
+    response: fastapi.Response,
+):
+    principal = auth.require_role(request, 'operator')
+    client_id = _client_id(request)
+    ca_certificate_pem = _capture_ca_certificate_pem(request)
+    try:
+        pairing = await coordinator.create_capture_pairing(
+            principal.id,
+            client_id,
+            label=body.label,
+        )
+    except Exception as error:
+        await _raise_session_error(error)
+        raise
+    response.status_code = 201
+    response.headers['Cache-Control'] = 'no-store'
+    return {
+        'code': 201,
+        'data': {
+            'pairing_id': pairing.pairing_id,
+            'pairing_code': pairing.pairing_code,
+            'expires_at': pairing.expires_at,
+            'websocket_path': '/ws/teleop-capture',
+            'ca_certificate_pem': ca_certificate_pem,
+            'ca_certificate_base64': base64.b64encode(
+                ca_certificate_pem.encode('ascii')
+            ).decode('ascii'),
+        },
+    }
+
+
+@router.get('/captures')
+async def list_captures(request: fastapi.Request, response: fastapi.Response):
+    principal = auth.require_role(request, 'operator')
+    _client_id(request)
+    try:
+        captures = await coordinator.list_captures(principal.id)
+    except Exception as error:
+        await _raise_session_error(error)
+        raise
+    response.headers['Cache-Control'] = 'no-store'
+    return {'code': 200, 'data': captures}
+
+
+@router.delete('/captures/{capture_id}')
+async def revoke_capture(
+    capture_id: str,
+    request: fastapi.Request,
+    response: fastapi.Response,
+):
+    principal = auth.require_role(request, 'operator')
+    _client_id(request)
+    try:
+        capture = await coordinator.revoke_capture(capture_id, principal.id)
+    except Exception as error:
+        await _raise_session_error(error)
+        raise
+    response.headers['Cache-Control'] = 'no-store'
+    return {'code': 200, 'data': capture}
+
+
+@router.post('/sessions/{session_id}/capture-attachment')
+async def attach_capture(
+    session_id: str,
+    body: CaptureAttachmentRequest,
+    request: fastapi.Request,
+    response: fastapi.Response,
+):
+    principal = auth.require_role(request, 'operator')
+    client_id = _client_id(request)
+    try:
+        assignment = await coordinator.attach_capture(
+            session_id,
+            principal.id,
+            client_id,
+            capture_id=body.capture_id,
+            mode=body.mode,
+            profile_id=body.profile_id,
+            capability_digest=body.capability_digest,
+        )
+    except Exception as error:
+        await _raise_session_error(error, session_id)
+        raise
+    response.headers['Cache-Control'] = 'no-store'
+    return {
+        'code': 200,
+        'data': coordinator.capture_manager.public_assignment(assignment),
+    }
+
+
+async def _raise_session_error(error: Exception, session_id: str = '') -> None:
+    if isinstance(error, CaptureError):
+        raise fastapi.HTTPException(
+            status_code=error.status_code,
+            detail={'code': error.code},
+        ) from None
+    if isinstance(error, TeleopServiceError):
+        raise fastapi.HTTPException(
+            status_code=error.status_code,
+            detail={'code': error.code},
+        ) from None
+    if isinstance(error, SessionConflict):
+        raise fastapi.HTTPException(
+            status_code=409,
+            detail={'code': 'robot_busy'},
+        ) from None
+    if isinstance(error, SessionForbidden):
+        code = (
+            'session_client_mismatch'
+            if isinstance(error, SessionClientMismatch)
+            else 'session_forbidden'
+        )
+        raise fastapi.HTTPException(
+            status_code=403,
+            detail={'code': code},
+        ) from None
+    if isinstance(error, SessionStateConflict):
+        raise fastapi.HTTPException(
+            status_code=409,
+            detail={'code': 'session_state_conflict'},
+        ) from None
+    if isinstance(error, SessionNotFound):
+        known = await coordinator.manager.get(session_id) if session_id else None
+        if known is not None and known.state in ('released', 'expired', 'faulted'):
+            raise fastapi.HTTPException(
+                status_code=410,
+                detail={'code': f'session_{known.state}'},
+            ) from None
+        raise fastapi.HTTPException(
+            status_code=404,
+            detail={'code': 'session_not_found'},
+        ) from None
+    raise error
+
+
+@router.post('/sessions')
+async def acquire_session(
+    body: SessionCreateRequest,
+    request: fastapi.Request,
+    response: fastapi.Response,
+):
+    principal = auth.require_role(request, 'operator')
+    client_id = _client_id(request)
+    try:
+        result = await coordinator.acquire(
+            body.driver_id,
+            principal.id,
+            client_id,
+            mode=body.mode,
+        )
+    except Exception as error:
+        await _raise_session_error(error)
+        raise
+
+    response.status_code = {
+        'created': 201,
+        'existing': 200,
+        'preparing': 202,
+        'confirmation_required': 202,
+    }[result.disposition]
+    return {
+        'code': response.status_code,
+        'data': {
+            'disposition': result.disposition,
+            'session': coordinator.public_session(result.session),
+        },
+    }
+
+
+@router.post('/sessions/{session_id}/confirm-live')
+async def confirm_live_session(
+    session_id: str,
+    body: LiveConfirmationRequest,
+    request: fastapi.Request,
+):
+    principal = auth.require_role(request, 'operator')
+    client_id = _client_id(request)
+    try:
+        result = await coordinator.confirm_live(
+            session_id,
+            principal.id,
+            client_id,
+            profile_id=body.profile_id,
+        )
+    except Exception as error:
+        await _raise_session_error(error, session_id)
+        raise
+    return {
+        'code': 200,
+        'data': {
+            'disposition': result.disposition,
+            'session': coordinator.public_session(result.session),
+        },
+    }
+
+
+@router.get('/sessions')
+async def list_sessions(request: fastapi.Request):
+    principal = auth.require_role(request, 'operator')
+    sessions = await coordinator.sessions_for(principal.id, owner=_owner(principal))
+    return {'code': 200, 'data': sessions}
+
+
+@router.get('/sessions/{session_id}')
+async def get_session(session_id: str, request: fastapi.Request):
+    principal = auth.require_role(request, 'operator')
+    try:
+        session = await coordinator.session_for(
+            session_id,
+            principal.id,
+            owner=_owner(principal),
+        )
+    except Exception as error:
+        await _raise_session_error(error, session_id)
+        raise
+    return {'code': 200, 'data': session}
+
+
+@router.get('/sessions/{session_id}/driver-status')
+async def get_driver_status(session_id: str, request: fastapi.Request):
+    principal = auth.require_role(request, 'operator')
+    try:
+        session = await coordinator.status(
+            session_id,
+            principal.id,
+            owner=_owner(principal),
+        )
+    except Exception as error:
+        await _raise_session_error(error, session_id)
+        raise
+    return {'code': 200, 'data': session}
+
+
+@router.post('/sessions/{session_id}/heartbeat')
+async def heartbeat_session(session_id: str, request: fastapi.Request):
+    principal = auth.require_role(request, 'operator')
+    client_id = _client_id(request)
+    try:
+        session = await coordinator.heartbeat(session_id, principal.id, client_id)
+    except Exception as error:
+        await _raise_session_error(error, session_id)
+        raise
+    return {'code': 200, 'data': coordinator.public_session(session)}
+
+
+@router.post('/sessions/{session_id}/signaling/offer')
+async def signaling_offer(
+    session_id: str,
+    request: fastapi.Request,
+    response: fastapi.Response,
+):
+    principal = auth.require_role(request, 'operator')
+    client_id = _client_id(request)
+    try:
+        body = await _signaling_offer_request(request)
+    except fastapi.HTTPException as error:
+        detail = error.detail if isinstance(error.detail, dict) else {}
+        code = detail.get('code')
+        reason = code if isinstance(code, str) else 'invalid_signaling_offer'
+        await audit.emit(
+            'teleop.signaling.offer.rejected',
+            session_id=session_id,
+            principal_id=principal.id,
+            source='api',
+            decision='rejected',
+            reason=reason,
+        )
+        raise
+    try:
+        answer = await coordinator.signaling_offer(
+            session_id,
+            principal.id,
+            client_id,
+            body.model_dump(),
+        )
+    except Exception as error:
+        await _raise_session_error(error, session_id)
+        raise
+    response.headers['Cache-Control'] = 'no-store'
+    return {'code': 200, 'data': answer}
+
+
+@router.post('/sessions/{session_id}/pause')
+async def pause_session(session_id: str, request: fastapi.Request):
+    principal = auth.require_role(request, 'operator')
+    client_id = _client_id(request)
+    try:
+        session = await coordinator.pause(
+            session_id,
+            principal.id,
+            client_id,
+            owner=_owner(principal),
+        )
+    except Exception as error:
+        await _raise_session_error(error, session_id)
+        raise
+    return {'code': 200, 'data': coordinator.public_session(session)}
+
+
+@router.post('/sessions/{session_id}/soft-stop')
+async def soft_stop_session(session_id: str, request: fastapi.Request):
+    principal = auth.require_role(request, 'operator')
+    client_id = _client_id(request)
+    try:
+        session = await coordinator.soft_stop(
+            session_id,
+            principal.id,
+            client_id,
+            owner=_owner(principal),
+        )
+    except Exception as error:
+        await _raise_session_error(error, session_id)
+        raise
+    return {'code': 200, 'data': coordinator.public_session(session)}
+
+
+@router.delete('/sessions/{session_id}')
+async def release_session(session_id: str, request: fastapi.Request):
+    principal = auth.require_role(request, 'operator')
+    client_id = _client_id(request)
+    try:
+        session, acknowledged = await coordinator.release(
+            session_id,
+            principal.id,
+            client_id,
+            owner=_owner(principal),
+        )
+    except Exception as error:
+        await _raise_session_error(error, session_id)
+        raise
+    return {
+        'code': 200,
+        'data': {
+            'session': coordinator.public_session(session),
+            'driver_acknowledged': acknowledged,
+        },
+    }
+
+
+@router.get('/sessions/{session_id}/events')
+async def session_events(
+    session_id: str,
+    request: fastapi.Request,
+    limit: int = fastapi.Query(default=50, ge=1, le=200),
+):
+    principal = auth.require_role(request, 'operator')
+    try:
+        session = await coordinator.manager.get_authorized(
+            session_id,
+            principal.id,
+            owner=_owner(principal),
+            include_terminal=True,
+        )
+    except Exception as error:
+        await _raise_session_error(error, session_id)
+        raise
+    stored_events = await asyncio.to_thread(
+        audit.list_events,
+        limit,
+        session.robot_id,
+        session.id,
+    )
+    return {'code': 200, 'data': stored_events}
+
+
+@ws_router.websocket('/ws/teleop-capture')
+async def teleop_capture_websocket(websocket: fastapi.WebSocket):
+    """Authenticate a capture in-band; never accept secrets in the URL or logs."""
+
+    connection = None
+    receive_task: asyncio.Task | None = None
+    event_task: asyncio.Task | None = None
+    await websocket.accept()
+    if getattr(websocket, 'scope', {}).get('query_string', b''):
+        await websocket.send_json({
+            'type': 'error',
+            'code': 'capture_query_forbidden',
+        })
+        await _close_capture_ws(
+            websocket,
+            code=4400,
+            reason='capture_query_forbidden',
+        )
+        return
+    try:
+        raw_first = await asyncio.wait_for(
+            _capture_ws_text(websocket),
+            timeout=_CAPTURE_WS_AUTH_TIMEOUT_SECONDS,
+        )
+        first = _capture_ws_payload(raw_first, first_message=True)
+        if isinstance(first, CapturePairMessage):
+            connection = await coordinator.connect_capture_with_pairing(
+                first.pairing_id,
+                first.pairing_code,
+                capture_protocol=first.capture_protocol,
+                frame_protocol=first.frame_protocol,
+                client_kind=first.client_kind,
+                app_version=first.app_version,
+            )
+            assert connection.capture_credential is not None
+            await websocket.send_json({
+                'type': 'paired',
+                'capture_id': connection.capture_id,
+                'capture_credential': connection.capture_credential,
+                'capture_protocol': first.capture_protocol,
+                'frame_protocol': first.frame_protocol,
+                'presence_interval_ms': 2_000,
+                'presence_timeout_ms': 5_000,
+            })
+        elif isinstance(first, CaptureCredentialMessage):
+            connection = await coordinator.connect_capture_with_credential(
+                first.capture_id,
+                first.capture_credential,
+                capture_protocol=first.capture_protocol,
+                frame_protocol=first.frame_protocol,
+                client_kind=first.client_kind,
+                app_version=first.app_version,
+            )
+            await websocket.send_json({
+                'type': 'connected',
+                'capture_id': connection.capture_id,
+                'capture_protocol': first.capture_protocol,
+                'frame_protocol': first.frame_protocol,
+                'presence_interval_ms': 2_000,
+                'presence_timeout_ms': 5_000,
+            })
+        else:  # pragma: no cover -- parser only returns the two exact models
+            raise CaptureError('capture_message_invalid', 400)
+
+        receive_task = asyncio.create_task(_capture_ws_text(websocket))
+        event_task = asyncio.create_task(connection.events.get())
+        while True:
+            done, _ = await asyncio.wait(
+                {receive_task, event_task},
+                timeout=_CAPTURE_WS_HEALTH_TICK_SECONDS,
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+            if not done:
+                stale = await coordinator.expire_capture_connection(
+                    connection.capture_id,
+                    connection.connection_id,
+                )
+                if stale:
+                    await websocket.send_json({
+                        'type': 'error',
+                        'code': 'capture_presence_timeout',
+                    })
+                    await _close_capture_ws(
+                        websocket,
+                        code=4408,
+                        reason='capture_presence_timeout',
+                    )
+                    return
+                continue
+
+            if event_task in done:
+                event = event_task.result()
+                await websocket.send_json(event)
+                if event.get('type') in {'capture_revoked', 'capture_stale'}:
+                    await _close_capture_ws(
+                        websocket,
+                        code=4403,
+                        reason=str(event.get('reason', 'capture_revoked')),
+                    )
+                    return
+                event_task = asyncio.create_task(connection.events.get())
+
+            if receive_task in done:
+                incoming = _capture_ws_payload(
+                    receive_task.result(),
+                    first_message=False,
+                )
+                if isinstance(incoming, CapturePresenceMessage):
+                    presence = await coordinator.capture_presence(
+                        connection.capture_id,
+                        connection.connection_id,
+                        state=incoming.state,
+                        assignment_id=incoming.assignment_id,
+                    )
+                    await websocket.send_json({
+                        'type': 'presence_ack',
+                        'state': presence['observed_state'],
+                    })
+                elif isinstance(incoming, CaptureSignalingOfferMessage):
+                    answer = await coordinator.capture_signaling_offer(
+                        connection.capture_id,
+                        connection.connection_id,
+                        incoming.assignment_id,
+                        incoming.offer.model_dump(),
+                    )
+                    await websocket.send_json({
+                        'type': 'signaling_answer',
+                        'assignment_id': incoming.assignment_id,
+                        'answer': answer,
+                    })
+                else:  # pragma: no cover -- parser only returns the two exact models
+                    raise CaptureError('capture_message_invalid', 400)
+                receive_task = asyncio.create_task(_capture_ws_text(websocket))
+    except fastapi.WebSocketDisconnect:
+        pass
+    except asyncio.CancelledError:
+        # Test clients and some ASGI servers cancel an authenticated handler
+        # to represent a normal peer disconnect. Once in-band authentication
+        # succeeded, falling through to ``finally`` is the required revoke
+        # path. Preserve cancellation before authentication completes.
+        if connection is None:
+            raise
+    except Exception as error:  # noqa: BLE001 -- WSS returns only stable error codes
+        code = _capture_ws_error_code(error)
+        try:
+            await websocket.send_json({'type': 'error', 'code': code})
+        except Exception:  # noqa: BLE001, S110 -- peer may already be disconnected
+            pass
+        await _close_capture_ws(
+            websocket,
+            code=4401 if connection is None else 4400,
+            reason=code,
+        )
+    finally:
+        tasks = [
+            task for task in (receive_task, event_task)
+            if task is not None
+        ]
+        for task in tasks:
+            if not task.done():
+                task.cancel()
+        # Consume exceptions from both tasks even when a terminal event and a
+        # peer disconnect become ready in the same wait cycle. Gathering only
+        # pending tasks leaves the completed receive exception unobserved.
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+        if connection is not None:
+            await coordinator.disconnect_capture(
+                connection.capture_id,
+                connection.connection_id,
+            )

--- a/agent-core/src/auth.py
+++ b/agent-core/src/auth.py
@@ -1,81 +1,739 @@
 """
-auth.py — Access token authentication for Dashboard and API.
+Authentication and role checks for the dashboard, API, and trusted drivers.
 
-Token source: /opt/phanthy-motus/.env file (volume-mounted from host).
-Read once at startup. Restart container to apply .env changes.
+Human principals are configured with:
+
+* ``ACCESS_TOKEN`` — backwards-compatible owner token.
+* ``MOTUS_OPERATOR_TOKENS`` — named operator tokens.
+* ``MOTUS_VIEWER_TOKENS`` — named viewer tokens.
+
+Named token settings accept either a JSON object (recommended), for example
+``{"alice": "secret"}``, or ``alice:secret,bob:secret``.
+
+Drivers use either the backwards-compatible ``MOTUS_DRIVER_TOKEN`` credential
+or an exact ``driver_id`` → token mapping in ``MOTUS_DRIVER_TOKENS``.  Dedicated
+credentials take precedence over the legacy credential, so one Driver cannot
+authenticate or receive Core credentials for another Driver identity.
+
+Core-to-Driver WebRTC signaling likewise selects a dedicated value from
+``MOTUS_TELEOP_TICKET_SECRETS`` or the legacy
+``MOTUS_TELEOP_TICKET_SECRET`` fallback.  These secrets sign short-lived,
+one-use offer tickets and are never returned to a browser.
 """
 
-import pathlib
+from __future__ import annotations
 
-from fastapi import Request, WebSocket
+import hashlib
+import json
+import os
+import pathlib
+import re
+import secrets
+from dataclasses import dataclass
+from typing import Mapping, Optional
+
+from fastapi import HTTPException, Request, WebSocket
 from fastapi.responses import JSONResponse
 
-
 _ENV_PATH = pathlib.Path('/opt/phanthy-motus/.env')
-# Fallback for local dev
 _ENV_PATH_DEV = pathlib.Path('.env')
 
-_token: str = ''
+_HUMAN_KEYS = ('ACCESS_TOKEN', 'MOTUS_OPERATOR_TOKENS', 'MOTUS_VIEWER_TOKENS')
+_ALL_KEYS = (
+    *_HUMAN_KEYS,
+    'MOTUS_DRIVER_TOKEN',
+    'MOTUS_DRIVER_TOKENS',
+    'MOTUS_ENFORCE_DRIVER_AUTH',
+    'MOTUS_TELEOP_TICKET_SECRET',
+    'MOTUS_TELEOP_TICKET_SECRETS',
+    'MOTUS_ENABLE_UNSAFE_DESKTOP_CODE_TOOLS',
+)
+_ROLE_LEVEL = {'viewer': 1, 'operator': 2, 'owner': 3}
+_DRIVER_ID_RE = re.compile(r'^[A-Za-z0-9][A-Za-z0-9_.:-]{0,63}$')
+_DRIVER_BEARER_RE = re.compile(r'^[A-Za-z0-9._~+/=-]{24,4096}$')
+
+
+@dataclass(frozen=True)
+class Principal:
+    """An authenticated dashboard/API identity."""
+
+    id: str
+    role: str
+
+    def as_dict(self) -> dict:
+        return {'id': self.id, 'role': self.role}
+
+
+_principals_by_token: dict[str, Principal] = {}
+_tokens_by_principal_id: dict[str, str] = {}
+_driver_token: str = ''
+_driver_tokens_by_id: dict[str, str] = {}
+_driver_auth_enforced: bool = False
+_teleop_ticket_secret: bytes = b''
+_teleop_ticket_secrets_by_driver: dict[str, bytes] = {}
 _auth_enabled: bool = False
+_unsafe_desktop_code_tools_enabled: bool = False
 
 
-def _read_token_from_env() -> str:
-    """Read ACCESS_TOKEN from .env file."""
+def _secret_text_equal(left: object, right: object) -> bool:
+    """Compare UTF-8 secrets without ``compare_digest`` Unicode failures."""
+
+    if not isinstance(left, str) or not isinstance(right, str):
+        return False
+    try:
+        return secrets.compare_digest(left.encode('utf-8'), right.encode('utf-8'))
+    except UnicodeEncodeError:
+        return False
+
+
+def _valid_driver_id(driver_id: object) -> bool:
+    return bool(
+        isinstance(driver_id, str)
+        and _DRIVER_ID_RE.fullmatch(driver_id)
+    )
+
+
+def _read_env_file() -> dict[str, str]:
     env_file = _ENV_PATH if _ENV_PATH.exists() else _ENV_PATH_DEV
     if not env_file.exists():
-        return ''
-    for line in env_file.read_text().splitlines():
-        line = line.strip()
-        if line.startswith('ACCESS_TOKEN=') and not line.startswith('#'):
-            return line.split('=', 1)[1].strip()
-    return ''
+        return {}
+
+    values: dict[str, str] = {}
+    for raw_line in env_file.read_text().splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith('#') or '=' not in line:
+            continue
+        key, value = line.split('=', 1)
+        values[key.strip()] = value.strip()
+    return values
 
 
-def init():
-    """Read token from .env and cache it. Called once at startup."""
-    global _token, _auth_enabled
-    _token = _read_token_from_env()
-    _auth_enabled = bool(_token)
-    if _auth_enabled:
-        print(f'[auth] Token authentication enabled')
+def _load_settings() -> dict[str, str]:
+    values = _read_env_file()
+    for key in _ALL_KEYS:
+        if key in os.environ:
+            values[key] = os.environ[key]
+    return values
+
+
+def _parse_named_tokens(raw: str, role: str) -> list[tuple[str, str]]:
+    if not raw.strip():
+        return []
+
+    def reject_duplicate_json_names(pairs):
+        parsed_object = {}
+        for name, token in pairs:
+            if name in parsed_object:
+                raise ValueError(f'{role} principal id is configured more than once: {name}')
+            parsed_object[name] = token
+        return parsed_object
+
+    try:
+        parsed = json.loads(raw, object_pairs_hook=reject_duplicate_json_names)
+    except json.JSONDecodeError:
+        parsed = None
+
+    pairs: list[tuple[str, str]] = []
+    if isinstance(parsed, dict):
+        pairs = [(str(name).strip(), str(token).strip()) for name, token in parsed.items()]
     else:
-        print(f'[auth] No ACCESS_TOKEN in .env — authentication disabled')
+        for item in raw.split(','):
+            item = item.strip()
+            if not item:
+                continue
+            separator = ':' if ':' in item else '=' if '=' in item else ''
+            if not separator:
+                raise ValueError(
+                    f'{role} token entry must be name:token or a JSON object'
+                )
+            name, token = item.split(separator, 1)
+            pairs.append((name.strip(), token.strip()))
+
+    for name, token in pairs:
+        if not name or not token:
+            raise ValueError(f'{role} token entries require non-empty names and tokens')
+    return pairs
+
+
+def _register_human_token(token: str, principal: Principal) -> None:
+    existing = _principals_by_token.get(token)
+    if existing:
+        if existing != principal:
+            raise ValueError(
+                f'authentication token is assigned to both {existing.id} and {principal.id}'
+            )
+        raise ValueError(f'authentication token is configured more than once: {principal.id}')
+    existing_token = _tokens_by_principal_id.get(principal.id)
+    if existing_token:
+        raise ValueError(f'principal id is configured more than once: {principal.id}')
+    _principals_by_token[token] = principal
+    _tokens_by_principal_id[principal.id] = token
+
+
+def _parse_driver_secret_map(
+    raw: str,
+    setting_name: str,
+    *,
+    minimum_bytes: int,
+    secret_pattern: re.Pattern[str] | None = None,
+) -> dict[str, str]:
+    """Parse a strict JSON object of stable Driver identities to secrets."""
+
+    if not isinstance(raw, str):
+        raise TypeError(f'{setting_name} must be a JSON object string')
+    if not raw.strip():
+        return {}
+
+    def reject_duplicate_driver_ids(pairs):
+        parsed_object = {}
+        for driver_id, token in pairs:
+            if driver_id in parsed_object:
+                raise ValueError(
+                    f'driver credential id is configured more than once: {driver_id}'
+                )
+            parsed_object[driver_id] = token
+        return parsed_object
+
+    try:
+        parsed = json.loads(raw, object_pairs_hook=reject_duplicate_driver_ids)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f'{setting_name} must be a valid JSON object') from exc
+    if not isinstance(parsed, dict):
+        raise TypeError(f'{setting_name} must be a JSON object')
+
+    credentials: dict[str, str] = {}
+    token_owners: dict[str, str] = {}
+    for raw_driver_id, raw_token in parsed.items():
+        if not isinstance(raw_driver_id, str) or not isinstance(raw_token, str):
+            raise TypeError(f'{setting_name} requires string ids and secrets')
+        driver_id = raw_driver_id.strip()
+        token = raw_token.strip()
+        if driver_id != raw_driver_id or not _DRIVER_ID_RE.fullmatch(driver_id):
+            raise ValueError(f'invalid driver credential id: {raw_driver_id!r}')
+        if (
+            not token
+            or token != raw_token
+            or len(token) > 4096
+            or '\r' in raw_token
+            or '\n' in raw_token
+        ):
+            raise ValueError(f'invalid {setting_name} secret for driver id: {driver_id}')
+        try:
+            token_bytes = token.encode('utf-8')
+        except UnicodeEncodeError:
+            raise ValueError(
+                f'invalid {setting_name} secret for driver id: {driver_id}'
+            ) from None
+        if len(token_bytes) < minimum_bytes:
+            raise ValueError(
+                f'{setting_name} secret for {driver_id} must contain at least '
+                f'{minimum_bytes} bytes'
+            )
+        if secret_pattern is not None and not secret_pattern.fullmatch(token):
+            raise ValueError(
+                f'{setting_name} secret for {driver_id} must use 24-4096 '
+                'restricted ASCII Bearer characters'
+            )
+        existing_owner = token_owners.get(token)
+        if existing_owner is not None:
+            raise ValueError(
+                'driver credential is assigned to more than one id: '
+                f'{existing_owner}, {driver_id}'
+            )
+        credentials[driver_id] = token
+        token_owners[token] = driver_id
+    return credentials
+
+
+def _parse_driver_tokens(raw: str) -> dict[str, str]:
+    return _parse_driver_secret_map(
+        raw,
+        'MOTUS_DRIVER_TOKENS',
+        minimum_bytes=24,
+        secret_pattern=_DRIVER_BEARER_RE,
+    )
+
+
+def _parse_driver_ticket_secrets(raw: str) -> dict[str, bytes]:
+    parsed = _parse_driver_secret_map(
+        raw,
+        'MOTUS_TELEOP_TICKET_SECRETS',
+        minimum_bytes=32,
+    )
+    return {driver_id: value.encode('utf-8') for driver_id, value in parsed.items()}
+
+
+def init(settings: Optional[Mapping[str, str]] = None):
+    """Load and cache authentication settings.
+
+    ``settings`` is intentionally injectable so focused tests can avoid reading
+    developer or deployment credentials from disk.
+    """
+
+    global _driver_token, _driver_auth_enforced, _teleop_ticket_secret, _auth_enabled
+    global _unsafe_desktop_code_tools_enabled
+    values = dict(settings) if settings is not None else _load_settings()
+    snapshot = {
+        'principals': dict(_principals_by_token),
+        'principal_tokens': dict(_tokens_by_principal_id),
+        'driver_token': _driver_token,
+        'driver_tokens': dict(_driver_tokens_by_id),
+        'driver_enforced': _driver_auth_enforced,
+        'ticket_secret': _teleop_ticket_secret,
+        'ticket_secrets': dict(_teleop_ticket_secrets_by_driver),
+        'auth_enabled': _auth_enabled,
+        'unsafe_code_tools': _unsafe_desktop_code_tools_enabled,
+    }
+    try:
+        _apply_settings(values)
+    except Exception:
+        _principals_by_token.clear()
+        _principals_by_token.update(snapshot['principals'])
+        _tokens_by_principal_id.clear()
+        _tokens_by_principal_id.update(snapshot['principal_tokens'])
+        _driver_token = snapshot['driver_token']
+        _driver_tokens_by_id.clear()
+        _driver_tokens_by_id.update(snapshot['driver_tokens'])
+        _driver_auth_enforced = snapshot['driver_enforced']
+        _teleop_ticket_secret = snapshot['ticket_secret']
+        _teleop_ticket_secrets_by_driver.clear()
+        _teleop_ticket_secrets_by_driver.update(snapshot['ticket_secrets'])
+        _auth_enabled = snapshot['auth_enabled']
+        _unsafe_desktop_code_tools_enabled = snapshot['unsafe_code_tools']
+        raise
+
+
+def _apply_settings(values: Mapping[str, str]) -> None:
+    """Validate and install one settings snapshot; ``init`` owns rollback."""
+
+    global _driver_token, _driver_auth_enforced, _teleop_ticket_secret, _auth_enabled
+    global _unsafe_desktop_code_tools_enabled
+
+    _unsafe_desktop_code_tools_enabled = False
+    _teleop_ticket_secret = b''
+    _teleop_ticket_secrets_by_driver.clear()
+    _principals_by_token.clear()
+    _tokens_by_principal_id.clear()
+    owner_token = values.get('ACCESS_TOKEN', '').strip()
+    if owner_token:
+        _register_human_token(owner_token, Principal(id='owner:legacy', role='owner'))
+
+    for name, token in _parse_named_tokens(values.get('MOTUS_OPERATOR_TOKENS', ''), 'operator'):
+        _register_human_token(token, Principal(id=f'operator:{name}', role='operator'))
+    for name, token in _parse_named_tokens(values.get('MOTUS_VIEWER_TOKENS', ''), 'viewer'):
+        _register_human_token(token, Principal(id=f'viewer:{name}', role='viewer'))
+
+    _driver_tokens_by_id.clear()
+    _driver_tokens_by_id.update(
+        _parse_driver_tokens(values.get('MOTUS_DRIVER_TOKENS', ''))
+    )
+    _driver_token = values.get('MOTUS_DRIVER_TOKEN', '').strip()
+    if _driver_token and authenticate(_driver_token) is not None:
+        raise ValueError('MOTUS_DRIVER_TOKEN must not reuse a human access token')
+    for driver_id, token in _driver_tokens_by_id.items():
+        if authenticate(token) is not None:
+            raise ValueError(
+                f'driver credential must not reuse a human access token: {driver_id}'
+            )
+        if _driver_token and _secret_text_equal(token, _driver_token):
+            raise ValueError(
+                f'MOTUS_DRIVER_TOKEN must not reuse dedicated credential: {driver_id}'
+            )
+    enforce_raw = values.get('MOTUS_ENFORCE_DRIVER_AUTH', '').strip().lower()
+    if enforce_raw not in ('', '0', 'false', 'no', 'off', '1', 'true', 'yes', 'on'):
+        raise ValueError('MOTUS_ENFORCE_DRIVER_AUTH must be true or false')
+    _driver_auth_enforced = enforce_raw in ('1', 'true', 'yes', 'on')
+    if _driver_auth_enforced and not (_driver_token or _driver_tokens_by_id):
+        raise ValueError(
+            'MOTUS_ENFORCE_DRIVER_AUTH requires MOTUS_DRIVER_TOKEN or '
+            'MOTUS_DRIVER_TOKENS'
+        )
+    ticket_secret = values.get('MOTUS_TELEOP_TICKET_SECRET', '')
+    if not isinstance(ticket_secret, str):
+        raise TypeError('MOTUS_TELEOP_TICKET_SECRET must be a string')
+    try:
+        ticket_secret_bytes = ticket_secret.encode('utf-8')
+    except UnicodeEncodeError:
+        raise ValueError('MOTUS_TELEOP_TICKET_SECRET must be valid UTF-8') from None
+    if ticket_secret_bytes and len(ticket_secret_bytes) < 32:
+        raise ValueError('MOTUS_TELEOP_TICKET_SECRET must contain at least 32 bytes')
+    dedicated_ticket_secrets = _parse_driver_ticket_secrets(
+        values.get('MOTUS_TELEOP_TICKET_SECRETS', '')
+    )
+    for driver_id, dedicated_secret in dedicated_ticket_secrets.items():
+        dedicated_text = dedicated_secret.decode('utf-8')
+        if authenticate(dedicated_text) is not None:
+            raise ValueError(
+                'teleop ticket secret must not reuse a human access token: '
+                f'{driver_id}'
+            )
+        if _driver_token and _secret_text_equal(
+            dedicated_text,
+            _driver_token,
+        ):
+            raise ValueError(
+                'teleop ticket secret must not reuse legacy Driver credential: '
+                f'{driver_id}'
+            )
+        bearer_owner = next(
+            (
+                owner
+                for owner, token in _driver_tokens_by_id.items()
+                if _secret_text_equal(dedicated_text, token)
+            ),
+            None,
+        )
+        if bearer_owner is not None:
+            raise ValueError(
+                'teleop ticket secret must not reuse dedicated Driver credential: '
+                f'{driver_id}, {bearer_owner}'
+            )
+        if ticket_secret_bytes and secrets.compare_digest(
+            dedicated_secret,
+            ticket_secret_bytes,
+        ):
+            raise ValueError(
+                'MOTUS_TELEOP_TICKET_SECRET must not reuse dedicated secret: '
+                f'{driver_id}'
+            )
+    if ticket_secret_bytes:
+        if authenticate(ticket_secret) is not None:
+            raise ValueError(
+                'MOTUS_TELEOP_TICKET_SECRET must not reuse a human access token'
+            )
+        if _driver_token and _secret_text_equal(ticket_secret, _driver_token):
+            raise ValueError(
+                'MOTUS_TELEOP_TICKET_SECRET must not reuse legacy Driver credential'
+            )
+        conflicting_bearer = next(
+            (
+                driver_id
+                for driver_id, token in _driver_tokens_by_id.items()
+                if _secret_text_equal(ticket_secret, token)
+            ),
+            None,
+        )
+        if conflicting_bearer is not None:
+            raise ValueError(
+                'MOTUS_TELEOP_TICKET_SECRET must not reuse dedicated Driver '
+                f'credential: {conflicting_bearer}'
+            )
+    _teleop_ticket_secrets_by_driver.update(dedicated_ticket_secrets)
+    _teleop_ticket_secret = ticket_secret_bytes
+    # Service credentials turn otherwise anonymous API routes into confused
+    # deputies: an unauthenticated caller could make Core send a trusted
+    # Driver Bearer or mint a WebRTC ticket. Enable the API authentication
+    # boundary whenever any such credential exists, even if the deployment
+    # forgot to configure a human principal. With no human token this fails
+    # closed (management APIs return 401) until the environment is corrected.
+    _auth_enabled = bool(
+        _principals_by_token
+        or _driver_token
+        or _driver_tokens_by_id
+        or _teleop_ticket_secret
+        or _teleop_ticket_secrets_by_driver
+    )
+    unsafe_raw = values.get(
+        'MOTUS_ENABLE_UNSAFE_DESKTOP_CODE_TOOLS', ''
+    ).strip().lower()
+    if unsafe_raw not in ('', '0', 'false', 'no', 'off', '1', 'true', 'yes', 'on'):
+        raise ValueError(
+            'MOTUS_ENABLE_UNSAFE_DESKTOP_CODE_TOOLS must be true or false'
+        )
+    requested_unsafe_code_tools = unsafe_raw in ('1', 'true', 'yes', 'on')
+    if requested_unsafe_code_tools and (
+        _principals_by_token
+        or _driver_token
+        or _driver_tokens_by_id
+        or _teleop_ticket_secret
+        or _teleop_ticket_secrets_by_driver
+    ):
+        raise ValueError(
+            'MOTUS_ENABLE_UNSAFE_DESKTOP_CODE_TOOLS cannot be enabled when '
+            'authentication or teleop credentials are configured'
+        )
+    _unsafe_desktop_code_tools_enabled = requested_unsafe_code_tools
+
+    if _principals_by_token:
+        print(f'[auth] Principal authentication enabled ({len(_principals_by_token)} identities)')
+    elif _auth_enabled:
+        print(
+            '[auth] Service credentials configured without human tokens '
+            '— protected management APIs are locked until an ACCESS_TOKEN '
+            'owner is configured'
+        )
+    else:
+        print('[auth] No human tokens configured — legacy API authentication disabled')
+    if not (_driver_token or _driver_tokens_by_id):
+        print('[auth] Driver credentials not configured — driver registrations are untrusted')
+    elif _driver_auth_enforced:
+        print(
+            '[auth] Driver authentication enforcement enabled '
+            f'({_driver_credential_summary()})'
+        )
+    else:
+        print(
+            '[auth] Driver credentials configured in compatibility mode '
+            f'({_driver_credential_summary()}) — legacy services remain untrusted'
+        )
+    if not (_teleop_ticket_secret or _teleop_ticket_secrets_by_driver):
+        print('[auth] Teleop ticket secrets not configured — WebRTC signaling disabled')
+    else:
+        print(
+            '[auth] Teleop WebRTC ticket signing enabled '
+            f'({len(_teleop_ticket_secrets_by_driver)} dedicated, '
+            f'{"legacy fallback enabled" if _teleop_ticket_secret else "no legacy fallback"})'
+        )
 
 
 def get_token() -> str:
-    return _token
+    """Return the legacy owner token for backwards compatibility."""
+    for token, principal in _principals_by_token.items():
+        if principal.role == 'owner':
+            return token
+    return ''
 
 
 def is_enabled() -> bool:
     return _auth_enabled
 
 
+def _driver_credential_summary() -> str:
+    dedicated = len(_driver_tokens_by_id)
+    legacy = 'legacy fallback enabled' if _driver_token else 'no legacy fallback'
+    return f'{dedicated} dedicated, {legacy}'
+
+
+def has_any_driver_credentials() -> bool:
+    """Return whether any Core → Driver bearer credential is configured."""
+
+    return bool(_driver_token or _driver_tokens_by_id)
+
+
+def is_driver_auth_configured(driver_id: str) -> bool:
+    """Return whether Core can authenticate to the exact Driver identity."""
+
+    if not _valid_driver_id(driver_id):
+        return False
+    if driver_id in _driver_tokens_by_id:
+        return True
+    return bool(_driver_token)
+
+
+def driver_runtime_credential_available(driver_id: str) -> bool:
+    """Require an outbound credential for every persisted trusted record."""
+
+    return is_driver_auth_configured(driver_id)
+
+
+def driver_credential_binding(driver_id: str) -> str:
+    """Return a non-secret binding for the currently selected dedicated token."""
+
+    if not _valid_driver_id(driver_id):
+        return ''
+    token = _driver_tokens_by_id.get(driver_id)
+    if token is None:
+        return ''
+    digest = hashlib.sha256(
+        b'motus.driver.credential-binding.v1\0'
+        + driver_id.encode('ascii')
+        + b'\0'
+        + token.encode('ascii')
+    ).hexdigest()
+    return f'sha256:{digest}'
+
+
+def driver_record_credential_available(
+    driver_id: str,
+    credential_binding: object,
+) -> bool:
+    """Require re-registration after a dedicated credential is added or rotated."""
+
+    if not is_driver_auth_configured(driver_id):
+        return False
+    selected_binding = driver_credential_binding(driver_id)
+    if selected_binding:
+        return bool(
+            isinstance(credential_binding, str)
+            and _secret_text_equal(credential_binding, selected_binding)
+        )
+    # A stale dedicated binding must not silently downgrade to the legacy
+    # fallback. A valid legacy-token registration removes the old binding.
+    return credential_binding is None or credential_binding == ''
+
+
+def is_driver_auth_enforced() -> bool:
+    return _driver_auth_enforced
+
+
+def unsafe_desktop_code_tools_enabled() -> bool:
+    """Return whether an administrator explicitly enabled in-process code tools."""
+
+    return _unsafe_desktop_code_tools_enabled
+
+
+def has_dedicated_teleop_ticket_secret(driver_id: str) -> bool:
+    return bool(
+        _valid_driver_id(driver_id)
+        and driver_id in _teleop_ticket_secrets_by_driver
+    )
+
+
+def teleop_ticket_secret(driver_id: str) -> bytes:
+    """Return the server-only RTC ticket secret for one exact Driver."""
+
+    if not _valid_driver_id(driver_id):
+        return b''
+    return _teleop_ticket_secrets_by_driver.get(driver_id, _teleop_ticket_secret)
+
+
+def teleop_ticket_credential_available(driver_id: str) -> bool:
+    """Return whether Core can sign an offer ticket for one exact Driver."""
+
+    return bool(teleop_ticket_secret(driver_id))
+
+
+def authenticate(token: str) -> Optional[Principal]:
+    if not token:
+        return None
+    # Iterate and compare in constant time instead of using a direct dict lookup.
+    for configured, principal in _principals_by_token.items():
+        if _secret_text_equal(token, configured):
+            return principal
+    return None
+
+
 def verify(token: str) -> bool:
+    # Preserve the pre-teleop behavior for existing non-teleop APIs.
     if not _auth_enabled:
         return True
-    return bool(token) and token == _token
+    return authenticate(token) is not None
+
+
+def has_dedicated_driver_token(driver_id: str) -> bool:
+    return bool(
+        _valid_driver_id(driver_id)
+        and driver_id in _driver_tokens_by_id
+    )
+
+
+def driver_token_identity(token: str) -> str | None:
+    """Return the dedicated identity owning ``token`` without exposing a secret."""
+
+    if not isinstance(token, str) or not token:
+        return None
+    matched_identity = None
+    for driver_id, configured in _driver_tokens_by_id.items():
+        if _secret_text_equal(token, configured):
+            matched_identity = driver_id
+    return matched_identity
+
+
+def is_known_driver_token(token: str) -> bool:
+    """Return whether ``token`` is any configured Driver bearer credential."""
+
+    if not isinstance(token, str) or not token:
+        return False
+    matched = bool(_driver_token and _secret_text_equal(token, _driver_token))
+    for configured in _driver_tokens_by_id.values():
+        matched = _secret_text_equal(token, configured) or matched
+    return matched
+
+
+def verify_driver_token(token: str, driver_id: str) -> bool:
+    """Verify a registration credential against one claimed stable identity."""
+
+    if not isinstance(token, str) or not token or not _valid_driver_id(driver_id):
+        return False
+    dedicated = _driver_tokens_by_id.get(driver_id)
+    if dedicated is not None:
+        return _secret_text_equal(token, dedicated)
+    return bool(_driver_token and _secret_text_equal(token, _driver_token))
+
+
+def driver_request_headers(driver_id: str) -> dict[str, str]:
+    """Return the service credential for Core → Driver MCP requests.
+
+    Callers must never log this mapping.  An empty mapping preserves legacy
+    deployments that have not enabled driver authentication.
+    """
+    if not _valid_driver_id(driver_id):
+        return {}
+    token = _driver_tokens_by_id.get(driver_id)
+    if token is None:
+        token = _driver_token
+    if not token:
+        return {}
+    return {'Authorization': f'Bearer {token}'}
+
+
+def _extract_token(request: Request) -> str:
+    auth_header = request.headers.get('authorization', '')
+    if auth_header.startswith('Bearer '):
+        return auth_header[7:]
+    return request.query_params.get('token', '')
+
+
+def extract_driver_token(request: Request) -> str:
+    token = request.headers.get('x-motus-driver-token', '')
+    if token:
+        return token
+    auth_header = request.headers.get('authorization', '')
+    if auth_header.startswith('Bearer '):
+        return auth_header[7:]
+    return ''
+
+
+def request_principal(request: Request) -> Optional[Principal]:
+    cached = getattr(request.state, 'principal', None)
+    if cached is not None:
+        return cached
+    principal = authenticate(_extract_token(request))
+    request.state.principal = principal
+    return principal
+
+
+def require_role(request: Request, required_role: str = 'viewer') -> Principal:
+    principal = request_principal(request)
+    if principal is None:
+        raise HTTPException(status_code=401, detail='Authentication required')
+    if _ROLE_LEVEL.get(principal.role, 0) < _ROLE_LEVEL.get(required_role, 0):
+        raise HTTPException(
+            status_code=403,
+            detail=f'{required_role} role required',
+        )
+    return principal
 
 
 async def auth_middleware(request: Request, call_next):
-    """FastAPI middleware: enforce token auth on /api/* and /ws/* paths."""
+    """Enforce legacy API authentication and attach a trusted Principal."""
+
+    token = _extract_token(request)
+    request.state.principal = authenticate(token)
+
     if not _auth_enabled:
         return await call_next(request)
 
     path = request.url.path
-
-    # Static files and HTML — no auth needed
     if not path.startswith('/api/') and not path.startswith('/ws/'):
         return await call_next(request)
 
-    # Exempt paths
     if path == '/api/auth/verify':
         return await call_next(request)
+
+    principal = request.state.principal
+    # A recognized human identity is always governed by its role, including on
+    # service callback routes that remain open for legacy machine callers.
+    if principal is not None and principal.role != 'owner':
+        if path.startswith('/api/teleop/'):
+            return await call_next(request)
+        return JSONResponse(status_code=403, content={'detail': 'Owner role required'})
+
     if path.startswith('/api/channel/webhook/'):
         return await call_next(request)
-    # MCP registration from driver containers
+    # Driver/perception registration authenticates and records trust itself.
     if path == '/api/mcp' and request.method == 'POST':
         return await call_next(request)
-    # ACP completion callback from driver containers
     if path == '/api/acp/complete' and request.method == 'POST':
         return await call_next(request)
     # System hooks fire (internal/driver calls)
@@ -85,26 +743,14 @@ async def auth_middleware(request: Request, call_next):
     if path == '/ws/mic':
         return await call_next(request)
 
-    # Check token
-    token = _extract_token(request)
-    if not verify(token):
+    if principal is None:
         return JSONResponse(status_code=401, content={'detail': 'Unauthorized'})
 
     return await call_next(request)
 
 
 def check_ws_token(websocket: WebSocket) -> bool:
-    """Check token in WebSocket query params."""
     if not _auth_enabled:
         return True
-    token = websocket.query_params.get('token', '')
-    return verify(token)
-
-
-def _extract_token(request: Request) -> str:
-    """Extract token from Authorization header or query param."""
-    auth = request.headers.get('authorization', '')
-    if auth.startswith('Bearer '):
-        return auth[7:]
-    return request.query_params.get('token', '')
-
+    principal = authenticate(websocket.query_params.get('token', ''))
+    return bool(principal and principal.role == 'owner')

--- a/agent-core/src/client/llm.py
+++ b/agent-core/src/client/llm.py
@@ -1,5 +1,3 @@
-import typing
-import base64
 import pathlib
 import asyncio
 import re
@@ -86,12 +84,14 @@ def _classify_error(e: Exception) -> tuple[str, float | None]:
 # ── Client ────────────────────────────────────────────────────────────────────
 
 class Client():
-    def __init__(self):
+    def __init__(self, configs: list[dict] | None = None):
         LOG_PATH.mkdir(parents=True, exist_ok=True)
-        self._init_clients()
+        self._init_clients(configs)
 
-    def _init_clients(self):
+    def _init_clients(self, configs: list[dict] | None = None):
         """从配置创建 OpenAI client 列表。"""
+        if configs is None:
+            configs = config.main['client']['llm']
         self.client_list = [
             openai.AsyncOpenAI(
                 base_url=config_it['url'],
@@ -102,11 +102,19 @@ class Client():
                     event_hooks={"request": [_log_request]},
                 ),
             )
-            for config_it in config.main['client']['llm']
+            for config_it in configs
             if config_it.get('key')  # 跳过未配置 credentials 的条目
         ]
         # 跟踪每个 endpoint 的健康状态
         self._endpoint_dead: list[bool] = [False] * len(self.client_list)
+
+    async def aclose(self) -> None:
+        """Close a staged client that could not be committed."""
+
+        await asyncio.gather(
+            *(client.close() for client in self.client_list),
+            return_exceptions=True,
+        )
 
     async def __call__(self,
         message_list: list[dict],
@@ -261,14 +269,14 @@ class Client():
                 # 标记触发 402 的 endpoint 为 dead，切换到下一个
                 for idx, _, cfg in alive:
                     endpoint_dead[idx] = True
-                print(f'[llm] billing error — marked endpoint(s) dead, trying others')
+                print('[llm] billing error — marked endpoint(s) dead, trying others')
                 continue  # 立即重试剩余 endpoint
 
             if kind == LLMErrorKind.AUTH:
                 # 认证错误不可恢复
                 for idx, _, cfg in alive:
                     endpoint_dead[idx] = True
-                print(f'[llm] auth error — marked endpoint(s) dead')
+                print('[llm] auth error — marked endpoint(s) dead')
                 continue
 
             if kind == LLMErrorKind.RATE_LIMIT:
@@ -287,7 +295,7 @@ class Client():
 
             if kind == LLMErrorKind.TIMEOUT:
                 if attempt < max_retries:
-                    print(f'[llm] timeout — retrying immediately')
+                    print('[llm] timeout — retrying immediately')
                     continue
 
             if kind == LLMErrorKind.CONNECTION:
@@ -301,7 +309,7 @@ class Client():
 
             if kind == LLMErrorKind.CONTEXT_OVERFLOW:
                 # 上下文溢出：不重试，由调用方处理（需要压缩历史）
-                print(f'[llm] context overflow — caller should compress history')
+                print('[llm] context overflow — caller should compress history')
                 raise error
 
             # UNKNOWN：不重试

--- a/agent-core/src/config.py
+++ b/agent-core/src/config.py
@@ -205,6 +205,17 @@ _seed_defaults()
 def _migrate():
     """One-time data migrations to fix stale values from previous versions."""
     with _get_conn() as conn:
+        guard_table = conn.execute(
+            """SELECT 1 FROM sqlite_master
+               WHERE type='table' AND name='teleop_authority_guards'"""
+        ).fetchone()
+        if guard_table is not None:
+            guarded = conn.execute(
+                'SELECT 1 FROM teleop_authority_guards LIMIT 1'
+            ).fetchone()
+            if guarded is not None:
+                print('[config] deferred MCP dedup while teleop recovery is pending')
+                return
         # Dedup MCP list by id (keep last occurrence)
         row_svc = conn.execute("SELECT value FROM config WHERE key='services'").fetchone()
         if row_svc:
@@ -249,6 +260,26 @@ class ConfigDB:
                 (key, json.dumps(value))
             )
             conn.commit()
+
+    def set_many(self, values: dict[str, object]) -> None:
+        """Persist a related configuration snapshot in one SQLite transaction."""
+
+        encoded = {
+            key: json.dumps(value)
+            for key, value in values.items()
+        }
+        with _get_conn() as conn:
+            try:
+                conn.execute('BEGIN IMMEDIATE')
+                for key, value in encoded.items():
+                    conn.execute(
+                        'INSERT OR REPLACE INTO config (key, value) VALUES (?, ?)',
+                        (key, value),
+                    )
+                conn.commit()
+            except Exception:
+                conn.rollback()
+                raise
 
     def __contains__(self, key: str) -> bool:
         with _get_conn() as conn:

--- a/agent-core/src/event/desktop.py
+++ b/agent-core/src/event/desktop.py
@@ -36,6 +36,52 @@ _PYTHON_ALLOWED_MODULES = {
     'dataclasses', 'csv', 'io', 'os.path',
 }
 
+_PROTECTED_FILE_SUFFIXES = {'.key', '.pem', '.p12', '.pfx'}
+
+
+def _path_is_protected(p: pathlib.Path) -> bool:
+    """Keep deployment credentials and the runtime config DB out of file tools."""
+
+    name = p.name.lower()
+    if name == '.env' or name.startswith('.env.'):
+        return True
+    if (
+        name in {'id_rsa', 'id_ed25519', 'credentials.json', 'secrets.json'}
+        or 'privkey' in name
+        or 'private-key' in name
+    ):
+        return True
+    if p.suffix.lower() in _PROTECTED_FILE_SUFFIXES:
+        return True
+
+    protected_paths = {
+        pathlib.Path('/opt/phanthy-motus/.env'),
+        pathlib.Path('.env'),
+    }
+    tls_key_path = os.environ.get('MOTUS_TLS_KEY_FILE', '').strip()
+    if tls_key_path:
+        protected_paths.add(pathlib.Path(tls_key_path))
+    try:
+        config_db = pathlib.Path(config.DB_PATH).resolve()
+        protected_paths.update({
+            config_db,
+            pathlib.Path(f'{config_db}-shm'),
+            pathlib.Path(f'{config_db}-wal'),
+            pathlib.Path(f'{config_db}-journal'),
+        })
+    except (OSError, RuntimeError, TypeError):
+        pass
+    for protected in protected_paths:
+        try:
+            protected = protected.resolve()
+            if p == protected:
+                return True
+            if p.exists() and protected.exists() and os.path.samefile(p, protected):
+                return True
+        except (OSError, RuntimeError):
+            continue
+    return False
+
 
 def _resolve_path(path: str) -> pathlib.Path:
     """Resolve path, default relative to /work."""
@@ -47,6 +93,12 @@ def _resolve_path(path: str) -> pathlib.Path:
 
 def _check_path_allowed(p: pathlib.Path, dirs: list[str] | None = None) -> str | None:
     """Return error message if path is not within allowed dirs, else None."""
+    try:
+        p = p.resolve()
+    except (OSError, RuntimeError):
+        return f'Access denied: cannot safely resolve path {p}'
+    if _path_is_protected(p):
+        return f'Access denied: {p} is a protected credential or runtime config path'
     allowed = dirs or _ALLOWED_DIRS
     s = str(p)
     for d in allowed:
@@ -138,8 +190,12 @@ class DesktopTools:
 
         # Build restricted builtins
         import builtins as _builtins
-        safe_builtins = {k: getattr(_builtins, k) for k in dir(_builtins)
-                        if not k.startswith('_') and k not in ('exec', 'eval', 'compile', 'exit', 'quit')}
+        safe_builtins = {
+            k: getattr(_builtins, k)
+            for k in dir(_builtins)
+            if not k.startswith('_')
+            and k not in ('exec', 'eval', 'compile', 'exit', 'quit', 'open')
+        }
 
         original_import = __builtins__.__import__ if hasattr(__builtins__, '__import__') else __import__
 
@@ -324,7 +380,15 @@ class DesktopTools:
             return f'Error: directory not found: {root}'
 
         try:
-            matches = sorted(root.glob(pattern), key=lambda p: p.stat().st_mtime, reverse=True)
+            matches = sorted(
+                (
+                    match
+                    for match in root.glob(pattern)
+                    if _check_path_allowed(match) is None
+                ),
+                key=lambda p: p.stat().st_mtime,
+                reverse=True,
+            )
         except Exception as e:
             return f'Error: {e}'
 
@@ -353,40 +417,10 @@ class DesktopTools:
         if err:
             return err
 
-        # Try using grep/rg subprocess for speed
-        cmd_parts = []
-        if os.path.exists('/usr/bin/grep') or os.path.exists('/bin/grep'):
-            cmd_parts = ['grep', '-rn', '--color=never', '-E']
-            if include:
-                cmd_parts.extend(['--include', include])
-            cmd_parts.extend([pattern, str(root)])
-        else:
-            # Fallback: pure Python
-            return await self._grep_python(pattern, root, include)
-
-        try:
-            proc = await asyncio.create_subprocess_exec(
-                *cmd_parts,
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE,
-            )
-            stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=30)
-            output = stdout.decode('utf-8', errors='replace')
-        except asyncio.TimeoutError:
-            return 'Error: grep timed out after 30s'
-        except Exception as e:
-            return await self._grep_python(pattern, root, include)
-
-        if not output.strip():
-            return f'No matches for pattern "{pattern}" in {root}'
-
-        # Limit output
-        lines = output.splitlines()
-        if len(lines) > 50:
-            result = '\n'.join(lines[:50])
-            result += f'\n\n... ({len(lines) - 50} more matches not shown)'
-            return _truncate(result)
-        return _truncate(output)
+        # A Python traversal makes the per-file protected-path check explicit;
+        # recursive grep subprocesses can otherwise read hidden .env or SQLite
+        # credential stores even when their root directory itself is allowed.
+        return await self._grep_python(pattern, root, include)
 
     async def _grep_python(self, pattern: str, root: pathlib.Path, include: str) -> str:
         """Pure Python grep fallback."""
@@ -400,10 +434,16 @@ class DesktopTools:
 
         def _search_file(fp: pathlib.Path):
             try:
-                text = fp.read_text(encoding='utf-8', errors='ignore')
+                resolved = fp.resolve()
+            except (OSError, RuntimeError):
+                return
+            if _check_path_allowed(resolved) is not None:
+                return
+            try:
+                text = resolved.read_text(encoding='utf-8', errors='ignore')
                 for i, line in enumerate(text.splitlines(), 1):
                     if regex.search(line):
-                        results.append(f'{fp}:{i}: {line.rstrip()}')
+                        results.append(f'{resolved}:{i}: {line.rstrip()}')
                         if len(results) >= max_results:
                             return
             except (OSError, UnicodeDecodeError):
@@ -453,8 +493,7 @@ class DesktopTools:
         try:
             async with aiohttp.ClientSession() as session:
                 async with session.get(url, timeout=aiohttp.ClientTimeout(total=timeout),
-                                       headers={'User-Agent': 'Mozilla/5.0 (compatible; AgentBot/1.0)'},
-                                       ssl=False) as resp:
+                                       headers={'User-Agent': 'Mozilla/5.0 (compatible; AgentBot/1.0)'}) as resp:
                     if resp.status >= 400:
                         return f'Error: HTTP {resp.status} {resp.reason}'
                     content_type = resp.headers.get('content-type', '')
@@ -545,7 +584,6 @@ class DesktopTools:
                     json=payload,
                     headers=headers,
                     timeout=aiohttp.ClientTimeout(total=30),
-                    ssl=False,
                 ) as resp:
                     if resp.status == 401:
                         return 'Error: Search API key is invalid (401 Unauthorized)'

--- a/agent-core/src/event/llm.py
+++ b/agent-core/src/event/llm.py
@@ -25,6 +25,7 @@ import client
 import event
 import event_bus
 import collector
+import auth
 import mcp_client
 import perf_log
 import prompt as prompt_mod
@@ -75,6 +76,26 @@ def _build_system_tools(named_functions: list[tuple[str, callable]]) -> dict:
             },
         }
     return tool_dict
+
+
+def _desktop_tool_functions(desktop_tools) -> list[tuple[str, callable]]:
+    """Return desktop tools safe for the current deployment credential mode."""
+
+    tools = [
+        ('Read', desktop_tools.Read),
+        ('Glob', desktop_tools.Glob),
+        ('Grep', desktop_tools.Grep),
+        ('WebSearch', desktop_tools.WebSearch),
+    ]
+    if auth.unsafe_desktop_code_tools_enabled():
+        tools[:0] = [
+            ('Bash', desktop_tools.Bash),
+            ('PythonExec', desktop_tools.PythonExec),
+            ('Write', desktop_tools.Write),
+            ('Edit', desktop_tools.Edit),
+            ('WebFetch', desktop_tools.WebFetch),
+        ]
+    return tools
 
 
 # ── History helpers ────────────────────────────────────────────────────────────
@@ -479,7 +500,7 @@ class Event:
         self._desktop_tools = DesktopTools()
 
         # 注册系统工具（finish / memory / task / detailed_info / subagent / desktop）
-        self._sys_tools = _build_system_tools([
+        system_functions = [
             ('finish', event.finish.__call__),
             ('update_memory', event.memory.update),
             ('activate_skill', event.skills.activate_skill),
@@ -499,17 +520,9 @@ class Event:
             ('subagent_cancel', _sa_tools.subagent_cancel),
             ('subagent_message', _sa_tools.subagent_message),
             ('subagent_result', _sa_tools.subagent_result),
-            # Desktop tools (Claude Code 风格)
-            ('Bash', self._desktop_tools.Bash),
-            ('PythonExec', self._desktop_tools.PythonExec),
-            ('Read', self._desktop_tools.Read),
-            ('Write', self._desktop_tools.Write),
-            ('Edit', self._desktop_tools.Edit),
-            ('Glob', self._desktop_tools.Glob),
-            ('Grep', self._desktop_tools.Grep),
-            ('WebFetch', self._desktop_tools.WebFetch),
-            ('WebSearch', self._desktop_tools.WebSearch),
-        ])
+        ]
+        system_functions.extend(_desktop_tool_functions(self._desktop_tools))
+        self._sys_tools = _build_system_tools(system_functions)
         # 连接并注册所有 MCP 工具
         await mcp_client.init_all()
         # 恢复持久化的活跃任务及其定时检查

--- a/agent-core/src/mcp_client.py
+++ b/agent-core/src/mcp_client.py
@@ -21,15 +21,27 @@ mcp_client.py — MCP HTTP transport 客户端。
 """
 
 import asyncio
+import hashlib
+import ipaddress
 import json
-import time
+import math
 import uuid
+from dataclasses import dataclass
+from urllib.parse import urlsplit, urlunsplit
 
 import aiohttp
-import jsonschema
-
+import auth
 import config
 import event_bus
+import jsonschema
+from mcp_protocol import rpc_response_error, tool_result_error
+from teleop.command_broker import (
+    InvalidAuthorityBinding,
+    TeleopCommandBlocked,
+    authority_domain_for_mcp,
+    classify_tool_access,
+)
+from teleop.contracts import TeleopContractError, project_teleop_descriptor
 
 # ── 全局注册表 ─────────────────────────────────────────────────────────────────
 registry: dict[str, dict] = {}   # mcp_id → info
@@ -41,13 +53,216 @@ _pending_timeouts: dict[str, float] = {}          # action_id → dynamic timeou
 _pending_tools: dict[str, str] = {}               # action_id → tool_name (资源冲突检测用)
 
 
+_TELEOP_RESPONSE_LIMIT = 1024 * 1024
+_TELEOP_SIGNALING_RESPONSE_LIMIT = 256 * 1024
+_TELEOP_TIMEOUT_MIN = 0.25
+_TELEOP_TIMEOUT_MAX = 10.0
+_SAFE_DRIVER_ERROR_CODES = {
+    'boot_mismatch',
+    'epoch_mismatch',
+    'fence_mismatch',
+    'frame_too_large',
+    'invalid_arguments',
+    'invalid_control',
+    'invalid_encoding',
+    'invalid_epoch',
+    'invalid_fence',
+    'invalid_json',
+    'invalid_length',
+    'invalid_params',
+    'invalid_quaternion',
+    'invalid_session_id',
+    'invalid_type',
+    'invalid_value',
+    'message_too_large',
+    'missing_action',
+    'missing_field',
+    'missing_identity',
+    'non_finite',
+    'out_of_range',
+    'session_inactive',
+    'session_expired',
+    'session_mismatch',
+    'session_paused',
+    'stale_epoch',
+    'tracking_mismatch',
+    'unknown_action',
+    'unknown_field',
+    'unknown_tool',
+    'unsupported_mode',
+    'unsupported_version',
+}
+
+
+class TrustedShadowTransportError(RuntimeError):
+    """Sanitized failure from the dedicated Core → Shadow Driver boundary.
+
+    The exception deliberately retains only bounded machine codes.  Driver
+    response text, request arguments, service credentials and target URLs are
+    never included because teleop arguments contain the active fence token.
+    """
+
+    def __init__(
+        self,
+        code: str,
+        *,
+        http_status: int | None = None,
+        rpc_code: int | None = None,
+        rpc_data_code: str | None = None,
+    ) -> None:
+        self.code = code
+        self.http_status = http_status
+        self.rpc_code = rpc_code
+        self.rpc_data_code = rpc_data_code
+        details = [f'code={code}']
+        if http_status is not None:
+            details.append(f'http_status={http_status}')
+        if rpc_code is not None:
+            details.append(f'rpc_code={rpc_code}')
+        if rpc_data_code is not None:
+            details.append(f'rpc_data_code={rpc_data_code}')
+        super().__init__(f'trusted shadow driver call failed ({", ".join(details)})')
+
+
+@dataclass(frozen=True)
+class TrustedShadowTarget:
+    """Immutable authority endpoint pinned before a fence is issued."""
+
+    mcp_id: str
+    url: str
+    capability_digest: str
+    descriptor_fingerprint: str
+    actions: frozenset[str]
+
+
+def teleop_tool_fingerprint(tool: object) -> str | None:
+    """Return a stable fingerprint for the authority-relevant tool contract."""
+
+    if not isinstance(tool, dict) or tool.get('name') != 'teleop_session':
+        return None
+    try:
+        encoded = json.dumps(
+            {
+                'name': tool.get('name'),
+                'type': tool.get('type'),
+                'inputSchema': tool.get('inputSchema'),
+                'x-teleop': tool.get('x-teleop'),
+            },
+            ensure_ascii=False,
+            allow_nan=False,
+            sort_keys=True,
+            separators=(',', ':'),
+        ).encode('utf-8')
+    except (TypeError, ValueError, RecursionError):
+        return None
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def teleop_tools_fingerprint(tools: object) -> str | None:
+    if not isinstance(tools, list):
+        return None
+    matches = [
+        tool for tool in tools
+        if isinstance(tool, dict) and tool.get('name') == 'teleop_session'
+    ]
+    return teleop_tool_fingerprint(matches[0]) if len(matches) == 1 else None
+
+
+def teleop_url_safety_code(url: object) -> str | None:
+    """Return a stable rejection code, or ``None`` for a safe endpoint URL."""
+
+    if not isinstance(url, str) or len(url) > 2048 or any(char.isspace() for char in url):
+        return 'invalid_url'
+    try:
+        parsed_url = urlsplit(url)
+        _ = parsed_url.port
+    except ValueError:
+        return 'invalid_url'
+    if (
+        parsed_url.scheme not in ('http', 'https')
+        or not parsed_url.hostname
+        or parsed_url.username is not None
+        or parsed_url.password is not None
+        or parsed_url.query
+        or parsed_url.fragment
+    ):
+        return 'invalid_url'
+    if parsed_url.scheme == 'http':
+        hostname = parsed_url.hostname.lower()
+        try:
+            is_loopback = ipaddress.ip_address(hostname).is_loopback
+        except ValueError:
+            is_loopback = hostname == 'localhost'
+        if not is_loopback:
+            return 'insecure_transport'
+    return None
+
+
+def _is_reserved_teleop_tool(mcp_id: str, tool_name: str) -> bool:
+    if tool_name == 'teleop_session':
+        return True
+    for mcp in config.main.get('services', {}).get('mcp', []):
+        if mcp.get('id') != mcp_id:
+            continue
+        return any(
+            isinstance(tool, dict)
+            and tool.get('name') == tool_name
+            and 'x-teleop' in tool
+            for tool in mcp.get('tools', [])
+        )
+    return False
+
+
+def _configured_tool_descriptor(mcp_id: str, tool_name: str) -> dict | None:
+    matches = [
+        mcp for mcp in config.main.get('services', {}).get('mcp', [])
+        if isinstance(mcp, dict) and mcp.get('id') == mcp_id
+    ]
+    if len(matches) != 1:
+        return None
+    tools = [
+        tool for tool in matches[0].get('tools', [])
+        if isinstance(tool, dict) and tool.get('name') == tool_name
+    ]
+    return tools[0] if len(tools) == 1 else None
+
+
 # ── 内部 JSON-RPC 助手 ─────────────────────────────────────────────────────────
 
-async def _jrpc(session: aiohttp.ClientSession, url: str, method: str, params: dict, req_id: int = 1) -> dict:
+async def _jrpc(
+    session: aiohttp.ClientSession,
+    url: str,
+    method: str,
+    params: dict,
+    req_id: int = 1,
+    *,
+    trusted: bool = False,
+    driver_id: str | None = None,
+) -> dict:
     payload = {'jsonrpc': '2.0', 'id': req_id, 'method': method, 'params': params}
-    async with session.post(url, json=payload) as resp:
+    headers = {'Content-Type': 'application/json'}
+    if trusted:
+        driver_headers = auth.driver_request_headers(driver_id)
+        if not driver_headers:
+            raise PermissionError(
+                f'trusted Driver request requires an exact credential: {driver_id!r}'
+            )
+        headers.update(driver_headers)
+    async with session.post(
+        url,
+        json=payload,
+        headers=headers,
+        allow_redirects=False,
+    ) as resp:
         data = await resp.json(content_type=None)
-    return data.get('result', {})
+        response_error = rpc_response_error(
+            data,
+            request_id=req_id,
+            http_status=resp.status,
+        )
+    if response_error:
+        raise ConnectionError(f'MCP {method} failed: {response_error}')
+    return data['result']
 
 
 def _to_openai_schema(mcp_id: str, tool: dict) -> list[dict]:
@@ -97,7 +312,14 @@ def _to_openai_schema(mcp_id: str, tool: dict) -> list[dict]:
 
 # ── 连接单个 MCP ───────────────────────────────────────────────────────────────
 
-async def _connect_one(mcp_id: str, name: str, url: str, render_hint: str) -> None:
+async def _connect_one(
+    mcp_id: str,
+    name: str,
+    url: str,
+    render_hint: str,
+    *,
+    trusted: bool = False,
+) -> None:
     timeout = aiohttp.ClientTimeout(total=8)
     schemas: dict[str, dict] = {}
     tools:   list[str]       = []
@@ -105,6 +327,7 @@ async def _connect_one(mcp_id: str, name: str, url: str, render_hint: str) -> No
     split_map:  dict[str, dict] = {}  # split_schema_name → {tool, action}
     tool_groups: dict[str, list] = {} # original_tool_name → [split_schema_names]
     input_schemas: dict[str, dict] = {}  # schema_name → 原始 MCP inputSchema（用于参数校验）
+    teleop_fingerprint: str | None = None
 
     async with aiohttp.ClientSession(timeout=timeout) as session:
         try:
@@ -113,11 +336,24 @@ async def _connect_one(mcp_id: str, name: str, url: str, render_hint: str) -> No
                 'protocolVersion': '2024-11-05',
                 'capabilities':    {},
                 'clientInfo':      {'name': 'phanthy-motus', 'version': '1.0'},
-            })
+            }, trusted=trusted, driver_id=mcp_id)
 
             # 2. tools/list
-            result = await _jrpc(session, url, 'tools/list', {})
-            for tool in result.get('tools', []):
+            result = await _jrpc(
+                session,
+                url,
+                'tools/list',
+                {},
+                trusted=trusted,
+                driver_id=mcp_id,
+            )
+            discovered_tools = result.get('tools', [])
+            teleop_fingerprint = teleop_tools_fingerprint(discovered_tools)
+            for tool in discovered_tools:
+                if 'x-teleop' in tool:
+                    # Dedicated teleop descriptors remain discoverable through
+                    # /api/teleop only; never expose them to ordinary agents.
+                    continue
                 tool_schemas = _to_openai_schema(mcp_id, tool)
                 tools.append(tool['name'])
 
@@ -133,6 +369,8 @@ async def _connect_one(mcp_id: str, name: str, url: str, render_hint: str) -> No
                         'action_enum': action_enum,
                         'has_config_schema': bool(tool.get('configSchema')),
                         'completion': raw_input_schema.get('x-completion'),
+                        'annotations': tool.get('annotations') or {},
+                        'x_teleop': tool.get('x-teleop'),
                     }
                 else:
                     # 拆分：多个 sub-schemas
@@ -146,6 +384,8 @@ async def _connect_one(mcp_id: str, name: str, url: str, render_hint: str) -> No
                             'action_enum': None,
                             'has_config_schema': bool(tool.get('configSchema')),
                             'completion': (tool.get('inputSchema') or {}).get('x-completion'),
+                            'annotations': tool.get('annotations') or {},
+                            'x_teleop': tool.get('x-teleop'),
                         }
                         # 解析 action name（最后一段 __）
                         action_name = schema['name'].split('__')[-1]
@@ -157,7 +397,7 @@ async def _connect_one(mcp_id: str, name: str, url: str, render_hint: str) -> No
                     tool_groups[tool['name']] = group
 
             online = True
-        except Exception as e:
+        except Exception:
             online = False
 
     registry[mcp_id] = {
@@ -171,14 +411,16 @@ async def _connect_one(mcp_id: str, name: str, url: str, render_hint: str) -> No
         'split_map':     split_map,
         'tool_groups':   tool_groups,
         'input_schemas': input_schemas,
+        'trusted':       trusted,
+        'teleop_fingerprint': teleop_fingerprint,
     }
 
     # 3. 后台订阅 SSE 事件流（非阻塞）
     if online:
-        asyncio.create_task(_subscribe_sse(mcp_id, url))
+        asyncio.create_task(_subscribe_sse(mcp_id, url, trusted=trusted))
 
 
-async def _subscribe_sse(mcp_id: str, url: str) -> None:
+async def _subscribe_sse(mcp_id: str, url: str, *, trusted: bool = False) -> None:
     """长连接订阅 MCP 的 SSE 事件流，推到 event_bus。重连策略：指数退避最多 60s。"""
     sse_url   = url.rstrip('/') + '/sse'
     delay     = 2.0
@@ -187,7 +429,10 @@ async def _subscribe_sse(mcp_id: str, url: str) -> None:
     while True:
         try:
             async with aiohttp.ClientSession(timeout=timeout) as session:
-                async with session.get(sse_url) as resp:
+                headers = auth.driver_request_headers(mcp_id) if trusted else {}
+                if trusted and not headers:
+                    return
+                async with session.get(sse_url, headers=headers) as resp:
                     if resp.status >= 400:
                         await asyncio.sleep(delay)
                         delay = min(delay * 2, 60)
@@ -231,15 +476,33 @@ async def _subscribe_sse(mcp_id: str, url: str) -> None:
 async def init_all() -> None:
     """在启动时并行连接所有 services.mcp 配置项。"""
     mcp_list = config.main.get('services', {}).get('mcp', [])
+
+    def _runtime_allowed(mcp: dict) -> bool:
+        state = mcp.get('trust_state')
+        if state == 'trusted':
+            return auth.driver_record_credential_available(
+                mcp.get('id', ''),
+                mcp.get('credential_binding'),
+            )
+        # Before enforcement, preserve legacy MCP runtime behavior.  Once
+        # enforcement is enabled, missing/untrusted records remain discovery-
+        # only until they re-register with the driver token.
+        return not auth.is_driver_auth_enforced() and state in (None, 'untrusted')
+
     tasks = [
         _connect_one(
             mcp_id      = m['id'],
             name        = m.get('name', m['id']),
             url         = m.get('url', ''),
             render_hint = m.get('render_hint', ''),
+            trusted     = m.get('trust_state') == 'trusted',
         )
         for m in mcp_list
-        if m.get('transport', 'http') == 'http' and m.get('url')
+        if (
+            m.get('transport', 'http') == 'http'
+            and m.get('url')
+            and _runtime_allowed(m)
+        )
     ]
     if tasks:
         await asyncio.gather(*tasks)
@@ -291,6 +554,509 @@ def _get_tool_config(mcp_id: str, tool_name: str) -> dict | None:
     return config.main.get(f'tool_config:{mcp_id}:{tool_name}', None)
 
 
+def _safe_saved_config(value: object) -> dict:
+    if not isinstance(value, dict):
+        return {}
+    return {
+        key: item
+        for key, item in value.items()
+        if key not in {'action', 'instance_id'}
+    }
+
+
+def _trusted_shadow_target(mcp_id: str, action: str) -> TrustedShadowTarget:
+    """Resolve one exact, trusted Shadow Driver target from config + runtime."""
+    services = config.main.get('services', {})
+    entries = services.get('mcp', []) if isinstance(services, dict) else []
+    matches = [
+        entry for entry in entries
+        if isinstance(entry, dict) and entry.get('id') == mcp_id
+    ]
+    if not matches:
+        raise TrustedShadowTransportError('target_not_found')
+    if len(matches) != 1:
+        raise TrustedShadowTransportError('target_ambiguous')
+
+    target = matches[0]
+    if target.get('trust_state') != 'trusted':
+        raise TrustedShadowTransportError('target_not_trusted')
+    if not auth.driver_record_credential_available(
+        mcp_id,
+        target.get('credential_binding'),
+    ):
+        raise TrustedShadowTransportError('driver_auth_unavailable')
+    if target.get('transport') != 'http':
+        raise TrustedShadowTransportError('invalid_transport')
+
+    url = target.get('url')
+    url_rejection = teleop_url_safety_code(url)
+    if url_rejection is not None:
+        raise TrustedShadowTransportError(url_rejection)
+    assert isinstance(url, str)
+
+    runtime = registry.get(mcp_id)
+    if not isinstance(runtime, dict) or runtime.get('online') is not True:
+        raise TrustedShadowTransportError('registry_offline')
+    if runtime.get('trusted') is not True:
+        raise TrustedShadowTransportError('registry_not_trusted')
+    if runtime.get('url') != url:
+        raise TrustedShadowTransportError('registry_target_mismatch')
+
+    tools = target.get('tools')
+    if not isinstance(tools, list):
+        raise TrustedShadowTransportError('descriptor_invalid')
+    session_tools = [
+        tool for tool in tools
+        if isinstance(tool, dict) and tool.get('name') == 'teleop_session'
+    ]
+    if len(session_tools) != 1:
+        raise TrustedShadowTransportError('descriptor_invalid')
+    session_tool = session_tools[0]
+    try:
+        descriptor = project_teleop_descriptor(
+            session_tool,
+            expected_driver_id=mcp_id,
+        )
+    except TeleopContractError:
+        raise TrustedShadowTransportError('descriptor_invalid')
+    digest = descriptor['capability_digest']
+
+    input_schema = session_tool.get('inputSchema')
+    properties = input_schema.get('properties') if isinstance(input_schema, dict) else None
+    action_schema = properties.get('action') if isinstance(properties, dict) else None
+    action_enum = action_schema.get('enum') if isinstance(action_schema, dict) else None
+    action_params = input_schema.get('x-action-params') if isinstance(input_schema, dict) else None
+    if not isinstance(action_enum, list) or not isinstance(action_params, dict):
+        raise TrustedShadowTransportError('descriptor_invalid')
+    declared_actions = frozenset(
+        item for item in action_enum
+        if isinstance(item, str) and item
+    )
+    if (
+        len(declared_actions) != len(action_enum)
+        or not set(action_params).issuperset(declared_actions)
+    ):
+        raise TrustedShadowTransportError('descriptor_invalid')
+    if (
+        not isinstance(action, str)
+        or action not in declared_actions
+        or action not in action_params
+    ):
+        raise TrustedShadowTransportError('action_not_declared')
+    descriptor_fingerprint = teleop_tool_fingerprint(session_tool)
+    if (
+        descriptor_fingerprint is None
+        or runtime.get('teleop_fingerprint') != descriptor_fingerprint
+    ):
+        raise TrustedShadowTransportError('registry_descriptor_mismatch')
+
+    return TrustedShadowTarget(
+        mcp_id=mcp_id,
+        url=url,
+        capability_digest=digest,
+        descriptor_fingerprint=descriptor_fingerprint,
+        actions=declared_actions,
+    )
+
+
+def _validate_pinned_shadow_target(
+    mcp_id: str,
+    action: str,
+    target: TrustedShadowTarget,
+) -> str:
+    """Validate only in-memory identity before reusing an issued fence."""
+
+    if target.mcp_id != mcp_id or action not in target.actions:
+        raise TrustedShadowTransportError('pinned_target_changed')
+    runtime = registry.get(mcp_id)
+    if not auth.driver_runtime_credential_available(mcp_id):
+        raise TrustedShadowTransportError('driver_auth_unavailable')
+    if (
+        not isinstance(runtime, dict)
+        or runtime.get('trusted') is not True
+        or runtime.get('url') != target.url
+        or runtime.get('teleop_fingerprint') != target.descriptor_fingerprint
+    ):
+        raise TrustedShadowTransportError('pinned_target_changed')
+    return target.url
+
+
+async def resolve_trusted_shadow_target(
+    mcp_id: str,
+    *,
+    timeout_seconds: float = 2.0,
+) -> TrustedShadowTarget:
+    """Resolve one immutable target before creating a Driver session."""
+
+    timeout_value = _bounded_teleop_timeout(timeout_seconds)
+    try:
+        return await asyncio.wait_for(
+            asyncio.to_thread(_trusted_shadow_target, mcp_id, 'status'),
+            timeout=timeout_value,
+        )
+    except TrustedShadowTransportError:
+        raise
+    except asyncio.TimeoutError:
+        raise TrustedShadowTransportError('timeout') from None
+    except Exception:  # noqa: BLE001 -- keep ConfigDB details private
+        raise TrustedShadowTransportError('target_resolution_error') from None
+
+
+def _bounded_teleop_timeout(timeout_seconds: float) -> float:
+    if (
+        isinstance(timeout_seconds, bool)
+        or not isinstance(timeout_seconds, (int, float))
+        or not math.isfinite(float(timeout_seconds))
+    ):
+        raise TrustedShadowTransportError('invalid_timeout')
+    return min(_TELEOP_TIMEOUT_MAX, max(_TELEOP_TIMEOUT_MIN, float(timeout_seconds)))
+
+
+def _reject_non_finite_json(value: str):
+    raise ValueError(f'non-finite JSON token: {value}')
+
+
+def _decode_strict_json_object(raw: bytes, error_code: str) -> dict:
+    try:
+        value = json.loads(
+            raw.decode('utf-8'),
+            parse_constant=_reject_non_finite_json,
+        )
+    except (UnicodeDecodeError, json.JSONDecodeError, ValueError, RecursionError):
+        raise TrustedShadowTransportError(error_code) from None
+    if not isinstance(value, dict):
+        raise TrustedShadowTransportError(error_code)
+    return value
+
+
+def _decode_strict_signaling_json_object(raw: bytes) -> dict:
+    def reject_duplicate_fields(pairs):
+        value = {}
+        for key, item in pairs:
+            if key in value:
+                raise ValueError('duplicate JSON field')
+            value[key] = item
+        return value
+
+    try:
+        value = json.loads(
+            raw.decode('utf-8'),
+            object_pairs_hook=reject_duplicate_fields,
+            parse_constant=_reject_non_finite_json,
+        )
+    except (UnicodeDecodeError, json.JSONDecodeError, ValueError, RecursionError):
+        raise TrustedShadowTransportError('invalid_response') from None
+    if not isinstance(value, dict):
+        raise TrustedShadowTransportError('invalid_response')
+    return value
+
+
+def _safe_rpc_data_code(error) -> str | None:
+    if not isinstance(error, dict):
+        return None
+    data = error.get('data')
+    value = data.get('code') if isinstance(data, dict) else None
+    return value if isinstance(value, str) and value in _SAFE_DRIVER_ERROR_CODES else None
+
+
+async def call_trusted_shadow_session(
+    mcp_id: str,
+    action: str,
+    arguments: dict | None = None,
+    *,
+    timeout_seconds: float = 5.0,
+    session: aiohttp.ClientSession | None = None,
+    target: TrustedShadowTarget | None = None,
+) -> dict:
+    """Call a declared ``teleop_session`` action on one trusted Shadow Driver.
+
+    This is intentionally separate from :func:`call_tool`: reserved teleop
+    tools stay unavailable to LLM, Canvas and generic MCP callers.  Successful
+    calls return the Driver's single JSON text object; every failure uses a
+    sanitized :class:`TrustedShadowTransportError`.  Coordinators should pass
+    their lifespan-owned ``session`` so heartbeat calls reuse its connector;
+    the per-call timeout remains bounded and the supplied session is not closed.
+    """
+    timeout_value = _bounded_teleop_timeout(timeout_seconds)
+    if arguments is None:
+        arguments = {}
+    if not isinstance(arguments, dict) or 'action' in arguments:
+        raise TrustedShadowTransportError('invalid_arguments')
+
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout_value
+    if target is not None:
+        url = _validate_pinned_shadow_target(mcp_id, action, target)
+    else:
+        # ConfigDB is SQLite-backed.  Non-session calls resolve off-loop within
+        # the same total budget.  Live authority calls always pass a pinned
+        # target and therefore never touch SQLite on the 4 Hz heartbeat path.
+        try:
+            resolved = await asyncio.wait_for(
+                asyncio.to_thread(_trusted_shadow_target, mcp_id, action),
+                timeout=timeout_value,
+            )
+            url = resolved.url
+        except TrustedShadowTransportError:
+            raise
+        except asyncio.TimeoutError:
+            raise TrustedShadowTransportError('timeout') from None
+        except Exception:  # noqa: BLE001 -- never expose ConfigDB/runtime details
+            raise TrustedShadowTransportError('target_resolution_error') from None
+
+    request_id = uuid.uuid4().hex
+    payload = {
+        'jsonrpc': '2.0',
+        'id': request_id,
+        'method': 'tools/call',
+        'params': {
+            'name': 'teleop_session',
+            'arguments': {'action': action, **arguments},
+        },
+    }
+    try:
+        encoded_payload = json.dumps(
+            payload,
+            ensure_ascii=False,
+            allow_nan=False,
+            separators=(',', ':'),
+        ).encode('utf-8')
+    except (TypeError, ValueError, RecursionError):
+        raise TrustedShadowTransportError('invalid_arguments') from None
+
+    driver_headers = auth.driver_request_headers(mcp_id)
+    authorization = driver_headers.get('Authorization')
+    if (
+        not isinstance(authorization, str)
+        or not authorization.startswith('Bearer ')
+        or not authorization[7:]
+    ):
+        raise TrustedShadowTransportError('driver_auth_unavailable')
+    headers = {
+        'Authorization': authorization,
+        'Content-Type': 'application/json',
+    }
+    remaining_timeout = deadline - loop.time()
+    if remaining_timeout <= 0:
+        raise TrustedShadowTransportError('timeout')
+    request_timeout = aiohttp.ClientTimeout(total=remaining_timeout)
+
+    async def _read_bounded(response: aiohttp.ClientResponse) -> bytes:
+        body = bytearray()
+        async for chunk in response.content.iter_chunked(64 * 1024):
+            if len(body) + len(chunk) > _TELEOP_RESPONSE_LIMIT:
+                raise TrustedShadowTransportError('response_too_large')
+            body.extend(chunk)
+        return bytes(body)
+
+    async def _post(client: aiohttp.ClientSession) -> bytes:
+        async with client.post(
+            url,
+            data=encoded_payload,
+            headers=headers,
+            allow_redirects=False,
+            timeout=request_timeout,
+        ) as response:
+            status = response.status
+            if status < 200 or status >= 300:
+                raise TrustedShadowTransportError('http_error', http_status=status)
+            return await _read_bounded(response)
+
+    try:
+        if session is not None:
+            if session.closed:
+                raise TrustedShadowTransportError('client_session_closed')
+            raw = await _post(session)
+        else:
+            async with aiohttp.ClientSession() as owned_session:
+                raw = await _post(owned_session)
+    except TrustedShadowTransportError:
+        raise
+    except asyncio.TimeoutError:
+        raise TrustedShadowTransportError('timeout') from None
+    except (aiohttp.ClientError, OSError, RuntimeError, ValueError, TypeError):
+        raise TrustedShadowTransportError('network_error') from None
+
+    response_payload = _decode_strict_json_object(raw, 'invalid_response')
+    if (
+        response_payload.get('jsonrpc') != '2.0'
+        or response_payload.get('id') != request_id
+    ):
+        raise TrustedShadowTransportError('invalid_response')
+
+    if 'error' in response_payload:
+        rpc_error = response_payload.get('error')
+        raw_rpc_code = rpc_error.get('code') if isinstance(rpc_error, dict) else None
+        rpc_code = raw_rpc_code if isinstance(raw_rpc_code, int) and not isinstance(raw_rpc_code, bool) else None
+        raise TrustedShadowTransportError(
+            'rpc_error',
+            rpc_code=rpc_code,
+            rpc_data_code=_safe_rpc_data_code(rpc_error),
+        )
+
+    result = response_payload.get('result')
+    content = result.get('content') if isinstance(result, dict) else None
+    if not isinstance(content, list) or len(content) != 1:
+        raise TrustedShadowTransportError('invalid_result')
+    item = content[0]
+    if (
+        not isinstance(item, dict)
+        or item.get('type') != 'text'
+        or not isinstance(item.get('text'), str)
+    ):
+        raise TrustedShadowTransportError('invalid_result')
+    is_error = result.get('isError', False)
+    if not isinstance(is_error, bool):
+        raise TrustedShadowTransportError('invalid_result')
+    if is_error:
+        raise TrustedShadowTransportError('tool_result_error')
+
+    return _decode_strict_json_object(item['text'].encode('utf-8'), 'invalid_result')
+
+
+def _trusted_shadow_offer_url(target: TrustedShadowTarget) -> str:
+    """Derive the Driver's same-origin RTC endpoint from its pinned MCP URL."""
+
+    if teleop_url_safety_code(target.url) is not None:
+        raise TrustedShadowTransportError('invalid_url')
+    try:
+        parsed = urlsplit(target.url)
+        # The generic teleop Driver advertises exactly its root MCP endpoint.
+        # Requiring that contract prevents surprising path-prefix, query, or
+        # encoded-path interpretations at the separate signaling boundary.
+        if parsed.path != '/mcp':
+            raise TrustedShadowTransportError('invalid_url')
+        offer_url = urlunsplit((parsed.scheme, parsed.netloc, '/offer', '', ''))
+        offer = urlsplit(offer_url)
+    except (TypeError, ValueError):
+        raise TrustedShadowTransportError('invalid_url') from None
+    if (
+        teleop_url_safety_code(offer_url) is not None
+        or (offer.scheme, offer.hostname, offer.port)
+        != (parsed.scheme, parsed.hostname, parsed.port)
+    ):
+        raise TrustedShadowTransportError('invalid_url')
+    return offer_url
+
+
+async def call_trusted_shadow_offer(
+    mcp_id: str,
+    offer: dict,
+    ticket: str,
+    *,
+    timeout_seconds: float = 2.0,
+    session: aiohttp.ClientSession | None = None,
+    target: TrustedShadowTarget,
+) -> dict:
+    """Exchange one ticket-bound SDP offer with the pinned Shadow Driver.
+
+    The ticket and Driver bearer are intentionally accepted only by this
+    server-to-server boundary.  Errors retain machine codes, never response
+    bodies, URLs, credentials, ticket claims, or SDP.
+    """
+
+    timeout_value = _bounded_teleop_timeout(timeout_seconds)
+    if (
+        not isinstance(offer, dict)
+        or set(offer) != {'sdp', 'type'}
+        or offer.get('type') != 'offer'
+        or not isinstance(offer.get('sdp'), str)
+        or not offer['sdp']
+        or not isinstance(ticket, str)
+        or not ticket
+    ):
+        raise TrustedShadowTransportError('invalid_arguments')
+    if not isinstance(target, TrustedShadowTarget):
+        raise TrustedShadowTransportError('pinned_target_changed')
+
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout_value
+    mcp_url = _validate_pinned_shadow_target(mcp_id, 'status', target)
+    if mcp_url != target.url:
+        raise TrustedShadowTransportError('pinned_target_changed')
+    url = _trusted_shadow_offer_url(target)
+
+    try:
+        encoded_payload = json.dumps(
+            {'sdp': offer['sdp'], 'type': 'offer', 'ticket': ticket},
+            ensure_ascii=False,
+            allow_nan=False,
+            separators=(',', ':'),
+        ).encode('utf-8')
+    except (TypeError, ValueError, RecursionError):
+        raise TrustedShadowTransportError('invalid_arguments') from None
+
+    driver_headers = auth.driver_request_headers(mcp_id)
+    authorization = driver_headers.get('Authorization')
+    if (
+        not isinstance(authorization, str)
+        or not authorization.startswith('Bearer ')
+        or not authorization[7:]
+    ):
+        raise TrustedShadowTransportError('driver_auth_unavailable')
+    headers = {
+        'Authorization': authorization,
+        'Content-Type': 'application/json',
+    }
+    remaining_timeout = deadline - loop.time()
+    if remaining_timeout <= 0:
+        raise TrustedShadowTransportError('timeout')
+    request_timeout = aiohttp.ClientTimeout(total=remaining_timeout)
+
+    async def _read_bounded(response: aiohttp.ClientResponse) -> bytes:
+        body = bytearray()
+        async for chunk in response.content.iter_chunked(64 * 1024):
+            if len(body) + len(chunk) > _TELEOP_SIGNALING_RESPONSE_LIMIT:
+                raise TrustedShadowTransportError('response_too_large')
+            body.extend(chunk)
+        return bytes(body)
+
+    async def _post(client: aiohttp.ClientSession) -> bytes:
+        async with client.post(
+            url,
+            data=encoded_payload,
+            headers=headers,
+            allow_redirects=False,
+            timeout=request_timeout,
+        ) as response:
+            if 300 <= response.status < 400:
+                raise TrustedShadowTransportError(
+                    'redirect_rejected',
+                    http_status=response.status,
+                )
+            if response.status < 200 or response.status >= 300:
+                raise TrustedShadowTransportError(
+                    'http_error',
+                    http_status=response.status,
+                )
+            return await _read_bounded(response)
+
+    try:
+        if session is not None:
+            if session.closed:
+                raise TrustedShadowTransportError('client_session_closed')
+            raw = await _post(session)
+        else:
+            async with aiohttp.ClientSession() as owned_session:
+                raw = await _post(owned_session)
+    except TrustedShadowTransportError:
+        raise
+    except asyncio.TimeoutError:
+        raise TrustedShadowTransportError('timeout') from None
+    except (aiohttp.ClientError, OSError, RuntimeError, ValueError, TypeError):
+        raise TrustedShadowTransportError('network_error') from None
+
+    # Registry identity must still match after the network await.  A concurrent
+    # Driver retarget may not turn an old ticket into authority on a new target.
+    if loop.time() > deadline:
+        raise TrustedShadowTransportError('timeout')
+    _validate_pinned_shadow_target(mcp_id, 'status', target)
+    response = _decode_strict_signaling_json_object(raw)
+    if loop.time() > deadline:
+        raise TrustedShadowTransportError('timeout')
+    return response
+
+
 async def call_tool(full_name: str, args: dict) -> str:
     """
     调用 MCP 工具。full_name 格式: 'mcp__<mcp_id>__<tool_name>'
@@ -299,15 +1065,19 @@ async def call_tool(full_name: str, args: dict) -> str:
     返回工具结果的文本表示（用于填入 tool role 消息）。
     图片内容返回 OpenAI multi-modal list。
     """
+    args = dict(args)
+
     # 优先查找 split_map（拆分工具的反向解析）
     mcp_id = None
     tool_name = None
+    split_action = None
     for mid, info in registry.items():
         split = info.get('split_map', {}).get(full_name)
         if split:
             mcp_id = mid
             tool_name = split['tool']
-            args = {**args, 'action': split['action']}
+            split_action = split['action']
+            args = {**args, 'action': split_action}
             break
 
     if mcp_id is None:
@@ -317,6 +1087,9 @@ async def call_tool(full_name: str, args: dict) -> str:
             return f'工具名格式错误: {full_name}'
         _, mcp_id, tool_name = parts
 
+    if _is_reserved_teleop_tool(mcp_id, tool_name):
+        return 'Teleop tools are reserved for the dedicated teleop API'
+
     info = registry.get(mcp_id)
     if not info:
         return f'MCP {mcp_id} 未注册'
@@ -325,11 +1098,86 @@ async def call_tool(full_name: str, args: dict) -> str:
     if info.get('transport') == 'internal':
         return await _dispatch_internal(mcp_id, tool_name, args)
 
+    configured_tool = _configured_tool_descriptor(mcp_id, tool_name)
+    if configured_tool is None:
+        return 'MCP tool not found'
+
+    action = args.get('action')
+    meta = info.get('tool_meta', {}).get(full_name)
+    if not isinstance(meta, dict):
+        return 'MCP tool not found'
+    configured_schema = configured_tool.get('inputSchema')
+    configured_schema = configured_schema if isinstance(configured_schema, dict) else {}
+    properties = configured_schema.get('properties')
+    properties = properties if isinstance(properties, dict) else {}
+    action_schema = properties.get('action')
+    action_schema = action_schema if isinstance(action_schema, dict) else {}
+    action_enum = action_schema.get('enum')
+    action_declared = isinstance(action_enum, list) and action in action_enum
+    access = classify_tool_access(
+        tool_type=configured_tool.get('type'),
+        annotations=configured_tool.get('annotations'),
+        action=action,
+        action_declared=action_declared,
+    )
+    # Imported lazily to keep the trusted teleop transport independent from
+    # ordinary MCP dispatch during module initialization.
+    from teleop.service import coordinator
+
+    try:
+        authority_domain = authority_domain_for_mcp(mcp_id)
+    except InvalidAuthorityBinding:
+        return json.dumps(
+            {
+                'error': {
+                    'code': 'authority_binding_invalid',
+                    'reason': 'core_authority_binding_invalid',
+                    'robot_id': mcp_id,
+                },
+            },
+            ensure_ascii=False,
+            separators=(',', ':'),
+        )
+
+    try:
+        async with coordinator.command_broker.ordinary_command(
+            authority_domain,
+            read_only=access.read_only,
+            source='mcp_client',
+            tool=tool_name,
+            action=action if isinstance(action, str) else '',
+            tool_verified=True,
+            action_verified=action_declared,
+        ):
+            return await _call_external_tool(
+                full_name,
+                mcp_id,
+                tool_name,
+                args,
+                info,
+            )
+    except TeleopCommandBlocked as error:
+        return json.dumps(
+            {'error': error.public_detail()},
+            ensure_ascii=False,
+            separators=(',', ':'),
+        )
+
+
+async def _call_external_tool(
+    full_name: str,
+    mcp_id: str,
+    tool_name: str,
+    args: dict,
+    info: dict,
+):
+    """Execute one already-admitted ordinary MCP call."""
+
     url     = info['url']
     timeout = aiohttp.ClientTimeout(total=30)
 
     # ── ACP: 提取内部控制参数（不送给 driver）──────────────────────────────────
-    cancel_event = args.pop('_cancel_event', None)
+    args.pop('_cancel_event', None)
     trace_id = args.pop('_trace_id', None)
     if trace_id:
         args['_trace_id'] = trace_id  # _trace_id 保留给 driver（driver 需要）
@@ -351,21 +1199,21 @@ async def call_tool(full_name: str, args: dict) -> str:
     if action == 'start':
         meta = info.get('tool_meta', {}).get(full_name, {})
         if meta.get('has_config_schema'):
-            saved_cfg = _get_tool_config(mcp_id, tool_name)
+            saved_cfg = _safe_saved_config(
+                _get_tool_config(mcp_id, tool_name)
+            )
             if saved_cfg:
                 async with aiohttp.ClientSession(timeout=timeout) as session:
                     cfg_result = await _jrpc(session, url, 'tools/call', {
                         'name':      tool_name,
-                        'arguments': {'action': 'config', **saved_cfg},
-                    })
-                # 检查 config 结果，adapter_ok=false 说明凭据无效
-                try:
-                    cfg_text = (cfg_result.get('content') or [{}])[0].get('text', '{}')
-                    cfg_parsed = json.loads(cfg_text)
-                    if not cfg_parsed.get('adapter_ok', True):
-                        return f'[{tool_name}] 配置无效（缺少 url/key），请在设备面板中检查配置后再启动。'
-                except (json.JSONDecodeError, IndexError, KeyError):
-                    pass
+                        'arguments': {**saved_cfg, 'action': 'config'},
+                    }, trusted=bool(info.get('trusted')), driver_id=mcp_id)
+                cfg_error = tool_result_error(
+                    cfg_result,
+                    require_structured_ack=True,
+                )
+                if cfg_error:
+                    return f'[{tool_name}] Driver 拒绝配置，启动已取消。'
             else:
                 return f'[{tool_name}] 尚未配置，请先在设备面板中完成配置（provider/url/key）后再启动。'
 
@@ -373,7 +1221,16 @@ async def call_tool(full_name: str, args: dict) -> str:
         result = await _jrpc(session, url, 'tools/call', {
             'name':      tool_name,
             'arguments': args,
-        })
+        }, trusted=bool(info.get('trusted')), driver_id=mcp_id)
+
+    result_error = tool_result_error(
+        result,
+        require_structured_ack=(
+            isinstance(action, str) and action in {'config', 'start', 'stop'}
+        ),
+    )
+    if result_error:
+        return f'[{tool_name}] Driver 调用失败: {result_error}'
 
     # MCP call result: list of content items
     content_items = result.get('content', [])

--- a/agent-core/src/mcp_client.py
+++ b/agent-core/src/mcp_client.py
@@ -25,6 +25,7 @@ import hashlib
 import ipaddress
 import json
 import math
+import time
 import uuid
 from dataclasses import dataclass
 from urllib.parse import urlsplit, urlunsplit

--- a/agent-core/src/mcp_protocol.py
+++ b/agent-core/src/mcp_protocol.py
@@ -1,0 +1,154 @@
+"""Strict helpers for the MCP 2024-11-05 HTTP/JSON-RPC boundary."""
+
+from __future__ import annotations
+
+import json
+
+
+def content_block_valid(item: object) -> bool:
+    """Validate one MCP 2024-11-05 ContentBlock without interpreting it."""
+
+    if not isinstance(item, dict):
+        return False
+    block_type = item.get('type')
+    if block_type == 'text':
+        return isinstance(item.get('text'), str)
+    if block_type == 'image':
+        return (
+            isinstance(item.get('data'), str)
+            and isinstance(item.get('mimeType'), str)
+            and bool(item['mimeType'])
+        )
+    if block_type == 'resource':
+        resource = item.get('resource')
+        if not isinstance(resource, dict) or not isinstance(resource.get('uri'), str):
+            return False
+        text = resource.get('text')
+        blob = resource.get('blob')
+        return (isinstance(text, str) and blob is None) or (
+            isinstance(blob, str) and text is None
+        )
+    return False
+
+
+def _reject_non_finite(value: str):
+    raise ValueError(f'non-finite JSON constant: {value}')
+
+
+def tool_result_error(
+    result: object,
+    *,
+    require_structured_ack: bool = False,
+) -> str | None:
+    """Validate CallToolResult and optionally require a JSON-object ack."""
+
+    if not isinstance(result, dict):
+        return 'Driver returned an invalid tool result'
+    content = result.get('content')
+    if not isinstance(content, list) or any(
+        not content_block_valid(item) for item in content
+    ):
+        return 'Driver returned an invalid tool result'
+    is_error = result.get('isError', False)
+    if not isinstance(is_error, bool):
+        return 'Driver returned an invalid tool result'
+
+    parsed_items: list[dict] = []
+    text_messages: list[str] = []
+    for item in content:
+        if item.get('type') != 'text':
+            continue
+        text = item['text']
+        try:
+            parsed = json.loads(text, parse_constant=_reject_non_finite)
+        except (json.JSONDecodeError, ValueError, RecursionError):
+            if text:
+                text_messages.append(text[:200])
+            continue
+        if isinstance(parsed, dict):
+            parsed_items.append(parsed)
+
+    if is_error:
+        for parsed in parsed_items:
+            message = parsed.get('message') or parsed.get('error')
+            if isinstance(message, str) and message:
+                return message[:200]
+        if text_messages:
+            return text_messages[0]
+        return 'Driver reported a tool error'
+
+    if require_structured_ack:
+        if not parsed_items:
+            return 'Driver did not return a structured acknowledgement'
+        for parsed in parsed_items:
+            explicit_error = parsed.get('error')
+            if explicit_error not in (None, '', False):
+                return (
+                    explicit_error[:200]
+                    if isinstance(explicit_error, str)
+                    else 'Driver returned an explicit error'
+                )
+            if parsed.get('adapter_ok') is False:
+                message = parsed.get('message')
+                return (
+                    message[:200]
+                    if isinstance(message, str) and message
+                    else 'Driver rejected the configuration'
+                )
+            if parsed.get('state') == 'error':
+                message = parsed.get('message')
+                return (
+                    message[:200]
+                    if isinstance(message, str) and message
+                    else 'Driver reported an error state'
+                )
+            if (
+                parsed.get('ok') is False
+                or parsed.get('success') is False
+                or parsed.get('configured') is False
+                or (
+                    isinstance(parsed.get('status'), str)
+                    and parsed['status'] in {'error', 'failed', 'failure'}
+                )
+            ):
+                message = parsed.get('message')
+                return (
+                    message[:200]
+                    if isinstance(message, str) and message
+                    else 'Driver rejected the operation'
+                )
+    return None
+
+
+def rpc_response_error(
+    payload: object,
+    *,
+    request_id: int | str,
+    http_status: int,
+) -> str | None:
+    """Return a safe error for an invalid or failed JSON-RPC response."""
+
+    if http_status < 200 or http_status >= 300:
+        return f'Driver returned HTTP {http_status}'
+    if not isinstance(payload, dict):
+        return 'Driver returned an invalid JSON-RPC response'
+    if payload.get('jsonrpc') != '2.0':
+        return 'Driver returned an invalid JSON-RPC version'
+    response_id = payload.get('id')
+    if type(response_id) is not type(request_id) or response_id != request_id:
+        return 'Driver returned a mismatched JSON-RPC id'
+    has_result = 'result' in payload
+    has_error = 'error' in payload
+    if has_result == has_error:
+        return 'Driver returned an invalid JSON-RPC envelope'
+    if has_error:
+        error = payload.get('error')
+        if not isinstance(error, dict):
+            return 'Driver returned an invalid JSON-RPC error'
+        message = error.get('message')
+        return (
+            message[:200]
+            if isinstance(message, str) and message
+            else 'Driver tool call failed'
+        )
+    return None

--- a/agent-core/src/start.py
+++ b/agent-core/src/start.py
@@ -4,7 +4,6 @@ import json
 import logging
 import pathlib
 import shutil
-import subprocess
 import sys
 
 # Fix Python "dual module" bug: start.py runs as __main__, but other modules
@@ -21,6 +20,7 @@ import daily_summary
 import topic_subscriber
 import mcp_client
 from channel.manager import manager as channel_manager
+from tls_config import load_public_certificate_chain, resolve_tls_certificates
 
 
 def _init_resource_files():
@@ -78,7 +78,7 @@ async def _auto_ping_all_mcps():
     import api.mcp_manage as mcp_mgr
     for mcp in mcp_mgr._get_mcp_list():
         mcp_id = mcp.get('id', '')
-        if not mcp_id:
+        if not mcp_id or not mcp_mgr._runtime_registration_allowed(mcp):
             continue
         try:
             await mcp_mgr._do_ping(mcp_id)
@@ -87,7 +87,7 @@ async def _auto_ping_all_mcps():
             print(f'[startup] auto-ping failed: {mcp_id}: {e}')
 
 
-def _register_core_mcp(silent=False):
+def _register_core_mcp_locked(silent=False):
     """Register agent-core itself as an MCP with decision_core tool."""
     import api.mcp_manage as mcp_mgr
 
@@ -104,6 +104,7 @@ def _register_core_mcp(silent=False):
         'render_hint': '',
         'server_name': 'AgentCore',
         'category': 'controller',
+        'trust_state': 'internal',
         'online': True,
         'tools': [
             {
@@ -190,6 +191,7 @@ def _register_core_mcp(silent=False):
         'url': '',
         'server_name': 'Channel',
         'category': 'controller',
+        'trust_state': 'internal',
         'online': True,
         'tools': [
             {
@@ -244,13 +246,21 @@ def _register_core_mcp(silent=False):
         print(f'[startup] registered core MCP: {CORE_MCP_ID}')
 
 
+async def _register_core_mcp(silent=False):
+    """Update internal MCP records without overwriting guarded target changes."""
+
+    import api.mcp_manage as mcp_mgr
+
+    async with mcp_mgr._mcp_write_lock:
+        await asyncio.to_thread(_register_core_mcp_locked, silent=silent)
+
+
 async def _heartbeat_core_mcp():
     """Periodically re-register agent-core MCP every 30s."""
-    import api.mcp_manage as mcp_mgr
     while True:
         await asyncio.sleep(30)
         try:
-            _register_core_mcp(silent=True)
+            await _register_core_mcp(silent=True)
         except Exception as e:
             print(f'[heartbeat] core re-register failed: {e}')
 
@@ -299,7 +309,12 @@ async def lifespan(app):
     _ensure_mic_pub()
 
     # 注册 AgentCore 自身为 MCP（含 decision_core 工具）
-    await loop.run_in_executor(None, _register_core_mcp)
+    await _register_core_mcp()
+
+    # Authority aliases are owner-controlled and frozen for the process
+    # lifetime.  Pending changes become active only at this startup boundary.
+    from api.mcp_manage import activate_pending_authority_bindings
+    await activate_pending_authority_bindings()
 
     # 注册 /decision_core output topic 到 inspection
     from api.inspection import register_topic_internal
@@ -325,9 +340,21 @@ async def lifespan(app):
     # 启动 Channel Manager（消息平台适配器）
     await channel_manager.start()
 
+    # Start the dedicated teleop ownership/Driver-heartbeat supervisor only
+    # after authentication and service discovery infrastructure are ready.
+    from teleop.service import coordinator as teleop_coordinator
+    await teleop_coordinator.start()
+
     async with event.llm:
-        # Auto-start project if configured, otherwise reset running state
-        if config.main.get('core', {}).get('auto_start', False):
+        # Runtime project state never survives a Core process boundary. Reset
+        # both fields together before optionally issuing a fresh auto-start.
+        core = config.main.get('core', {})
+        auto_start = bool(core.get('auto_start', False))
+        core['project_running'] = False
+        core['project_state'] = 'stopped'
+        core.pop('active_project_cards', None)
+        config.main['core'] = core
+        if auto_start:
             async def _safe_auto_start():
                 try:
                     await _auto_start_project()
@@ -336,13 +363,6 @@ async def lifespan(app):
                     import traceback
                     traceback.print_exc()
             asyncio.create_task(_safe_auto_start())
-        else:
-            # Not auto-starting: clear stale project_running flag from last session
-            core = config.main.get('core', {})
-            if core.get('project_running'):
-                core['project_running'] = False
-                config.main['core'] = core
-
         tasks = [
             asyncio.create_task(event.llm.run_forever()),
             asyncio.create_task(scheduler.run()),
@@ -351,6 +371,10 @@ async def lifespan(app):
         try:
             yield
         finally:
+            # Revoke teleop authority before tearing down the remaining Core
+            # transports. If a Driver is unreachable, its own short watchdog
+            # lease still expires independently.
+            await teleop_coordinator.stop()
             for t in tasks:
                 t.cancel()
             await channel_manager.stop()
@@ -421,6 +445,9 @@ app_api.include_router(api.channel.router)
 import api.performance
 app_api.include_router(api.performance.router)
 
+import api.teleop
+app_api.include_router(api.teleop.router)
+
 app = fastapi.FastAPI(lifespan=lifespan)
 app.middleware('http')(auth.auth_middleware)
 app.mount('/api', app_api)
@@ -429,19 +456,25 @@ app.mount('/api', app_api)
 @app_api.get('/auth/verify')
 async def _auth_verify(request: fastapi.Request):
     if not auth.is_enabled():
-        return {'valid': True, 'auth_required': False}
+        return {'valid': True, 'auth_required': False, 'principal': None}
     token = auth._extract_token(request)
-    if auth.verify(token):
-        return {'valid': True, 'auth_required': True}
+    principal = auth.authenticate(token)
+    if principal:
+        return {
+            'valid': True,
+            'auth_required': True,
+            'principal': principal.as_dict(),
+        }
     return fastapi.responses.JSONResponse(
         status_code=401,
-        content={'valid': False, 'auth_required': True}
+        content={'valid': False, 'auth_required': True, 'principal': None}
     )
 
 import api.motus_stream
 app.include_router(api.motus_stream.router)
 
 app.include_router(api.inspection.ws_router)
+app.include_router(api.teleop.ws_router)
 
 # ── ACP: 异步动作完成回调接口 ─────────────────────────────────────────────────
 
@@ -631,6 +664,9 @@ _mic_ws_connected = False
 async def _ws_mic(ws: fastapi.WebSocket):
     """Receive PCM-16k audio from browser and publish to ROS2 topic."""
     global _mic_chunk_count, _mic_ws_connected
+    if not auth.check_ws_token(ws):
+        await ws.close(code=4003, reason='Owner role required')
+        return
     await ws.accept()
     _mic_ws_connected = True
     try:
@@ -669,24 +705,6 @@ class _HTTPOnlyStaticFiles(fastapi.staticfiles.StaticFiles):
 app.mount('/', _HTTPOnlyStaticFiles(directory='./web', html=True), name='web')
 
 
-# ========== SSL 自签名证书 ==========
-def _ensure_ssl_certs(cert_dir: str = "./resource/certs") -> tuple[str, str]:
-    """自动生成自签名 SSL 证书（如不存在）。首次启动生成，后续复用。"""
-    cert_path = pathlib.Path(cert_dir) / "cert.pem"
-    key_path = pathlib.Path(cert_dir) / "key.pem"
-    if cert_path.exists() and key_path.exists():
-        return str(cert_path), str(key_path)
-    pathlib.Path(cert_dir).mkdir(parents=True, exist_ok=True)
-    subprocess.run([
-        "openssl", "req", "-x509", "-newkey", "rsa:2048",
-        "-keyout", str(key_path), "-out", str(cert_path),
-        "-days", "3650", "-nodes",
-        "-subj", "/CN=phanthy-motus",
-    ], check=True, capture_output=True)
-    print(f"[ssl] Generated self-signed certificate: {cert_path}")
-    return str(cert_path), str(key_path)
-
-
 # ========== 启动服务 ==========
 if __name__ == '__main__':
     # Suppress noisy "SSL connection is closed" from uvicorn/asyncio
@@ -697,7 +715,13 @@ if __name__ == '__main__':
     logging.getLogger('uvicorn.error').addFilter(_SSLCloseFilter())
     logging.getLogger('asyncio').addFilter(_SSLCloseFilter())
 
-    cert_file, key_file = _ensure_ssl_certs()
+    cert_file, key_file = resolve_tls_certificates()
+    # The mounted API app is the request.app seen by /api/teleop routes. Keep
+    # only a bounded, certificate-only public chain there; the private-key path
+    # remains local to this startup block and is passed solely to Uvicorn.
+    app_api.state.teleop_capture_ca_certificate_pem = (
+        load_public_certificate_chain(cert_file)
+    )
     uvicorn.run(app, host='0.0.0.0', port=15678, ws_ping_interval=None,
                 ssl_certfile=cert_file, ssl_keyfile=key_file,
                 timeout_keep_alive=65)

--- a/agent-core/src/teleop/__init__.py
+++ b/agent-core/src/teleop/__init__.py
@@ -1,0 +1,1 @@
+"""Shared teleoperation session and audit services."""

--- a/agent-core/src/teleop/audit.py
+++ b/agent-core/src/teleop/audit.py
@@ -1,0 +1,350 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import math
+import time
+import uuid
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+import config
+
+MAX_DETAIL_DEPTH = 5
+MAX_COLLECTION_ITEMS = 50
+MAX_STRING_LENGTH = 512
+MAX_KEY_LENGTH = 128
+MAX_STORED_EVENTS = 10_000
+MAX_PENDING_DELIVERIES = 128
+_FAST_PATH_WAIT_SECONDS = 0.02
+_delivery_tasks: set[asyncio.Task] = set()
+_SENSITIVE_KEY_PARTS = (
+    'credential',
+    'fence',
+    'password',
+    'privatekey',
+    'secret',
+    'token',
+)
+
+
+def _is_sensitive_key(key: object) -> bool:
+    normalized = ''.join(character for character in str(key).lower() if character.isalnum())
+    return any(part in normalized for part in _SENSITIVE_KEY_PARTS)
+
+
+def _bounded_text(value: object, limit: int = MAX_STRING_LENGTH) -> str:
+    try:
+        text = str(value)
+    except Exception:  # noqa: BLE001 -- sanitizer must tolerate hostile values
+        return '<unprintable>'
+    return text[:limit]
+
+
+def _sanitize_value(value: Any, *, depth: int, seen: set[int]) -> Any:
+    if depth > MAX_DETAIL_DEPTH:
+        return None
+    if value is None or isinstance(value, (bool, int)):
+        return value
+    if isinstance(value, float):
+        return value if math.isfinite(value) else None
+    if isinstance(value, str):
+        return value[:MAX_STRING_LENGTH]
+    if isinstance(value, (bytes, bytearray, memoryview)):
+        return bytes(value[:MAX_STRING_LENGTH]).decode('utf-8', errors='replace')
+
+    container = isinstance(value, Mapping) or (
+        isinstance(value, Sequence) and not isinstance(value, str)
+    ) or isinstance(value, (set, frozenset))
+    identity = id(value)
+    if container:
+        if identity in seen:
+            return None
+        seen.add(identity)
+
+    try:
+        if isinstance(value, Mapping):
+            sanitized: dict[str, Any] = {}
+            try:
+                items = value.items()
+            except Exception:  # noqa: BLE001 -- custom Mapping may fail
+                return {}
+            for index, pair in enumerate(items):
+                if index >= MAX_COLLECTION_ITEMS:
+                    break
+                try:
+                    key, item = pair
+                except Exception:  # noqa: BLE001, S112 -- skip malformed pair
+                    continue
+                if _is_sensitive_key(key):
+                    continue
+                safe_key = _bounded_text(key, MAX_KEY_LENGTH)
+                sanitized[safe_key] = _sanitize_value(
+                    item,
+                    depth=depth + 1,
+                    seen=seen,
+                )
+            return sanitized
+
+        if isinstance(value, (set, frozenset)):
+            try:
+                values = sorted(value, key=lambda item: _bounded_text(item))
+            except Exception:  # noqa: BLE001 -- custom set values may fail
+                values = []
+            return [
+                _sanitize_value(item, depth=depth + 1, seen=seen)
+                for item in values[:MAX_COLLECTION_ITEMS]
+            ]
+
+        if isinstance(value, Sequence) and not isinstance(value, str):
+            sanitized_items: list[Any] = []
+            try:
+                for index, item in enumerate(value):
+                    if index >= MAX_COLLECTION_ITEMS:
+                        break
+                    sanitized_items.append(
+                        _sanitize_value(item, depth=depth + 1, seen=seen)
+                    )
+            except Exception:  # noqa: BLE001, S110 -- return bounded prefix
+                pass
+            return sanitized_items
+
+        return _bounded_text(value)
+    except Exception:  # noqa: BLE001 -- sanitizer is deliberately fail-closed
+        return None
+    finally:
+        if container:
+            seen.discard(identity)
+
+
+def _safe_details(details: Mapping[str, Any] | None) -> dict[str, Any]:
+    """Return bounded JSON data with secret-shaped keys removed at every depth."""
+
+    if not isinstance(details, Mapping):
+        return {}
+    sanitized = _sanitize_value(details, depth=0, seen=set())
+    return sanitized if isinstance(sanitized, dict) else {}
+
+
+def _ensure_table(conn) -> None:
+    conn.execute('''
+        CREATE TABLE IF NOT EXISTS teleop_audit (
+            id TEXT PRIMARY KEY,
+            created_at REAL NOT NULL,
+            event_type TEXT NOT NULL,
+            session_id TEXT DEFAULT '',
+            robot_id TEXT DEFAULT '',
+            principal_id TEXT DEFAULT '',
+            source TEXT DEFAULT '',
+            decision TEXT DEFAULT '',
+            reason TEXT DEFAULT '',
+            tool TEXT DEFAULT '',
+            action TEXT DEFAULT '',
+            details TEXT DEFAULT '{}'
+        )
+    ''')
+    conn.execute(
+        'CREATE INDEX IF NOT EXISTS idx_teleop_audit_created '
+        'ON teleop_audit(created_at)'
+    )
+
+
+async def emit(
+    event_type: str,
+    *,
+    session_id: str = '',
+    robot_id: str = '',
+    principal_id: str = '',
+    source: str = '',
+    decision: str = '',
+    reason: str = '',
+    tool: str = '',
+    action: str = '',
+    details: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Persist and broadcast a sanitized event without breaking control flow.
+
+    Audit storage and Activity delivery are observability paths, so either may
+    fail without changing the lifecycle decision that has already been made.
+    """
+
+    event = {
+        'id': str(uuid.uuid4()),
+        'created_at': time.time(),
+        'event_type': _bounded_text(event_type),
+        'session_id': _bounded_text(session_id),
+        'robot_id': _bounded_text(robot_id),
+        'principal_id': _bounded_text(principal_id),
+        'source': _bounded_text(source),
+        'decision': _bounded_text(decision),
+        'reason': _bounded_text(reason),
+        'tool': _bounded_text(tool),
+        'action': _bounded_text(action),
+        'details': _safe_details(details),
+    }
+
+    if len(_delivery_tasks) < MAX_PENDING_DELIVERIES:
+        task = asyncio.create_task(
+            _deliver_event(event),
+            name=f'teleop-audit-{event["id"]}',
+        )
+        _delivery_tasks.add(task)
+        task.add_done_callback(_delivery_tasks.discard)
+        # Preserve immediate visibility on a healthy database, but never let
+        # observability consume a meaningful fraction of a Driver watchdog.
+        try:
+            await asyncio.wait_for(
+                asyncio.shield(task),
+                timeout=_FAST_PATH_WAIT_SECONDS,
+            )
+        except asyncio.TimeoutError:
+            pass
+    return event
+
+
+async def _deliver_event(event: Mapping[str, Any]) -> None:
+    try:
+        await asyncio.to_thread(_persist_event, event)
+    except Exception:  # noqa: BLE001, S110 -- audit storage is fail-safe
+        pass
+
+    try:
+        from api.motus_stream import push_event
+
+        await push_event({
+            'type': 'teleop_activity',
+            'mcp_id': event['robot_id'],
+            'payload': event,
+        })
+    except Exception:  # noqa: BLE001, S110 -- broadcast is best effort
+        pass
+
+
+async def flush(timeout_seconds: float = 1.0) -> None:
+    """Best-effort test/shutdown helper; control paths never need to call it."""
+
+    pending = list(_delivery_tasks)
+    if not pending:
+        return
+    try:
+        await asyncio.wait_for(
+            asyncio.gather(*pending, return_exceptions=True),
+            timeout=max(0.0, timeout_seconds),
+        )
+    except asyncio.TimeoutError:
+        pass
+
+
+def _persist_event(event: Mapping[str, Any]) -> None:
+    """Persist one already-sanitized event from a worker thread."""
+
+    try:
+        with config._get_conn() as conn:
+            _ensure_table(conn)
+            conn.execute(
+                '''INSERT INTO teleop_audit
+                   (id, created_at, event_type, session_id, robot_id, principal_id,
+                    source, decision, reason, tool, action, details)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)''',
+                (
+                    event['id'],
+                    event['created_at'],
+                    event['event_type'],
+                    event['session_id'],
+                    event['robot_id'],
+                    event['principal_id'],
+                    event['source'],
+                    event['decision'],
+                    event['reason'],
+                    event['tool'],
+                    event['action'],
+                    json.dumps(
+                        event['details'],
+                        ensure_ascii=False,
+                        allow_nan=False,
+                    ),
+                ),
+            )
+            conn.execute(
+                '''DELETE FROM teleop_audit WHERE id IN (
+                       SELECT id FROM teleop_audit
+                       ORDER BY created_at DESC, id DESC
+                       LIMIT -1 OFFSET ?
+                   )''',
+                (MAX_STORED_EVENTS,),
+            )
+            conn.commit()
+    except Exception:  # noqa: BLE001, S110 -- audit storage is fail-safe
+        pass
+
+
+def _row_to_event(row) -> dict[str, Any]:
+    try:
+        decoded = json.loads(row[11] or '{}')
+    except (TypeError, ValueError, json.JSONDecodeError, RecursionError):
+        decoded = {}
+    created_at = row[1] if isinstance(row[1], (int, float)) else 0.0
+    if not math.isfinite(created_at):
+        created_at = 0.0
+    return {
+        'id': _bounded_text(row[0]),
+        'created_at': created_at,
+        'event_type': _bounded_text(row[2]),
+        'session_id': _bounded_text(row[3]),
+        'robot_id': _bounded_text(row[4]),
+        'principal_id': _bounded_text(row[5]),
+        'source': _bounded_text(row[6]),
+        'decision': _bounded_text(row[7]),
+        'reason': _bounded_text(row[8]),
+        'tool': _bounded_text(row[9]),
+        'action': _bounded_text(row[10]),
+        'details': _safe_details(decoded),
+    }
+
+
+def list_events(
+    limit: int = 100,
+    robot_id: str = '',
+    session_id: str = '',
+) -> list[dict[str, Any]]:
+    try:
+        bounded_limit = min(500, max(1, int(limit)))
+    except (TypeError, ValueError, OverflowError):
+        bounded_limit = 100
+
+    try:
+        with config._get_conn() as conn:
+            _ensure_table(conn)
+            if session_id:
+                rows = conn.execute(
+                    '''SELECT id, created_at, event_type, session_id, robot_id,
+                              principal_id, source, decision, reason, tool, action, details
+                       FROM teleop_audit WHERE session_id=?
+                       ORDER BY created_at DESC LIMIT ?''',
+                    (_bounded_text(session_id), bounded_limit),
+                ).fetchall()
+            elif robot_id:
+                rows = conn.execute(
+                    '''SELECT id, created_at, event_type, session_id, robot_id,
+                              principal_id, source, decision, reason, tool, action, details
+                       FROM teleop_audit WHERE robot_id=?
+                       ORDER BY created_at DESC LIMIT ?''',
+                    (_bounded_text(robot_id), bounded_limit),
+                ).fetchall()
+            else:
+                rows = conn.execute(
+                    '''SELECT id, created_at, event_type, session_id, robot_id,
+                              principal_id, source, decision, reason, tool, action, details
+                       FROM teleop_audit ORDER BY created_at DESC LIMIT ?''',
+                    (bounded_limit,),
+                ).fetchall()
+    except Exception:  # noqa: BLE001 -- reads are an observability path
+        return []
+
+    events: list[dict[str, Any]] = []
+    for row in rows:
+        try:
+            events.append(_row_to_event(row))
+        except Exception:  # noqa: BLE001, S112 -- skip malformed legacy row
+            continue
+    return events

--- a/agent-core/src/teleop/authority_guard.py
+++ b/agent-core/src/teleop/authority_guard.py
@@ -1,0 +1,386 @@
+from __future__ import annotations
+
+import asyncio
+import math
+import re
+import sqlite3
+import time
+import uuid
+from dataclasses import dataclass
+
+import config
+
+MAX_SQLITE_INTEGER = (1 << 63) - 1
+MAX_DRIVER_EPOCH = MAX_SQLITE_INTEGER - 1
+AUTHORITY_GUARD_PHASES = frozenset(
+    {
+        "preparing",
+        "active",
+        "stopping",
+        "recovery_required",
+        "reconciling",
+    }
+)
+
+_AUTHORITY_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:-]{0,63}$")
+_HEX_DIGEST_RE = re.compile(r"^[0-9a-f]{64}$")
+_TABLE_NAME = "teleop_authority_guards"
+_COLUMNS = (
+    "robot_id",
+    "driver_id",
+    "session_id",
+    "boot_id",
+    "epoch",
+    "capability_digest",
+    "target_fingerprint",
+    "dispatch_generation",
+    "phase",
+    "created_at",
+    "updated_at",
+)
+
+# One Core process serializes safety-relevant target writes with the transition
+# that makes a persistent guard visible. SQLite remains the durable boundary;
+# this lock closes the in-process check/write race around config.main.
+target_mutation_lock = asyncio.Lock()
+
+
+class AuthorityGuardError(RuntimeError):
+    """Base error for a persistent authority guard operation."""
+
+
+class AuthorityGuardSchemaError(AuthorityGuardError):
+    """The guard table does not have the fail-closed schema we require."""
+
+
+class AuthorityGuardStateConflict(AuthorityGuardError):
+    """A requested state transition would move persisted safety state backwards."""
+
+
+class AuthorityGuardNotFound(AuthorityGuardStateConflict):
+    """The exact robot/session pair does not own a persistent guard."""
+
+
+def _authority_id(value: object, field: str) -> str:
+    if not isinstance(value, str) or not _AUTHORITY_ID_RE.fullmatch(value):
+        raise ValueError(f"{field} must be a 1-64 character authority identifier")
+    return value
+
+
+def _canonical_uuid(value: object, field: str) -> str:
+    if not isinstance(value, str):
+        raise TypeError(f"{field} must be a canonical UUID")
+    try:
+        parsed = uuid.UUID(value)
+    except (AttributeError, ValueError):
+        raise ValueError(f"{field} must be a canonical UUID") from None
+    if parsed.int == 0 or str(parsed) != value:
+        raise ValueError(f"{field} must be a canonical non-nil UUID")
+    return value
+
+
+def _digest(value: object, field: str) -> str:
+    if not isinstance(value, str) or not _HEX_DIGEST_RE.fullmatch(value):
+        raise ValueError(f"{field} must be a lowercase SHA-256 digest")
+    return value
+
+
+def _integer(value: object, field: str, *, minimum: int, maximum: int) -> int:
+    if type(value) is not int or value < minimum or value > maximum:
+        raise ValueError(f"{field} must be an integer in [{minimum}, {maximum}]")
+    return value
+
+
+def _timestamp(value: object, field: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise TypeError(f"{field} must be a finite non-negative timestamp")
+    result = float(value)
+    if not math.isfinite(result) or result < 0:
+        raise ValueError(f"{field} must be a finite non-negative timestamp")
+    return result
+
+
+def _phase(value: object) -> str:
+    if not isinstance(value, str) or value not in AUTHORITY_GUARD_PHASES:
+        raise ValueError("phase is not an allowed authority guard phase")
+    return value
+
+
+@dataclass(frozen=True, slots=True)
+class AuthorityGuard:
+    """Secret-free evidence that a robot must remain authority-quarantined.
+
+    A guard deliberately contains no fence, bearer token, browser/client identity,
+    or human principal.  Such credentials remain process-local and cannot be
+    recovered after a Core restart.
+    """
+
+    robot_id: str
+    driver_id: str
+    session_id: str
+    boot_id: str
+    epoch: int
+    capability_digest: str
+    target_fingerprint: str
+    dispatch_generation: int
+    phase: str
+    created_at: float
+    updated_at: float
+
+    def __post_init__(self) -> None:
+        _authority_id(self.robot_id, "robot_id")
+        _authority_id(self.driver_id, "driver_id")
+        _canonical_uuid(self.session_id, "session_id")
+        _canonical_uuid(self.boot_id, "boot_id")
+        _integer(self.epoch, "epoch", minimum=1, maximum=MAX_DRIVER_EPOCH)
+        _digest(self.capability_digest, "capability_digest")
+        _digest(self.target_fingerprint, "target_fingerprint")
+        _integer(
+            self.dispatch_generation,
+            "dispatch_generation",
+            minimum=0,
+            maximum=MAX_SQLITE_INTEGER,
+        )
+        _phase(self.phase)
+        created_at = _timestamp(self.created_at, "created_at")
+        updated_at = _timestamp(self.updated_at, "updated_at")
+        if updated_at < created_at:
+            raise ValueError("updated_at cannot precede created_at")
+        object.__setattr__(self, "created_at", created_at)
+        object.__setattr__(self, "updated_at", updated_at)
+
+
+def _ensure_table(conn: sqlite3.Connection) -> None:
+    phases = ", ".join(repr(item) for item in sorted(AUTHORITY_GUARD_PHASES))
+    conn.execute(f"""
+        CREATE TABLE IF NOT EXISTS {_TABLE_NAME} (
+            robot_id TEXT NOT NULL PRIMARY KEY,
+            driver_id TEXT NOT NULL UNIQUE,
+            session_id TEXT NOT NULL UNIQUE,
+            boot_id TEXT NOT NULL,
+            epoch INTEGER NOT NULL CHECK (
+                typeof(epoch) = 'integer' AND epoch BETWEEN 1 AND {MAX_DRIVER_EPOCH}
+            ),
+            capability_digest TEXT NOT NULL,
+            target_fingerprint TEXT NOT NULL,
+            dispatch_generation INTEGER NOT NULL CHECK (
+                typeof(dispatch_generation) = 'integer'
+                AND dispatch_generation BETWEEN 0 AND {MAX_SQLITE_INTEGER}
+            ),
+            phase TEXT NOT NULL CHECK (phase IN ({phases})),
+            created_at REAL NOT NULL CHECK (created_at >= 0),
+            updated_at REAL NOT NULL CHECK (
+                updated_at >= created_at AND updated_at >= 0
+            )
+        )
+    """)
+    _verify_schema(conn)
+
+
+def _verify_schema(conn: sqlite3.Connection) -> None:
+    rows = conn.execute(f"PRAGMA table_info({_TABLE_NAME})").fetchall()
+    expected = (
+        ("robot_id", "TEXT", 1, 1),
+        ("driver_id", "TEXT", 1, 0),
+        ("session_id", "TEXT", 1, 0),
+        ("boot_id", "TEXT", 1, 0),
+        ("epoch", "INTEGER", 1, 0),
+        ("capability_digest", "TEXT", 1, 0),
+        ("target_fingerprint", "TEXT", 1, 0),
+        ("dispatch_generation", "INTEGER", 1, 0),
+        ("phase", "TEXT", 1, 0),
+        ("created_at", "REAL", 1, 0),
+        ("updated_at", "REAL", 1, 0),
+    )
+    actual = tuple((row[1], row[2].upper(), row[3], row[5]) for row in rows)
+    if actual != expected:
+        raise AuthorityGuardSchemaError(
+            "authority guard table columns are incompatible"
+        )
+
+    unique_columns: set[tuple[str, ...]] = set()
+    for index in conn.execute(f"PRAGMA index_list({_TABLE_NAME})").fetchall():
+        if not index[2]:
+            continue
+        columns = tuple(
+            row[2]
+            for row in conn.execute(f'PRAGMA index_info("{index[1]}")').fetchall()
+        )
+        unique_columns.add(columns)
+    required_unique = {("robot_id",), ("driver_id",), ("session_id",)}
+    if unique_columns != required_unique:
+        raise AuthorityGuardSchemaError("authority guard uniqueness is incompatible")
+
+
+def _row_to_guard(row: tuple[object, ...]) -> AuthorityGuard:
+    if len(row) != len(_COLUMNS):
+        raise AuthorityGuardSchemaError("authority guard row has incompatible shape")
+    return AuthorityGuard(**dict(zip(_COLUMNS, row, strict=True)))
+
+
+def _select_guard(
+    conn: sqlite3.Connection,
+    robot_id: str,
+) -> AuthorityGuard | None:
+    row = conn.execute(
+        f"SELECT {', '.join(_COLUMNS)} FROM {_TABLE_NAME} WHERE robot_id=?",
+        (robot_id,),
+    ).fetchone()
+    return None if row is None else _row_to_guard(row)
+
+
+def _begin(conn: sqlite3.Connection) -> None:
+    conn.execute("BEGIN IMMEDIATE")
+    _ensure_table(conn)
+
+
+def create_guard(guard: AuthorityGuard) -> AuthorityGuard:
+    """Insert a new guard without ever replacing an existing authority claim."""
+
+    if not isinstance(guard, AuthorityGuard):
+        raise TypeError("guard must be an AuthorityGuard")
+    # Reconstruct to prevent a caller from bypassing frozen dataclass validation
+    # through object.__setattr__ before crossing the storage boundary.
+    validated = AuthorityGuard(**{field: getattr(guard, field) for field in _COLUMNS})
+    with config._get_conn() as conn:
+        try:
+            _begin(conn)
+            conn.execute(
+                f"""INSERT INTO {_TABLE_NAME} ({", ".join(_COLUMNS)})
+                    VALUES ({", ".join("?" for _ in _COLUMNS)})""",
+                tuple(getattr(validated, field) for field in _COLUMNS),
+            )
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            raise
+    return validated
+
+
+def get_guard(robot_id: str) -> AuthorityGuard | None:
+    """Return one validated guard; corrupted storage raises instead of unlocking."""
+
+    validated_robot_id = _authority_id(robot_id, "robot_id")
+    with config._get_conn() as conn:
+        try:
+            _begin(conn)
+            guard = _select_guard(conn, validated_robot_id)
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            raise
+    return guard
+
+
+def list_guards() -> list[AuthorityGuard]:
+    """Return every validated guard in deterministic robot-id order."""
+
+    with config._get_conn() as conn:
+        try:
+            _begin(conn)
+            rows = conn.execute(
+                f"""SELECT {", ".join(_COLUMNS)} FROM {_TABLE_NAME}
+                    ORDER BY robot_id"""
+            ).fetchall()
+            guards = [_row_to_guard(row) for row in rows]
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            raise
+    return guards
+
+
+def update_guard(
+    robot_id: str,
+    session_id: str,
+    *,
+    phase: str,
+    dispatch_generation: int,
+    updated_at: float | None = None,
+) -> AuthorityGuard:
+    """Conditionally advance one exact robot/session guard in one transaction.
+
+    An exact-pair miss, storage error, or backwards generation/time transition
+    raises, so callers must keep their in-memory authority lock when the
+    persistent result is uncertain.  ``updated_at`` defaults to the wall clock
+    but never moves an existing timestamp backwards after a clock rollback.
+    """
+
+    validated_robot_id = _authority_id(robot_id, "robot_id")
+    validated_session_id = _canonical_uuid(session_id, "session_id")
+    validated_phase = _phase(phase)
+    validated_generation = _integer(
+        dispatch_generation,
+        "dispatch_generation",
+        minimum=0,
+        maximum=MAX_SQLITE_INTEGER,
+    )
+    validated_updated_at = (
+        None if updated_at is None else _timestamp(updated_at, "updated_at")
+    )
+
+    with config._get_conn() as conn:
+        try:
+            _begin(conn)
+            current = _select_guard(conn, validated_robot_id)
+            if current is None or current.session_id != validated_session_id:
+                raise AuthorityGuardNotFound("exact authority guard pair was not found")
+            if validated_generation < current.dispatch_generation:
+                raise AuthorityGuardStateConflict("dispatch_generation cannot regress")
+            next_updated_at = (
+                max(_timestamp(time.time(), "updated_at"), current.updated_at)
+                if validated_updated_at is None
+                else validated_updated_at
+            )
+            if next_updated_at < current.updated_at:
+                raise AuthorityGuardStateConflict("updated_at cannot regress")
+            cursor = conn.execute(
+                f"""UPDATE {_TABLE_NAME}
+                    SET phase=?, dispatch_generation=?, updated_at=?
+                    WHERE robot_id=? AND session_id=?""",
+                (
+                    validated_phase,
+                    validated_generation,
+                    next_updated_at,
+                    validated_robot_id,
+                    validated_session_id,
+                ),
+            )
+            if cursor.rowcount != 1:
+                raise AuthorityGuardStateConflict(
+                    "authority guard changed concurrently"
+                )
+            updated = _select_guard(conn, validated_robot_id)
+            if updated is None:
+                raise AuthorityGuardStateConflict(
+                    "authority guard disappeared during update"
+                )
+            conn.commit()
+            return updated
+        except Exception:
+            conn.rollback()
+            raise
+
+
+def delete_guard(robot_id: str, session_id: str) -> bool:
+    """Delete only the exact robot/session guard and report whether it existed."""
+
+    validated_robot_id = _authority_id(robot_id, "robot_id")
+    validated_session_id = _canonical_uuid(session_id, "session_id")
+    with config._get_conn() as conn:
+        try:
+            _begin(conn)
+            cursor = conn.execute(
+                f"DELETE FROM {_TABLE_NAME} WHERE robot_id=? AND session_id=?",
+                (validated_robot_id, validated_session_id),
+            )
+            if cursor.rowcount not in {0, 1}:
+                raise AuthorityGuardStateConflict(
+                    "authority guard delete was not singular"
+                )
+            deleted = cursor.rowcount == 1
+            conn.commit()
+            return deleted
+        except Exception:
+            conn.rollback()
+            raise

--- a/agent-core/src/teleop/capture_manager.py
+++ b/agent-core/src/teleop/capture_manager.py
@@ -1,0 +1,852 @@
+from __future__ import annotations
+
+import asyncio
+import copy
+import hashlib
+import hmac
+import re
+import secrets
+import time
+import uuid
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any
+
+PAIRING_TTL_SECONDS = 60.0
+MAX_PAIRINGS_PER_SUPERVISOR = 4
+MAX_PAIRING_RECORDS = 256
+MAX_CAPTURES_PER_SUPERVISOR = 4
+MAX_CAPTURE_RECORDS = 256
+CAPTURE_EVENT_QUEUE_SIZE = 8
+CAPTURE_PRESENCE_TIMEOUT_SECONDS = 5.0
+
+_CAPTURE_PRESENCE_STATES = frozenset({
+    'browser_ready',
+    'error',
+    'rtc_connecting',
+    'streaming',
+    'xr_ended',
+    'xr_standby',
+})
+_ASSIGNMENT_PRESENCE_STATES = frozenset({'error', 'rtc_connecting', 'streaming'})
+_CAPTURE_PROTOCOL = 'motus.teleop.capture.v1'
+_FRAME_PROTOCOL = 'motus.teleop.rtc-frame.v1'
+_CLIENT_KINDS = frozenset({'browser_webxr', 'native_openxr'})
+_APP_VERSION_RE = re.compile(r'^[A-Za-z0-9][A-Za-z0-9_.+-]{0,31}$')
+_ACTIVE_ASSIGNMENT_STATES = frozenset({
+    'issued',
+    'negotiated',
+    'offer_consumed',
+})
+
+
+class CaptureError(RuntimeError):
+    """Stable, secret-free capture contract failure."""
+
+    def __init__(self, code: str, status_code: int):
+        self.code = code
+        self.status_code = status_code
+        super().__init__(f'capture error: {code}')
+
+
+@dataclass(frozen=True)
+class CapturePairingResult:
+    pairing_id: str
+    pairing_code: str = field(repr=False)
+    expires_at: float
+
+
+@dataclass(frozen=True)
+class CaptureConnection:
+    capture_id: str
+    connection_id: str
+    events: asyncio.Queue
+    capture_credential: str | None = field(default=None, repr=False)
+
+
+@dataclass
+class _Pairing:
+    id: str
+    principal_id: str = field(repr=False)
+    client_id: str = field(repr=False)
+    label: str
+    code_digest: bytes = field(repr=False)
+    created_at: float
+    expires_at: float
+
+
+@dataclass
+class _Capture:
+    id: str
+    principal_id: str = field(repr=False)
+    label: str
+    capture_protocol: str
+    frame_protocol: str
+    client_kind: str
+    app_version: str
+    credential_digest: bytes = field(repr=False)
+    created_at: float
+    connected_at: float
+    last_seen_at: float
+    last_seen_monotonic: float = field(repr=False)
+    observed_state: str = 'browser_ready'
+    connection_id: str | None = field(default=None, repr=False)
+    events: asyncio.Queue | None = field(default=None, repr=False)
+    revoked: bool = False
+
+
+@dataclass
+class CaptureAssignment:
+    id: str
+    generation: int
+    capture_id: str
+    session_id: str
+    operation_generation: int
+    mode: str
+    profile_id: str
+    capability_digest: str
+    capabilities: dict[str, Any]
+    effectors: list[str]
+    state: str
+    created_at: float
+    updated_at: float
+    failure_code: str | None = None
+
+
+def _token_digest(value: str) -> bytes:
+    return hashlib.sha256(value.encode('utf-8')).digest()
+
+
+def _bounded_label(value: object) -> str:
+    if not isinstance(value, str):
+        raise CaptureError('capture_label_invalid', 400)
+    label = value.strip()
+    if not label or len(label) > 64 or any(ord(character) < 0x20 for character in label):
+        raise CaptureError('capture_label_invalid', 400)
+    return label
+
+
+def _validate_client_metadata(
+    capture_protocol: object,
+    frame_protocol: object,
+    client_kind: object,
+    app_version: object,
+) -> None:
+    if (
+        capture_protocol != _CAPTURE_PROTOCOL
+        or frame_protocol != _FRAME_PROTOCOL
+        or client_kind not in _CLIENT_KINDS
+        or not isinstance(app_version, str)
+        or not _APP_VERSION_RE.fullmatch(app_version)
+    ):
+        raise CaptureError('capture_protocol_mismatch', 409)
+
+
+class CaptureManager:
+    """Own ephemeral capture pairing, presence, and per-session assignments.
+
+    Capture credentials never confer a human role or a robot lease.  The
+    coordinator remains responsible for checking the original supervisor tab
+    and the current robot session before creating or consuming an assignment.
+    """
+
+    def __init__(
+        self,
+        *,
+        monotonic: Callable[[], float] = time.monotonic,
+        wall_clock: Callable[[], float] = time.time,
+    ):
+        self._lock = asyncio.Lock()
+        self._monotonic = monotonic
+        self._wall_clock = wall_clock
+        self._pairings: dict[str, _Pairing] = {}
+        self._captures: dict[str, _Capture] = {}
+        self._assignments: dict[str, CaptureAssignment] = {}
+        self._assignment_by_capture: dict[str, str] = {}
+        self._assignment_by_session: dict[str, str] = {}
+        self._loss_pending_by_session: dict[str, tuple[str, int]] = {}
+        self._assignment_sequence = 0
+
+    async def create_pairing(
+        self,
+        principal_id: str,
+        client_id: str,
+        *,
+        label: str,
+    ) -> CapturePairingResult:
+        if not principal_id or not client_id:
+            raise CaptureError('capture_supervisor_required', 400)
+        bounded_label = _bounded_label(label)
+        pairing_code = secrets.token_urlsafe(32)
+        async with self._lock:
+            now_monotonic = self._monotonic()
+            now_wall = self._wall_clock()
+            self._prune_pairings_locked(now_monotonic)
+            supervisor_pairings = sum(
+                pairing.principal_id == principal_id
+                for pairing in self._pairings.values()
+            )
+            if (
+                supervisor_pairings >= MAX_PAIRINGS_PER_SUPERVISOR
+                or len(self._pairings) >= MAX_PAIRING_RECORDS
+            ):
+                raise CaptureError('capture_pairing_limit', 409)
+            pairing_id = str(uuid.uuid4())
+            pairing = _Pairing(
+                id=pairing_id,
+                principal_id=principal_id,
+                client_id=client_id,
+                label=bounded_label,
+                code_digest=_token_digest(pairing_code),
+                created_at=now_wall,
+                expires_at=now_monotonic + PAIRING_TTL_SECONDS,
+            )
+            self._pairings[pairing_id] = pairing
+            return CapturePairingResult(
+                pairing_id=pairing.id,
+                pairing_code=pairing_code,
+                expires_at=now_wall + PAIRING_TTL_SECONDS,
+            )
+
+    async def connect_with_pairing(
+        self,
+        pairing_id: str,
+        pairing_code: str,
+        *,
+        capture_protocol: str,
+        frame_protocol: str,
+        client_kind: str,
+        app_version: str,
+    ) -> CaptureConnection:
+        _validate_client_metadata(
+            capture_protocol,
+            frame_protocol,
+            client_kind,
+            app_version,
+        )
+        if not isinstance(pairing_code, str) or not 32 <= len(pairing_code) <= 128:
+            raise CaptureError('capture_pairing_invalid', 401)
+        async with self._lock:
+            now_monotonic = self._monotonic()
+            now_wall = self._wall_clock()
+            self._prune_pairings_locked(now_monotonic)
+            pairing = self._pairings.get(pairing_id)
+            if pairing is None or not hmac.compare_digest(
+                pairing.code_digest,
+                _token_digest(pairing_code),
+            ):
+                raise CaptureError('capture_pairing_invalid', 401)
+            supervisor_captures = sum(
+                not capture.revoked
+                and capture.principal_id == pairing.principal_id
+                for capture in self._captures.values()
+            )
+            if (
+                supervisor_captures >= MAX_CAPTURES_PER_SUPERVISOR
+                or len(self._captures) >= MAX_CAPTURE_RECORDS
+            ):
+                raise CaptureError('capture_device_limit', 409)
+
+            # Consume the code before producing any credential. A cancelled or
+            # disconnected redemption therefore cannot be replayed.
+            self._pairings.pop(pairing.id, None)
+            credential = secrets.token_urlsafe(32)
+            capture_id = str(uuid.uuid4())
+            connection_id = str(uuid.uuid4())
+            events: asyncio.Queue = asyncio.Queue(maxsize=CAPTURE_EVENT_QUEUE_SIZE)
+            self._captures[capture_id] = _Capture(
+                id=capture_id,
+                principal_id=pairing.principal_id,
+                label=pairing.label,
+                capture_protocol=capture_protocol,
+                frame_protocol=frame_protocol,
+                client_kind=client_kind,
+                app_version=app_version,
+                credential_digest=_token_digest(credential),
+                created_at=now_wall,
+                connected_at=now_wall,
+                last_seen_at=now_wall,
+                last_seen_monotonic=now_monotonic,
+                connection_id=connection_id,
+                events=events,
+            )
+            return CaptureConnection(
+                capture_id=capture_id,
+                connection_id=connection_id,
+                events=events,
+                capture_credential=credential,
+            )
+
+    async def connect_with_credential(
+        self,
+        capture_id: str,
+        capture_credential: str,
+        *,
+        capture_protocol: str,
+        frame_protocol: str,
+        client_kind: str,
+        app_version: str,
+    ) -> CaptureConnection:
+        _validate_client_metadata(
+            capture_protocol,
+            frame_protocol,
+            client_kind,
+            app_version,
+        )
+        if (
+            not isinstance(capture_credential, str)
+            or not 32 <= len(capture_credential) <= 128
+        ):
+            raise CaptureError('capture_auth_invalid', 401)
+        async with self._lock:
+            capture = self._captures.get(capture_id)
+            if (
+                capture is None
+                or capture.revoked
+                or not hmac.compare_digest(
+                    capture.credential_digest,
+                    _token_digest(capture_credential),
+                )
+            ):
+                raise CaptureError('capture_auth_invalid', 401)
+            if capture.connection_id is not None:
+                raise CaptureError('capture_already_connected', 409)
+            if (
+                capture.capture_protocol != capture_protocol
+                or capture.frame_protocol != frame_protocol
+                or capture.client_kind != client_kind
+            ):
+                raise CaptureError('capture_protocol_mismatch', 409)
+            connection_id = str(uuid.uuid4())
+            events: asyncio.Queue = asyncio.Queue(maxsize=CAPTURE_EVENT_QUEUE_SIZE)
+            now_wall = self._wall_clock()
+            capture.connection_id = connection_id
+            capture.events = events
+            capture.connected_at = now_wall
+            capture.last_seen_at = now_wall
+            capture.last_seen_monotonic = self._monotonic()
+            capture.observed_state = 'browser_ready'
+            capture.app_version = app_version
+            return CaptureConnection(
+                capture_id=capture.id,
+                connection_id=connection_id,
+                events=events,
+            )
+
+    async def disconnect(
+        self,
+        capture_id: str,
+        connection_id: str,
+    ) -> CaptureAssignment | None:
+        async with self._lock:
+            capture = self._captures.get(capture_id)
+            if capture is None or capture.connection_id != connection_id:
+                return None
+            capture.connection_id = None
+            capture.events = None
+            capture.observed_state = 'offline'
+            capture.last_seen_at = self._wall_clock()
+            return self._lose_for_capture_locked(
+                capture_id,
+                'capture_disconnected',
+            )
+
+    async def update_presence(
+        self,
+        capture_id: str,
+        connection_id: str,
+        *,
+        state: str,
+        assignment_id: str | None,
+    ) -> tuple[dict[str, Any], CaptureAssignment | None]:
+        if state not in _CAPTURE_PRESENCE_STATES:
+            raise CaptureError('capture_presence_invalid', 400)
+        async with self._lock:
+            capture = self._require_connection_locked(capture_id, connection_id)
+            assignment = self._active_assignment_for_capture_locked(capture_id)
+            if state in _ASSIGNMENT_PRESENCE_STATES:
+                if assignment is None or assignment.id != assignment_id:
+                    raise CaptureError('capture_assignment_mismatch', 409)
+            elif assignment_id is not None:
+                raise CaptureError('capture_presence_invalid', 400)
+            capture.observed_state = state
+            capture.last_seen_at = self._wall_clock()
+            capture.last_seen_monotonic = self._monotonic()
+            lost_assignment = None
+            if assignment is not None and state in {
+                'browser_ready', 'error', 'xr_ended', 'xr_standby',
+            }:
+                lost_assignment = self._lose_assignment_locked(
+                    assignment,
+                    f'capture_{state}',
+                )
+            return self._public_capture_locked(capture), lost_assignment
+
+    async def list_for_supervisor(
+        self,
+        principal_id: str,
+    ) -> list[dict[str, Any]]:
+        async with self._lock:
+            captures = [
+                capture
+                for capture in self._captures.values()
+                if not capture.revoked
+                and capture.principal_id == principal_id
+            ]
+            return [
+                self._public_capture_locked(capture)
+                for capture in sorted(captures, key=lambda item: (item.label, item.id))
+            ]
+
+    async def expire_stale_connection(
+        self,
+        capture_id: str,
+        connection_id: str,
+    ) -> tuple[bool, CaptureAssignment | None]:
+        async with self._lock:
+            capture = self._captures.get(capture_id)
+            if capture is None or capture.connection_id != connection_id:
+                return True, None
+            if (
+                self._monotonic() - capture.last_seen_monotonic
+                < CAPTURE_PRESENCE_TIMEOUT_SECONDS
+            ):
+                return False, None
+            return True, self._expire_capture_connection_locked(capture)
+
+    async def assignment_loss_is_pending(
+        self,
+        lost_assignment: CaptureAssignment,
+    ) -> bool:
+        """Return whether this exact passive loss still requires fail-close."""
+
+        async with self._lock:
+            return self._loss_pending_by_session.get(
+                lost_assignment.session_id,
+            ) == (lost_assignment.id, lost_assignment.generation)
+
+    async def complete_assignment_loss(
+        self,
+        lost_assignment: CaptureAssignment,
+    ) -> bool:
+        """Clear one exact loss fence after Core proves HOLD or terminal state."""
+
+        async with self._lock:
+            expected = (lost_assignment.id, lost_assignment.generation)
+            if self._loss_pending_by_session.get(
+                lost_assignment.session_id,
+            ) != expected:
+                return False
+            replacement = self._active_assignment_for_session_locked(
+                lost_assignment.session_id,
+            )
+            if replacement is not None:
+                self._revoke_assignment_locked(
+                    replacement,
+                    'capture_loss_fail_closed',
+                )
+            self._loss_pending_by_session.pop(lost_assignment.session_id, None)
+            return True
+
+    async def revoke_capture(
+        self,
+        capture_id: str,
+        principal_id: str,
+    ) -> dict[str, Any]:
+        async with self._lock:
+            capture = self._require_supervisor_capture_locked(
+                capture_id,
+                principal_id,
+            )
+            if self._active_assignment_for_capture_locked(capture.id) is not None:
+                # Deleting enrollment does not terminate an already negotiated
+                # capture-to-Driver peer connection. Require the operator to
+                # enter Pause/HOLD first so the Driver safety path is explicit.
+                raise CaptureError('capture_attached', 409)
+            if any(
+                assignment.capture_id == capture.id
+                and self._loss_pending_by_session.get(assignment.session_id)
+                == (assignment.id, assignment.generation)
+                for assignment in self._assignments.values()
+            ):
+                raise CaptureError('capture_loss_pending', 409)
+            public = self._public_capture_locked(capture)
+            capture.revoked = True
+            self._publish_locked(capture, {
+                'type': 'capture_revoked',
+                'reason': 'operator_revoked',
+            })
+            self._captures.pop(capture.id, None)
+            self._assignment_by_capture.pop(capture.id, None)
+            for assignment_id, assignment in list(self._assignments.items()):
+                if assignment.capture_id != capture.id:
+                    continue
+                if self._assignment_by_session.get(assignment.session_id) == assignment_id:
+                    self._assignment_by_session.pop(assignment.session_id, None)
+                self._assignments.pop(assignment_id, None)
+            return {**public, 'revoked': True, 'assignment': None}
+
+    async def attach(
+        self,
+        *,
+        capture_id: str,
+        principal_id: str,
+        session_id: str,
+        operation_generation: int,
+        mode: str,
+        profile_id: str,
+        capability_digest: str,
+        capabilities: dict[str, Any],
+        effectors: list[str],
+    ) -> CaptureAssignment:
+        async with self._lock:
+            capture = self._require_supervisor_capture_locked(
+                capture_id,
+                principal_id,
+            )
+            if session_id in self._loss_pending_by_session:
+                raise CaptureError('capture_loss_pending', 409)
+            if capture.connection_id is None or capture.observed_state != 'xr_standby':
+                raise CaptureError('capture_not_ready', 409)
+            if capture.frame_protocol != 'motus.teleop.rtc-frame.v1':
+                raise CaptureError('capture_protocol_mismatch', 409)
+
+            session_assignment = self._active_assignment_for_session_locked(session_id)
+            capture_assignment = self._active_assignment_for_capture_locked(capture_id)
+            existing = session_assignment or capture_assignment
+            if existing is not None:
+                same_binding = (
+                    existing.capture_id == capture_id
+                    and existing.session_id == session_id
+                    and existing.operation_generation == operation_generation
+                    and existing.mode == mode
+                    and existing.profile_id == profile_id
+                    and existing.capability_digest == capability_digest
+                )
+                if same_binding:
+                    return copy.deepcopy(existing)
+                raise CaptureError('capture_assignment_conflict', 409)
+
+            self._assignment_sequence += 1
+            now = self._wall_clock()
+            assignment = CaptureAssignment(
+                id=str(uuid.uuid4()),
+                generation=self._assignment_sequence,
+                capture_id=capture.id,
+                session_id=session_id,
+                operation_generation=operation_generation,
+                mode=mode,
+                profile_id=profile_id,
+                capability_digest=capability_digest,
+                capabilities=copy.deepcopy(capabilities),
+                effectors=copy.deepcopy(effectors),
+                state='issued',
+                created_at=now,
+                updated_at=now,
+            )
+            self._assignments[assignment.id] = assignment
+            self._assignment_by_capture[capture.id] = assignment.id
+            self._assignment_by_session[session_id] = assignment.id
+            self._publish_locked(capture, self._assignment_event_locked(assignment))
+            return copy.deepcopy(assignment)
+
+    async def claim_offer(
+        self,
+        capture_id: str,
+        connection_id: str,
+        assignment_id: str,
+    ) -> CaptureAssignment:
+        async with self._lock:
+            self._require_connection_locked(capture_id, connection_id)
+            assignment = self._active_assignment_for_capture_locked(capture_id)
+            if assignment is None or assignment.id != assignment_id:
+                raise CaptureError('capture_assignment_mismatch', 409)
+            if assignment.state != 'issued':
+                raise CaptureError('capture_offer_already_consumed', 409)
+            assignment.state = 'offer_consumed'
+            assignment.updated_at = self._wall_clock()
+            return copy.deepcopy(assignment)
+
+    async def complete_offer(
+        self,
+        capture_id: str,
+        connection_id: str,
+        assignment_id: str,
+    ) -> bool:
+        async with self._lock:
+            try:
+                self._require_connection_locked(capture_id, connection_id)
+            except CaptureError:
+                return False
+            assignment = self._active_assignment_for_capture_locked(capture_id)
+            if (
+                assignment is None
+                or assignment.id != assignment_id
+                or assignment.state != 'offer_consumed'
+            ):
+                return False
+            assignment.state = 'negotiated'
+            assignment.updated_at = self._wall_clock()
+            return True
+
+    async def fail_offer(
+        self,
+        capture_id: str,
+        assignment_id: str,
+    ) -> CaptureAssignment | None:
+        async with self._lock:
+            assignment = self._active_assignment_for_capture_locked(capture_id)
+            if assignment is None or assignment.id != assignment_id:
+                return None
+            if assignment.state not in {'issued', 'offer_consumed'}:
+                return None
+            return self._lose_assignment_locked(
+                assignment,
+                'capture_signaling_failed',
+            )
+
+    async def assignment_is_current(
+        self,
+        capture_id: str,
+        connection_id: str,
+        assignment_id: str,
+        *,
+        session_id: str,
+        operation_generation: int,
+    ) -> bool:
+        async with self._lock:
+            try:
+                self._require_connection_locked(capture_id, connection_id)
+            except CaptureError:
+                return False
+            assignment = self._active_assignment_for_capture_locked(capture_id)
+            return bool(
+                assignment is not None
+                and assignment.id == assignment_id
+                and assignment.session_id == session_id
+                and assignment.operation_generation == operation_generation
+                and assignment.state == 'offer_consumed'
+            )
+
+    async def revoke_for_session(self, session_id: str, reason: str) -> None:
+        async with self._lock:
+            assignment = self._active_assignment_for_session_locked(session_id)
+            if assignment is not None:
+                self._revoke_assignment_locked(assignment, reason)
+
+    async def reset(self, reason: str = 'core_stopped') -> None:
+        async with self._lock:
+            for assignment in list(self._assignments.values()):
+                if assignment.state in _ACTIVE_ASSIGNMENT_STATES:
+                    self._revoke_assignment_locked(assignment, reason)
+            for capture in self._captures.values():
+                self._publish_locked(capture, {'type': 'capture_revoked', 'reason': reason})
+                capture.revoked = True
+                capture.connection_id = None
+                capture.events = None
+            self._pairings.clear()
+            self._captures.clear()
+            self._assignments.clear()
+            self._assignment_by_capture.clear()
+            self._assignment_by_session.clear()
+            self._loss_pending_by_session.clear()
+
+    def public_assignment(self, assignment: CaptureAssignment) -> dict[str, Any]:
+        return {
+            'id': assignment.id,
+            'generation': assignment.generation,
+            'session_id': assignment.session_id,
+            'mode': assignment.mode,
+            'profile_id': assignment.profile_id,
+            'capability_digest': assignment.capability_digest,
+            'capabilities': copy.deepcopy(assignment.capabilities),
+            'effectors': copy.deepcopy(assignment.effectors),
+            'state': assignment.state,
+            'created_at': assignment.created_at,
+            'updated_at': assignment.updated_at,
+            'failure_code': assignment.failure_code,
+        }
+
+    def _prune_pairings_locked(self, now_monotonic: float) -> None:
+        expired = [
+            pairing_id
+            for pairing_id, pairing in self._pairings.items()
+            if pairing.expires_at <= now_monotonic
+        ]
+        for pairing_id in expired:
+            self._pairings.pop(pairing_id, None)
+
+    def _expire_capture_connection_locked(
+        self,
+        capture: _Capture,
+    ) -> CaptureAssignment | None:
+        lost_assignment = self._lose_for_capture_locked(
+            capture.id,
+            'capture_presence_timeout',
+        )
+        self._publish_locked(capture, {
+            'type': 'capture_stale',
+            'reason': 'capture_presence_timeout',
+        })
+        capture.connection_id = None
+        capture.events = None
+        capture.observed_state = 'offline'
+        return lost_assignment
+
+    def _require_supervisor_capture_locked(
+        self,
+        capture_id: str,
+        principal_id: str,
+    ) -> _Capture:
+        capture = self._captures.get(capture_id)
+        if capture is None or capture.revoked:
+            raise CaptureError('capture_not_found', 404)
+        if capture.principal_id != principal_id:
+            raise CaptureError('capture_forbidden', 403)
+        return capture
+
+    def _require_connection_locked(
+        self,
+        capture_id: str,
+        connection_id: str,
+    ) -> _Capture:
+        capture = self._captures.get(capture_id)
+        if (
+            capture is None
+            or capture.revoked
+            or capture.connection_id != connection_id
+        ):
+            raise CaptureError('capture_auth_invalid', 401)
+        return capture
+
+    def _active_assignment_for_capture_locked(
+        self,
+        capture_id: str,
+    ) -> CaptureAssignment | None:
+        assignment_id = self._assignment_by_capture.get(capture_id)
+        assignment = self._assignments.get(assignment_id) if assignment_id else None
+        return (
+            assignment
+            if assignment is not None and assignment.state in _ACTIVE_ASSIGNMENT_STATES
+            else None
+        )
+
+    def _active_assignment_for_session_locked(
+        self,
+        session_id: str,
+    ) -> CaptureAssignment | None:
+        assignment_id = self._assignment_by_session.get(session_id)
+        assignment = self._assignments.get(assignment_id) if assignment_id else None
+        return (
+            assignment
+            if assignment is not None and assignment.state in _ACTIVE_ASSIGNMENT_STATES
+            else None
+        )
+
+    def _public_capture_locked(self, capture: _Capture) -> dict[str, Any]:
+        assignment = self._active_assignment_for_capture_locked(capture.id)
+        return {
+            'id': capture.id,
+            'label': capture.label,
+            'capture_protocol': capture.capture_protocol,
+            'frame_protocol': capture.frame_protocol,
+            'client_kind': capture.client_kind,
+            'app_version': capture.app_version,
+            'connected': capture.connection_id is not None,
+            'observed_state': capture.observed_state,
+            'created_at': capture.created_at,
+            'connected_at': capture.connected_at,
+            'last_seen_at': capture.last_seen_at,
+            'assignment': self.public_assignment(assignment) if assignment else None,
+        }
+
+    def _assignment_event_locked(
+        self,
+        assignment: CaptureAssignment,
+    ) -> dict[str, Any]:
+        return {
+            'type': 'assignment',
+            'assignment': self.public_assignment(assignment),
+        }
+
+    def _revoke_for_capture_locked(
+        self,
+        capture_id: str,
+        reason: str,
+    ) -> CaptureAssignment | None:
+        assignment = self._active_assignment_for_capture_locked(capture_id)
+        if assignment is not None:
+            return self._revoke_assignment_locked(assignment, reason)
+        return None
+
+    def _lose_for_capture_locked(
+        self,
+        capture_id: str,
+        reason: str,
+    ) -> CaptureAssignment | None:
+        assignment = self._active_assignment_for_capture_locked(capture_id)
+        if assignment is None:
+            return None
+        return self._lose_assignment_locked(assignment, reason)
+
+    def _lose_assignment_locked(
+        self,
+        assignment: CaptureAssignment,
+        reason: str,
+    ) -> CaptureAssignment | None:
+        lost_assignment = self._revoke_assignment_locked(assignment, reason)
+        if lost_assignment is not None:
+            self._loss_pending_by_session[lost_assignment.session_id] = (
+                lost_assignment.id,
+                lost_assignment.generation,
+            )
+        return lost_assignment
+
+    def _revoke_assignment_locked(
+        self,
+        assignment: CaptureAssignment,
+        reason: str,
+    ) -> CaptureAssignment | None:
+        if assignment.state not in _ACTIVE_ASSIGNMENT_STATES:
+            return None
+        assignment.state = 'revoked'
+        assignment.failure_code = reason
+        assignment.updated_at = self._wall_clock()
+        if self._assignment_by_capture.get(assignment.capture_id) == assignment.id:
+            self._assignment_by_capture.pop(assignment.capture_id, None)
+        if self._assignment_by_session.get(assignment.session_id) == assignment.id:
+            self._assignment_by_session.pop(assignment.session_id, None)
+        capture = self._captures.get(assignment.capture_id)
+        if capture is not None:
+            self._publish_locked(capture, {
+                'type': 'assignment_revoked',
+                'assignment_id': assignment.id,
+                'reason': reason,
+            })
+        return copy.deepcopy(assignment)
+
+    @staticmethod
+    def _publish_locked(capture: _Capture, event: dict[str, Any]) -> None:
+        queue = capture.events
+        if queue is None:
+            return
+        try:
+            queue.put_nowait(copy.deepcopy(event))
+        except asyncio.QueueFull:
+            try:
+                queue.get_nowait()
+            except asyncio.QueueEmpty:
+                pass
+            try:
+                queue.put_nowait(copy.deepcopy(event))
+            except asyncio.QueueFull:
+                pass
+
+
+__all__ = [
+    'CaptureAssignment',
+    'CaptureConnection',
+    'CaptureError',
+    'CaptureManager',
+    'CapturePairingResult',
+]

--- a/agent-core/src/teleop/command_broker.py
+++ b/agent-core/src/teleop/command_broker.py
@@ -1,0 +1,434 @@
+"""Admission control between teleoperation authority and ordinary MCP commands."""
+
+from __future__ import annotations
+
+import asyncio
+import re
+from collections.abc import AsyncIterator, Mapping
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+
+import auth
+from teleop import audit
+
+_LOCK_STRIPE_COUNT = 256
+_READ_ONLY_TOOL_TYPES = frozenset({'resource', 'sensor'})
+_READ_ONLY_ACTIONS = frozenset({'info', 'status'})
+_SAFE_AUDIT_IDENTIFIER_RE = re.compile(r'^[A-Za-z0-9][A-Za-z0-9_.:-]{0,63}$')
+
+
+@dataclass(frozen=True, slots=True)
+class ToolAccess:
+    """A fail-closed interpretation of one MCP tool invocation."""
+
+    read_only: bool
+    basis: str
+
+
+class InvalidAuthorityBinding(RuntimeError):
+    """The persisted Core-owned authority mapping is not safe to use."""
+
+
+def authority_domain_for_target(
+    mcp_id: str,
+    target: object,
+    *,
+    targets: object = None,
+) -> str:
+    """Resolve the trusted physical-robot authority domain for an MCP target.
+
+    A standalone teleop adapter and the robot's actuator MCP may have different
+    MCP ids.  Trusted registration may bind both to the same ``robot_id``.  A
+    legacy or untrusted record cannot choose another target's authority domain
+    and therefore remains isolated under its own MCP id.
+    """
+
+    descriptor = target if isinstance(target, Mapping) else {}
+    if descriptor.get('authority_binding_error') or (
+        descriptor.get('authority_binding_required')
+        and not descriptor.get('authority_domain')
+    ):
+        raise InvalidAuthorityBinding(mcp_id)
+    trusted = descriptor.get('trust_state') == 'trusted' or descriptor.get('trusted') is True
+    if trusted and not auth.driver_record_credential_available(
+        mcp_id,
+        descriptor.get('credential_binding'),
+    ):
+        raise InvalidAuthorityBinding(mcp_id)
+    candidate = descriptor.get('authority_domain')
+    if candidate is None or candidate == mcp_id:
+        return mcp_id
+    if (
+        not trusted
+        or not isinstance(candidate, str)
+        or not _SAFE_AUDIT_IDENTIFIER_RE.fullmatch(candidate)
+    ):
+        raise InvalidAuthorityBinding(mcp_id)
+    if targets is not None:
+        records = targets if isinstance(targets, list) else []
+        roots = [
+            item for item in records
+            if isinstance(item, Mapping) and item.get('id') == candidate
+        ]
+        if len(roots) != 1:
+            raise InvalidAuthorityBinding(mcp_id)
+        root = roots[0]
+        root_domain = root.get('authority_domain')
+        root_tools = root.get('tools')
+        ordinary_actuator = any(
+            isinstance(tool, Mapping)
+            and tool.get('type') == 'actuator'
+            and tool.get('name') != 'teleop_session'
+            and 'x-teleop' not in tool
+            for tool in (root_tools if isinstance(root_tools, list) else [])
+        )
+        if (
+            root.get('trust_state') != 'trusted'
+            or not auth.driver_record_credential_available(
+                candidate,
+                root.get('credential_binding'),
+            )
+            or root.get('transport') != 'http'
+            or root.get('category') != 'driver'
+            or root_domain not in (None, '', candidate)
+            or not ordinary_actuator
+        ):
+            raise InvalidAuthorityBinding(mcp_id)
+    return candidate
+
+
+def authority_domain_for_mcp(mcp_id: str) -> str:
+    """Resolve against persisted Core configuration, the authorization source."""
+
+    import config
+
+    services = config.main.get('services', {})
+    records = services.get('mcp', []) if isinstance(services, Mapping) else []
+    matches = [
+        item for item in records
+        if isinstance(item, Mapping) and item.get('id') == mcp_id
+    ]
+    if len(matches) != 1:
+        raise InvalidAuthorityBinding(mcp_id)
+    return authority_domain_for_target(mcp_id, matches[0], targets=records)
+
+
+def _audit_identifier(value: object, *, verified: bool) -> str:
+    if (
+        verified
+        and isinstance(value, str)
+        and _SAFE_AUDIT_IDENTIFIER_RE.fullmatch(value)
+    ):
+        return value
+    return '<unverified>'
+
+
+def classify_tool_access(
+    *,
+    tool_type: object,
+    annotations: object,
+    action: object,
+    action_declared: bool = False,
+) -> ToolAccess:
+    """Return whether a call is provably observational.
+
+    Tool names are deliberately ignored: several robot Drivers have historical
+    ``get_*`` actions that move hardware.  A sensor/resource declaration or the
+    MCP readOnlyHint is explicit evidence only for tools without an action
+    multiplexer.  Once an action is present, only an exactly declared ``info``
+    or ``status`` action is admitted; every other action fails closed.
+    """
+
+    if action is not None:
+        if action_declared and action in _READ_ONLY_ACTIONS:
+            return ToolAccess(True, 'declared_diagnostic_action')
+        return ToolAccess(False, 'action_not_proven_read_only')
+    if isinstance(annotations, Mapping) and annotations.get('readOnlyHint') is True:
+        return ToolAccess(True, 'annotation')
+    if isinstance(tool_type, str) and tool_type.lower() in _READ_ONLY_TOOL_TYPES:
+        return ToolAccess(True, 'tool_type')
+    return ToolAccess(False, 'fail_closed')
+
+
+@dataclass(frozen=True, slots=True)
+class AuthorityClaim:
+    robot_id: str
+    token: str
+    session_id: str
+    principal_id: str
+    state: str
+
+
+@dataclass(slots=True)
+class _MutableAuthorityClaim:
+    robot_id: str
+    token: str
+    session_id: str = ''
+    principal_id: str = ''
+    state: str = 'acquiring'
+    ready: bool = False
+
+    def public_view(self) -> AuthorityClaim:
+        return AuthorityClaim(
+            robot_id=self.robot_id,
+            token=self.token,
+            session_id=self.session_id,
+            principal_id=self.principal_id,
+            state=self.state,
+        )
+
+
+class AuthorityAlreadyClaimed(RuntimeError):
+    def __init__(self, claim: AuthorityClaim):
+        self.claim = claim
+        super().__init__(f'teleop authority already claimed for {claim.robot_id}')
+
+
+class CommandDrainTimeout(RuntimeError):
+    def __init__(self, robot_id: str):
+        self.robot_id = robot_id
+        super().__init__(f'ordinary command did not drain for {robot_id}')
+
+
+class TeleopCommandBlocked(RuntimeError):
+    code = 'teleop_command_blocked'
+    reason = 'teleop_session_active'
+
+    def __init__(self, claim: AuthorityClaim, *, tool: str, action: str):
+        self.claim = claim
+        self.tool = tool
+        self.action = action
+        super().__init__(f'ordinary command blocked by teleop authority for {claim.robot_id}')
+
+    def public_detail(self) -> dict[str, str]:
+        return {
+            'code': self.code,
+            'reason': self.reason,
+            'robot_id': self.claim.robot_id,
+            'session_id': self.claim.session_id,
+            'state': self.claim.state,
+        }
+
+
+class CommandBroker:
+    """Serialize authority admission with ordinary mutating MCP calls.
+
+    State is keyed by canonical physical robot id while locks are fixed-size
+    stripes, so untrusted/random identifiers cannot grow lock storage.
+    """
+
+    def __init__(self) -> None:
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._conditions: tuple[asyncio.Condition, ...] = ()
+        self._claims: dict[str, _MutableAuthorityClaim] = {}
+        self._ordinary_inflight: dict[str, int] = {}
+
+    def _ensure_loop(self) -> None:
+        loop = asyncio.get_running_loop()
+        if self._loop is loop:
+            return
+        if self._claims or self._ordinary_inflight:
+            raise RuntimeError('command broker loop changed with live admissions')
+        self._conditions = tuple(
+            asyncio.Condition() for _ in range(_LOCK_STRIPE_COUNT)
+        )
+        self._loop = loop
+
+    def _condition(self, robot_id: str) -> asyncio.Condition:
+        self._ensure_loop()
+        return self._conditions[hash(robot_id) % _LOCK_STRIPE_COUNT]
+
+    async def begin_authority(
+        self,
+        robot_id: str,
+        token: str,
+        *,
+        drain_timeout_seconds: float = 5.0,
+    ) -> AuthorityClaim:
+        """Block new writes, then wait a bounded time for admitted writes."""
+
+        condition = self._condition(robot_id)
+        async with condition:
+            existing = self._claims.get(robot_id)
+            if existing is not None:
+                if existing.token != token:
+                    raise AuthorityAlreadyClaimed(existing.public_view())
+                try:
+                    await asyncio.wait_for(
+                        condition.wait_for(
+                            lambda: (
+                                existing.ready
+                                or self._claims.get(robot_id) is not existing
+                            ),
+                        ),
+                        timeout=max(0.0, drain_timeout_seconds),
+                    )
+                except TimeoutError as error:
+                    raise CommandDrainTimeout(robot_id) from error
+                if self._claims.get(robot_id) is not existing:
+                    raise AuthorityAlreadyClaimed(existing.public_view())
+                return existing.public_view()
+
+            claim = _MutableAuthorityClaim(robot_id=robot_id, token=token)
+            self._claims[robot_id] = claim
+            try:
+                await asyncio.wait_for(
+                    condition.wait_for(
+                        lambda: self._ordinary_inflight.get(robot_id, 0) == 0,
+                    ),
+                    timeout=max(0.0, drain_timeout_seconds),
+                )
+            except TimeoutError as error:
+                if self._claims.get(robot_id) is claim:
+                    self._claims.pop(robot_id, None)
+                    condition.notify_all()
+                raise CommandDrainTimeout(robot_id) from error
+            except BaseException:
+                if self._claims.get(robot_id) is claim:
+                    self._claims.pop(robot_id, None)
+                    condition.notify_all()
+                raise
+            claim.ready = True
+            condition.notify_all()
+            return claim.public_view()
+
+    async def update_authority(
+        self,
+        robot_id: str,
+        token: str,
+        *,
+        session_id: str | None = None,
+        principal_id: str | None = None,
+        state: str | None = None,
+    ) -> AuthorityClaim | None:
+        condition = self._condition(robot_id)
+        async with condition:
+            claim = self._claims.get(robot_id)
+            if claim is None or claim.token != token:
+                return None
+            if session_id is not None:
+                claim.session_id = session_id
+            if principal_id is not None:
+                claim.principal_id = principal_id
+            if state is not None:
+                claim.state = state
+            return claim.public_view()
+
+    async def release_authority(self, robot_id: str, token: str) -> bool:
+        condition = self._condition(robot_id)
+        async with condition:
+            claim = self._claims.get(robot_id)
+            if claim is None or claim.token != token:
+                return False
+            self._claims.pop(robot_id, None)
+            condition.notify_all()
+            return True
+
+    async def authority_for(self, robot_id: str) -> AuthorityClaim | None:
+        condition = self._condition(robot_id)
+        async with condition:
+            claim = self._claims.get(robot_id)
+            return claim.public_view() if claim is not None else None
+
+    async def _finish_ordinary(self, robot_id: str) -> None:
+        condition = self._condition(robot_id)
+        async with condition:
+            remaining = self._ordinary_inflight.get(robot_id, 0) - 1
+            if remaining > 0:
+                self._ordinary_inflight[robot_id] = remaining
+            else:
+                self._ordinary_inflight.pop(robot_id, None)
+            condition.notify_all()
+
+    @staticmethod
+    async def _await_cleanup(task: asyncio.Task) -> None:
+        cancelled = False
+        while True:
+            try:
+                await asyncio.shield(task)
+                break
+            except asyncio.CancelledError:
+                cancelled = True
+                if task.done():
+                    task.result()
+                    break
+        if cancelled:
+            raise asyncio.CancelledError
+
+    @asynccontextmanager
+    async def ordinary_command(
+        self,
+        robot_id: str,
+        *,
+        read_only: bool,
+        source: str,
+        tool: str,
+        action: str,
+        tool_verified: bool = False,
+        action_verified: bool = False,
+    ) -> AsyncIterator[None]:
+        """Admit one ordinary call or reject it before any network write."""
+
+        if read_only:
+            yield
+            return
+
+        condition = self._condition(robot_id)
+        blocked: AuthorityClaim | None = None
+        async with condition:
+            claim = self._claims.get(robot_id)
+            if claim is not None:
+                blocked = claim.public_view()
+            else:
+                self._ordinary_inflight[robot_id] = (
+                    self._ordinary_inflight.get(robot_id, 0) + 1
+                )
+
+        if blocked is not None:
+            try:
+                await audit.emit(
+                    'teleop.command.blocked',
+                    session_id=blocked.session_id,
+                    robot_id=blocked.robot_id,
+                    principal_id=blocked.principal_id,
+                    source=source,
+                    decision='blocked',
+                    reason=TeleopCommandBlocked.reason,
+                    tool=_audit_identifier(tool, verified=tool_verified),
+                    action=_audit_identifier(action, verified=action_verified),
+                    details={'state': blocked.state},
+                )
+            except Exception:  # noqa: BLE001 -- observability cannot change admission
+                pass
+            raise TeleopCommandBlocked(
+                blocked,
+                tool=_audit_identifier(tool, verified=tool_verified),
+                action=_audit_identifier(action, verified=action_verified),
+            )
+
+        try:
+            yield
+        finally:
+            cleanup = asyncio.create_task(
+                self._finish_ordinary(robot_id),
+                name=f'teleop-command-finish-{robot_id}',
+            )
+            await self._await_cleanup(cleanup)
+
+
+broker = CommandBroker()
+
+
+__all__ = [
+    'AuthorityAlreadyClaimed',
+    'AuthorityClaim',
+    'InvalidAuthorityBinding',
+    'authority_domain_for_mcp',
+    'authority_domain_for_target',
+    'CommandBroker',
+    'CommandDrainTimeout',
+    'TeleopCommandBlocked',
+    'ToolAccess',
+    'broker',
+    'classify_tool_access',
+]

--- a/agent-core/src/teleop/contracts.py
+++ b/agent-core/src/teleop/contracts.py
@@ -1,0 +1,355 @@
+from __future__ import annotations
+
+import math
+import re
+from collections.abc import Mapping
+from typing import Any
+
+
+SHADOW_MODE = 'shadow'
+LIVE_MODE = 'live'
+TELEOP_MODES = frozenset({SHADOW_MODE, LIVE_MODE})
+PROTOCOL_BY_MODE = {
+    SHADOW_MODE: 'motus.teleop.shadow.v1',
+    LIVE_MODE: 'motus.teleop.live.v1',
+}
+DISPATCH_CONTRACT_BY_MODE = {
+    SHADOW_MODE: 'motus.teleop.dispatch.recording.v1',
+    LIVE_MODE: 'motus.teleop.dispatch.hardware.v1',
+}
+PREPARE_ACTION_BY_MODE = {
+    SHADOW_MODE: 'prepare_shadow',
+    LIVE_MODE: 'prepare_live',
+}
+WEBRTC_SIGNALING_PROTOCOL = 'motus.teleop.webrtc-offer-answer.v1'
+WEBRTC_SIGNALING_PATH = '/offer'
+WEBRTC_SIGNALING_ACCESS = 'authenticated-core-proxy-only'
+WEBRTC_SIGNALING_AUDIENCES = frozenset({'teleop-shadow-rtc', 'motus-teleop-rtc'})
+
+_CAPABILITY_DIGEST_RE = re.compile(r'^[0-9a-f]{64}$')
+_SAFE_ID_RE = re.compile(r'^[A-Za-z0-9][A-Za-z0-9_.:-]{0,127}$')
+_BASE_TWIST_AXES = ('linear_x', 'linear_y', 'angular_z')
+_BASE_TWIST_BINDING_KEYS = frozenset({'hand', 'axis', 'scale', 'deadzone', 'direction'})
+_ROLE_BINDING_KEYS = frozenset({'required', 'role'})
+_OUTPUT_KEYS = frozenset({'enabled', 'joint_count'})
+_CAPABILITY_KEYS = frozenset({'profile_id', 'input_bindings', 'outputs', 'effectors'})
+_DESCRIPTOR_KEYS = frozenset({
+    'protocol',
+    'driver_id',
+    'driver_name',
+    'robot_id',
+    'profile_id',
+    'mode',
+    'actuation_enabled',
+    'capability_digest',
+    'dispatch_contract',
+    'signaling',
+    'capabilities',
+    'dry_run_profile',
+})
+_COMMON_ACTIONS = frozenset({'heartbeat', 'pause', 'release', 'soft_stop', 'status', 'stop'})
+_IDENTITY_PARAMS = ['boot_id', 'session_id', 'epoch', 'fence']
+
+
+class TeleopContractError(ValueError):
+    pass
+
+
+def _safe_id(value: object, *, field: str) -> str:
+    if not isinstance(value, str) or not _SAFE_ID_RE.fullmatch(value):
+        raise TeleopContractError(f'{field} is invalid')
+    return value
+
+
+def _strict_bool(value: object, *, field: str) -> bool:
+    if not isinstance(value, bool):
+        raise TeleopContractError(f'{field} is invalid')
+    return value
+
+
+def _finite_number(
+    value: object,
+    *,
+    field: str,
+    minimum: float,
+    maximum: float,
+) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise TeleopContractError(f'{field} is invalid')
+    number = float(value)
+    if not math.isfinite(number) or number < minimum or number > maximum:
+        raise TeleopContractError(f'{field} is invalid')
+    return number
+
+
+def _strict_mapping(value: object, *, field: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise TeleopContractError(f'{field} is invalid')
+    return value
+
+
+def _project_axis_binding(value: object, *, field: str) -> dict[str, object]:
+    binding = _strict_mapping(value, field=field)
+    if set(binding) != _BASE_TWIST_BINDING_KEYS:
+        raise TeleopContractError(f'{field} is invalid')
+    hand = binding.get('hand')
+    axis = binding.get('axis')
+    direction = binding.get('direction')
+    if hand not in {'left', 'right'}:
+        raise TeleopContractError(f'{field}.hand is invalid')
+    if isinstance(axis, bool) or not isinstance(axis, int) or not 0 <= axis <= 7:
+        raise TeleopContractError(f'{field}.axis is invalid')
+    if direction not in {-1, 1} or isinstance(direction, bool):
+        raise TeleopContractError(f'{field}.direction is invalid')
+    return {
+        'hand': hand,
+        'axis': axis,
+        'scale': _finite_number(
+            binding.get('scale'),
+            field=f'{field}.scale',
+            minimum=0.0,
+            maximum=10.0,
+        ),
+        'deadzone': _finite_number(
+            binding.get('deadzone'),
+            field=f'{field}.deadzone',
+            minimum=0.0,
+            maximum=0.95,
+        ),
+        'direction': direction,
+    }
+
+
+def _project_input_bindings(value: object) -> dict[str, object]:
+    bindings = _strict_mapping(value, field='capabilities.input_bindings')
+    if len(bindings) > 16:
+        raise TeleopContractError('capabilities.input_bindings is invalid')
+    result: dict[str, object] = {}
+    for raw_name, raw_binding in bindings.items():
+        name = _safe_id(raw_name, field='capabilities.input_bindings key')
+        if name == 'base_twist':
+            base_twist = _strict_mapping(raw_binding, field='input_bindings.base_twist')
+            if set(base_twist) != set(_BASE_TWIST_AXES):
+                raise TeleopContractError('input_bindings.base_twist is invalid')
+            result[name] = {
+                axis_name: _project_axis_binding(
+                    base_twist[axis_name],
+                    field=f'input_bindings.base_twist.{axis_name}',
+                )
+                for axis_name in _BASE_TWIST_AXES
+            }
+            continue
+        binding = _strict_mapping(raw_binding, field=f'input_bindings.{name}')
+        if set(binding) != _ROLE_BINDING_KEYS:
+            raise TeleopContractError(f'input_bindings.{name} is invalid')
+        result[name] = {
+            'required': _strict_bool(
+                binding.get('required'),
+                field=f'input_bindings.{name}.required',
+            ),
+            'role': _safe_id(binding.get('role'), field=f'input_bindings.{name}.role'),
+        }
+    return result
+
+
+def _project_outputs(value: object) -> dict[str, dict[str, object]]:
+    outputs = _strict_mapping(value, field='capabilities.outputs')
+    if not outputs or len(outputs) > 16:
+        raise TeleopContractError('capabilities.outputs is invalid')
+    result: dict[str, dict[str, object]] = {}
+    for raw_name, raw_output in outputs.items():
+        name = _safe_id(raw_name, field='capabilities.outputs key')
+        output = _strict_mapping(raw_output, field=f'capabilities.outputs.{name}')
+        if not set(output).issubset(_OUTPUT_KEYS) or 'enabled' not in output:
+            raise TeleopContractError(f'capabilities.outputs.{name} is invalid')
+        projected: dict[str, object] = {
+            'enabled': _strict_bool(
+                output.get('enabled'),
+                field=f'capabilities.outputs.{name}.enabled',
+            ),
+        }
+        if 'joint_count' in output:
+            joint_count = output.get('joint_count')
+            if (
+                isinstance(joint_count, bool)
+                or not isinstance(joint_count, int)
+                or not 0 <= joint_count <= 128
+            ):
+                raise TeleopContractError(
+                    f'capabilities.outputs.{name}.joint_count is invalid',
+                )
+            projected['joint_count'] = joint_count
+        result[name] = projected
+    return result
+
+
+def project_capabilities(value: object, *, profile_id: str) -> dict[str, object]:
+    capabilities = _strict_mapping(value, field='capabilities')
+    if set(capabilities) - _CAPABILITY_KEYS:
+        raise TeleopContractError('capabilities contains unsupported fields')
+    if capabilities.get('profile_id') != profile_id:
+        raise TeleopContractError('capabilities.profile_id does not match profile_id')
+    input_bindings = _project_input_bindings(capabilities.get('input_bindings'))
+    outputs = _project_outputs(capabilities.get('outputs'))
+    base_enabled = outputs.get('base', {}).get('enabled') is True
+    if base_enabled != ('base_twist' in input_bindings):
+        raise TeleopContractError(
+            'base output and input_bindings.base_twist must be enabled together',
+        )
+
+    effectors_raw = capabilities.get('effectors')
+    if effectors_raw is None:
+        effectors = [name for name, output in outputs.items() if output['enabled']]
+    else:
+        if not isinstance(effectors_raw, list) or len(effectors_raw) > 16:
+            raise TeleopContractError('capabilities.effectors is invalid')
+        effectors = [
+            _safe_id(item, field='capabilities.effectors item')
+            for item in effectors_raw
+        ]
+        if len(effectors) != len(set(effectors)):
+            raise TeleopContractError('capabilities.effectors contains duplicates')
+        enabled_outputs = {name for name, output in outputs.items() if output['enabled']}
+        if set(effectors) != enabled_outputs:
+            raise TeleopContractError('capabilities.effectors does not match enabled outputs')
+    return {
+        'profile_id': profile_id,
+        'input_bindings': input_bindings,
+        'outputs': outputs,
+        'effectors': effectors,
+    }
+
+
+def project_teleop_descriptor(
+    tool: object,
+    *,
+    expected_driver_id: str | None = None,
+) -> dict[str, object]:
+    if not isinstance(tool, Mapping) or tool.get('type') != 'actuator':
+        raise TeleopContractError('teleop_session tool is invalid')
+    descriptor = _strict_mapping(tool.get('x-teleop'), field='x-teleop')
+    mode = descriptor.get('mode')
+    if mode not in TELEOP_MODES:
+        raise TeleopContractError('x-teleop.mode is invalid')
+    driver_id = _safe_id(descriptor.get('driver_id'), field='x-teleop.driver_id')
+    robot_id = _safe_id(descriptor.get('robot_id'), field='x-teleop.robot_id')
+    legacy_shadow = mode == SHADOW_MODE and 'profile_id' not in descriptor
+    if set(descriptor) - _DESCRIPTOR_KEYS:
+        raise TeleopContractError('x-teleop contains unsupported fields')
+    if legacy_shadow:
+        if descriptor.get('dry_run_profile', 'recording') != 'recording':
+            raise TeleopContractError('legacy Shadow profile is invalid')
+        profile_id = 'recording'
+    else:
+        if 'dry_run_profile' in descriptor:
+            raise TeleopContractError('dry_run_profile is legacy Shadow-only')
+        profile_id = _safe_id(descriptor.get('profile_id'), field='x-teleop.profile_id')
+    if expected_driver_id is not None and driver_id != expected_driver_id:
+        raise TeleopContractError('x-teleop.driver_id does not match')
+    expected_actuation = mode == LIVE_MODE
+    if descriptor.get('actuation_enabled') is not expected_actuation:
+        raise TeleopContractError('x-teleop.actuation_enabled is invalid')
+    if descriptor.get('protocol') != PROTOCOL_BY_MODE[mode]:
+        raise TeleopContractError('x-teleop.protocol is invalid')
+    if descriptor.get('dispatch_contract') != DISPATCH_CONTRACT_BY_MODE[mode]:
+        raise TeleopContractError('x-teleop.dispatch_contract is invalid')
+    digest = descriptor.get('capability_digest')
+    if not isinstance(digest, str) or not _CAPABILITY_DIGEST_RE.fullmatch(digest):
+        raise TeleopContractError('x-teleop.capability_digest is invalid')
+
+    signaling = _strict_mapping(descriptor.get('signaling'), field='x-teleop.signaling')
+    signaling_audience = signaling.get('audience')
+    if legacy_shadow and signaling_audience is None:
+        signaling_audience = 'teleop-shadow-rtc'
+    expected_signaling_keys = {'protocol', 'path', 'access', 'audience'}
+    if legacy_shadow and 'audience' not in signaling:
+        expected_signaling_keys.remove('audience')
+    if (
+        set(signaling) != expected_signaling_keys
+        or signaling.get('protocol') != WEBRTC_SIGNALING_PROTOCOL
+        or signaling.get('path') != WEBRTC_SIGNALING_PATH
+        or signaling.get('access') != WEBRTC_SIGNALING_ACCESS
+        or signaling_audience not in WEBRTC_SIGNALING_AUDIENCES
+        or (mode == LIVE_MODE and signaling_audience != 'motus-teleop-rtc')
+    ):
+        raise TeleopContractError('x-teleop.signaling is invalid')
+
+    input_schema = _strict_mapping(tool.get('inputSchema'), field='inputSchema')
+    properties = _strict_mapping(input_schema.get('properties'), field='inputSchema.properties')
+    action_schema = _strict_mapping(properties.get('action'), field='inputSchema.action')
+    action_enum = action_schema.get('enum')
+    action_params = input_schema.get('x-action-params')
+    required_actions = _COMMON_ACTIONS | {PREPARE_ACTION_BY_MODE[mode]}
+    if (
+        not isinstance(action_enum, list)
+        or not isinstance(action_params, Mapping)
+        or any(not isinstance(item, str) or not item for item in action_enum)
+        or len(action_enum) != len(set(action_enum))
+        or not set(action_enum).issubset(action_params)
+        or not required_actions.issubset(action_enum)
+        or not required_actions.issubset(action_params)
+    ):
+        raise TeleopContractError('teleop_session actions are invalid')
+
+    expected_action_params = {
+        PREPARE_ACTION_BY_MODE[mode]: ['session_id', 'epoch', 'fence'],
+        'heartbeat': _IDENTITY_PARAMS,
+        'pause': _IDENTITY_PARAMS,
+        'release': _IDENTITY_PARAMS,
+        'soft_stop': _IDENTITY_PARAMS,
+        'status': [],
+        'stop': [],
+    }
+    for action, expected_params in expected_action_params.items():
+        declaration = action_params.get(action)
+        if (
+            not isinstance(declaration, Mapping)
+            or declaration.get('params') != expected_params
+        ):
+            raise TeleopContractError(f'teleop_session action {action} is invalid')
+
+    if legacy_shadow and descriptor.get('capabilities') is None:
+        capabilities = {
+            'profile_id': profile_id,
+            'input_bindings': {},
+            'outputs': {'recording': {'enabled': False}},
+            'effectors': [],
+        }
+    else:
+        capabilities = project_capabilities(
+            descriptor.get('capabilities'),
+            profile_id=profile_id,
+        )
+    driver_name = descriptor.get('driver_name', driver_id)
+    if not isinstance(driver_name, str) or not 1 <= len(driver_name) <= 256:
+        raise TeleopContractError('x-teleop.driver_name is invalid')
+    return {
+        'protocol': PROTOCOL_BY_MODE[mode],
+        'driver_id': driver_id,
+        'driver_name': driver_name,
+        'robot_id': robot_id,
+        'profile_id': profile_id,
+        'mode': mode,
+        'actuation_enabled': expected_actuation,
+        'capability_digest': digest,
+        'dispatch_contract': DISPATCH_CONTRACT_BY_MODE[mode],
+        'signaling': {
+            'protocol': WEBRTC_SIGNALING_PROTOCOL,
+            'path': WEBRTC_SIGNALING_PATH,
+            'access': WEBRTC_SIGNALING_ACCESS,
+            'audience': signaling_audience,
+        },
+        'capabilities': capabilities,
+    }
+
+
+def valid_teleop_descriptor(
+    tool: object,
+    *,
+    expected_driver_id: str | None = None,
+) -> bool:
+    try:
+        project_teleop_descriptor(tool, expected_driver_id=expected_driver_id)
+    except TeleopContractError:
+        return False
+    return True

--- a/agent-core/src/teleop/models.py
+++ b/agent-core/src/teleop/models.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import math
+import time
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from typing import Any
+
+_SECRET_KEY_PARTS = (
+    'credential',
+    'fence',
+    'password',
+    'privatekey',
+    'secret',
+    'token',
+)
+
+
+def _is_secret_key(key: object) -> bool:
+    normalized = ''.join(character for character in str(key).lower() if character.isalnum())
+    return any(part in normalized for part in _SECRET_KEY_PARTS)
+
+
+def _public_value(value: Any, *, depth: int = 0) -> Any:
+    """Build a JSON-safe value while recursively dropping secret-shaped keys.
+
+    ``ShadowSession.public_dict`` currently constructs a fixed schema, but keeping
+    the final redaction recursive makes future nested public fields safe by
+    default instead of relying on every caller to remember the fence rule.
+    """
+
+    if depth > 6:
+        return None
+    if value is None or isinstance(value, (bool, int, str)):
+        return value
+    if isinstance(value, float):
+        return value if math.isfinite(value) else None
+    if isinstance(value, Mapping):
+        return {
+            str(key): _public_value(item, depth=depth + 1)
+            for key, item in value.items()
+            if not _is_secret_key(key)
+        }
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return [_public_value(item, depth=depth + 1) for item in value]
+    return str(value)
+
+
+@dataclass
+class ShadowSession:
+    id: str
+    robot_id: str
+    driver_id: str
+    principal_id: str
+    boot_id: str
+    epoch: int
+    capability_digest: str
+    client_id: str = field(repr=False)
+    fence: str = field(repr=False)
+    state: str
+    operation_generation: int
+    operation_state: str
+    created_at: float
+    lease_seconds: float
+    deadline_monotonic: float = field(repr=False)
+    mode: str = 'shadow'
+    profile_id: str = 'recording'
+    capabilities: dict[str, Any] = field(default_factory=dict)
+    effectors: list[str] = field(default_factory=list)
+    signaling_audience: str = 'teleop-shadow-rtc'
+    live_confirmed: bool = True
+
+    @property
+    def fence_token(self) -> str:
+        """Compatibility alias for internal driver calls; never serialize it."""
+
+        return self.fence
+
+    @property
+    def dry_run_profile(self) -> str:
+        """Compatibility alias for older Shadow-only internal callers."""
+
+        return self.profile_id
+
+    def remaining_seconds(self, *, monotonic_now: float | None = None) -> float:
+        now = time.monotonic() if monotonic_now is None else monotonic_now
+        return max(0.0, self.deadline_monotonic - now)
+
+    def public_dict(
+        self,
+        *,
+        monotonic_now: float | None = None,
+        wall_now: float | None = None,
+    ) -> dict[str, Any]:
+        """Return a browser-safe snapshot with a wall-clock expiry estimate.
+
+        Ownership decisions use only ``deadline_monotonic``.  ``expires_at`` is
+        deliberately derived at snapshot time for display and is never read back
+        by the session manager.
+        """
+
+        remaining = self.remaining_seconds(monotonic_now=monotonic_now)
+        wall = time.time() if wall_now is None else wall_now
+        snapshot = {
+            'id': self.id,
+            'robot_id': self.robot_id,
+            'driver_id': self.driver_id,
+            'principal_id': self.principal_id,
+            'boot_id': self.boot_id,
+            'epoch': self.epoch,
+            'capability_digest': self.capability_digest,
+            'state': self.state,
+            'operation': {
+                'generation': self.operation_generation,
+                'state': self.operation_state,
+            },
+            'mode': self.mode,
+            'profile_id': self.profile_id,
+            'capabilities': self.capabilities,
+            'effectors': self.effectors,
+            'live_confirmed': self.live_confirmed,
+            'created_at': self.created_at,
+            'expires_at': wall + remaining,
+            'lease_seconds': self.lease_seconds,
+            'remaining_seconds': round(remaining, 3),
+        }
+        if self.mode == 'shadow':
+            snapshot['configured_dry_run_profile'] = self.profile_id
+        return _public_value(snapshot)

--- a/agent-core/src/teleop/service.py
+++ b/agent-core/src/teleop/service.py
@@ -1,0 +1,4536 @@
+from __future__ import annotations
+
+import asyncio
+import base64
+import hashlib
+import hmac
+import json
+import math
+import os
+import re
+import time
+import uuid
+from collections.abc import Awaitable, Callable, Mapping
+from dataclasses import dataclass, replace
+
+import aiohttp
+
+import auth
+import config
+import mcp_client
+from teleop import audit, authority_guard
+from teleop.capture_manager import (
+    CaptureAssignment,
+    CaptureConnection,
+    CaptureError,
+    CaptureManager,
+    CapturePairingResult,
+)
+from teleop.command_broker import (
+    AuthorityAlreadyClaimed,
+    CommandBroker,
+    CommandDrainTimeout,
+    InvalidAuthorityBinding,
+    authority_domain_for_target,
+)
+from teleop.command_broker import broker as global_command_broker
+from teleop.contracts import (
+    LIVE_MODE,
+    PREPARE_ACTION_BY_MODE,
+    SHADOW_MODE,
+    TeleopContractError,
+    project_teleop_descriptor,
+)
+from teleop.models import ShadowSession
+from teleop.session_manager import (
+    MAX_DRIVER_EPOCH,
+    MIN_LEASE_SECONDS,
+    EpochExhausted,
+    SessionClientMismatch,
+    SessionConflict,
+    SessionForbidden,
+    SessionNotFound,
+    SessionStateConflict,
+    ShadowSessionManager,
+    manager,
+)
+
+_AUTHORITY_ID_RE = re.compile(r'^[A-Za-z0-9][A-Za-z0-9_.:-]{0,63}$')
+_SAFE_COUNTER_RE = re.compile(r'^[a-z][a-z0-9_]{0,63}$')
+_RECORDING_DISPATCH_CONTRACT = 'motus.teleop.dispatch.recording.v1'
+_HARDWARE_DISPATCH_CONTRACT = 'motus.teleop.dispatch.hardware.v1'
+_WEBRTC_SIGNALING_PROTOCOL = 'motus.teleop.webrtc-offer-answer.v1'
+_WEBRTC_SIGNALING_PATH = '/offer'
+_WEBRTC_SIGNALING_ACCESS = 'authenticated-core-proxy-only'
+_MAX_WIRE_INTEGER = 2**63 - 1
+_AUTHORITY_DRIVER_STATES = frozenset({
+    'prepared_shadow', 'active_shadow', 'prepared_live', 'active_live', 'hold', 'paused',
+})
+_STATE_REASONS = {
+    'idle': frozenset({None}),
+    'prepared_shadow': frozenset({None}),
+    'active_shadow': frozenset({None}),
+    'prepared_live': frozenset({None}),
+    'active_live': frozenset({None}),
+    'paused': frozenset({'operator_pause'}),
+    'hold': frozenset({
+        'deadman_released',
+        'command_timeout',
+        'intent_expired',
+        'lease_timeout',
+        'pose_timeout',
+        'rtc_closed',
+        'rtc_disconnected',
+        'rtc_failed',
+        'rtc_not_ready',
+        'soft_stop',
+        'tracking_lost',
+    }),
+    'released': frozenset({'lifecycle_stop', 'operator_release'}),
+    'fault': frozenset({'dispatch_fault'}),
+}
+_PUBLIC_COUNTERS = frozenset({
+    'explicit_reclutches',
+    'frames_accepted',
+    'frames_held_without_reclutch',
+    'frames_rejected',
+    'lease_heartbeats',
+    'lease_timeouts',
+    'pose_timeouts',
+    'protocol_errors',
+    'rtc_disconnects',
+    'sessions_prepared',
+    'sessions_released',
+    'soft_stops',
+})
+_PUBLIC_DISPATCH_COUNTERS = frozenset({
+    'adapter_faults',
+    'adapter_io_stalls',
+    'dispatch_reclutches',
+    'late_adapter_returns',
+    'mailbox_cleared_by_stop',
+    'mailbox_replacements',
+    'motion_admitted',
+    'motion_applied',
+    'motion_dropped_expired',
+    'motion_dropped_stale',
+    'sessions_armed',
+    'startup_safe_acks',
+    'stop_acks',
+    'stop_requests',
+})
+_DISPATCH_STATES = frozenset({
+    'safe_unarmed',
+    'safe_waiting_frame',
+    'motion_eligible',
+    'safe_reclutch_required',
+    'safe_latched',
+    'safe_revoked',
+    'fault_latched',
+})
+_ACTIVE_DISPATCH_DECISIONS = frozenset({
+    'admitted',
+    'motion_committed',
+    'published',
+    'would_apply',
+})
+_STOP_DISPATCH_STATES = frozenset({
+    'safe_reclutch_required',
+    'safe_latched',
+    'safe_revoked',
+    'fault_latched',
+})
+_RETRYABLE_TRANSPORT_CODES = {'timeout', 'network_error'}
+_TERMINAL_RPC_CODES = {
+    'boot_mismatch',
+    'epoch_mismatch',
+    'fence_mismatch',
+    'session_expired',
+    'session_inactive',
+    'session_mismatch',
+}
+_MIN_DRIVER_LEASE_SECONDS = 0.75
+_MAX_DRIVER_LEASE_SECONDS = 10.0
+_DEFAULT_CONTROL_TIMEOUT_SECONDS = 2.0
+_MAX_HEARTBEAT_INTERVAL_SECONDS = 0.25
+_REAPER_INTERVAL_SECONDS = 0.1
+_LOCK_STRIPE_COUNT = 256
+_COMMAND_DRAIN_TIMEOUT_SECONDS = 2.0
+_SIGNALING_TIMEOUT_SECONDS = 2.0
+_SIGNALING_TICKET_TTL_SECONDS = 20
+_MAX_SIGNALING_SDP_BYTES = 128 * 1024
+# Core Pause and HOLD are both non-resuming latches: Driver closes every peer
+# and accepts no more Pose frames until release + a new prepare_shadow. Driver
+# may report a recoverable transport HOLD while Core still remains active, so
+# only the Core active state may open or replace an RTC peer.
+_LIVE_SIGNALING_STATES = frozenset({'active'})
+_CAPTURE_FAIL_CLOSE_REASONS = frozenset({
+    'capture_browser_ready',
+    'capture_disconnected',
+    'capture_error',
+    'capture_presence_timeout',
+    'capture_signaling_failed',
+    'capture_xr_ended',
+    'capture_xr_standby',
+})
+_SIGNALING_ANSWER_FIELDS = frozenset({
+    'actuation_enabled',
+    'boot_id',
+    'capability_digest',
+    'epoch',
+    'mode',
+    'sdp',
+    'session_id',
+    'type',
+})
+
+
+class TeleopServiceError(RuntimeError):
+    """Stable, secret-free error suitable for the dedicated REST API."""
+
+    def __init__(self, code: str, status_code: int):
+        self.code = code
+        self.status_code = status_code
+        super().__init__(f'teleop service error: {code}')
+
+
+@dataclass(frozen=True)
+class AcquireResult:
+    session: ShadowSession
+    disposition: str
+
+
+def _base64url(value: bytes) -> str:
+    return base64.urlsafe_b64encode(value).rstrip(b'=').decode('ascii')
+
+
+def _signaling_ticket(session: ShadowSession, sdp: str, *, wall_now: float) -> str:
+    """Issue a Driver-compatible, one-use RTC offer ticket.
+
+    The Driver owns replay consumption.  Core deliberately keeps the ticket and
+    its private fence claim on the server-to-server hop.
+    """
+
+    # Focused tests and explicit process configuration may override the cached
+    # deployment setting.  Production normally loads the same value from
+    # /opt/phanthy-motus/.env during auth.init().
+    process_secret = os.environ.get('MOTUS_TELEOP_TICKET_SECRET')
+    try:
+        secret_bytes = (
+            auth.teleop_ticket_secret(session.driver_id)
+            if auth.has_dedicated_teleop_ticket_secret(session.driver_id)
+            else (
+                process_secret.encode('utf-8')
+                if process_secret is not None
+                else auth.teleop_ticket_secret(session.driver_id)
+            )
+        )
+    except UnicodeEncodeError:
+        raise TeleopServiceError('teleop_signaling_unavailable', 503) from None
+    if len(secret_bytes) < 32:
+        raise TeleopServiceError('teleop_signaling_unavailable', 503)
+    if (
+        not isinstance(sdp, str)
+        or not sdp
+        or not isinstance(wall_now, (int, float))
+        or isinstance(wall_now, bool)
+        or not math.isfinite(float(wall_now))
+        or wall_now < 0
+    ):
+        raise TeleopServiceError('teleop_signaling_unavailable', 503)
+
+    issued_at = int(wall_now)
+    claims = {
+        'v': 1,
+        'aud': session.signaling_audience,
+        'boot_id': session.boot_id,
+        'session_id': session.id,
+        'epoch': session.epoch,
+        'fence': session.fence,
+        'capability_digest': session.capability_digest,
+        'sdp_sha256': hashlib.sha256(sdp.encode('utf-8')).hexdigest(),
+        'iat': issued_at,
+        'exp': issued_at + _SIGNALING_TICKET_TTL_SECONDS,
+        'jti': _base64url(uuid.uuid4().bytes),
+    }
+    try:
+        canonical = json.dumps(
+            claims,
+            ensure_ascii=False,
+            allow_nan=False,
+            separators=(',', ':'),
+            sort_keys=True,
+        ).encode('utf-8')
+    except (TypeError, ValueError, RecursionError):
+        raise TeleopServiceError('teleop_signaling_unavailable', 503) from None
+    payload = _base64url(canonical)
+    signature = _base64url(
+        hmac.new(secret_bytes, payload.encode('ascii'), hashlib.sha256).digest(),
+    )
+    return f'{payload}.{signature}'
+
+
+def _validated_signaling_offer_sdp(offer: object) -> str:
+    if (
+        not isinstance(offer, dict)
+        or set(offer) != {'sdp', 'type'}
+        or offer.get('type') != 'offer'
+        or not isinstance(offer.get('sdp'), str)
+        or not offer['sdp']
+    ):
+        raise TeleopServiceError('invalid_signaling_offer', 400)
+    try:
+        offer_sdp_size = len(offer['sdp'].encode('utf-8'))
+    except UnicodeEncodeError:
+        raise TeleopServiceError('invalid_signaling_offer', 400) from None
+    if offer_sdp_size > _MAX_SIGNALING_SDP_BYTES:
+        raise TeleopServiceError('invalid_signaling_offer', 400)
+    return offer['sdp']
+
+
+def _project_signaling_answer(
+    raw: object,
+    session: ShadowSession,
+    ticket: str,
+) -> dict:
+    if not isinstance(raw, dict) or set(raw) != _SIGNALING_ANSWER_FIELDS:
+        raise TeleopServiceError('driver_protocol_error', 502)
+    sdp = raw.get('sdp')
+    try:
+        sdp_size = len(sdp.encode('utf-8')) if isinstance(sdp, str) else -1
+    except UnicodeEncodeError:
+        sdp_size = -1
+    if (
+        raw.get('type') != 'answer'
+        or not isinstance(sdp, str)
+        or not sdp
+        or sdp_size < 1
+        or sdp_size > _MAX_SIGNALING_SDP_BYTES
+        or raw.get('boot_id') != session.boot_id
+        or raw.get('session_id') != session.id
+        or isinstance(raw.get('epoch'), bool)
+        or not isinstance(raw.get('epoch'), int)
+        or raw.get('epoch') != session.epoch
+        or raw.get('capability_digest') != session.capability_digest
+        or raw.get('mode') != session.mode
+        or raw.get('actuation_enabled') is not (session.mode == LIVE_MODE)
+        or session.fence in sdp
+        or ticket in sdp
+    ):
+        raise TeleopServiceError('driver_protocol_error', 502)
+    projection = {'sdp': sdp, 'type': 'answer'}
+    if session.fence in repr(projection):
+        raise TeleopServiceError('driver_protocol_error', 502)
+    return projection
+
+
+@dataclass
+class _HeartbeatHealth:
+    last_confirmed_monotonic: float
+    last_confirmed_at: float
+    consecutive_failures: int = 0
+    state: str = 'healthy'
+
+    def public_dict(self) -> dict:
+        return {
+            'state': self.state,
+            'last_confirmed_at': self.last_confirmed_at,
+            'consecutive_failures': self.consecutive_failures,
+        }
+
+
+def _canonical_uuid(value: object) -> str:
+    if not isinstance(value, str):
+        raise TeleopServiceError('driver_response_invalid', 502)
+    try:
+        parsed = uuid.UUID(value)
+    except ValueError:
+        raise TeleopServiceError('driver_response_invalid', 502) from None
+    if str(parsed) != value.lower():
+        raise TeleopServiceError('driver_response_invalid', 502)
+    return str(parsed)
+
+
+def _strict_int(
+    value: object,
+    *,
+    minimum: int = 0,
+    maximum: int | None = None,
+) -> int:
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, int)
+        or value < minimum
+        or (maximum is not None and value > maximum)
+    ):
+        raise TeleopServiceError('driver_response_invalid', 502)
+    return value
+
+
+def _finite_number(value: object, *, minimum: float, maximum: float) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise TeleopServiceError('driver_response_invalid', 502)
+    try:
+        number = float(value)
+    except (OverflowError, TypeError, ValueError):
+        raise TeleopServiceError('driver_response_invalid', 502) from None
+    if not math.isfinite(number) or number < minimum or number > maximum:
+        raise TeleopServiceError('driver_response_invalid', 502)
+    return number
+
+
+def _bounded_text(value: object, maximum: int = 256) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise TeleopServiceError('driver_response_invalid', 502)
+    return value[:maximum]
+
+
+def _driver_descriptor(driver_id: str) -> dict:
+    services = config.main.get('services', {})
+    entries = services.get('mcp', []) if isinstance(services, dict) else []
+    matches = [
+        entry for entry in entries
+        if isinstance(entry, dict) and entry.get('id') == driver_id
+    ]
+    if len(matches) != 1:
+        raise TeleopServiceError('driver_not_found', 404)
+    target = matches[0]
+    tools = target.get('tools')
+    session_tools = [
+        tool for tool in tools or []
+        if isinstance(tool, dict) and tool.get('name') == 'teleop_session'
+    ]
+    try:
+        descriptor = project_teleop_descriptor(
+            session_tools[0] if len(session_tools) == 1 else None,
+            expected_driver_id=driver_id,
+        )
+    except TeleopContractError:
+        raise TeleopServiceError('driver_not_ready', 503) from None
+    descriptor_robot_id = descriptor['robot_id']
+    reported_robot_id = target.get('reported_robot_id')
+    try:
+        robot_id = authority_domain_for_target(
+            driver_id,
+            target,
+            targets=entries,
+        )
+    except InvalidAuthorityBinding:
+        raise TeleopServiceError('driver_not_ready', 503) from None
+    if not auth.teleop_ticket_credential_available(driver_id):
+        raise TeleopServiceError('teleop_signaling_unavailable', 503)
+    if (
+        target.get('trust_state') != 'trusted'
+        or not auth.driver_record_credential_available(
+            driver_id,
+            target.get('credential_binding'),
+        )
+        or target.get('transport') != 'http'
+        or not isinstance(robot_id, str)
+        or not _AUTHORITY_ID_RE.fullmatch(robot_id)
+        or (robot_id != driver_id and descriptor_robot_id != robot_id)
+        or (
+            reported_robot_id is not None
+            and reported_robot_id != ''
+            and reported_robot_id != robot_id
+        )
+        or (
+            descriptor_robot_id is not None
+            and descriptor_robot_id != robot_id
+        )
+    ):
+        raise TeleopServiceError('driver_not_ready', 503)
+    return {
+        **descriptor,
+        'robot_id': robot_id,
+    }
+
+
+def _safe_submapping(value: object, allowed: Mapping[str, str]) -> dict:
+    if not isinstance(value, dict):
+        raise TeleopServiceError('driver_response_invalid', 502)
+    result = {}
+    for key, kind in allowed.items():
+        item = value.get(key)
+        if kind == 'bool':
+            if not isinstance(item, bool):
+                raise TeleopServiceError('driver_response_invalid', 502)
+            result[key] = item
+        elif kind == 'number_or_none':
+            if item is None:
+                result[key] = None
+            else:
+                result[key] = _finite_number(item, minimum=0.0, maximum=86_400_000.0)
+        elif kind == 'int_or_none':
+            result[key] = None if item is None else _strict_int(item)
+        elif kind == 'text':
+            result[key] = _bounded_text(item)
+        else:
+            raise RuntimeError('invalid projection schema')
+    return result
+
+
+def _expected_dispatch_state(state: str, reason: str | None) -> str:
+    if state == 'idle':
+        return 'safe_unarmed'
+    if state in {'prepared_shadow', 'prepared_live'}:
+        return 'safe_waiting_frame'
+    if state in {'active_shadow', 'active_live'}:
+        return 'motion_eligible'
+    if state == 'paused' or (state == 'hold' and reason == 'soft_stop'):
+        return 'safe_latched'
+    if state == 'hold' and reason == 'lease_timeout':
+        return 'safe_revoked'
+    if state == 'hold':
+        return 'safe_reclutch_required'
+    if state == 'released':
+        return 'safe_revoked'
+    if state == 'fault' and reason == 'dispatch_fault':
+        return 'fault_latched'
+    raise TeleopServiceError('driver_response_invalid', 502)
+
+
+def _terminal_fault_decision_valid(
+    last_decision: str,
+    *,
+    stop_acknowledged: bool,
+) -> bool:
+    if stop_acknowledged:
+        return last_decision == 'would_stop:adapter_fault'
+    return last_decision.startswith((
+        'apply_failed:',
+        'async_fault:',
+        'io_stalled:',
+        'stop_failed:',
+    ))
+
+
+def _project_dry_run_adapter(
+    value: object,
+) -> dict:
+    """Project only adapter-neutral recording evidence.
+
+    Core deliberately does not decode vendor SDK calls, joint mappings, gait
+    policy, or robot-specific limits. Those remain Driver-owned diagnostics.
+    """
+
+    if not isinstance(value, dict):
+        raise TeleopServiceError('driver_response_invalid', 502)
+    kind = value.get('kind')
+    if kind == 'recording':
+        current = value.get('current')
+        records = value.get('records')
+        if (
+            value.get('closed') is not False
+            or (
+                'hardware_output' in value
+                and value.get('hardware_output') is not False
+            )
+            or (
+                'actuation_enabled' in value
+                and value.get('actuation_enabled') is not False
+            )
+            or not isinstance(current, dict)
+            or not isinstance(current.get('kind'), str)
+            or current.get('kind') not in {'safe', 'would_apply', 'would_stop'}
+            or not isinstance(records, list)
+            or len(records) > 64
+        ):
+            raise TeleopServiceError('driver_response_invalid', 502)
+        return {
+            'profile': 'recording',
+            'hardware_output': False,
+            'actuation_enabled': False,
+            'operation': 'recording',
+            'sequence': None,
+            'requested': None,
+            'effective': None,
+            'clamped_axes': [],
+            'stop_reason': None,
+            'gait_policy': None,
+        }
+    if kind == 'unavailable':
+        reason = value.get('reason')
+        if not isinstance(reason, str) or reason not in {
+            'startup_in_progress',
+            'invalid_adapter_snapshot',
+            'adapter_snapshot_exception',
+        }:
+            raise TeleopServiceError('driver_response_invalid', 502)
+        return {
+            'profile': 'unavailable',
+            'hardware_output': None,
+            'actuation_enabled': None,
+            'operation': 'unavailable',
+            'sequence': None,
+            'requested': None,
+            'effective': None,
+            'clamped_axes': [],
+            'stop_reason': reason,
+            'gait_policy': None,
+        }
+    raise TeleopServiceError('driver_response_invalid', 502)
+
+
+def _project_recording_dispatch(
+    value: object,
+    *,
+    state: str,
+    reason: str | None,
+    allow_stop_pending: bool,
+) -> dict:
+    if not isinstance(value, dict) or value.get('kind') != 'recording':
+        raise TeleopServiceError('driver_response_invalid', 502)
+    dispatch_state = value.get('state')
+    ready = value.get('ready')
+    stop_acknowledged = value.get('stop_acknowledged')
+    io_inflight = value.get('io_inflight')
+    fault_code = value.get('fault_code')
+    last_decision = value.get('last_decision')
+    if (
+        not isinstance(dispatch_state, str)
+        or dispatch_state not in _DISPATCH_STATES
+        or not isinstance(ready, bool)
+        or not isinstance(stop_acknowledged, bool)
+        or (
+            io_inflight is not None
+            and (
+                not isinstance(io_inflight, str)
+                or io_inflight not in {'apply', 'safe_stop'}
+            )
+        )
+        or (
+            fault_code is not None
+            and (
+                not isinstance(fault_code, str)
+                or not 1 <= len(fault_code) <= 96
+            )
+        )
+        or not isinstance(last_decision, str)
+        or not 1 <= len(last_decision) <= 96
+    ):
+        raise TeleopServiceError('driver_response_invalid', 502)
+
+    generation = _strict_int(value.get('generation'), maximum=_MAX_WIRE_INTEGER)
+    mailbox_depth = _strict_int(value.get('mailbox_depth'), maximum=1)
+    stop_queue_depth = _strict_int(value.get('stop_queue_depth'), maximum=64)
+    admitted_raw = value.get('last_admitted_sequence')
+    applied_raw = value.get('last_would_apply_sequence')
+    admitted = (
+        None
+        if admitted_raw is None
+        else _strict_int(admitted_raw, maximum=_MAX_WIRE_INTEGER)
+    )
+    applied = (
+        None
+        if applied_raw is None
+        else _strict_int(applied_raw, maximum=_MAX_WIRE_INTEGER)
+    )
+    if applied is not None and (admitted is None or applied > admitted):
+        raise TeleopServiceError('driver_response_invalid', 502)
+
+    expected_state = _expected_dispatch_state(state, reason)
+    if dispatch_state != expected_state:
+        raise TeleopServiceError('driver_response_invalid', 502)
+    terminal_fault = state == 'fault' and reason == 'dispatch_fault'
+    if terminal_fault:
+        if (
+            ready is not False
+            or mailbox_depth != 0
+            or stop_queue_depth != 0
+            or io_inflight is not None
+            or fault_code is None
+            or not _terminal_fault_decision_valid(
+                last_decision,
+                stop_acknowledged=stop_acknowledged,
+            )
+        ):
+            raise TeleopServiceError('driver_response_invalid', 502)
+    elif ready is not True or fault_code is not None:
+        raise TeleopServiceError('driver_response_invalid', 502)
+    stop_pending = (
+        not terminal_fault
+        and allow_stop_pending
+        and reason is not None
+        and expected_state != 'motion_eligible'
+        and stop_acknowledged is False
+        and last_decision == f'stop_requested:{reason}'
+    )
+    if terminal_fault:
+        pass
+    elif stop_pending:
+        if mailbox_depth != 0 or io_inflight not in {None, 'safe_stop'}:
+            raise TeleopServiceError('driver_response_invalid', 502)
+    elif stop_acknowledged is not True or stop_queue_depth != 0:
+        raise TeleopServiceError('driver_response_invalid', 502)
+    elif expected_state == 'motion_eligible':
+        if io_inflight not in {None, 'apply'} or admitted is None:
+            raise TeleopServiceError('driver_response_invalid', 502)
+        if last_decision not in _ACTIVE_DISPATCH_DECISIONS:
+            raise TeleopServiceError('driver_response_invalid', 502)
+    else:
+        if mailbox_depth != 0 or io_inflight is not None:
+            raise TeleopServiceError('driver_response_invalid', 502)
+        if expected_state == 'safe_unarmed':
+            expected_decision = 'startup_safe_ack'
+        elif expected_state == 'safe_waiting_frame':
+            expected_decision = 'prepared_after_stop_ack'
+        else:
+            expected_decision = f'would_stop:{reason}'
+        if last_decision != expected_decision:
+            raise TeleopServiceError('driver_response_invalid', 502)
+    if expected_state in {'safe_unarmed', 'safe_waiting_frame'} and (
+        admitted is not None or applied is not None
+    ):
+        raise TeleopServiceError('driver_response_invalid', 502)
+
+    counters_raw = value.get('counters')
+    if not isinstance(counters_raw, dict):
+        raise TeleopServiceError('driver_response_invalid', 502)
+    counters = {}
+    for key in _PUBLIC_DISPATCH_COUNTERS:
+        if key not in counters_raw:
+            continue
+        counter = counters_raw[key]
+        counters[key] = _strict_int(counter, maximum=_MAX_WIRE_INTEGER)
+
+    dry_run = _project_dry_run_adapter(value.get('adapter'))
+
+    return {
+        'contract': _RECORDING_DISPATCH_CONTRACT,
+        'kind': 'recording',
+        'state': dispatch_state,
+        'ready': ready,
+        'generation': generation,
+        'mailbox_depth': mailbox_depth,
+        'stop_queue_depth': stop_queue_depth,
+        'last_admitted_sequence': admitted,
+        'last_would_apply_sequence': applied,
+        'last_decision': last_decision,
+        'stop_acknowledged': stop_acknowledged,
+        'fault_code': fault_code,
+        'io_inflight': io_inflight,
+        'counters': dict(sorted(counters.items())),
+        'dry_run': dry_run,
+    }
+
+
+def _project_hardware_dispatch(
+    value: object,
+    *,
+    state: str,
+    reason: str | None,
+    allow_stop_pending: bool,
+) -> dict:
+    if not isinstance(value, dict) or value.get('kind') != 'hardware':
+        raise TeleopServiceError('driver_response_invalid', 502)
+    dispatch_state = value.get('state')
+    ready = value.get('ready')
+    stop_acknowledged = value.get('stop_acknowledged')
+    io_inflight = value.get('io_inflight')
+    last_decision = value.get('last_decision')
+    fault_code = value.get('fault_code')
+    if (
+        dispatch_state not in _DISPATCH_STATES
+        or not isinstance(ready, bool)
+        or not isinstance(stop_acknowledged, bool)
+        or (
+            io_inflight is not None
+            and io_inflight not in {'apply', 'safe_stop'}
+        )
+        or not isinstance(last_decision, str)
+        or not 1 <= len(last_decision) <= 96
+        or (
+            fault_code is not None
+            and (
+                not isinstance(fault_code, str)
+                or not 1 <= len(fault_code) <= 96
+            )
+        )
+    ):
+        raise TeleopServiceError('driver_response_invalid', 502)
+    generation = _strict_int(value.get('generation'), maximum=_MAX_WIRE_INTEGER)
+    mailbox_depth = _strict_int(value.get('mailbox_depth'), maximum=1)
+    stop_queue_depth = _strict_int(value.get('stop_queue_depth'), maximum=64)
+    admitted_raw = value.get('last_admitted_sequence')
+    if (
+        'last_published_sequence' not in value
+        or 'last_applied_sequence' in value
+        or 'last_would_apply_sequence' in value
+    ):
+        raise TeleopServiceError('driver_response_invalid', 502)
+    published_raw = value.get('last_published_sequence')
+    admitted = None if admitted_raw is None else _strict_int(
+        admitted_raw,
+        maximum=_MAX_WIRE_INTEGER,
+    )
+    published = None if published_raw is None else _strict_int(
+        published_raw,
+        maximum=_MAX_WIRE_INTEGER,
+    )
+    if published is not None and (admitted is None or published > admitted):
+        raise TeleopServiceError('driver_response_invalid', 502)
+
+    expected_state = _expected_dispatch_state(state, reason)
+    if dispatch_state != expected_state:
+        raise TeleopServiceError('driver_response_invalid', 502)
+    terminal_fault = state == 'fault' and reason == 'dispatch_fault'
+    if terminal_fault:
+        if (
+            ready is not False
+            or mailbox_depth != 0
+            or stop_queue_depth != 0
+            or io_inflight is not None
+            or fault_code is None
+            or not _terminal_fault_decision_valid(
+                last_decision,
+                stop_acknowledged=stop_acknowledged,
+            )
+        ):
+            raise TeleopServiceError('driver_response_invalid', 502)
+    elif ready is not True or fault_code is not None:
+        raise TeleopServiceError('driver_response_invalid', 502)
+    stop_pending = (
+        not terminal_fault
+        and allow_stop_pending
+        and reason is not None
+        and expected_state != 'motion_eligible'
+        and stop_acknowledged is False
+        and last_decision == f'stop_requested:{reason}'
+    )
+    if terminal_fault:
+        pass
+    elif stop_pending:
+        if mailbox_depth != 0 or io_inflight not in {None, 'safe_stop'}:
+            raise TeleopServiceError('driver_response_invalid', 502)
+    elif stop_acknowledged is not True or stop_queue_depth != 0:
+        raise TeleopServiceError('driver_response_invalid', 502)
+    elif expected_state == 'motion_eligible':
+        if io_inflight not in {None, 'apply'} or admitted is None:
+            raise TeleopServiceError('driver_response_invalid', 502)
+        if last_decision not in _ACTIVE_DISPATCH_DECISIONS:
+            raise TeleopServiceError('driver_response_invalid', 502)
+    elif mailbox_depth != 0 or io_inflight is not None:
+        raise TeleopServiceError('driver_response_invalid', 502)
+
+    counters_raw = value.get('counters')
+    if not isinstance(counters_raw, dict):
+        raise TeleopServiceError('driver_response_invalid', 502)
+    counters = {
+        key: _strict_int(counters_raw[key], maximum=_MAX_WIRE_INTEGER)
+        for key in _PUBLIC_DISPATCH_COUNTERS
+        if key in counters_raw
+    }
+    return {
+        'contract': _HARDWARE_DISPATCH_CONTRACT,
+        'kind': 'hardware',
+        'state': dispatch_state,
+        'ready': ready,
+        'generation': generation,
+        'mailbox_depth': mailbox_depth,
+        'stop_queue_depth': stop_queue_depth,
+        'last_admitted_sequence': admitted,
+        'last_published_sequence': published,
+        'last_decision': last_decision,
+        'stop_acknowledged': stop_acknowledged,
+        'fault_code': fault_code,
+        'io_inflight': io_inflight,
+        'counters': dict(sorted(counters.items())),
+    }
+
+
+_TRANSPORT_DIAGNOSTIC_FIELDS = {
+    'rtc_rtt_ms': 'number_or_none',
+    'pose_age_ms': 'number_or_none',
+    'frame_rate_hz': 'number_or_none',
+    'frames_received': 'int',
+    'frames_rejected': 'int',
+    'sequence_gaps': 'int',
+    'mailbox_replacements': 'int',
+}
+_LATENCY_STAGES = (
+    'receive_to_admit',
+    'mailbox_wait',
+    'ik',
+    'adapter_apply',
+    'robot_follow',
+)
+
+
+def _project_diagnostics(value: object) -> dict:
+    if not isinstance(value, dict) or set(value) != {'transport', 'latency_ms'}:
+        raise TeleopServiceError('driver_response_invalid', 502)
+    transport_raw = value.get('transport')
+    if not isinstance(transport_raw, dict) or set(transport_raw) != set(
+        _TRANSPORT_DIAGNOSTIC_FIELDS,
+    ):
+        raise TeleopServiceError('driver_response_invalid', 502)
+    transport: dict[str, int | float | None] = {}
+    for key, kind in _TRANSPORT_DIAGNOSTIC_FIELDS.items():
+        item = transport_raw[key]
+        if kind == 'int':
+            transport[key] = _strict_int(item, maximum=_MAX_WIRE_INTEGER)
+        else:
+            transport[key] = None if item is None else _finite_number(
+                item,
+                minimum=0.0,
+                maximum=86_400_000.0,
+            )
+
+    latency_raw = value.get('latency_ms')
+    if not isinstance(latency_raw, dict) or set(latency_raw) != set(_LATENCY_STAGES):
+        raise TeleopServiceError('driver_response_invalid', 502)
+    latency: dict[str, dict] = {}
+    for stage in _LATENCY_STAGES:
+        sample = latency_raw[stage]
+        if not isinstance(sample, dict) or set(sample) != {
+            'last', 'p50', 'p95', 'p99', 'count',
+        }:
+            raise TeleopServiceError('driver_response_invalid', 502)
+        count = _strict_int(sample['count'], maximum=_MAX_WIRE_INTEGER)
+        timings = {
+            key: None if sample[key] is None else _finite_number(
+                sample[key],
+                minimum=0.0,
+                maximum=86_400_000.0,
+            )
+            for key in ('last', 'p50', 'p95', 'p99')
+        }
+        percentiles = [timings[key] for key in ('p50', 'p95', 'p99')]
+        if (
+            count == 0
+            and any(item is not None for item in timings.values())
+        ) or (
+            count > 0
+            and any(item is None for item in timings.values())
+        ) or (
+            all(item is not None for item in percentiles)
+            and percentiles != sorted(percentiles)
+        ):
+            raise TeleopServiceError('driver_response_invalid', 502)
+        latency[stage] = {**timings, 'count': count}
+    return {'transport': transport, 'latency_ms': latency}
+
+
+def _project_joint_vector(value: object) -> list[float]:
+    if not isinstance(value, list) or len(value) > 128:
+        raise TeleopServiceError('driver_response_invalid', 502)
+    return [
+        _finite_number(item, minimum=-1_000.0, maximum=1_000.0)
+        for item in value
+    ]
+
+
+def _project_output(
+    value: object,
+    *,
+    mode: str,
+    profile_id: str,
+    capabilities: Mapping[str, object],
+    driver_state: str,
+) -> dict:
+    expected_fields = {
+        'profile_id',
+        'hardware_output',
+        'state',
+        'target_joint_positions_rad',
+        'measured_joint_positions_rad',
+        'max_abs_error_rad',
+        'arm_sdk_weight',
+        'command_age_ms',
+        'fault_reason',
+    }
+    if not isinstance(value, dict) or set(value) != expected_fields:
+        raise TeleopServiceError('driver_response_invalid', 502)
+    state = value.get('state')
+    fault_reason = value.get('fault_reason')
+    if (
+        value.get('profile_id') != profile_id
+        or value.get('hardware_output') is not (mode == LIVE_MODE)
+        or not isinstance(state, str)
+        or not _SAFE_COUNTER_RE.fullmatch(state)
+        or (
+            fault_reason is not None
+            and (not isinstance(fault_reason, str) or not 1 <= len(fault_reason) <= 256)
+        )
+    ):
+        raise TeleopServiceError('driver_response_invalid', 502)
+    target = _project_joint_vector(value.get('target_joint_positions_rad'))
+    measured = _project_joint_vector(value.get('measured_joint_positions_rad'))
+    if len(target) != len(measured):
+        raise TeleopServiceError('driver_response_invalid', 502)
+    outputs = capabilities.get('outputs')
+    if not isinstance(outputs, Mapping):
+        raise TeleopServiceError('driver_response_invalid', 502)
+    declared_joint_count = 0
+    for output in outputs.values():
+        if not isinstance(output, Mapping):
+            raise TeleopServiceError('driver_response_invalid', 502)
+        if output.get('enabled') is True:
+            count = output.get('joint_count', 0)
+            if isinstance(count, bool) or not isinstance(count, int):
+                raise TeleopServiceError('driver_response_invalid', 502)
+            declared_joint_count += count
+    allowed_counts = (
+        {declared_joint_count}
+        if driver_state in _AUTHORITY_DRIVER_STATES or driver_state == 'fault'
+        else {0, declared_joint_count}
+    )
+    if len(target) not in allowed_counts:
+        raise TeleopServiceError('driver_response_invalid', 502)
+    nullable_numbers = {}
+    for key, maximum in (
+        ('max_abs_error_rad', 1_000.0),
+        ('arm_sdk_weight', 1.0),
+        ('command_age_ms', 86_400_000.0),
+    ):
+        item = value.get(key)
+        nullable_numbers[key] = None if item is None else _finite_number(
+            item,
+            minimum=0.0,
+            maximum=maximum,
+        )
+    if (
+        mode == SHADOW_MODE
+        and nullable_numbers['arm_sdk_weight'] is not None
+    ) or (
+        mode == LIVE_MODE
+        and nullable_numbers['arm_sdk_weight'] is None
+    ):
+        raise TeleopServiceError('driver_response_invalid', 502)
+    if driver_state == 'fault' and (
+        state != 'fault'
+        or fault_reason is None
+        or (mode == LIVE_MODE and nullable_numbers['arm_sdk_weight'] != 0.0)
+    ):
+        raise TeleopServiceError('driver_response_invalid', 502)
+    return {
+        'profile_id': profile_id,
+        'hardware_output': mode == LIVE_MODE,
+        'state': state,
+        'target_joint_positions_rad': target,
+        'measured_joint_positions_rad': measured,
+        **nullable_numbers,
+        'fault_reason': fault_reason,
+    }
+
+
+def _project_driver_snapshot(
+    raw: Mapping[str, object],
+    *,
+    driver_id: str,
+    robot_id: str,
+    capability_digest: str,
+    action: str,
+    session: ShadowSession | None = None,
+    expected_mode: str | None = None,
+    expected_profile_id: str | None = None,
+    expected_capabilities: Mapping[str, object] | None = None,
+    expected_dry_run_profile: str | None = None,
+    allow_stop_pending: bool = False,
+) -> tuple[dict, float]:
+    """Validate one trusted Driver response into an adapter-neutral projection."""
+
+    if not isinstance(raw, dict):
+        raise TeleopServiceError('driver_response_invalid', 502)
+    mode = session.mode if session is not None else (expected_mode or SHADOW_MODE)
+    profile_id = (
+        session.profile_id
+        if session is not None
+        else (expected_profile_id or expected_dry_run_profile or 'recording')
+    )
+    capabilities = (
+        session.capabilities
+        if session is not None
+        else dict(expected_capabilities or {})
+    )
+    driver_type = raw.get('driver_type')
+    if (
+        raw.get('driver_id') != driver_id
+        or (
+            raw.get('robot_id') != robot_id
+            and not (raw.get('robot_id') is None and robot_id == driver_id)
+        )
+        or driver_type not in {'teleop-shadow', 'teleop'}
+        or (driver_type == 'teleop-shadow' and mode != SHADOW_MODE)
+        or raw.get('mode') != mode
+        or raw.get('actuation_enabled') is not (mode == LIVE_MODE)
+        or raw.get('capability_digest') != capability_digest
+        or not isinstance(raw.get('authority_valid'), bool)
+    ):
+        raise TeleopServiceError('driver_response_invalid', 502)
+
+    boot_id = _canonical_uuid(raw.get('boot_id'))
+    epoch = _strict_int(raw.get('epoch'), maximum=MAX_DRIVER_EPOCH)
+    raw_session_id = raw.get('session_id')
+    session_id = None if raw_session_id is None else _canonical_uuid(raw_session_id)
+    state = raw.get('state')
+    reason = raw.get('reason')
+    if (
+        not isinstance(state, str)
+        or (reason is not None and not isinstance(reason, str))
+        or state not in _STATE_REASONS
+        or reason not in _STATE_REASONS[state]
+        or (state == 'fault' and driver_type != 'teleop')
+    ):
+        raise TeleopServiceError('driver_response_invalid', 502)
+    authority_valid = raw['authority_valid']
+
+    lease = _safe_submapping(raw.get('lease'), {
+        'source': 'text',
+        'timeout_ms': 'number_or_none',
+        'age_ms': 'number_or_none',
+        'fresh': 'bool',
+        'authority_valid': 'bool',
+        'expired_latched': 'bool',
+    })
+    if lease['source'] != 'agent-core-mcp-heartbeat-only':
+        raise TeleopServiceError('driver_response_invalid', 502)
+    timeout_ms = lease['timeout_ms']
+    if timeout_ms is None:
+        raise TeleopServiceError('driver_response_invalid', 502)
+    driver_lease_seconds = timeout_ms / 1000.0
+    if not _MIN_DRIVER_LEASE_SECONDS <= driver_lease_seconds <= _MAX_DRIVER_LEASE_SECONDS:
+        raise TeleopServiceError('driver_lease_unsafe', 502)
+    if lease['authority_valid'] is not authority_valid:
+        raise TeleopServiceError('driver_response_invalid', 502)
+    lease_age = lease['age_ms']
+    expected_fresh = lease_age is not None and lease_age <= timeout_ms
+    if lease['fresh'] is not expected_fresh:
+        raise TeleopServiceError('driver_response_invalid', 502)
+
+    if authority_valid:
+        if (
+            session_id is None
+            or state not in _AUTHORITY_DRIVER_STATES
+            or lease['fresh'] is not True
+            or lease['expired_latched'] is not False
+        ):
+            raise TeleopServiceError('driver_response_invalid', 502)
+    else:
+        terminal_consistent = (
+            state in {'idle', 'released'}
+            and lease['expired_latched'] is False
+        ) or (
+            state == 'hold'
+            and reason == 'lease_timeout'
+            and lease['expired_latched'] is True
+        ) or (
+            state == 'fault'
+            and reason == 'dispatch_fault'
+            and lease['expired_latched'] is False
+            and lease['age_ms'] is None
+        )
+        if session_id is not None or lease['fresh'] is not False or not terminal_consistent:
+            raise TeleopServiceError('driver_response_invalid', 502)
+
+    if session is not None:
+        identity_changed = boot_id != session.boot_id or epoch != session.epoch
+        if action != 'release' and state != 'fault':
+            identity_changed = identity_changed or session_id != session.id
+        if identity_changed:
+            raise TeleopServiceError('driver_identity_changed', 409)
+
+    prepare_action = PREPARE_ACTION_BY_MODE[mode]
+    prepared_state = f'prepared_{mode}'
+    active_state = f'active_{mode}'
+    if action == prepare_action:
+        if (
+            state != prepared_state
+            or reason is not None
+            or authority_valid is not True
+            or lease['fresh'] is not True
+            or lease['expired_latched'] is not False
+        ):
+            raise TeleopServiceError('driver_prepare_rejected', 502)
+    elif action == 'heartbeat' and state != 'fault':
+        if (
+            state not in {prepared_state, active_state, 'hold', 'paused'}
+            or authority_valid is not True
+            or lease['fresh'] is not True
+        ):
+            raise TeleopServiceError('driver_session_lost', 409)
+    elif action == 'pause':
+        if state != 'paused' or reason != 'operator_pause' or authority_valid is not True:
+            raise TeleopServiceError('driver_pause_rejected', 502)
+    elif action == 'soft_stop':
+        if state != 'hold' or reason != 'soft_stop' or authority_valid is not True:
+            raise TeleopServiceError('driver_soft_stop_rejected', 502)
+    elif (
+        action == 'release'
+        and (
+            state != 'released'
+            or reason not in {'operator_release', 'lifecycle_stop'}
+            or authority_valid is not False
+            or session_id is not None
+        )
+    ):
+        raise TeleopServiceError('driver_release_invalid', 502)
+
+    if mode == SHADOW_MODE:
+        dispatch = _project_recording_dispatch(
+            raw.get('dispatch'),
+            state=state,
+            reason=reason,
+            allow_stop_pending=allow_stop_pending,
+        )
+    else:
+        dispatch = _project_hardware_dispatch(
+            raw.get('dispatch'),
+            state=state,
+            reason=reason,
+            allow_stop_pending=allow_stop_pending,
+        )
+
+    pose = _safe_submapping(raw.get('pose'), {
+        'timeout_ms': 'number_or_none',
+        'age_ms': 'number_or_none',
+        'fresh': 'bool',
+        'latest_sequence': 'int_or_none',
+    })
+    rtc_raw = raw.get('rtc')
+    if not isinstance(rtc_raw, dict) or not isinstance(rtc_raw.get('channels'), dict):
+        raise TeleopServiceError('driver_response_invalid', 502)
+    if (
+        not isinstance(rtc_raw.get('connected'), bool)
+        or rtc_raw.get('renews_lease') is not False
+    ):
+        raise TeleopServiceError('driver_response_invalid', 502)
+    channels = rtc_raw['channels']
+    if set(channels) != {'teleop-control', 'teleop-pose'} or not all(
+        isinstance(item, bool) for item in channels.values()
+    ):
+        raise TeleopServiceError('driver_response_invalid', 502)
+    if rtc_raw['connected'] is not all(channels.values()):
+        raise TeleopServiceError('driver_response_invalid', 502)
+    rtc = {
+        'connected': rtc_raw['connected'],
+        'channels': dict(channels),
+        'renews_lease': False,
+    }
+    if state == 'fault' and (
+        pose['age_ms'] is not None
+        or pose['fresh'] is not False
+        or pose['latest_sequence'] is not None
+        or rtc['connected'] is not False
+        or any(rtc['channels'].values())
+    ):
+        raise TeleopServiceError('driver_response_invalid', 502)
+    counters_raw = raw.get('counters')
+    counters: dict[str, int] = {}
+    if isinstance(counters_raw, dict):
+        for key, value in list(counters_raw.items())[:100]:
+            if (
+                isinstance(key, str)
+                and key in _PUBLIC_COUNTERS
+                and _SAFE_COUNTER_RE.fullmatch(key)
+                and isinstance(value, int)
+                and not isinstance(value, bool)
+                and 0 <= value <= 2**63 - 1
+            ):
+                counters[key] = value
+
+    projection = {
+        'driver_id': driver_id,
+        'driver_name': driver_id,
+        'robot_id': robot_id,
+        'mode': mode,
+        'actuation_enabled': mode == LIVE_MODE,
+        'profile_id': profile_id,
+        'capabilities': capabilities,
+        'boot_id': boot_id,
+        'session_id': session_id,
+        'epoch': epoch,
+        'state': state,
+        'reason': reason,
+        'authority_valid': authority_valid,
+        'capability_digest': capability_digest,
+        'lease': lease,
+        'pose': pose,
+        'rtc': rtc,
+        'counters': counters,
+    }
+    projection['dispatch'] = dispatch
+    if driver_type == 'teleop':
+        projection['diagnostics'] = _project_diagnostics(raw.get('diagnostics'))
+        output = _project_output(
+            raw.get('output'),
+            mode=mode,
+            profile_id=profile_id,
+            capabilities=capabilities,
+            driver_state=state,
+        )
+        if state == 'fault' and output['fault_reason'] != dispatch['fault_code']:
+            raise TeleopServiceError('driver_response_invalid', 502)
+        projection['output'] = output
+    else:
+        projection['diagnostics'] = None
+        projection['output'] = {
+            'profile_id': profile_id,
+            'hardware_output': False,
+            'state': dispatch['state'],
+            'target_joint_positions_rad': [],
+            'measured_joint_positions_rad': [],
+            'max_abs_error_rad': None,
+            'arm_sdk_weight': None,
+            'command_age_ms': None,
+            'fault_reason': dispatch.get('fault_code'),
+        }
+    if session is not None and session.fence in repr(projection):
+        raise TeleopServiceError('driver_secret_reflected', 502)
+    return projection, driver_lease_seconds
+
+
+class TeleopCoordinator:
+    def __init__(
+        self,
+        *,
+        session_manager: ShadowSessionManager = manager,
+        caller: Callable[..., Awaitable[dict]] = mcp_client.call_trusted_shadow_session,
+        signaler: Callable[..., Awaitable[dict]] = mcp_client.call_trusted_shadow_offer,
+        monotonic: Callable[[], float] = time.monotonic,
+        wall_clock: Callable[[], float] = time.time,
+        command_broker: CommandBroker = global_command_broker,
+        capture_manager: CaptureManager | None = None,
+    ):
+        self.manager = session_manager
+        self.command_broker = command_broker
+        self._caller = caller
+        self._signaler = signaler
+        self._uses_pinned_targets = caller is mcp_client.call_trusted_shadow_session
+        self._monotonic = monotonic
+        self._wall_clock = wall_clock
+        self.capture_manager = capture_manager or CaptureManager(
+            monotonic=monotonic,
+            wall_clock=wall_clock,
+        )
+        self._http_session: aiohttp.ClientSession | None = None
+        self._heartbeat_tasks: dict[str, asyncio.Task] = {}
+        self._supervisor_tasks: set[asyncio.Task] = set()
+        self._safety_tasks: set[asyncio.Task] = set()
+        self._acquire_tasks: set[asyncio.Task] = set()
+        self._acquire_locks = tuple(asyncio.Lock() for _ in range(_LOCK_STRIPE_COUNT))
+        self._operation_locks = tuple(asyncio.Lock() for _ in range(_LOCK_STRIPE_COUNT))
+        self._signaling_locks = tuple(asyncio.Lock() for _ in range(_LOCK_STRIPE_COUNT))
+        self._signaling_sources: dict[str, tuple[str, str]] = {}
+        self._heartbeat_health: dict[str, _HeartbeatHealth] = {}
+        self._driver_snapshots: dict[str, dict] = {}
+        self._driver_snapshot_revisions: dict[str, int] = {}
+        self._driver_lease_seconds: dict[str, float] = {}
+        self._pinned_targets: dict[str, mcp_client.TrustedShadowTarget] = {}
+        self._release_results: dict[str, bool] = {}
+        self._terminal_cleanup_done: set[str] = set()
+        self._command_claims: dict[str, tuple[str, str]] = {}
+        self._authority_guards: dict[str, authority_guard.AuthorityGuard] = {}
+        self._recovery_claims: dict[str, tuple[str, str]] = {}
+        self._guard_store_loaded = False
+        self._release_reconcile_tasks: dict[str, asyncio.Task] = {}
+        self._reaper_task: asyncio.Task | None = None
+        self._stopping = False
+
+    async def start(self) -> None:
+        if not self._guard_store_loaded:
+            await self._restore_authority_guards()
+            self._guard_store_loaded = True
+        if self._http_session is None or self._http_session.closed:
+            self._http_session = aiohttp.ClientSession()
+        self._stopping = False
+        if self._reaper_task is None or self._reaper_task.done():
+            self._reaper_task = asyncio.create_task(
+                self._reaper_loop(),
+                name='teleop-session-reaper',
+            )
+
+    @staticmethod
+    def _authority_root_fingerprint(robot_id: str) -> str:
+        services = config.main.get('services', {})
+        entries = services.get('mcp', []) if isinstance(services, dict) else []
+        matches = [
+            entry for entry in entries
+            if isinstance(entry, dict) and entry.get('id') == robot_id
+        ]
+        if len(matches) != 1:
+            raise TeleopServiceError('driver_not_ready', 503)
+        target = matches[0]
+        payload = {
+            'id': target.get('id'),
+            'url': target.get('url', ''),
+            'transport': target.get('transport', 'http'),
+            'trust_state': target.get('trust_state', ''),
+            'category': target.get('category', ''),
+            'authority_domain': target.get('authority_domain', ''),
+            'pending_authority_domain': target.get('pending_authority_domain', ''),
+            'authority_binding_error': target.get('authority_binding_error', ''),
+            'authority_binding_required': bool(
+                target.get('authority_binding_required', False),
+            ),
+            'capability_refresh_required': bool(
+                target.get('capability_refresh_required', False),
+            ),
+            'reported_robot_id': target.get('reported_robot_id', ''),
+            'tools': target.get('tools', []),
+        }
+        try:
+            encoded = json.dumps(
+                payload,
+                allow_nan=False,
+                ensure_ascii=False,
+                separators=(',', ':'),
+                sort_keys=True,
+            ).encode('utf-8')
+        except (TypeError, ValueError, RecursionError) as error:
+            raise TeleopServiceError('driver_not_ready', 503) from error
+        return hashlib.sha256(encoded).hexdigest()
+
+    @staticmethod
+    def _target_fingerprint(
+        driver_id: str,
+        robot_id: str,
+        capability_digest: str,
+        target: mcp_client.TrustedShadowTarget | None,
+        authority_root_fingerprint: str,
+    ) -> str:
+        payload = {
+            'driver_id': driver_id,
+            'robot_id': robot_id,
+            'capability_digest': capability_digest,
+            'authority_root_fingerprint': authority_root_fingerprint,
+            'url': target.url if target is not None else '',
+            'descriptor_fingerprint': (
+                target.descriptor_fingerprint if target is not None else ''
+            ),
+            'actions': sorted(target.actions) if target is not None else [],
+        }
+        encoded = json.dumps(
+            payload,
+            allow_nan=False,
+            ensure_ascii=False,
+            separators=(',', ':'),
+            sort_keys=True,
+        ).encode('utf-8')
+        return hashlib.sha256(encoded).hexdigest()
+
+    def authority_guard_for_robot(self, robot_id: str) -> dict | None:
+        """Return the public, secret-free restart quarantine for one robot."""
+
+        guard = self._authority_guards.get(robot_id)
+        if guard is None or guard.phase not in {'recovery_required', 'reconciling'}:
+            return None
+        return {
+            'state': 'recovery_required',
+            'phase': guard.phase,
+            'driver_id': guard.driver_id,
+            'robot_id': guard.robot_id,
+            'retryable': True,
+            'created_at': guard.created_at,
+            'updated_at': guard.updated_at,
+        }
+
+    def list_authority_guards(self) -> list[dict]:
+        """Return every public restart quarantine in deterministic order."""
+
+        return [
+            public
+            for robot_id in sorted(self._authority_guards)
+            if (public := self.authority_guard_for_robot(robot_id)) is not None
+        ]
+
+    async def _restore_authority_guards(self) -> None:
+        """Rebuild deny-only command claims; never recover old authority."""
+
+        try:
+            stored = await asyncio.to_thread(authority_guard.list_guards)
+        except Exception as error:
+            raise TeleopServiceError('authority_guard_persistence_error', 503) from error
+
+        acquired: list[tuple[str, str]] = []
+        try:
+            for guard in stored:
+                recovered = await asyncio.to_thread(
+                    authority_guard.update_guard,
+                    guard.robot_id,
+                    guard.session_id,
+                    phase='recovery_required',
+                    dispatch_generation=guard.dispatch_generation,
+                )
+                token = str(uuid.uuid4())
+                await self._begin_command_claim(recovered.robot_id, token)
+                await self.command_broker.update_authority(
+                    recovered.robot_id,
+                    token,
+                    session_id=recovered.session_id,
+                    principal_id='core:recovery',
+                    state='recovery_required',
+                )
+                acquired.append((recovered.robot_id, token))
+                self._authority_guards[recovered.robot_id] = recovered
+                self._recovery_claims[recovered.robot_id] = (
+                    recovered.session_id,
+                    token,
+                )
+        except Exception:
+            for robot_id, token in acquired:
+                await self.command_broker.release_authority(robot_id, token)
+            self._authority_guards.clear()
+            self._recovery_claims.clear()
+            raise
+
+        for guard in stored:
+            try:
+                await audit.emit(
+                    'teleop.authority_guard.restored',
+                    session_id=guard.session_id,
+                    robot_id=guard.robot_id,
+                    principal_id='core:recovery',
+                    source='core',
+                    decision='blocked',
+                    reason='core_restart_recovery_required',
+                    details={'driver_id': guard.driver_id},
+                )
+            except Exception:  # noqa: BLE001, S110 -- observability cannot open gate
+                pass
+
+    async def _create_authority_guard(
+        self,
+        session: ShadowSession,
+        status: dict,
+        target: mcp_client.TrustedShadowTarget | None,
+    ) -> None:
+        commit = asyncio.create_task(
+            self._commit_authority_guard(session, status, target),
+            name=f'teleop-authority-guard-commit-{session.id}',
+        )
+        await self._await_safety_completion(commit)
+
+    async def _commit_authority_guard(
+        self,
+        session: ShadowSession,
+        status: dict,
+        target: mcp_client.TrustedShadowTarget | None,
+    ) -> None:
+        async with authority_guard.target_mutation_lock:
+            try:
+                current_descriptor = await asyncio.to_thread(
+                    _driver_descriptor,
+                    session.driver_id,
+                )
+            except TeleopServiceError as error:
+                raise TeleopServiceError('driver_not_ready', 503) from error
+            if (
+                current_descriptor['robot_id'] != session.robot_id
+                or current_descriptor['capability_digest']
+                != session.capability_digest
+                or current_descriptor['mode'] != session.mode
+                or current_descriptor['profile_id'] != session.profile_id
+                or current_descriptor['capabilities'] != session.capabilities
+            ):
+                raise TeleopServiceError('driver_not_ready', 503)
+            authority_root_fingerprint = self._authority_root_fingerprint(
+                session.robot_id,
+            )
+
+            current_target = None
+            if self._uses_pinned_targets:
+                try:
+                    current_target = await mcp_client.resolve_trusted_shadow_target(
+                        session.driver_id,
+                        timeout_seconds=_DEFAULT_CONTROL_TIMEOUT_SECONDS,
+                    )
+                except mcp_client.TrustedShadowTransportError as error:
+                    raise self._transport_service_error(error) from None
+                if target is None or self._target_fingerprint(
+                    session.driver_id,
+                    session.robot_id,
+                    session.capability_digest,
+                    current_target,
+                    authority_root_fingerprint,
+                ) != self._target_fingerprint(
+                    session.driver_id,
+                    session.robot_id,
+                    session.capability_digest,
+                    target,
+                    authority_root_fingerprint,
+                ):
+                    raise TeleopServiceError('driver_not_ready', 503)
+
+            now = self._wall_clock()
+            guard = authority_guard.AuthorityGuard(
+                robot_id=session.robot_id,
+                driver_id=session.driver_id,
+                session_id=session.id,
+                boot_id=session.boot_id,
+                epoch=session.epoch,
+                capability_digest=session.capability_digest,
+                target_fingerprint=self._target_fingerprint(
+                    session.driver_id,
+                    session.robot_id,
+                    session.capability_digest,
+                    current_target,
+                    authority_root_fingerprint,
+                ),
+                dispatch_generation=status['dispatch']['generation'],
+                phase='preparing',
+                created_at=now,
+                updated_at=now,
+            )
+            try:
+                created = await asyncio.to_thread(authority_guard.create_guard, guard)
+            except Exception as error:
+                raise TeleopServiceError(
+                    'authority_guard_persistence_error',
+                    503,
+                ) from error
+        self._authority_guards[created.robot_id] = created
+
+    async def _advance_authority_guard(
+        self,
+        session: ShadowSession,
+        *,
+        phase: str,
+        dispatch_generation: int,
+    ) -> None:
+        current = self._authority_guards.get(session.robot_id)
+        if current is None or current.session_id != session.id:
+            return
+        try:
+            updated = await asyncio.to_thread(
+                authority_guard.update_guard,
+                session.robot_id,
+                session.id,
+                phase=phase,
+                dispatch_generation=dispatch_generation,
+            )
+        except Exception as error:
+            raise TeleopServiceError('authority_guard_persistence_error', 503) from error
+        self._authority_guards[session.robot_id] = updated
+
+    async def _delete_authority_guard_after_safe(self, session: ShadowSession) -> bool:
+        current = self._authority_guards.get(session.robot_id)
+        if current is None:
+            return True
+        if current.session_id != session.id:
+            return False
+        try:
+            deleted = await asyncio.to_thread(
+                authority_guard.delete_guard,
+                session.robot_id,
+                session.id,
+            )
+        except Exception:  # noqa: BLE001 -- DB uncertainty keeps command admission shut
+            return False
+        if not deleted:
+            return False
+        self._authority_guards.pop(session.robot_id, None)
+        return True
+
+    @staticmethod
+    def _recovery_status_proves_safe(
+        guard: authority_guard.AuthorityGuard,
+        projected: dict,
+    ) -> bool:
+        if projected['authority_valid'] is not False or projected['session_id'] is not None:
+            return False
+        dispatch = projected.get('dispatch')
+        if (
+            not isinstance(dispatch, dict)
+            or dispatch['stop_acknowledged'] is not True
+            or dispatch['stop_queue_depth'] != 0
+            or dispatch['io_inflight'] is not None
+        ):
+            return False
+        if projected['boot_id'] != guard.boot_id:
+            return (
+                projected['state'] == 'idle'
+                and dispatch['state'] == 'safe_unarmed'
+                and dispatch['last_decision'] == 'startup_safe_ack'
+            )
+        return (
+            projected['epoch'] <= guard.epoch
+            and dispatch['state'] == 'safe_revoked'
+            and dispatch['generation'] > guard.dispatch_generation
+        )
+
+    async def _clear_recovery_guard(
+        self,
+        guard: authority_guard.AuthorityGuard,
+        *,
+        principal_id: str,
+        reason: str,
+    ) -> dict:
+        cleanup = asyncio.create_task(
+            self._complete_recovery_guard_clear(
+                guard,
+                principal_id=principal_id,
+                reason=reason,
+            ),
+            name=f'teleop-authority-guard-clear-{guard.robot_id}',
+        )
+        return await self._await_safety_completion(cleanup)
+
+    async def _complete_recovery_guard_clear(
+        self,
+        guard: authority_guard.AuthorityGuard,
+        *,
+        principal_id: str,
+        reason: str,
+    ) -> dict:
+        claim = self._recovery_claims.get(guard.robot_id)
+        if claim is None or claim[0] != guard.session_id:
+            raise TeleopServiceError('authority_guard_persistence_error', 503)
+        try:
+            deleted = await asyncio.to_thread(
+                authority_guard.delete_guard,
+                guard.robot_id,
+                guard.session_id,
+            )
+        except Exception as error:
+            raise TeleopServiceError('authority_guard_persistence_error', 503) from error
+        if not deleted:
+            try:
+                persisted = await asyncio.to_thread(
+                    authority_guard.get_guard,
+                    guard.robot_id,
+                )
+            except Exception as error:
+                raise TeleopServiceError(
+                    'authority_guard_persistence_error',
+                    503,
+                ) from error
+            if persisted is not None:
+                raise TeleopServiceError('authority_guard_persistence_error', 503)
+        released = await self.command_broker.release_authority(
+            guard.robot_id,
+            claim[1],
+        )
+        if not released:
+            current_claim = await self.command_broker.authority_for(guard.robot_id)
+            if current_claim is not None:
+                raise TeleopServiceError('authority_guard_persistence_error', 503)
+        self._authority_guards.pop(guard.robot_id, None)
+        self._recovery_claims.pop(guard.robot_id, None)
+        try:
+            await audit.emit(
+                'teleop.authority_guard.cleared',
+                session_id=guard.session_id,
+                robot_id=guard.robot_id,
+                principal_id=principal_id,
+                source='api',
+                decision='released',
+                reason=reason,
+                details={'driver_id': guard.driver_id, 'old_session_restored': False},
+            )
+        except Exception:  # noqa: BLE001, S110 -- proof and deletion already succeeded
+            pass
+        return {
+            'state': 'clear',
+            'robot_id': guard.robot_id,
+            'driver_id': guard.driver_id,
+            'old_session_restored': False,
+            'reacquire_required': True,
+        }
+
+    async def reconcile_authority_guard(
+        self,
+        robot_id: str,
+        *,
+        principal_id: str,
+    ) -> dict:
+        """Owner-triggered proof that a restarted Core may reopen writes."""
+
+        if not _AUTHORITY_ID_RE.fullmatch(robot_id):
+            raise TeleopServiceError('authority_guard_not_found', 404)
+        if not self._guard_store_loaded:
+            await self.start()
+        lock = self._driver_acquire_lock(robot_id)
+        async with lock:
+            guard = self._authority_guards.get(robot_id)
+            if guard is None:
+                return {
+                    'state': 'clear',
+                    'robot_id': robot_id,
+                    'old_session_restored': False,
+                    'reacquire_required': True,
+                    'already_clear': True,
+                }
+            if guard.phase not in {'recovery_required', 'reconciling'}:
+                raise TeleopServiceError('authority_guard_not_safe', 409)
+
+            try:
+                descriptor = await asyncio.to_thread(_driver_descriptor, guard.driver_id)
+                authority_root_fingerprint = self._authority_root_fingerprint(
+                    guard.robot_id,
+                )
+            except TeleopServiceError as error:
+                raise TeleopServiceError('authority_guard_target_changed', 409) from error
+            if (
+                descriptor['robot_id'] != guard.robot_id
+                or descriptor['capability_digest'] != guard.capability_digest
+            ):
+                raise TeleopServiceError('authority_guard_target_changed', 409)
+
+            target = None
+            if self._uses_pinned_targets:
+                try:
+                    target = await mcp_client.resolve_trusted_shadow_target(
+                        guard.driver_id,
+                        timeout_seconds=_DEFAULT_CONTROL_TIMEOUT_SECONDS,
+                    )
+                except mcp_client.TrustedShadowTransportError as error:
+                    raise self._transport_service_error(error) from None
+            if self._target_fingerprint(
+                guard.driver_id,
+                guard.robot_id,
+                guard.capability_digest,
+                target,
+                authority_root_fingerprint,
+            ) != guard.target_fingerprint:
+                raise TeleopServiceError('authority_guard_target_changed', 409)
+
+            try:
+                raw_status = await self._call(
+                    guard.driver_id,
+                    'status',
+                    timeout_seconds=0.5,
+                    pinned_target=target,
+                )
+            except mcp_client.TrustedShadowTransportError as error:
+                raise self._transport_service_error(error) from None
+            projected, _ = _project_driver_snapshot(
+                raw_status,
+                driver_id=guard.driver_id,
+                robot_id=guard.robot_id,
+                capability_digest=guard.capability_digest,
+                action='status',
+                expected_mode=descriptor['mode'],
+                expected_profile_id=descriptor['profile_id'],
+                expected_capabilities=descriptor['capabilities'],
+                allow_stop_pending=True,
+            )
+            if self._recovery_status_proves_safe(guard, projected):
+                return await self._clear_recovery_guard(
+                    guard,
+                    principal_id=principal_id,
+                    reason=(
+                        'driver_restart_safe_unarmed'
+                        if projected['boot_id'] != guard.boot_id
+                        else 'driver_watchdog_safe_revoked'
+                    ),
+                )
+            if (
+                projected['boot_id'] == guard.boot_id
+                and (
+                    projected['epoch'] > guard.epoch
+                    or projected['dispatch']['generation'] < guard.dispatch_generation
+                )
+            ):
+                raise TeleopServiceError('authority_guard_not_safe', 409)
+
+            try:
+                reconciling = await asyncio.to_thread(
+                    authority_guard.update_guard,
+                    guard.robot_id,
+                    guard.session_id,
+                    phase='reconciling',
+                    dispatch_generation=max(
+                        guard.dispatch_generation,
+                        projected['dispatch']['generation'],
+                    ),
+                )
+            except Exception as error:
+                raise TeleopServiceError('authority_guard_persistence_error', 503) from error
+            self._authority_guards[robot_id] = reconciling
+            await self.command_broker.update_authority(
+                robot_id,
+                self._recovery_claims[robot_id][1],
+                state='reconciling',
+            )
+
+            try:
+                raw_stopped = await self._call(
+                    guard.driver_id,
+                    'stop',
+                    timeout_seconds=0.5,
+                    pinned_target=target,
+                )
+            except mcp_client.TrustedShadowTransportError as error:
+                raise self._transport_service_error(error) from None
+            stopped, _ = _project_driver_snapshot(
+                raw_stopped,
+                driver_id=guard.driver_id,
+                robot_id=guard.robot_id,
+                capability_digest=guard.capability_digest,
+                action='release',
+                expected_mode=descriptor['mode'],
+                expected_profile_id=descriptor['profile_id'],
+                expected_capabilities=descriptor['capabilities'],
+            )
+            same_observed_boot = stopped['boot_id'] == projected['boot_id']
+            if (
+                (same_observed_boot and stopped['dispatch']['generation']
+                 <= projected['dispatch']['generation'])
+                or (stopped['boot_id'] == guard.boot_id and stopped['epoch'] > guard.epoch)
+            ):
+                raise TeleopServiceError('authority_guard_not_safe', 409)
+            return await self._clear_recovery_guard(
+                reconciling,
+                principal_id=principal_id,
+                reason='driver_lifecycle_stop_acknowledged',
+            )
+
+    async def stop(self) -> None:
+        self._stopping = True
+        await self.capture_manager.reset('core_stopped')
+        current_task = asyncio.current_task()
+        acquire_tasks = [
+            task for task in self._acquire_tasks
+            if task is not current_task and not task.done()
+        ]
+        if acquire_tasks:
+            await asyncio.gather(*acquire_tasks, return_exceptions=True)
+        await self._drain_safety_tasks()
+
+        reaper = self._reaper_task
+        self._reaper_task = None
+        if reaper is not None:
+            reaper.cancel()
+            await asyncio.gather(reaper, return_exceptions=True)
+
+        tasks = list(self._heartbeat_tasks.values())
+        self._heartbeat_tasks.clear()
+        for task in tasks:
+            task.cancel()
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+
+        supervisor_tasks = list(self._supervisor_tasks)
+        self._supervisor_tasks.clear()
+        for task in supervisor_tasks:
+            task.cancel()
+        if supervisor_tasks:
+            await asyncio.gather(*supervisor_tasks, return_exceptions=True)
+
+        reconcile_tasks = list(self._release_reconcile_tasks.values())
+        self._release_reconcile_tasks.clear()
+        for task in reconcile_tasks:
+            task.cancel()
+        if reconcile_tasks:
+            await asyncio.gather(*reconcile_tasks, return_exceptions=True)
+
+        sessions = await self.manager.list_visible('', owner=True)
+        for session in sessions:
+            lock = self._session_lock(session.id)
+            async with lock:
+                await self._shutdown_session_locked(session)
+        await self._drain_safety_tasks()
+
+        if self._http_session is not None:
+            await self._http_session.close()
+            self._http_session = None
+        await self.manager.reset()
+        self._safety_tasks.clear()
+        self._acquire_tasks.clear()
+        self._heartbeat_health.clear()
+        self._driver_snapshots.clear()
+        self._driver_snapshot_revisions.clear()
+        self._driver_lease_seconds.clear()
+        self._pinned_targets.clear()
+        self._signaling_sources.clear()
+        self._release_results.clear()
+        self._terminal_cleanup_done.clear()
+        self._release_reconcile_tasks.clear()
+
+    async def _shutdown_session_locked(self, session: ShadowSession) -> None:
+        if session.mode == LIVE_MODE and not session.live_confirmed:
+            if session.state == 'awaiting_confirmation':
+                try:
+                    session = await self.manager.release(
+                        session.id,
+                        'core:shutdown',
+                        session.client_id,
+                        owner=True,
+                    )
+                    await self._update_command_claim(session, 'releasing')
+                except (SessionNotFound, SessionStateConflict):
+                    pass
+            self._terminal_cleanup_done.add(session.id)
+            await self._cleanup_terminal_runtime(session.id)
+            return
+        was_live = session.state in {'preparing', 'active', 'paused', 'hold'}
+        acknowledged = False
+        if was_live:
+            try:
+                session = await self.manager.release(
+                    session.id,
+                    'core:shutdown',
+                    session.client_id,
+                    owner=True,
+                )
+                await self._update_command_claim(session, 'releasing')
+            except (SessionNotFound, SessionStateConflict):
+                was_live = False
+
+        if session.id not in self._terminal_cleanup_done:
+            target_available = (
+                not self._uses_pinned_targets
+                or session.id in self._pinned_targets
+            )
+            if target_available:
+                if session.state == 'released':
+                    acknowledged = await self._best_effort_release(session)
+                    self._release_results[session.id] = acknowledged
+                else:
+                    acknowledged = await self._best_effort_soft_stop_and_release(session)
+                driver_acknowledged = acknowledged
+                if acknowledged:
+                    acknowledged = await self._delete_authority_guard_after_safe(session)
+                if acknowledged:
+                    self._terminal_cleanup_done.add(session.id)
+            else:
+                driver_acknowledged = False
+        else:
+            driver_acknowledged = acknowledged
+
+        if was_live:
+            await audit.emit(
+                'teleop.session.shutdown',
+                session_id=session.id,
+                robot_id=session.robot_id,
+                principal_id=session.principal_id,
+                source='core',
+                decision='released' if acknowledged else 'quarantined',
+                reason=(
+                    'core_shutdown_release_acknowledged'
+                    if acknowledged else 'core_shutdown_release_unconfirmed'
+                ),
+                details={
+                    'driver_acknowledged': driver_acknowledged,
+                    'guard_deleted': acknowledged,
+                },
+            )
+        if acknowledged:
+            await self._cleanup_terminal_runtime(session.id)
+
+    def _session_lock(self, session_id: str) -> asyncio.Lock:
+        return self._operation_locks[hash(session_id) % _LOCK_STRIPE_COUNT]
+
+    def _signaling_lock(self, session_id: str) -> asyncio.Lock:
+        return self._signaling_locks[hash(session_id) % _LOCK_STRIPE_COUNT]
+
+    def _driver_acquire_lock(self, robot_id: str) -> asyncio.Lock:
+        return self._acquire_locks[hash(robot_id) % _LOCK_STRIPE_COUNT]
+
+    async def _begin_command_claim(self, driver_id: str, token: str) -> None:
+        try:
+            await self.command_broker.begin_authority(
+                driver_id,
+                token,
+                drain_timeout_seconds=_COMMAND_DRAIN_TIMEOUT_SECONDS,
+            )
+        except CommandDrainTimeout:
+            raise TeleopServiceError('driver_command_busy', 409) from None
+        except AuthorityAlreadyClaimed:
+            raise TeleopServiceError('driver_authority_busy', 409) from None
+        except asyncio.CancelledError:
+            # Cancellation can arrive after Broker committed the claim but before
+            # this wrapper returns. Releasing by token is safe even if the claim
+            # was never committed, and the shielded cleanup survives re-cancel.
+            cleanup = asyncio.create_task(
+                self.command_broker.release_authority(driver_id, token),
+                name=f'teleop-cancelled-command-claim-{driver_id}',
+            )
+            await self._await_safety_completion(cleanup)
+            raise
+
+    async def _ensure_command_claim(self, session: ShadowSession) -> None:
+        claim = self._command_claims.get(session.id)
+        if claim is None:
+            token = str(uuid.uuid4())
+            await self._begin_command_claim(session.robot_id, token)
+            self._command_claims[session.id] = (session.robot_id, token)
+            claim = (session.robot_id, token)
+        await self.command_broker.update_authority(
+            claim[0],
+            claim[1],
+            session_id=session.id,
+            principal_id=session.principal_id,
+            state=session.state,
+        )
+
+    async def _update_command_claim(self, session: ShadowSession, state: str) -> None:
+        claim = self._command_claims.get(session.id)
+        if claim is None:
+            return
+        await self.command_broker.update_authority(
+            claim[0],
+            claim[1],
+            session_id=session.id,
+            principal_id=session.principal_id,
+            state=state,
+        )
+
+    async def _call(
+        self,
+        driver_id: str,
+        action: str,
+        arguments: dict | None = None,
+        *,
+        timeout_seconds: float = _DEFAULT_CONTROL_TIMEOUT_SECONDS,
+        pinned_target: mcp_client.TrustedShadowTarget | None = None,
+    ) -> dict:
+        if self._http_session is None or self._http_session.closed:
+            if self._stopping:
+                raise TeleopServiceError('coordinator_stopping', 503)
+            await self.start()
+        assert self._http_session is not None
+        kwargs = {
+            'timeout_seconds': timeout_seconds,
+            'session': self._http_session,
+        }
+        if self._uses_pinned_targets:
+            if pinned_target is None and isinstance(arguments, dict):
+                session_id = arguments.get('session_id')
+                if isinstance(session_id, str):
+                    pinned_target = self._pinned_targets.get(session_id)
+            kwargs['target'] = pinned_target
+        try:
+            return await self._caller(driver_id, action, arguments, **kwargs)
+        except (mcp_client.TrustedShadowTransportError, asyncio.CancelledError):
+            raise
+        except Exception:  # noqa: BLE001 -- normalize injected/unknown transports
+            raise mcp_client.TrustedShadowTransportError(
+                'internal_transport_error',
+            ) from None
+
+    async def _signal_offer(
+        self,
+        session: ShadowSession,
+        offer: dict,
+        ticket: str,
+        target: mcp_client.TrustedShadowTarget,
+    ) -> dict:
+        if self._http_session is None or self._http_session.closed:
+            if self._stopping:
+                raise TeleopServiceError('coordinator_stopping', 503)
+            await self.start()
+        assert self._http_session is not None
+        try:
+            return await self._signaler(
+                session.driver_id,
+                offer,
+                ticket,
+                timeout_seconds=_SIGNALING_TIMEOUT_SECONDS,
+                session=self._http_session,
+                target=target,
+            )
+        except (mcp_client.TrustedShadowTransportError, asyncio.CancelledError):
+            raise
+        except Exception:  # noqa: BLE001 -- normalize injected/unknown transports
+            raise mcp_client.TrustedShadowTransportError(
+                'internal_transport_error',
+            ) from None
+
+    @staticmethod
+    def _transport_service_error(error: mcp_client.TrustedShadowTransportError) -> TeleopServiceError:
+        if error.code == 'timeout':
+            return TeleopServiceError('driver_timeout', 504)
+        if error.code in {
+            'target_not_found', 'target_ambiguous', 'target_not_trusted',
+            'invalid_transport', 'invalid_url', 'registry_offline',
+            'registry_not_trusted', 'registry_target_mismatch',
+            'registry_descriptor_mismatch', 'insecure_transport',
+            'descriptor_invalid', 'action_not_declared', 'driver_auth_unavailable',
+            'client_session_closed', 'target_resolution_error',
+        }:
+            return TeleopServiceError('driver_not_ready', 503)
+        if error.code == 'pinned_target_changed':
+            return TeleopServiceError('driver_session_lost', 409)
+        if error.code == 'http_error' and error.http_status in {401, 403}:
+            return TeleopServiceError('driver_auth_rejected', 502)
+        if error.code == 'rpc_error' and error.rpc_data_code in _TERMINAL_RPC_CODES:
+            return TeleopServiceError('driver_session_lost', 409)
+        if error.code == 'network_error':
+            return TeleopServiceError('driver_unreachable', 503)
+        return TeleopServiceError('driver_protocol_error', 502)
+
+    async def acquire(
+        self,
+        driver_id: str,
+        principal_id: str,
+        client_id: str,
+        mode: str = SHADOW_MODE,
+    ) -> AcquireResult:
+        if self._stopping:
+            raise TeleopServiceError('coordinator_stopping', 503)
+        task = asyncio.current_task()
+        if task is None:
+            raise TeleopServiceError('coordinator_stopping', 503)
+        self._acquire_tasks.add(task)
+        try:
+            # The authenticated teleop descriptor binds a potentially standalone
+            # adapter id to the physical robot authority domain.
+            descriptor = await asyncio.to_thread(_driver_descriptor, driver_id)
+            if descriptor['mode'] != mode:
+                raise TeleopServiceError('teleop_mode_unavailable', 409)
+            robot_id = descriptor['robot_id']
+            lock = self._driver_acquire_lock(robot_id)
+            async with lock:
+                return await self._acquire_locked(
+                    driver_id,
+                    robot_id,
+                    principal_id,
+                    client_id,
+                    descriptor,
+                )
+        finally:
+            self._acquire_tasks.discard(task)
+
+    async def confirm_live(
+        self,
+        session_id: str,
+        principal_id: str,
+        client_id: str,
+        *,
+        profile_id: str,
+    ) -> AcquireResult:
+        """Turn a memory-only live reservation into Driver authority exactly once."""
+
+        lock = self._session_lock(session_id)
+        async with lock:
+            session = await self.manager.get_authorized(
+                session_id,
+                principal_id,
+                owner=False,
+                client_id=client_id,
+                require_client=True,
+            )
+            if session.mode != LIVE_MODE or session.profile_id != profile_id:
+                raise TeleopServiceError('live_confirmation_mismatch', 409)
+            if session.state == 'active' and session.live_confirmed:
+                return AcquireResult(session, 'existing')
+            if session.state != 'awaiting_confirmation' or session.live_confirmed:
+                raise SessionStateConflict(session_id)
+
+            descriptor = await asyncio.to_thread(_driver_descriptor, session.driver_id)
+            if (
+                descriptor['mode'] != LIVE_MODE
+                or descriptor['profile_id'] != session.profile_id
+                or descriptor['capability_digest'] != session.capability_digest
+                or descriptor['capabilities'] != session.capabilities
+                or descriptor['robot_id'] != session.robot_id
+            ):
+                raise TeleopServiceError('driver_not_ready', 503)
+            pinned_target = None
+            if self._uses_pinned_targets:
+                try:
+                    pinned_target = await mcp_client.resolve_trusted_shadow_target(
+                        session.driver_id,
+                        timeout_seconds=_DEFAULT_CONTROL_TIMEOUT_SECONDS,
+                    )
+                except mcp_client.TrustedShadowTransportError as error:
+                    raise self._transport_service_error(error) from None
+                if pinned_target.capability_digest != session.capability_digest:
+                    raise TeleopServiceError('driver_not_ready', 503)
+            try:
+                raw_status = await self._call(
+                    session.driver_id,
+                    'status',
+                    pinned_target=pinned_target,
+                )
+            except mcp_client.TrustedShadowTransportError as error:
+                raise self._transport_service_error(error) from None
+            status, _ = _project_driver_snapshot(
+                raw_status,
+                driver_id=session.driver_id,
+                robot_id=session.robot_id,
+                capability_digest=session.capability_digest,
+                action='status',
+                expected_mode=LIVE_MODE,
+                expected_profile_id=session.profile_id,
+                expected_capabilities=session.capabilities,
+            )
+            if status['authority_valid'] is True or status['session_id'] is not None:
+                raise TeleopServiceError('driver_authority_busy', 409)
+
+            await audit.emit(
+                'teleop.session.live_confirmed',
+                session_id=session.id,
+                robot_id=session.robot_id,
+                principal_id=principal_id,
+                source='api',
+                decision='confirmed',
+                reason='operator_confirmed_hardware_actuation',
+                details={
+                    'mode': LIVE_MODE,
+                    'profile_id': session.profile_id,
+                    'capability_digest': session.capability_digest,
+                    'hardware_output': True,
+                },
+            )
+
+            identity_bound = False
+            guard_created = False
+            prepare_started = False
+            generation = session.operation_generation
+            claim = self._command_claims.get(session.id)
+            if claim is None:
+                raise TeleopServiceError('driver_session_lost', 409)
+            try:
+                session = await self.manager.confirm_live_identity(
+                    session.id,
+                    principal_id,
+                    client_id,
+                    boot_id=status['boot_id'],
+                    minimum_epoch=status['epoch'] + 1,
+                )
+                identity_bound = True
+                self._store_driver_snapshot(session, status)
+                if pinned_target is not None:
+                    self._pinned_targets[session.id] = pinned_target
+                await self._create_authority_guard(session, status, pinned_target)
+                guard_created = True
+                await self._update_command_claim(session, 'preparing')
+                prepare_started = True
+                result = await self._activate_reserved_session(
+                    session,
+                    generation=generation,
+                    digest=session.capability_digest,
+                    principal_id=principal_id,
+                )
+                await self._update_command_claim(result.session, 'active')
+                return result
+            except asyncio.CancelledError:
+                cleanup = asyncio.create_task(
+                    self._cleanup_live_confirmation_interruption(
+                        session,
+                        generation=generation,
+                        claim_token=claim[1],
+                        identity_bound=identity_bound,
+                        guard_created=guard_created,
+                        prepare_started=prepare_started,
+                        reason='request_cancelled',
+                    ),
+                    name=f'teleop-cancelled-live-confirm-{session.id}',
+                )
+                await self._await_safety_completion(cleanup)
+                raise
+            except Exception:
+                await self._cleanup_live_confirmation_interruption(
+                    session,
+                    generation=generation,
+                    claim_token=claim[1],
+                    identity_bound=identity_bound,
+                    guard_created=guard_created,
+                    prepare_started=prepare_started,
+                    reason='prepare_failed',
+                )
+                raise
+
+    async def _cleanup_live_confirmation_interruption(
+        self,
+        session: ShadowSession,
+        *,
+        generation: int,
+        claim_token: str,
+        identity_bound: bool,
+        guard_created: bool,
+        prepare_started: bool,
+        reason: str,
+    ) -> None:
+        """Close every post-confirm commit/return race without opening authority."""
+
+        current = await self.manager.get(session.id)
+        identity_bound = identity_bound or (
+            current is session
+            and session.mode == LIVE_MODE
+            and session.live_confirmed
+            and session.epoch > 0
+            and bool(session.boot_id)
+        )
+        if not identity_bound or session.id not in self._command_claims:
+            return
+        if session.robot_id in self._recovery_claims:
+            return
+        committed = self._authority_guards.get(session.robot_id)
+        guard_created = guard_created or (
+            committed is not None and committed.session_id == session.id
+        )
+        if guard_created and prepare_started:
+            await self._fail_prepare_locked(session, generation, reason)
+        elif guard_created:
+            await self._discard_guard_before_prepare(
+                session,
+                generation,
+                claim_token,
+                reason,
+            )
+        else:
+            await self._abandon_before_prepare(session, generation, reason)
+
+    async def _acquire_locked(
+        self,
+        driver_id: str,
+        robot_id: str,
+        principal_id: str,
+        client_id: str,
+        descriptor: dict,
+    ) -> AcquireResult:
+        guard = self._authority_guards.get(robot_id)
+        if guard is not None and guard.phase in {'recovery_required', 'reconciling'}:
+            raise TeleopServiceError('robot_recovery_required', 409)
+        existing = await self.manager.active_for_robot(robot_id)
+        if existing is not None:
+            if (
+                existing.driver_id != driver_id
+                or existing.principal_id != principal_id
+                or existing.client_id != client_id
+            ):
+                raise SessionConflict(existing)
+            if (
+                existing.mode != descriptor['mode']
+                or existing.profile_id != descriptor['profile_id']
+                or existing.capability_digest != descriptor['capability_digest']
+            ):
+                raise TeleopServiceError('driver_not_ready', 503)
+            await self._ensure_command_claim(existing)
+            disposition = (
+                'confirmation_required'
+                if existing.state == 'awaiting_confirmation'
+                else 'preparing'
+                if existing.state == 'preparing'
+                else 'existing'
+            )
+            return AcquireResult(existing, disposition)
+
+        claim_token = str(uuid.uuid4())
+        await self._begin_command_claim(robot_id, claim_token)
+        try:
+            return await self._acquire_claimed(
+                driver_id,
+                robot_id,
+                principal_id,
+                client_id,
+                claim_token,
+                descriptor,
+            )
+        finally:
+            claim_retained = any(
+                token == claim_token
+                for _claimed_driver_id, token in self._command_claims.values()
+            ) or any(
+                token == claim_token
+                for _recovered_session_id, token in self._recovery_claims.values()
+            )
+            if not claim_retained:
+                cleanup = asyncio.create_task(
+                    self.command_broker.release_authority(robot_id, claim_token),
+                    name=f'teleop-unreserved-command-claim-{robot_id}',
+                )
+                await self._await_safety_completion(cleanup)
+
+    async def _acquire_claimed(
+        self,
+        driver_id: str,
+        robot_id: str,
+        principal_id: str,
+        client_id: str,
+        claim_token: str,
+        descriptor: dict,
+    ) -> AcquireResult:
+        if descriptor['mode'] == LIVE_MODE:
+            try:
+                session = await self.manager.reserve(
+                    robot_id,
+                    principal_id,
+                    driver_id=driver_id,
+                    boot_id='',
+                    capability_digest=descriptor['capability_digest'],
+                    mode=LIVE_MODE,
+                    profile_id=descriptor['profile_id'],
+                    capabilities=descriptor['capabilities'],
+                    effectors=descriptor['capabilities']['effectors'],
+                    signaling_audience=descriptor['signaling']['audience'],
+                    defer_identity=True,
+                    client_id=client_id,
+                    lease_seconds=MIN_LEASE_SECONDS,
+                )
+            except EpochExhausted:
+                raise TeleopServiceError('driver_epoch_exhausted', 409) from None
+            self._command_claims[session.id] = (robot_id, claim_token)
+            await self._update_command_claim(session, 'awaiting_confirmation')
+            await audit.emit(
+                'teleop.session.live_confirmation_required',
+                session_id=session.id,
+                robot_id=session.robot_id,
+                principal_id=principal_id,
+                source='api',
+                decision='reserved',
+                reason='operator_acquire_live',
+                details={
+                    'mode': LIVE_MODE,
+                    'profile_id': session.profile_id,
+                    'hardware_output': False,
+                    'lease_seconds': session.lease_seconds,
+                },
+            )
+            return AcquireResult(session, 'confirmation_required')
+
+        pinned_target = None
+        if self._uses_pinned_targets:
+            try:
+                pinned_target = await mcp_client.resolve_trusted_shadow_target(
+                    driver_id,
+                    timeout_seconds=_DEFAULT_CONTROL_TIMEOUT_SECONDS,
+                )
+            except mcp_client.TrustedShadowTransportError as error:
+                raise self._transport_service_error(error) from None
+            if pinned_target.capability_digest != descriptor['capability_digest']:
+                raise TeleopServiceError('driver_not_ready', 503)
+        digest = descriptor['capability_digest']
+        try:
+            raw_status = await self._call(
+                driver_id,
+                'status',
+                pinned_target=pinned_target,
+            )
+        except mcp_client.TrustedShadowTransportError as error:
+            raise self._transport_service_error(error) from None
+        status, _ = _project_driver_snapshot(
+            raw_status,
+            driver_id=driver_id,
+            robot_id=descriptor['robot_id'],
+            capability_digest=digest,
+            action='status',
+            expected_mode=descriptor['mode'],
+            expected_profile_id=descriptor['profile_id'],
+            expected_capabilities=descriptor['capabilities'],
+        )
+        if status['authority_valid'] is True or status['session_id'] is not None:
+            raise TeleopServiceError('driver_authority_busy', 409)
+        minimum_epoch = status['epoch'] + 1
+        try:
+            session = await self.manager.reserve(
+                robot_id,
+                principal_id,
+                driver_id=driver_id,
+                boot_id=status['boot_id'],
+                capability_digest=digest,
+                mode=descriptor['mode'],
+                profile_id=descriptor['profile_id'],
+                capabilities=descriptor['capabilities'],
+                effectors=descriptor['capabilities']['effectors'],
+                signaling_audience=descriptor['signaling']['audience'],
+                client_id=client_id,
+                minimum_epoch=minimum_epoch,
+            )
+        except EpochExhausted:
+            raise TeleopServiceError('driver_epoch_exhausted', 409) from None
+        generation = session.operation_generation
+        self._command_claims[session.id] = (robot_id, claim_token)
+        guard_created = False
+        prepare_started = False
+        try:
+            self._store_driver_snapshot(session, status)
+            if pinned_target is not None:
+                self._pinned_targets[session.id] = pinned_target
+            # The durable deny record is committed before the first request that
+            # can install a Driver fence. A failed/uncertain write cannot reach
+            # prepare_shadow.
+            await self._create_authority_guard(session, status, pinned_target)
+            guard_created = True
+            await self._update_command_claim(session, 'preparing')
+            # Publish the lock in the same event-loop turn as the reservation.
+            # Owner Release may observe a preparing session, but it cannot pass a
+            # delayed prepare/heartbeat and allow authority to reappear afterward.
+            operation_lock = self._session_lock(session.id)
+            async with operation_lock:
+                prepare_started = True
+                result = await self._activate_reserved_session(
+                    session,
+                    generation=generation,
+                    digest=digest,
+                    principal_id=principal_id,
+                )
+            await self._update_command_claim(result.session, 'active')
+        except asyncio.CancelledError:
+            committed = self._authority_guards.get(session.robot_id)
+            guard_created = guard_created or (
+                committed is not None and committed.session_id == session.id
+            )
+            cleanup = asyncio.create_task(
+                self._fail_prepare_locked(session, generation, 'request_cancelled')
+                if guard_created and prepare_started
+                else self._discard_guard_before_prepare(
+                    session,
+                    generation,
+                    claim_token,
+                    'request_cancelled',
+                )
+                if guard_created
+                else self._abandon_before_prepare(
+                    session,
+                    generation,
+                    'request_cancelled',
+                ),
+                name=f'teleop-cancelled-command-claim-{session.id}',
+            )
+            await self._await_safety_completion(cleanup)
+            raise
+        except Exception:
+            committed = self._authority_guards.get(session.robot_id)
+            guard_created = guard_created or (
+                committed is not None and committed.session_id == session.id
+            )
+            if guard_created and prepare_started:
+                await self._fail_prepare_locked(session, generation, 'prepare_failed')
+            elif guard_created:
+                await self._discard_guard_before_prepare(
+                    session,
+                    generation,
+                    claim_token,
+                    'prepare_not_started',
+                )
+            else:
+                await self._abandon_before_prepare(
+                    session,
+                    generation,
+                    'authority_guard_not_committed',
+                )
+            raise
+        return result
+
+    async def _discard_guard_before_prepare(
+        self,
+        session: ShadowSession,
+        generation: int,
+        claim_token: str,
+        reason: str,
+    ) -> None:
+        """Remove a committed guard when no Driver fence request was sent."""
+
+        current = self._authority_guards.get(session.robot_id)
+        if current is None or current.session_id != session.id:
+            await self._abandon_before_prepare(session, generation, reason)
+            return
+
+        deletion_confirmed = False
+        try:
+            deletion_confirmed = await asyncio.to_thread(
+                authority_guard.delete_guard,
+                session.robot_id,
+                session.id,
+            )
+            if not deletion_confirmed:
+                deletion_confirmed = await asyncio.to_thread(
+                    authority_guard.get_guard,
+                    session.robot_id,
+                ) is None
+        except Exception:  # noqa: BLE001 -- uncertain storage becomes recovery lock
+            try:
+                deletion_confirmed = await asyncio.to_thread(
+                    authority_guard.get_guard,
+                    session.robot_id,
+                ) is None
+            except Exception:  # noqa: BLE001 -- preserve the deny-only claim
+                deletion_confirmed = False
+
+        if deletion_confirmed:
+            self._authority_guards.pop(session.robot_id, None)
+            await self._abandon_before_prepare(session, generation, reason)
+            return
+
+        try:
+            recovered = await asyncio.to_thread(
+                authority_guard.update_guard,
+                session.robot_id,
+                session.id,
+                phase='recovery_required',
+                dispatch_generation=current.dispatch_generation,
+            )
+        except Exception:  # noqa: BLE001 -- in-memory quarantine remains fail-closed
+            recovered = replace(
+                current,
+                phase='recovery_required',
+                updated_at=max(current.updated_at, self._wall_clock()),
+            )
+        self._authority_guards[session.robot_id] = recovered
+        self._command_claims.pop(session.id, None)
+        self._recovery_claims[session.robot_id] = (session.id, claim_token)
+        await self.command_broker.update_authority(
+            session.robot_id,
+            claim_token,
+            session_id=session.id,
+            principal_id='core:recovery',
+            state='recovery_required',
+        )
+        await self.manager.fail_reservation(session.id, generation)
+        self._pinned_targets.pop(session.id, None)
+        self._driver_snapshots.pop(session.id, None)
+        self._driver_snapshot_revisions.pop(session.id, None)
+        self._terminal_cleanup_done.add(session.id)
+
+    async def _abandon_before_prepare(
+        self,
+        session: ShadowSession,
+        generation: int,
+        reason: str,
+    ) -> None:
+        """Discard a reservation without contacting a Driver that was never prepared."""
+
+        await self.manager.fail_reservation(session.id, generation)
+        claim = self._command_claims.pop(session.id, None)
+        self._pinned_targets.pop(session.id, None)
+        self._driver_snapshots.pop(session.id, None)
+        self._driver_snapshot_revisions.pop(session.id, None)
+        self._terminal_cleanup_done.add(session.id)
+        if claim is not None:
+            await self.command_broker.release_authority(claim[0], claim[1])
+        try:
+            await audit.emit(
+                'teleop.session.prepare_rejected',
+                session_id=session.id,
+                robot_id=session.robot_id,
+                principal_id=session.principal_id,
+                source='core',
+                decision='rejected',
+                reason=reason,
+            )
+        except Exception:  # noqa: BLE001, S110 -- admission result is already closed
+            pass
+
+    async def _activate_reserved_session(
+        self,
+        session: ShadowSession,
+        *,
+        generation: int,
+        digest: str,
+        principal_id: str,
+    ) -> AcquireResult:
+        try:
+            await audit.emit(
+                'teleop.session.reserved',
+                session_id=session.id,
+                robot_id=session.robot_id,
+                principal_id=principal_id,
+                source='api',
+                decision='reserved',
+                reason='operator_acquire',
+                details={
+                    'mode': session.mode,
+                    'profile_id': session.profile_id,
+                    'lease_seconds': session.lease_seconds,
+                },
+            )
+            baseline_generation = self._driver_snapshots[
+                session.id
+            ]['dispatch']['generation']
+            raw_prepared = await self._prepare_with_reconcile(session)
+            projected, lease_seconds = _project_driver_snapshot(
+                raw_prepared,
+                driver_id=session.driver_id,
+                robot_id=session.robot_id,
+                capability_digest=digest,
+                action=PREPARE_ACTION_BY_MODE[session.mode],
+                session=session,
+            )
+            self._store_driver_snapshot(
+                session,
+                projected,
+                minimum_generation_exclusive=baseline_generation,
+            )
+            self._driver_lease_seconds[session.id] = lease_seconds
+            raw_heartbeat = await self._call(
+                session.driver_id,
+                'heartbeat',
+                self._identity(session),
+                timeout_seconds=self._heartbeat_timeout(lease_seconds),
+            )
+            projected, _ = _project_driver_snapshot(
+                raw_heartbeat,
+                driver_id=session.driver_id,
+                robot_id=session.robot_id,
+                capability_digest=digest,
+                action='heartbeat',
+                session=session,
+            )
+            self._store_driver_snapshot(session, projected)
+            activated = await self.manager.activate(session.id, generation)
+            now_mono = self._monotonic()
+            self._heartbeat_health[session.id] = _HeartbeatHealth(
+                last_confirmed_monotonic=now_mono,
+                last_confirmed_at=self._wall_clock(),
+            )
+            self._start_heartbeat(activated)
+            try:
+                await self._advance_authority_guard(
+                    session,
+                    phase='active',
+                    dispatch_generation=projected['dispatch']['generation'],
+                )
+            except TeleopServiceError:
+                # The committed guard already fails closed. Phase metadata must
+                # never delay or tear down a safely heartbeating Driver lease.
+                pass
+            await audit.emit(
+                'teleop.session.activated',
+                session_id=session.id,
+                robot_id=session.robot_id,
+                principal_id=principal_id,
+                source='core',
+                decision='activated',
+                reason='driver_prepared',
+                details={
+                    'mode': session.mode,
+                    'profile_id': session.profile_id,
+                    'state': 'active',
+                },
+            )
+        except asyncio.CancelledError:
+            cleanup = asyncio.create_task(
+                self._fail_prepare_locked(session, generation, 'request_cancelled'),
+                name=f'teleop-cancelled-prepare-{session.id}',
+            )
+            await self._await_safety_completion(cleanup)
+            raise
+        except mcp_client.TrustedShadowTransportError as error:
+            await self._fail_prepare_locked(session, generation, error.code)
+            raise self._transport_service_error(error) from None
+        except (TeleopServiceError, SessionNotFound, SessionStateConflict) as error:
+            code = error.code if isinstance(error, TeleopServiceError) else 'stale_prepare'
+            await self._fail_prepare_locked(session, generation, code)
+            if isinstance(error, TeleopServiceError):
+                raise
+            raise TeleopServiceError('session_prepare_stale', 409) from None
+        except Exception:  # noqa: BLE001 -- any post-fence fault must revoke authority
+            await self._fail_prepare_locked(
+                session,
+                generation,
+                'driver_response_invalid',
+            )
+            raise TeleopServiceError('driver_response_invalid', 502) from None
+
+        return AcquireResult(activated, 'created')
+
+    async def _fail_prepare_locked(
+        self,
+        session: ShadowSession,
+        generation: int,
+        reason: str,
+    ) -> None:
+        failed = await self.manager.fail_reservation(session.id, generation)
+        if failed is None:
+            current = await self.manager.get_current(session.id)
+            if current is None or current.operation_generation != generation:
+                return
+            try:
+                failed = await self.manager.release(
+                    session.id,
+                    'core:cancelled-acquire',
+                    session.client_id,
+                    owner=True,
+                )
+            except (SessionNotFound, SessionStateConflict):
+                return
+        await self._cancel_heartbeat(session.id, origin_task=asyncio.current_task())
+        await self._update_command_claim(failed, 'releasing')
+        acknowledged = await self._best_effort_release(failed)
+        await self._audit_prepare_failure(session, reason)
+        await self._finalize_or_quarantine_release(failed, acknowledged)
+
+    def _store_driver_snapshot(
+        self,
+        session: ShadowSession,
+        projected: dict,
+        *,
+        allow_restart: bool = False,
+        stale_after_revision: int | None = None,
+        minimum_generation_exclusive: int | None = None,
+    ) -> bool:
+        previous = self._driver_snapshots.get(session.id)
+        current_dispatch = projected.get('dispatch')
+        previous_dispatch = (
+            previous.get('dispatch') if isinstance(previous, dict) else None
+        )
+        if (
+            isinstance(current_dispatch, dict)
+            and minimum_generation_exclusive is not None
+            and current_dispatch['generation'] <= minimum_generation_exclusive
+        ):
+            raise TeleopServiceError('driver_response_invalid', 502)
+
+        def superseded_while_inflight() -> bool:
+            return (
+                stale_after_revision is not None
+                and self._driver_snapshot_revisions.get(session.id, 0)
+                > stale_after_revision
+            )
+
+        if isinstance(current_dispatch, dict) and isinstance(previous_dispatch, dict):
+            same_boot = projected['boot_id'] == previous['boot_id']
+            if not same_boot and not allow_restart:
+                raise TeleopServiceError('driver_identity_changed', 409)
+            if same_boot:
+                current_generation = current_dispatch['generation']
+                previous_generation = previous_dispatch['generation']
+                if current_generation < previous_generation:
+                    if superseded_while_inflight():
+                        return False
+                    raise TeleopServiceError('driver_response_invalid', 502)
+                stop_state_changed = (
+                    current_dispatch['state'] in _STOP_DISPATCH_STATES
+                    and (
+                        projected['state'],
+                        projected['reason'],
+                    ) != (
+                        previous['state'],
+                        previous['reason'],
+                    )
+                )
+                if stop_state_changed and current_generation <= previous_generation:
+                    if superseded_while_inflight():
+                        return False
+                    raise TeleopServiceError('driver_response_invalid', 502)
+                if current_generation == previous_generation:
+                    progression_regressed = (
+                        previous_dispatch['stop_acknowledged'] is True
+                        and current_dispatch['stop_acknowledged'] is False
+                    ) or (
+                        previous_dispatch['stop_queue_depth'] == 0
+                        and current_dispatch['stop_queue_depth'] > 0
+                    )
+                    evidence_key = (
+                        'last_published_sequence'
+                        if current_dispatch.get('kind') == 'hardware'
+                        else 'last_would_apply_sequence'
+                    )
+                    for key in ('last_admitted_sequence', evidence_key):
+                        before = previous_dispatch[key]
+                        after = current_dispatch[key]
+                        progression_regressed = progression_regressed or (
+                            before is not None and (after is None or after < before)
+                    )
+                    if progression_regressed:
+                        if superseded_while_inflight():
+                            return False
+                        raise TeleopServiceError('driver_response_invalid', 502)
+        self._driver_snapshots[session.id] = projected
+        self._driver_snapshot_revisions[session.id] = (
+            self._driver_snapshot_revisions.get(session.id, 0) + 1
+        )
+        return True
+
+    def _terminal_status_proves_safe(
+        self,
+        session: ShadowSession,
+        projected: dict,
+    ) -> bool:
+        if (
+            projected['authority_valid'] is not False
+            or projected['session_id'] is not None
+        ):
+            return False
+        dispatch = projected.get('dispatch')
+        if (
+            not isinstance(dispatch, dict)
+            or dispatch['stop_acknowledged'] is not True
+            or dispatch['stop_queue_depth'] != 0
+            or dispatch['io_inflight'] is not None
+        ):
+            return False
+        if projected['boot_id'] == session.boot_id:
+            return (
+                projected['epoch'] == session.epoch
+                and dispatch['state'] == 'safe_revoked'
+            )
+        return (
+            projected['state'] == 'idle'
+            and dispatch['state'] == 'safe_unarmed'
+        )
+
+    async def _cleanup_terminal_runtime(self, session_id: str) -> None:
+        if session_id not in self._terminal_cleanup_done:
+            raise RuntimeError('terminal cleanup requires acknowledged safety proof')
+        if any(
+            guard.session_id == session_id
+            for guard in self._authority_guards.values()
+        ):
+            raise RuntimeError('terminal cleanup requires durable guard deletion')
+        self._pinned_targets.pop(session_id, None)
+        self._signaling_sources.pop(session_id, None)
+        self._driver_lease_seconds.pop(session_id, None)
+        retained = await self.manager.retained_session_ids()
+        retained.update(self._command_claims)
+        retained.update(self._release_reconcile_tasks)
+        for mapping in (
+            self._driver_snapshots,
+            self._driver_snapshot_revisions,
+            self._heartbeat_health,
+            self._release_results,
+        ):
+            for stale_id in set(mapping) - retained:
+                mapping.pop(stale_id, None)
+        self._terminal_cleanup_done.intersection_update(retained)
+        claim = self._command_claims.get(session_id)
+        if (
+            claim is not None
+            and await self.command_broker.release_authority(claim[0], claim[1])
+        ):
+            self._command_claims.pop(session_id, None)
+        reconcile = self._release_reconcile_tasks.pop(session_id, None)
+        if reconcile is not None and reconcile is not asyncio.current_task():
+            reconcile.cancel()
+            await asyncio.gather(reconcile, return_exceptions=True)
+
+    def _schedule_release_reconcile(self, session: ShadowSession) -> None:
+        if self._stopping:
+            return
+        existing = self._release_reconcile_tasks.get(session.id)
+        if existing is not None and not existing.done():
+            return
+        task = asyncio.create_task(
+            self._reconcile_unconfirmed_release(session),
+            name=f'teleop-release-reconcile-{session.id}',
+        )
+        self._release_reconcile_tasks[session.id] = task
+
+        def forget(done: asyncio.Task) -> None:
+            if self._release_reconcile_tasks.get(session.id) is done:
+                self._release_reconcile_tasks.pop(session.id, None)
+
+        task.add_done_callback(forget)
+
+    async def _finalize_or_quarantine_release(
+        self,
+        session: ShadowSession,
+        acknowledged: bool,
+    ) -> None:
+        if acknowledged and await self._delete_authority_guard_after_safe(session):
+            self._terminal_cleanup_done.add(session.id)
+            await self._cleanup_terminal_runtime(session.id)
+        else:
+            self._schedule_release_reconcile(session)
+
+    async def _reconcile_unconfirmed_release(self, session: ShadowSession) -> None:
+        lease_seconds = self._driver_lease_seconds.get(
+            session.id,
+            _MAX_DRIVER_LEASE_SECONDS,
+        )
+        retry_seconds = min(
+            _MAX_DRIVER_LEASE_SECONDS,
+            max(_MIN_DRIVER_LEASE_SECONDS, lease_seconds),
+        ) + _MAX_HEARTBEAT_INTERVAL_SECONDS
+        while not self._stopping and session.id in self._command_claims:
+            await asyncio.sleep(retry_seconds)
+            lock = self._session_lock(session.id)
+            async with lock:
+                if self._stopping or session.id not in self._command_claims:
+                    return
+                if await self._best_effort_release(session):
+                    self._release_results[session.id] = True
+                    if not await self._delete_authority_guard_after_safe(session):
+                        continue
+                    self._terminal_cleanup_done.add(session.id)
+                    await audit.emit(
+                        'teleop.session.release_reconciled',
+                        session_id=session.id,
+                        robot_id=session.robot_id,
+                        principal_id=session.principal_id,
+                        source='core',
+                        decision='released',
+                        reason='driver_release_retry_acknowledged',
+                    )
+                    await self._cleanup_terminal_runtime(session.id)
+                    return
+                try:
+                    raw = await self._call(
+                        session.driver_id,
+                        'status',
+                        timeout_seconds=0.5,
+                        pinned_target=self._pinned_targets.get(session.id),
+                    )
+                    projected, _ = _project_driver_snapshot(
+                        raw,
+                        driver_id=session.driver_id,
+                        robot_id=session.robot_id,
+                        capability_digest=session.capability_digest,
+                        action='status',
+                        expected_mode=session.mode,
+                        expected_profile_id=session.profile_id,
+                        expected_capabilities=session.capabilities,
+                        allow_stop_pending=True,
+                    )
+                except Exception:  # noqa: BLE001, S112 -- quarantine stays closed
+                    continue
+                if self._terminal_status_proves_safe(session, projected):
+                    try:
+                        self._store_driver_snapshot(
+                            session,
+                            projected,
+                            allow_restart=True,
+                        )
+                    except TeleopServiceError:
+                        continue
+                    self._release_results[session.id] = True
+                    if not await self._delete_authority_guard_after_safe(session):
+                        continue
+                    self._terminal_cleanup_done.add(session.id)
+                    await audit.emit(
+                        'teleop.session.release_reconciled',
+                        session_id=session.id,
+                        robot_id=session.robot_id,
+                        principal_id=session.principal_id,
+                        source='core',
+                        decision='released',
+                        reason='driver_authority_observed_inactive',
+                    )
+                    await self._cleanup_terminal_runtime(session.id)
+                    return
+
+    async def _cancel_heartbeat(
+        self,
+        session_id: str,
+        *,
+        origin_task: asyncio.Task | None,
+    ) -> None:
+        task = self._heartbeat_tasks.pop(session_id, None)
+        if task is not None and task is not origin_task:
+            task.cancel()
+            await asyncio.gather(task, return_exceptions=True)
+
+    async def _await_safety_completion(self, task: asyncio.Task):
+        """Finish Driver revocation even when the initiating request is cancelled."""
+
+        self._safety_tasks.add(task)
+        cancelled = False
+        try:
+            while True:
+                try:
+                    result = await asyncio.shield(task)
+                    break
+                except asyncio.CancelledError:
+                    cancelled = True
+                    if task.done():
+                        result = task.result()
+                        break
+            if cancelled:
+                raise asyncio.CancelledError
+            return result
+        finally:
+            if task.done():
+                self._safety_tasks.discard(task)
+
+    async def _drain_safety_tasks(self) -> None:
+        current = asyncio.current_task()
+        while True:
+            pending = [
+                task for task in self._safety_tasks
+                if task is not current and not task.done()
+            ]
+            if not pending:
+                return
+            await asyncio.gather(*pending, return_exceptions=True)
+
+    async def _prepare_with_reconcile(self, session: ShadowSession) -> dict:
+        prepare_action = PREPARE_ACTION_BY_MODE[session.mode]
+        try:
+            return await self._call(
+                session.driver_id,
+                prepare_action,
+                {
+                    'session_id': session.id,
+                    'epoch': session.epoch,
+                    'fence': session.fence,
+                },
+            )
+        except mcp_client.TrustedShadowTransportError as error:
+            ambiguous = error.code in {'timeout', 'network_error'} or (
+                error.code == 'http_error'
+                and error.http_status is not None
+                and 500 <= error.http_status < 600
+            )
+            if not ambiguous:
+                raise
+            raw_status = await self._call(
+                session.driver_id,
+                'status',
+                pinned_target=self._pinned_targets.get(session.id),
+            )
+            _project_driver_snapshot(
+                raw_status,
+                driver_id=session.driver_id,
+                robot_id=session.robot_id,
+                capability_digest=session.capability_digest,
+                action=prepare_action,
+                session=session,
+            )
+            return raw_status
+
+    async def _audit_prepare_failure(self, session: ShadowSession, reason: str) -> None:
+        await audit.emit(
+            'teleop.session.prepare_failed',
+            session_id=session.id,
+            robot_id=session.robot_id,
+            principal_id=session.principal_id,
+            source='core',
+            decision='faulted',
+            reason=reason,
+        )
+
+    @staticmethod
+    def _identity(session: ShadowSession) -> dict:
+        return {
+            'boot_id': session.boot_id,
+            'session_id': session.id,
+            'epoch': session.epoch,
+            'fence': session.fence,
+        }
+
+    @staticmethod
+    def _heartbeat_timeout(driver_lease_seconds: float) -> float:
+        del driver_lease_seconds
+        return 0.25
+
+    def _start_heartbeat(self, session: ShadowSession) -> None:
+        old = self._heartbeat_tasks.pop(session.id, None)
+        if old is not None:
+            old.cancel()
+        task = asyncio.create_task(
+            self._heartbeat_loop(session.id, session.operation_generation),
+            name=f'teleop-heartbeat-{session.id}',
+        )
+        self._heartbeat_tasks[session.id] = task
+        task.add_done_callback(
+            lambda completed, session_id=session.id, generation=session.operation_generation: (
+                self._heartbeat_done(session_id, generation, completed)
+            )
+        )
+
+    def _heartbeat_done(
+        self,
+        session_id: str,
+        generation: int,
+        task: asyncio.Task,
+    ) -> None:
+        if self._heartbeat_tasks.get(session_id) is task:
+            self._heartbeat_tasks.pop(session_id, None)
+        if not task.cancelled():
+            error = task.exception()
+            if error is not None and not self._stopping:
+                fault_task = asyncio.create_task(
+                    self._fault_crashed_worker(session_id, generation),
+                    name=f'teleop-heartbeat-fault-{session_id}',
+                )
+                self._supervisor_tasks.add(fault_task)
+                fault_task.add_done_callback(self._supervisor_done)
+
+    def _supervisor_done(self, task: asyncio.Task) -> None:
+        self._supervisor_tasks.discard(task)
+        if not task.cancelled():
+            task.exception()
+
+    async def _fault_crashed_worker(self, session_id: str, generation: int) -> None:
+        session = await self.manager.get_current(session_id)
+        if session is not None and session.operation_generation == generation:
+            await self._fault_session(session, 'heartbeat_supervisor_error')
+
+    async def _heartbeat_loop(self, session_id: str, generation: int) -> None:
+        lease_seconds = self._driver_lease_seconds[session_id]
+        interval = min(_MAX_HEARTBEAT_INTERVAL_SECONDS, lease_seconds / 4.0)
+        # Schedule transport work against the event loop's clock.  The
+        # injectable monotonic clock remains the authority for lease-age
+        # decisions, but it may be deliberately frozen or advanced in tests.
+        # Mixing that clock with ``asyncio.sleep`` makes the second and third
+        # heartbeat drift to 2x/3x the intended interval when it is frozen.
+        loop = asyncio.get_running_loop()
+        next_tick = loop.time() + interval
+        while not self._stopping:
+            await asyncio.sleep(max(0.0, next_tick - loop.time()))
+            next_tick += interval
+            session = await self.manager.get_current(session_id)
+            if session is None or session.operation_generation != generation:
+                return
+            health = self._heartbeat_health.get(session_id)
+            if (
+                health is None
+                or self._monotonic() - health.last_confirmed_monotonic
+                >= lease_seconds * 0.75
+            ):
+                await self._fault_session(session, 'driver_heartbeat_lost')
+                return
+            try:
+                # Authority heartbeats deliberately do not share the operator
+                # operation lock.  Slow read-only status, Pause, or HOLD calls
+                # must never consume the Driver's short watchdog budget.
+                current = await self.manager.get_current(session_id)
+                if current is None or current.operation_generation != generation:
+                    return
+                snapshot_revision = self._driver_snapshot_revisions.get(
+                    session_id,
+                    0,
+                )
+                raw = await self._call(
+                    current.driver_id,
+                    'heartbeat',
+                    self._identity(current),
+                    timeout_seconds=self._heartbeat_timeout(lease_seconds),
+                )
+                projected, _ = _project_driver_snapshot(
+                    raw,
+                    driver_id=current.driver_id,
+                    robot_id=current.robot_id,
+                    capability_digest=current.capability_digest,
+                    action='heartbeat',
+                    session=current,
+                    allow_stop_pending=True,
+                )
+                self._store_driver_snapshot(
+                    current,
+                    projected,
+                    stale_after_revision=snapshot_revision,
+                )
+                if projected['state'] == 'fault':
+                    await self._fault_session(current, 'driver_dispatch_fault')
+                    return
+                if projected['dispatch']['stop_acknowledged'] is not True:
+                    # A pending final-output stop is valid transitional data,
+                    # not evidence that the safety path has completed.
+                    continue
+                # A concurrently completed Status/Pause may make this snapshot
+                # stale for display, but the validated heartbeat still renewed
+                # the Driver authority lease and therefore proves liveness.
+                await self._record_heartbeat_success(current)
+            except mcp_client.TrustedShadowTransportError as error:
+                if (
+                    error.code == 'rpc_error'
+                    and error.rpc_data_code in _TERMINAL_RPC_CODES
+                    and await self._capture_terminal_fault_after_heartbeat(
+                        current,
+                        snapshot_revision=snapshot_revision,
+                    )
+                ):
+                    return
+                if await self._record_heartbeat_failure(current, error):
+                    return
+            except TeleopServiceError as error:
+                await self._fault_session(session, error.code)
+                return
+
+    async def _record_heartbeat_success(self, session: ShadowSession) -> None:
+        health = self._heartbeat_health[session.id]
+        recovered = health.state == 'degraded'
+        health.last_confirmed_monotonic = self._monotonic()
+        health.last_confirmed_at = self._wall_clock()
+        health.consecutive_failures = 0
+        health.state = 'healthy'
+        if recovered:
+            await audit.emit(
+                'teleop.driver.recovered',
+                session_id=session.id,
+                robot_id=session.robot_id,
+                principal_id=session.principal_id,
+                source='core',
+                decision='healthy',
+                reason='heartbeat_recovered',
+            )
+
+    async def _capture_terminal_fault_after_heartbeat(
+        self,
+        session: ShadowSession,
+        *,
+        snapshot_revision: int,
+    ) -> bool:
+        """Preserve one strict terminal fault snapshot before fail-safe cleanup."""
+
+        target = self._pinned_targets.get(session.id)
+        if target is None:
+            return False
+        try:
+            raw = await self._call(
+                session.driver_id,
+                'status',
+                timeout_seconds=0.5,
+                pinned_target=target,
+            )
+            projected, _ = _project_driver_snapshot(
+                raw,
+                driver_id=session.driver_id,
+                robot_id=session.robot_id,
+                capability_digest=session.capability_digest,
+                action='status',
+                session=session,
+                allow_stop_pending=True,
+            )
+        except Exception:  # noqa: BLE001 -- fallback keeps the original fail-closed path
+            return False
+        if projected['state'] != 'fault':
+            return False
+
+        lock = self._session_lock(session.id)
+        async with lock:
+            current = await self.manager.get_current(session.id)
+            if (
+                current is None
+                or current is not session
+                or current.operation_generation != session.operation_generation
+            ):
+                return True
+            try:
+                stored = self._store_driver_snapshot(
+                    session,
+                    projected,
+                    stale_after_revision=snapshot_revision,
+                )
+            except TeleopServiceError:
+                return False
+            if not stored:
+                return False
+            await self._fault_session_locked(session, 'driver_dispatch_fault')
+            return True
+
+    async def _record_heartbeat_failure(
+        self,
+        session: ShadowSession,
+        error: mcp_client.TrustedShadowTransportError,
+    ) -> bool:
+        health = self._heartbeat_health[session.id]
+        retryable = error.code in _RETRYABLE_TRANSPORT_CODES or (
+            error.code == 'http_error'
+            and error.http_status is not None
+            and 500 <= error.http_status < 600
+        )
+        if error.code == 'rpc_error' and error.rpc_data_code in _TERMINAL_RPC_CODES:
+            retryable = False
+        if not retryable:
+            await self._fault_session(session, self._transport_service_error(error).code)
+            return True
+
+        health.consecutive_failures += 1
+        if health.state != 'degraded':
+            health.state = 'degraded'
+            await audit.emit(
+                'teleop.driver.degraded',
+                session_id=session.id,
+                robot_id=session.robot_id,
+                principal_id=session.principal_id,
+                source='core',
+                decision='retrying',
+                reason=error.code,
+            )
+        lease_seconds = self._driver_lease_seconds[session.id]
+        acknowledgement_age = self._monotonic() - health.last_confirmed_monotonic
+        if health.consecutive_failures >= 3 or acknowledgement_age >= lease_seconds * 0.75:
+            await self._fault_session(session, 'driver_heartbeat_lost')
+            return True
+        return False
+
+    async def _fault_session(
+        self,
+        session: ShadowSession,
+        reason: str,
+        *,
+        operation_locked: bool = False,
+    ) -> None:
+        if operation_locked:
+            await self._fault_session_locked(session, reason)
+            return
+        lock = self._session_lock(session.id)
+        async with lock:
+            await self._fault_session_locked(session, reason)
+
+    async def _fault_session_locked(self, session: ShadowSession, reason: str) -> None:
+        faulted = await self.manager.fault(session.id, session.operation_generation)
+        if faulted is None:
+            return
+        await self.capture_manager.revoke_for_session(session.id, 'session_faulted')
+        origin_task = asyncio.current_task()
+        cleanup = asyncio.create_task(
+            self._complete_fault_cleanup(faulted, reason, origin_task=origin_task),
+            name=f'teleop-fault-cleanup-{session.id}',
+        )
+        await self._await_safety_completion(cleanup)
+
+    async def _complete_fault_cleanup(
+        self,
+        session: ShadowSession,
+        reason: str,
+        *,
+        origin_task: asyncio.Task | None,
+    ) -> None:
+        await self._cancel_heartbeat(session.id, origin_task=origin_task)
+        await self._update_command_claim(session, 'faulted_cleanup')
+        health = self._heartbeat_health.get(session.id)
+        if health is not None:
+            health.state = 'faulted'
+        acknowledged = await self._best_effort_soft_stop_and_release(session)
+        await audit.emit(
+            'teleop.session.faulted',
+            session_id=session.id,
+            robot_id=session.robot_id,
+            principal_id=session.principal_id,
+            source='core',
+            decision='faulted',
+            reason=reason,
+        )
+        await self._finalize_or_quarantine_release(session, acknowledged)
+
+    async def _best_effort_soft_stop_and_release(self, session: ShadowSession) -> bool:
+        try:
+            await self._call(
+                session.driver_id,
+                'soft_stop',
+                self._identity(session),
+                timeout_seconds=0.25,
+            )
+        except Exception:  # noqa: BLE001, S110 -- cleanup must be fail-safe
+            pass
+        return await self._best_effort_release(session)
+
+    async def _best_effort_release(self, session: ShadowSession) -> bool:
+        try:
+            previous = self._driver_snapshots.get(session.id)
+            baseline_generation = (
+                previous['dispatch']['generation']
+                if isinstance(previous, dict)
+                else None
+            )
+            raw = await self._call(
+                session.driver_id,
+                'release',
+                self._identity(session),
+                timeout_seconds=0.5,
+            )
+            projected, _ = _project_driver_snapshot(
+                raw,
+                driver_id=session.driver_id,
+                robot_id=session.robot_id,
+                capability_digest=session.capability_digest,
+                action='release',
+                session=session,
+            )
+            self._store_driver_snapshot(
+                session,
+                projected,
+                minimum_generation_exclusive=baseline_generation,
+            )
+            return True
+        except Exception:  # noqa: BLE001 -- cleanup reports only acknowledgement
+            return False
+
+    async def create_capture_pairing(
+        self,
+        principal_id: str,
+        client_id: str,
+        *,
+        label: str,
+    ) -> CapturePairingResult:
+        pairing = await self.capture_manager.create_pairing(
+            principal_id,
+            client_id,
+            label=label,
+        )
+        await audit.emit(
+            'teleop.capture.pairing_created',
+            principal_id=principal_id,
+            source='api',
+            decision='created',
+            reason='operator_pairing_request',
+            details={'pairing_id': pairing.pairing_id},
+        )
+        return pairing
+
+    async def list_captures(self, principal_id: str) -> list[dict]:
+        return await self.capture_manager.list_for_supervisor(principal_id)
+
+    async def revoke_capture(self, capture_id: str, principal_id: str) -> dict:
+        capture = await self.capture_manager.revoke_capture(capture_id, principal_id)
+        await audit.emit(
+            'teleop.capture.revoked',
+            session_id=(capture.get('assignment') or {}).get('session_id', ''),
+            principal_id=principal_id,
+            source='api',
+            decision='revoked',
+            reason='operator_revoked',
+            details={'capture_id': capture_id},
+        )
+        return capture
+
+    async def attach_capture(
+        self,
+        session_id: str,
+        principal_id: str,
+        client_id: str,
+        *,
+        capture_id: str,
+        mode: str,
+        profile_id: str,
+        capability_digest: str,
+    ) -> CaptureAssignment:
+        lock = self._session_lock(session_id)
+        async with lock:
+            session = await self.manager.get_authorized(
+                session_id,
+                principal_id,
+                owner=False,
+                client_id=client_id,
+                require_client=True,
+            )
+            if (
+                session.state != 'active'
+                or (session.mode == LIVE_MODE and not session.live_confirmed)
+            ):
+                raise SessionStateConflict(session_id)
+            if (
+                mode != session.mode
+                or profile_id != session.profile_id
+                or capability_digest != session.capability_digest
+            ):
+                raise TeleopServiceError('capture_contract_mismatch', 409)
+            source = self._signaling_sources.get(session.id)
+            expected_source = ('capture', capture_id)
+            if source is not None and source != expected_source:
+                raise TeleopServiceError('signaling_source_conflict', 409)
+            assignment = await self.capture_manager.attach(
+                capture_id=capture_id,
+                principal_id=principal_id,
+                session_id=session.id,
+                operation_generation=session.operation_generation,
+                mode=session.mode,
+                profile_id=session.profile_id,
+                capability_digest=session.capability_digest,
+                capabilities=session.capabilities,
+                effectors=session.effectors,
+            )
+            # Source ownership belongs to the enrolled capture device, not to
+            # one disposable assignment. A signaling failure fails this whole
+            # session closed; the stable capture id only prevents another
+            # device or a direct browser from racing the current assignment.
+            if source is not None and source != expected_source:
+                await self.capture_manager.revoke_for_session(
+                    session.id,
+                    'signaling_source_conflict',
+                )
+                raise TeleopServiceError('signaling_source_conflict', 409)
+            self._signaling_sources[session.id] = expected_source
+        await audit.emit(
+            'teleop.capture.attached',
+            session_id=session.id,
+            robot_id=session.robot_id,
+            principal_id=principal_id,
+            source='api',
+            decision='attached',
+            reason='operator_start_capture',
+            details={
+                'capture_id': capture_id,
+                'assignment_id': assignment.id,
+                'mode': assignment.mode,
+            },
+        )
+        return assignment
+
+    async def connect_capture_with_pairing(
+        self,
+        pairing_id: str,
+        pairing_code: str,
+        *,
+        capture_protocol: str,
+        frame_protocol: str,
+        client_kind: str,
+        app_version: str,
+    ) -> CaptureConnection:
+        return await self.capture_manager.connect_with_pairing(
+            pairing_id,
+            pairing_code,
+            capture_protocol=capture_protocol,
+            frame_protocol=frame_protocol,
+            client_kind=client_kind,
+            app_version=app_version,
+        )
+
+    async def connect_capture_with_credential(
+        self,
+        capture_id: str,
+        capture_credential: str,
+        *,
+        capture_protocol: str,
+        frame_protocol: str,
+        client_kind: str,
+        app_version: str,
+    ) -> CaptureConnection:
+        return await self.capture_manager.connect_with_credential(
+            capture_id,
+            capture_credential,
+            capture_protocol=capture_protocol,
+            frame_protocol=frame_protocol,
+            client_kind=client_kind,
+            app_version=app_version,
+        )
+
+    async def disconnect_capture(self, capture_id: str, connection_id: str) -> None:
+        lost_assignment = await self.capture_manager.disconnect(
+            capture_id,
+            connection_id,
+        )
+        await self._fail_close_capture_assignment_loss(lost_assignment)
+
+    async def capture_presence(
+        self,
+        capture_id: str,
+        connection_id: str,
+        *,
+        state: str,
+        assignment_id: str | None,
+    ) -> dict:
+        presence, lost_assignment = await self.capture_manager.update_presence(
+            capture_id,
+            connection_id,
+            state=state,
+            assignment_id=assignment_id,
+        )
+        await self._fail_close_capture_assignment_loss(lost_assignment)
+        return presence
+
+    async def expire_capture_connection(
+        self,
+        capture_id: str,
+        connection_id: str,
+    ) -> bool:
+        stale, lost_assignment = await self.capture_manager.expire_stale_connection(
+            capture_id,
+            connection_id,
+        )
+        await self._fail_close_capture_assignment_loss(lost_assignment)
+        return stale
+
+    async def _fail_close_capture_assignment_loss(
+        self,
+        lost_assignment: CaptureAssignment | None,
+    ) -> None:
+        if lost_assignment is None:
+            return
+        cleanup = asyncio.create_task(
+            self._complete_capture_assignment_loss(lost_assignment),
+            name=(
+                'teleop-capture-loss-'
+                f'{lost_assignment.session_id}-{lost_assignment.generation}'
+            ),
+        )
+        await self._await_safety_completion(cleanup)
+
+    async def _complete_capture_assignment_loss(
+        self,
+        lost_assignment: CaptureAssignment,
+    ) -> None:
+        reason = lost_assignment.failure_code
+        if (
+            lost_assignment.state != 'revoked'
+            or reason not in _CAPTURE_FAIL_CLOSE_REASONS
+        ):
+            return
+
+        session: ShadowSession | None = None
+        held: ShadowSession | None = None
+        lock = self._session_lock(lost_assignment.session_id)
+        try:
+            async with lock:
+                if not await self.capture_manager.assignment_loss_is_pending(
+                    lost_assignment,
+                ):
+                    return
+                session = await self.manager.get_current(lost_assignment.session_id)
+                if (
+                    session is None
+                    or session.state != 'active'
+                    or session.operation_generation
+                    != lost_assignment.operation_generation
+                    or session.mode != lost_assignment.mode
+                    or session.profile_id != lost_assignment.profile_id
+                    or session.capability_digest != lost_assignment.capability_digest
+                    or self._signaling_sources.get(session.id)
+                    != ('capture', lost_assignment.capture_id)
+                ):
+                    return
+                try:
+                    held = await self._soft_stop_locked(
+                        session,
+                        session.principal_id,
+                        session.client_id,
+                        owner=False,
+                    )
+                except (TeleopServiceError, SessionStateConflict):
+                    # `_soft_stop_locked` faults the still-current session whenever
+                    # Driver HOLD cannot be proven. Do not turn a safety-complete
+                    # WSS disconnect into a second external error path.
+                    return
+        finally:
+            await self.capture_manager.complete_assignment_loss(lost_assignment)
+
+        assert session is not None and held is not None
+        await audit.emit(
+            'teleop.capture.assignment_lost',
+            session_id=session.id,
+            robot_id=session.robot_id,
+            principal_id=session.principal_id,
+            source='capture-wss',
+            decision='hold',
+            reason=reason,
+            details={
+                'assignment_id': lost_assignment.id,
+                'assignment_generation': lost_assignment.generation,
+                'capture_id': lost_assignment.capture_id,
+                'state': held.state,
+            },
+        )
+
+    async def capture_signaling_offer(
+        self,
+        capture_id: str,
+        connection_id: str,
+        assignment_id: str,
+        offer: dict,
+    ) -> dict:
+        """Consume one capture offer without giving the device session authority."""
+
+        assignment = await self.capture_manager.claim_offer(
+            capture_id,
+            connection_id,
+            assignment_id,
+        )
+        session: ShadowSession | None = None
+        try:
+            signaling_lock = self._signaling_lock(assignment.session_id)
+            async with signaling_lock:
+                lock = self._session_lock(assignment.session_id)
+                async with lock:
+                    session = await self.manager.get_current(assignment.session_id)
+                    if (
+                        session is None
+                        or session.state not in _LIVE_SIGNALING_STATES
+                        or session.operation_generation != assignment.operation_generation
+                        or session.mode != assignment.mode
+                        or session.profile_id != assignment.profile_id
+                        or session.capability_digest != assignment.capability_digest
+                        or (session.mode == LIVE_MODE and not session.live_confirmed)
+                    ):
+                        raise SessionStateConflict(assignment.session_id)
+                    if self._signaling_sources.get(session.id) != (
+                        'capture', capture_id,
+                    ):
+                        raise TeleopServiceError('signaling_source_conflict', 409)
+                    offer_sdp = _validated_signaling_offer_sdp(offer)
+                    target = self._pinned_targets.get(session.id)
+                    if (
+                        target is None
+                        or target.mcp_id != session.driver_id
+                        or target.capability_digest != session.capability_digest
+                    ):
+                        raise TeleopServiceError('driver_not_ready', 503)
+                    operation_generation = session.operation_generation
+                    ticket = _signaling_ticket(
+                        session,
+                        offer_sdp,
+                        wall_now=self._wall_clock(),
+                    )
+
+                try:
+                    raw_answer = await self._signal_offer(
+                        session,
+                        offer,
+                        ticket,
+                        target,
+                    )
+                except mcp_client.TrustedShadowTransportError as error:
+                    raise self._transport_service_error(error) from None
+                answer = _project_signaling_answer(raw_answer, session, ticket)
+
+                async with lock:
+                    current = await self.manager.get_current(session.id)
+                    assignment_current = await self.capture_manager.assignment_is_current(
+                        capture_id,
+                        connection_id,
+                        assignment.id,
+                        session_id=session.id,
+                        operation_generation=operation_generation,
+                    )
+                    if (
+                        current is not session
+                        or current.operation_generation != operation_generation
+                        or current.state not in _LIVE_SIGNALING_STATES
+                        or self._pinned_targets.get(session.id) != target
+                        or not assignment_current
+                    ):
+                        raise SessionStateConflict(session.id)
+                    if not await self.capture_manager.complete_offer(
+                        capture_id,
+                        connection_id,
+                        assignment.id,
+                    ):
+                        raise SessionStateConflict(session.id)
+        except BaseException as error:
+            lost_assignment = await self.capture_manager.fail_offer(
+                capture_id,
+                assignment.id,
+            )
+            await self._fail_close_capture_assignment_loss(lost_assignment)
+            if isinstance(error, (CaptureError, TeleopServiceError, SessionStateConflict)):
+                raise
+            if isinstance(error, asyncio.CancelledError):
+                raise
+            raise TeleopServiceError('capture_signaling_failed', 502) from None
+
+        assert session is not None
+        await audit.emit(
+            'teleop.capture.signaling_offer_accepted',
+            session_id=session.id,
+            robot_id=session.robot_id,
+            principal_id=session.principal_id,
+            source='capture-wss',
+            decision='accepted',
+            reason='capture_assignment_authorized',
+            details={
+                'capture_id': capture_id,
+                'assignment_id': assignment.id,
+                'mode': session.mode,
+            },
+        )
+        return answer
+
+    async def signaling_offer(
+        self,
+        session_id: str,
+        principal_id: str,
+        client_id: str,
+        offer: dict,
+    ) -> dict:
+        """Negotiate RTC without exposing or renewing session authority."""
+
+        session: ShadowSession | None = None
+        failure: Exception | None = None
+        try:
+            # Serialize competing offers without making a network round-trip
+            # part of the safety-operation critical section. Pause/HOLD/release
+            # must always be able to preempt a slow or abandoned offer.
+            signaling_lock = self._signaling_lock(session_id)
+            async with signaling_lock:
+                lock = self._session_lock(session_id)
+                async with lock:
+                    # Signaling has no owner override: both the human principal
+                    # and per-tab client UUID must match the reservation.
+                    session = await self.manager.get_authorized(
+                        session_id,
+                        principal_id,
+                        owner=False,
+                        client_id=client_id,
+                        require_client=True,
+                    )
+                    if (
+                        session.mode not in {SHADOW_MODE, LIVE_MODE}
+                        or session.state not in _LIVE_SIGNALING_STATES
+                        or (session.mode == LIVE_MODE and not session.live_confirmed)
+                    ):
+                        raise SessionStateConflict(session_id)
+                    source = self._signaling_sources.get(session.id)
+                    expected_source = ('direct', client_id)
+                    if source is not None and source != expected_source:
+                        raise TeleopServiceError('signaling_source_conflict', 409)
+                    offer_sdp = _validated_signaling_offer_sdp(offer)
+                    target = self._pinned_targets.get(session.id)
+                    if (
+                        target is None
+                        or target.mcp_id != session.driver_id
+                        or target.capability_digest != session.capability_digest
+                    ):
+                        raise TeleopServiceError('driver_not_ready', 503)
+                    operation_generation = session.operation_generation
+                    ticket = _signaling_ticket(
+                        session,
+                        offer_sdp,
+                        wall_now=self._wall_clock(),
+                    )
+                    self._signaling_sources[session.id] = expected_source
+
+                try:
+                    raw_answer = await self._signal_offer(
+                        session,
+                        offer,
+                        ticket,
+                        target,
+                    )
+                except mcp_client.TrustedShadowTransportError as error:
+                    raise self._transport_service_error(error) from None
+                answer = _project_signaling_answer(raw_answer, session, ticket)
+
+                # Re-enter the safety lock before returning the answer. This
+                # read does not renew the browser lease and rejects any offer
+                # preempted by expiry, Pause, HOLD, release, or target cleanup.
+                async with lock:
+                    current = await self.manager.get_current(session.id)
+                    if (
+                        current is not session
+                        or current.operation_generation != operation_generation
+                        or self._pinned_targets.get(session.id) != target
+                    ):
+                        raise SessionNotFound(session.id)
+                    if current.state not in _LIVE_SIGNALING_STATES:
+                        raise SessionStateConflict(session.id)
+        except (
+            SessionClientMismatch,
+            SessionForbidden,
+            SessionNotFound,
+            SessionStateConflict,
+            TeleopServiceError,
+        ) as error:
+            failure = error
+
+        if failure is not None:
+            reason = (
+                failure.code
+                if isinstance(failure, TeleopServiceError)
+                else 'session_client_mismatch'
+                if isinstance(failure, SessionClientMismatch)
+                else 'session_forbidden'
+                if isinstance(failure, SessionForbidden)
+                else 'session_state_conflict'
+                if isinstance(failure, SessionStateConflict)
+                else 'session_not_found'
+                if isinstance(failure, SessionNotFound)
+                else 'signaling_failed'
+            )
+            await audit.emit(
+                'teleop.signaling.offer.rejected',
+                session_id=session_id,
+                robot_id=session.robot_id if session is not None else '',
+                principal_id=principal_id,
+                source='api',
+                decision='rejected',
+                reason=reason,
+            )
+            raise failure
+
+        assert session is not None
+        await audit.emit(
+            'teleop.signaling.offer.accepted',
+            session_id=session.id,
+            robot_id=session.robot_id,
+            principal_id=principal_id,
+            source='api',
+            decision='accepted',
+            reason='rtc_offer_authorized',
+            details={'mode': session.mode, 'answer_type': 'answer'},
+        )
+        return answer
+
+    async def heartbeat(
+        self,
+        session_id: str,
+        principal_id: str,
+        client_id: str,
+    ) -> ShadowSession:
+        """Renew only the browser → Core ownership lease.
+
+        Owners deliberately cannot renew another operator's session.
+        """
+
+        return await self.manager.heartbeat(
+            session_id,
+            principal_id,
+            client_id,
+            owner=False,
+        )
+
+    async def pause(
+        self,
+        session_id: str,
+        principal_id: str,
+        client_id: str,
+        *,
+        owner: bool,
+    ) -> ShadowSession:
+        lock = self._session_lock(session_id)
+        async with lock:
+            session = await self.manager.get_authorized(
+                session_id,
+                principal_id,
+                owner=owner,
+                client_id=client_id,
+                require_client=True,
+            )
+            if session.state == 'awaiting_confirmation':
+                raise SessionStateConflict(session_id)
+            await self.capture_manager.revoke_for_session(session.id, 'operator_pause')
+            if session.state == 'paused':
+                return session
+            baseline_generation = self._driver_snapshots[
+                session.id
+            ]['dispatch']['generation']
+            try:
+                raw = await self._call(
+                    session.driver_id,
+                    'pause',
+                    self._identity(session),
+                    timeout_seconds=0.5,
+                )
+            except asyncio.CancelledError:
+                cleanup = asyncio.create_task(
+                    self._fault_session(
+                        session,
+                        'driver_pause_unconfirmed',
+                        operation_locked=True,
+                    ),
+                    name=f'teleop-cancelled-pause-{session.id}',
+                )
+                await self._await_safety_completion(cleanup)
+                raise
+            except mcp_client.TrustedShadowTransportError as error:
+                service_error = self._transport_service_error(error)
+                await self._fault_session(
+                    session,
+                    'driver_pause_unconfirmed',
+                    operation_locked=True,
+                )
+                raise service_error from None
+            try:
+                projected, _ = _project_driver_snapshot(
+                    raw,
+                    driver_id=session.driver_id,
+                    robot_id=session.robot_id,
+                    capability_digest=session.capability_digest,
+                    action='pause',
+                    session=session,
+                )
+                self._store_driver_snapshot(
+                    session,
+                    projected,
+                    minimum_generation_exclusive=baseline_generation,
+                )
+            except Exception:  # noqa: BLE001 -- an unconfirmed Pause must revoke
+                await self._fault_session(
+                    session,
+                    'driver_pause_unconfirmed',
+                    operation_locked=True,
+                )
+                raise TeleopServiceError('driver_pause_rejected', 502) from None
+            paused = await self.manager.pause(
+                session.id,
+                principal_id,
+                client_id,
+                owner=owner,
+            )
+            await self._update_command_claim(paused, 'paused')
+        await audit.emit(
+            'teleop.session.paused',
+            session_id=session.id,
+            robot_id=session.robot_id,
+            principal_id=principal_id,
+            source='api',
+            decision='paused',
+            reason='operator_pause',
+        )
+        return paused
+
+    async def soft_stop(
+        self,
+        session_id: str,
+        principal_id: str,
+        client_id: str,
+        *,
+        owner: bool,
+    ) -> ShadowSession:
+        lock = self._session_lock(session_id)
+        async with lock:
+            session = await self.manager.get_authorized(
+                session_id,
+                principal_id,
+                owner=owner,
+                client_id=client_id,
+                require_client=True,
+            )
+            if session.state == 'awaiting_confirmation':
+                raise SessionStateConflict(session_id)
+            await self.capture_manager.revoke_for_session(session.id, 'operator_soft_stop')
+            if session.state == 'hold':
+                return session
+            held = await self._soft_stop_locked(
+                session,
+                principal_id,
+                client_id,
+                owner=owner,
+            )
+        await audit.emit(
+            'teleop.session.held',
+            session_id=session.id,
+            robot_id=session.robot_id,
+            principal_id=principal_id,
+            source='api',
+            decision='hold',
+            reason='operator_soft_stop',
+        )
+        return held
+
+    async def _soft_stop_locked(
+        self,
+        session: ShadowSession,
+        principal_id: str,
+        client_id: str,
+        *,
+        owner: bool,
+    ) -> ShadowSession:
+        """Prove Driver HOLD, or fault the still-current session fail-closed."""
+
+        try:
+            baseline_generation = self._driver_snapshots[
+                session.id
+            ]['dispatch']['generation']
+        except (KeyError, TypeError):
+            await self._fault_session(
+                session,
+                'driver_soft_stop_unconfirmed',
+                operation_locked=True,
+            )
+            raise TeleopServiceError('driver_soft_stop_rejected', 502) from None
+        try:
+            raw = await self._call(
+                session.driver_id,
+                'soft_stop',
+                self._identity(session),
+                timeout_seconds=0.5,
+            )
+        except asyncio.CancelledError:
+            cleanup = asyncio.create_task(
+                self._fault_session(
+                    session,
+                    'driver_soft_stop_unconfirmed',
+                    operation_locked=True,
+                ),
+                name=f'teleop-cancelled-soft-stop-{session.id}',
+            )
+            await self._await_safety_completion(cleanup)
+            raise
+        except mcp_client.TrustedShadowTransportError as error:
+            service_error = self._transport_service_error(error)
+            await self._fault_session(
+                session,
+                'driver_soft_stop_unconfirmed',
+                operation_locked=True,
+            )
+            raise service_error from None
+        try:
+            projected, _ = _project_driver_snapshot(
+                raw,
+                driver_id=session.driver_id,
+                robot_id=session.robot_id,
+                capability_digest=session.capability_digest,
+                action='soft_stop',
+                session=session,
+            )
+            self._store_driver_snapshot(
+                session,
+                projected,
+                minimum_generation_exclusive=baseline_generation,
+            )
+        except Exception:  # noqa: BLE001 -- an unconfirmed HOLD must revoke
+            await self._fault_session(
+                session,
+                'driver_soft_stop_unconfirmed',
+                operation_locked=True,
+            )
+            raise TeleopServiceError('driver_soft_stop_rejected', 502) from None
+        held = await self.manager.soft_stop(
+            session.id,
+            principal_id,
+            client_id,
+            owner=owner,
+        )
+        await self._update_command_claim(held, 'hold')
+        return held
+
+    async def release(
+        self,
+        session_id: str,
+        principal_id: str,
+        client_id: str,
+        *,
+        owner: bool,
+    ) -> tuple[ShadowSession, bool]:
+        lock = self._session_lock(session_id)
+        async with lock:
+            existing = await self.manager.get_authorized(
+                session_id,
+                principal_id,
+                owner=owner,
+                include_terminal=True,
+                client_id=client_id,
+                require_client=True,
+            )
+            await self.capture_manager.revoke_for_session(existing.id, 'operator_release')
+            if existing.state in {'expired', 'faulted'}:
+                return existing, False
+            if existing.state == 'released':
+                if self._release_results.get(existing.id) is True:
+                    return existing, self._release_results[existing.id]
+                # Recover an interrupted local terminalization.  The Driver's
+                # exact identity tuple makes this bounded retry idempotent.
+                released = existing
+            else:
+                released = await self.manager.release(
+                    session_id,
+                    principal_id,
+                    client_id,
+                    owner=owner,
+                )
+            if released.mode == LIVE_MODE and not released.live_confirmed:
+                await self._update_command_claim(released, 'releasing')
+                self._release_results[released.id] = True
+                self._terminal_cleanup_done.add(released.id)
+                await audit.emit(
+                    'teleop.session.released',
+                    session_id=released.id,
+                    robot_id=released.robot_id,
+                    principal_id=principal_id,
+                    source='api',
+                    decision='released',
+                    reason='unconfirmed_live_reservation_released',
+                    details={
+                        'state': 'released',
+                        'driver_contacted': False,
+                        'hardware_output': False,
+                    },
+                )
+                await self._cleanup_terminal_runtime(released.id)
+                return released, True
+            await self._update_command_claim(released, 'releasing')
+            origin_task = asyncio.current_task()
+            cleanup = asyncio.create_task(
+                self._complete_release_cleanup(
+                    released,
+                    principal_id,
+                    origin_task=origin_task,
+                ),
+                name=f'teleop-release-cleanup-{session_id}',
+            )
+            acknowledged = await self._await_safety_completion(cleanup)
+            return released, acknowledged
+
+    async def _complete_release_cleanup(
+        self,
+        released: ShadowSession,
+        principal_id: str,
+        *,
+        origin_task: asyncio.Task | None,
+    ) -> bool:
+        await self._cancel_heartbeat(released.id, origin_task=origin_task)
+        acknowledged = await self._best_effort_release(released)
+        self._release_results[released.id] = acknowledged
+        await audit.emit(
+            'teleop.session.released',
+            session_id=released.id,
+            robot_id=released.robot_id,
+            principal_id=principal_id,
+            source='api',
+            decision='released',
+            reason='operator_release',
+            details={'state': 'released', 'driver_acknowledged': acknowledged},
+        )
+        await self._finalize_or_quarantine_release(released, acknowledged)
+        return acknowledged
+
+    async def status(self, session_id: str, principal_id: str, *, owner: bool) -> dict:
+        lock = self._session_lock(session_id)
+        async with lock:
+            session = await self.manager.get_authorized(session_id, principal_id, owner=owner)
+            if session.state == 'awaiting_confirmation':
+                raise SessionStateConflict(session_id)
+            snapshot_revision = self._driver_snapshot_revisions.get(session.id, 0)
+            try:
+                raw = await self._call(
+                    session.driver_id,
+                    'status',
+                    timeout_seconds=0.5,
+                    pinned_target=self._pinned_targets.get(session.id),
+                )
+            except mcp_client.TrustedShadowTransportError as error:
+                raise self._transport_service_error(error) from None
+            try:
+                projected, lease_seconds = _project_driver_snapshot(
+                    raw,
+                    driver_id=session.driver_id,
+                    robot_id=session.robot_id,
+                    capability_digest=session.capability_digest,
+                    action='status',
+                    session=session,
+                    allow_stop_pending=True,
+                )
+            except Exception:  # noqa: BLE001 -- invalid authority status must revoke
+                await self._fault_session(
+                    session,
+                    'driver_session_lost',
+                    operation_locked=True,
+                )
+                raise TeleopServiceError('driver_session_lost', 409) from None
+            if projected['state'] == 'fault':
+                current = await self.manager.get_current(session.id)
+                if (
+                    current is not session
+                    or current.operation_generation != session.operation_generation
+                ):
+                    raise SessionNotFound(session.id)
+                try:
+                    self._store_driver_snapshot(
+                        session,
+                        projected,
+                        stale_after_revision=snapshot_revision,
+                    )
+                except TeleopServiceError:
+                    await self._fault_session(
+                        session,
+                        'driver_session_lost',
+                        operation_locked=True,
+                    )
+                    raise TeleopServiceError('driver_session_lost', 409) from None
+                self._driver_lease_seconds[session.id] = lease_seconds
+                await self._fault_session(
+                    session,
+                    'driver_dispatch_fault',
+                    operation_locked=True,
+                )
+                return self.public_session(session)
+            if (
+                projected['authority_valid'] is not True
+                or projected['session_id'] != session.id
+                or projected['epoch'] != session.epoch
+                or projected['boot_id'] != session.boot_id
+            ):
+                await self._fault_session(
+                    session,
+                    'driver_session_lost',
+                    operation_locked=True,
+                )
+                raise TeleopServiceError('driver_session_lost', 409)
+            current = await self.manager.get_current(session.id)
+            if (
+                current is not session
+                or current.operation_generation != session.operation_generation
+            ):
+                raise SessionNotFound(session.id)
+            try:
+                self._store_driver_snapshot(
+                    session,
+                    projected,
+                    stale_after_revision=snapshot_revision,
+                )
+            except TeleopServiceError:
+                await self._fault_session(
+                    session,
+                    'driver_session_lost',
+                    operation_locked=True,
+                )
+                raise TeleopServiceError('driver_session_lost', 409) from None
+            self._driver_lease_seconds[session.id] = lease_seconds
+            return self.public_session(session)
+
+    async def sessions_for(self, principal_id: str, *, owner: bool) -> list[dict]:
+        sessions = await self.manager.list_visible(principal_id, owner=owner)
+        return [self.public_session(session) for session in sessions]
+
+    async def session_for(
+        self,
+        session_id: str,
+        principal_id: str,
+        *,
+        owner: bool,
+        include_terminal: bool = True,
+    ) -> dict:
+        session = await self.manager.get_authorized(
+            session_id,
+            principal_id,
+            owner=owner,
+            include_terminal=include_terminal,
+        )
+        return self.public_session(session)
+
+    def public_session(self, session: ShadowSession) -> dict:
+        public = self.manager.public_dict(session)
+        public['driver'] = self._driver_snapshots.get(session.id)
+        health = self._heartbeat_health.get(session.id)
+        public['driver_heartbeat'] = health.public_dict() if health else {
+            'state': 'pending' if session.state == 'preparing' else 'stopped',
+            'last_confirmed_at': None,
+            'consecutive_failures': 0,
+        }
+        if session.fence in repr(public):
+            raise RuntimeError('teleop public projection contained private authority')
+        return public
+
+    async def _reaper_loop(self) -> None:
+        while not self._stopping:
+            try:
+                expired = await self.manager.expire_due()
+                for session in expired:
+                    lock = self._session_lock(session.id)
+                    async with lock:
+                        if session.id in self._terminal_cleanup_done:
+                            continue
+                        origin_task = asyncio.current_task()
+                        cleanup = asyncio.create_task(
+                            self._complete_expiry_cleanup(
+                                session,
+                                origin_task=origin_task,
+                            ),
+                            name=f'teleop-expiry-cleanup-{session.id}',
+                        )
+                        await self._await_safety_completion(cleanup)
+            except asyncio.CancelledError:
+                raise
+            except Exception:  # noqa: BLE001, S110 -- keep the safety reaper alive
+                pass
+            await asyncio.sleep(_REAPER_INTERVAL_SECONDS)
+
+    async def _complete_expiry_cleanup(
+        self,
+        session: ShadowSession,
+        *,
+        origin_task: asyncio.Task | None,
+    ) -> None:
+        await self.capture_manager.revoke_for_session(session.id, 'session_expired')
+        await self._cancel_heartbeat(session.id, origin_task=origin_task)
+        await self._update_command_claim(session, 'expired_cleanup')
+        if session.mode == LIVE_MODE and not session.live_confirmed:
+            await audit.emit(
+                'teleop.session.expired',
+                session_id=session.id,
+                robot_id=session.robot_id,
+                principal_id=session.principal_id,
+                source='core',
+                decision='expired',
+                reason='unconfirmed_live_reservation_expired',
+                details={'driver_contacted': False, 'hardware_output': False},
+            )
+            self._terminal_cleanup_done.add(session.id)
+            await self._cleanup_terminal_runtime(session.id)
+            return
+        acknowledged = await self._best_effort_soft_stop_and_release(session)
+        await audit.emit(
+            'teleop.session.expired',
+            session_id=session.id,
+            robot_id=session.robot_id,
+            principal_id=session.principal_id,
+            source='core',
+            decision='expired',
+            reason='browser_lease_expired',
+        )
+        await self._finalize_or_quarantine_release(session, acknowledged)
+
+
+coordinator = TeleopCoordinator()
+
+
+__all__ = [
+    'AcquireResult',
+    'SessionConflict',
+    'SessionForbidden',
+    'SessionNotFound',
+    'SessionStateConflict',
+    'TeleopCoordinator',
+    'TeleopServiceError',
+    'coordinator',
+]

--- a/agent-core/src/teleop/session_manager.py
+++ b/agent-core/src/teleop/session_manager.py
@@ -1,0 +1,654 @@
+from __future__ import annotations
+
+import asyncio
+import copy
+import math
+import os
+import re
+import secrets
+import threading
+import time
+import uuid
+from collections.abc import Callable
+
+import config
+from teleop.models import ShadowSession
+
+MIN_LEASE_SECONDS = 15.0
+MAX_LEASE_SECONDS = 120.0
+DEFAULT_LEASE_SECONDS = 15.0
+MAX_TERMINAL_SESSIONS = 256
+MAX_DRIVER_EPOCH = (1 << 63) - 2
+_TERMINAL_STATES = frozenset({'released', 'expired', 'faulted'})
+_PROFILE_ID_RE = re.compile(r'^[A-Za-z0-9][A-Za-z0-9_.:-]{0,127}$')
+_epoch_process_lock = threading.Lock()
+
+
+class SessionConflict(Exception):
+    def __init__(self, session: ShadowSession):
+        super().__init__(f'robot {session.robot_id} is controlled by {session.principal_id}')
+        self.session = session
+
+
+class SessionNotFound(Exception):
+    pass
+
+
+class SessionForbidden(Exception):
+    pass
+
+
+class SessionClientMismatch(SessionForbidden):
+    pass
+
+
+class SessionStateConflict(Exception):
+    pass
+
+
+class StaleSessionOperation(SessionStateConflict):
+    pass
+
+
+class EpochExhausted(SessionStateConflict):
+    pass
+
+
+def _ensure_epoch_table(conn) -> None:
+    conn.execute('''
+        CREATE TABLE IF NOT EXISTS teleop_driver_epochs (
+            driver_id TEXT PRIMARY KEY,
+            epoch INTEGER NOT NULL CHECK (epoch >= 1)
+        )
+    ''')
+    conn.commit()
+
+
+def _allocate_driver_epoch(driver_id: str, minimum_epoch: int = 1) -> int:
+    """Atomically allocate an epoch that survives manager/Core restarts.
+
+    ``minimum_epoch`` is an inclusive floor supplied from the Driver status. It
+    lets Core recover safely if its database was restored or the Driver was
+    prepared by another Core instance.
+    """
+
+    if not driver_id:
+        raise ValueError('driver_id is required')
+    if isinstance(minimum_epoch, bool):
+        raise TypeError('minimum_epoch must be a positive integer')
+    try:
+        minimum = int(minimum_epoch)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError('minimum_epoch must be a positive integer') from exc
+    if minimum < 1 or minimum != minimum_epoch:
+        raise ValueError('minimum_epoch must be a positive integer')
+    if minimum > MAX_DRIVER_EPOCH:
+        raise EpochExhausted(driver_id)
+
+    # SQLite is the cross-process authority.  The process lock also prevents
+    # same-process threads from racing in config._get_conn's schema bootstrap.
+    with _epoch_process_lock, config._get_conn() as conn:
+        _ensure_epoch_table(conn)
+        try:
+            conn.execute('BEGIN IMMEDIATE')
+            row = conn.execute(
+                'SELECT epoch FROM teleop_driver_epochs WHERE driver_id=?',
+                (driver_id,),
+            ).fetchone()
+            stored = int(row[0]) if row else 0
+            if stored >= MAX_DRIVER_EPOCH:
+                raise EpochExhausted(driver_id)
+            stored_next = stored + 1
+            epoch = max(stored_next, minimum)
+            if epoch > MAX_DRIVER_EPOCH:
+                raise EpochExhausted(driver_id)
+            if row:
+                conn.execute(
+                    'UPDATE teleop_driver_epochs SET epoch=? WHERE driver_id=?',
+                    (epoch, driver_id),
+                )
+            else:
+                conn.execute(
+                    'INSERT INTO teleop_driver_epochs (driver_id, epoch) VALUES (?, ?)',
+                    (driver_id, epoch),
+                )
+            conn.commit()
+            return epoch
+        except Exception:
+            conn.rollback()
+            raise
+
+
+class ShadowSessionManager:
+    """Own one expiring Shadow session per robot.
+
+    The in-memory map is authoritative only for the current Core process. Driver
+    epochs are persisted separately so a restarted Core can never issue an older
+    fence epoch to the same driver.
+    """
+
+    def __init__(
+        self,
+        *,
+        monotonic: Callable[[], float] = time.monotonic,
+        wall_clock: Callable[[], float] = time.time,
+    ):
+        self._lock = asyncio.Lock()
+        self._sessions: dict[str, ShadowSession] = {}
+        self._robot_sessions: dict[str, str] = {}
+        self._pending_expired: dict[str, ShadowSession] = {}
+        self._monotonic = monotonic
+        self._wall_clock = wall_clock
+        self._operation_sequence = 0
+
+    @staticmethod
+    def _bounded_lease(value: object, fallback: float = DEFAULT_LEASE_SECONDS) -> float:
+        try:
+            lease = float(value)
+        except (TypeError, ValueError):
+            return fallback
+        if not math.isfinite(lease):
+            return fallback
+        return min(MAX_LEASE_SECONDS, max(MIN_LEASE_SECONDS, lease))
+
+    @classmethod
+    def default_lease_seconds(cls) -> float:
+        return cls._bounded_lease(
+            os.environ.get('MOTUS_TELEOP_LEASE_SECONDS', str(DEFAULT_LEASE_SECONDS))
+        )
+
+    def _next_operation_generation_locked(self) -> int:
+        self._operation_sequence += 1
+        return self._operation_sequence
+
+    def _is_current_locked(self, session: ShadowSession) -> bool:
+        return (
+            self._sessions.get(session.id) is session
+            and self._robot_sessions.get(session.robot_id) == session.id
+        )
+
+    def _unbind_robot_locked(self, session: ShadowSession) -> bool:
+        """Remove ownership only if this exact session still owns the mapping."""
+
+        if self._robot_sessions.get(session.robot_id) != session.id:
+            return False
+        self._robot_sessions.pop(session.robot_id, None)
+        return True
+
+    def _expire_due_locked(self, now_monotonic: float) -> list[ShadowSession]:
+        expired: list[ShadowSession] = []
+        # Authority work is O(live robots), never O(unbounded history).
+        live_ids = list(dict.fromkeys(self._robot_sessions.values()))
+        for session_id in live_ids:
+            session = self._sessions.get(session_id)
+            if session is None:
+                continue
+            if session.state in _TERMINAL_STATES:
+                continue
+            if session.deadline_monotonic > now_monotonic:
+                continue
+            session.state = 'expired'
+            session.operation_state = 'expired'
+            self._unbind_robot_locked(session)
+            self._pending_expired.setdefault(session.id, session)
+            expired.append(session)
+        return expired
+
+    def _prune_terminal_locked(self) -> None:
+        terminal_ids = [
+            session_id
+            for session_id, session in self._sessions.items()
+            if session.state in _TERMINAL_STATES
+            and session_id not in self._pending_expired
+        ]
+        excess = len(terminal_ids) - MAX_TERMINAL_SESSIONS
+        for session_id in terminal_ids[:max(0, excess)]:
+            self._sessions.pop(session_id, None)
+
+    async def reserve(
+        self,
+        robot_id: str,
+        principal_id: str,
+        *,
+        driver_id: str,
+        boot_id: str,
+        capability_digest: str,
+        client_id: str,
+        mode: str = 'shadow',
+        profile_id: str = 'recording',
+        capabilities: dict | None = None,
+        effectors: list[str] | None = None,
+        signaling_audience: str = 'teleop-shadow-rtc',
+        defer_identity: bool = False,
+        dry_run_profile: str | None = None,
+        lease_seconds: float | None = None,
+        minimum_epoch: int = 1,
+    ) -> ShadowSession:
+        if not robot_id or not principal_id or not capability_digest or not client_id:
+            raise ValueError(
+                'robot_id, principal_id, capability_digest and client_id are required'
+            )
+        if dry_run_profile is not None:
+            if dry_run_profile != 'recording' or profile_id != 'recording':
+                raise ValueError('dry_run_profile only supports legacy recording')
+        if not isinstance(profile_id, str) or not _PROFILE_ID_RE.fullmatch(profile_id):
+            raise ValueError('profile_id is not supported')
+        if mode not in {'shadow', 'live'}:
+            raise ValueError('mode is not supported')
+        if defer_identity is not (mode == 'live'):
+            raise ValueError('only live reservations defer Driver identity')
+        if not defer_identity and not boot_id:
+            raise ValueError('boot_id is required')
+        expected_audiences = {
+            'shadow': {'teleop-shadow-rtc', 'motus-teleop-rtc'},
+            'live': {'motus-teleop-rtc'},
+        }
+        if signaling_audience not in expected_audiences[mode]:
+            raise ValueError('signaling_audience is not supported')
+        if not isinstance(capabilities or {}, dict):
+            raise ValueError('capabilities must be an object')
+        if not isinstance(effectors or [], list):
+            raise ValueError('effectors must be a list')
+        if capabilities:
+            if capabilities.get('profile_id') != profile_id:
+                raise ValueError('capabilities.profile_id does not match profile_id')
+            capability_effectors = capabilities.get('effectors')
+            if not isinstance(capability_effectors, list):
+                raise ValueError('capabilities.effectors must be a list')
+            if capability_effectors != (effectors or []):
+                raise ValueError('effectors do not match capabilities.effectors')
+        lease = (
+            self.default_lease_seconds()
+            if lease_seconds is None
+            else self._bounded_lease(lease_seconds)
+        )
+        # Epoch persistence is SQLite-backed and may wait on a writer.  Allocate
+        # outside both the event loop and the manager lock: wasting an epoch on
+        # a concurrent reservation conflict is safe, while delaying existing
+        # session heartbeats behind database I/O is not.
+        epoch = 0
+        if not defer_identity:
+            epoch = await asyncio.to_thread(
+                _allocate_driver_epoch,
+                driver_id,
+                minimum_epoch,
+            )
+        async with self._lock:
+            now_monotonic = self._monotonic()
+            now_wall = self._wall_clock()
+            self._expire_due_locked(now_monotonic)
+            existing_id = self._robot_sessions.get(robot_id)
+            if existing_id:
+                existing = self._sessions.get(existing_id)
+                if existing is not None and existing.state not in _TERMINAL_STATES:
+                    raise SessionConflict(existing)
+                # Repair an impossible/stale map entry conditionally.
+                if self._robot_sessions.get(robot_id) == existing_id:
+                    self._robot_sessions.pop(robot_id, None)
+
+            session = ShadowSession(
+                id=str(uuid.uuid4()),
+                robot_id=robot_id,
+                driver_id=driver_id,
+                principal_id=principal_id,
+                boot_id=boot_id,
+                epoch=epoch,
+                capability_digest=capability_digest,
+                mode=mode,
+                profile_id=profile_id,
+                capabilities=copy.deepcopy(capabilities or {}),
+                effectors=copy.deepcopy(effectors or []),
+                signaling_audience=signaling_audience,
+                live_confirmed=mode == 'shadow',
+                client_id=client_id,
+                fence=secrets.token_urlsafe(32),
+                state='awaiting_confirmation' if defer_identity else 'preparing',
+                operation_generation=self._next_operation_generation_locked(),
+                operation_state='pending',
+                created_at=now_wall,
+                lease_seconds=lease,
+                deadline_monotonic=now_monotonic + lease,
+            )
+            self._sessions[session.id] = session
+            self._robot_sessions[robot_id] = session.id
+            return session
+
+    async def confirm_live_identity(
+        self,
+        session_id: str,
+        principal_id: str,
+        client_id: str,
+        *,
+        boot_id: str,
+        minimum_epoch: int,
+    ) -> ShadowSession:
+        """Bind Driver identity only after the owning tab explicitly confirms live."""
+
+        if not boot_id:
+            raise ValueError('boot_id is required')
+        candidate = await self.get_authorized(
+            session_id,
+            principal_id,
+            owner=False,
+            client_id=client_id,
+            require_client=True,
+        )
+        if (
+            candidate.mode != 'live'
+            or candidate.state != 'awaiting_confirmation'
+            or candidate.live_confirmed
+        ):
+            raise SessionStateConflict(
+                f'session {session_id} cannot confirm live from {candidate.state}'
+            )
+        epoch = await asyncio.to_thread(
+            _allocate_driver_epoch,
+            candidate.driver_id,
+            minimum_epoch,
+        )
+        async with self._lock:
+            now = self._monotonic()
+            self._expire_due_locked(now)
+            session = self._require_current_locked(session_id)
+            self._authorize_locked(session, principal_id, False)
+            self._authorize_client_locked(session, client_id, False)
+            if session.mode != 'live' or session.state != 'awaiting_confirmation':
+                raise SessionStateConflict(
+                    f'session {session_id} cannot confirm live from {session.state}'
+                )
+            session.boot_id = boot_id
+            session.epoch = epoch
+            session.live_confirmed = True
+            session.state = 'preparing'
+            session.operation_state = 'pending'
+            session.deadline_monotonic = now + session.lease_seconds
+            return session
+
+    async def activate(
+        self,
+        session_id: str,
+        operation_generation: int,
+    ) -> ShadowSession:
+        async with self._lock:
+            now = self._monotonic()
+            self._expire_due_locked(now)
+            session = self._sessions.get(session_id)
+            if session is None:
+                raise SessionNotFound(session_id)
+            if session.operation_generation != operation_generation:
+                raise StaleSessionOperation(session_id)
+            if session.state != 'preparing' or not self._is_current_locked(session):
+                raise SessionStateConflict(
+                    f'session {session_id} cannot activate from {session.state}'
+                )
+            session.state = 'active'
+            session.operation_state = 'succeeded'
+            return session
+
+    async def heartbeat(
+        self,
+        session_id: str,
+        principal_id: str,
+        client_id: str,
+        owner: bool = False,
+    ) -> ShadowSession:
+        async with self._lock:
+            now = self._monotonic()
+            self._expire_due_locked(now)
+            session = self._require_current_locked(session_id)
+            self._authorize_locked(session, principal_id, owner)
+            self._authorize_client_locked(session, client_id, owner)
+            if session.state not in ('active', 'paused', 'hold'):
+                raise SessionStateConflict(
+                    f'session {session_id} cannot heartbeat from {session.state}'
+                )
+            session.deadline_monotonic = now + session.lease_seconds
+            return session
+
+    async def pause(
+        self,
+        session_id: str,
+        principal_id: str,
+        client_id: str,
+        owner: bool = False,
+    ) -> ShadowSession:
+        async with self._lock:
+            self._expire_due_locked(self._monotonic())
+            session = self._require_current_locked(session_id)
+            self._authorize_locked(session, principal_id, owner)
+            self._authorize_client_locked(session, client_id, owner)
+            if session.state not in ('active', 'paused', 'hold'):
+                raise SessionStateConflict(
+                    f'session {session_id} cannot pause from {session.state}'
+                )
+            session.state = 'paused'
+            return session
+
+    async def soft_stop(
+        self,
+        session_id: str,
+        principal_id: str,
+        client_id: str,
+        owner: bool = False,
+    ) -> ShadowSession:
+        """Enter the visible HOLD state; repeated HOLD requests are idempotent."""
+
+        async with self._lock:
+            self._expire_due_locked(self._monotonic())
+            session = self._require_current_locked(session_id)
+            self._authorize_locked(session, principal_id, owner)
+            self._authorize_client_locked(session, client_id, owner)
+            if session.state not in ('active', 'hold'):
+                raise SessionStateConflict(
+                    f'session {session_id} cannot soft-stop from {session.state}'
+                )
+            session.state = 'hold'
+            return session
+
+    async def release(
+        self,
+        session_id: str,
+        principal_id: str,
+        client_id: str,
+        owner: bool = False,
+    ) -> ShadowSession:
+        async with self._lock:
+            self._expire_due_locked(self._monotonic())
+            session = self._require_current_locked(session_id)
+            self._authorize_locked(session, principal_id, owner)
+            self._authorize_client_locked(session, client_id, owner)
+            session.state = 'released'
+            session.operation_state = 'cancelled'
+            self._unbind_robot_locked(session)
+            self._prune_terminal_locked()
+            return session
+
+    async def fail_reservation(
+        self,
+        session_id: str,
+        operation_generation: int,
+    ) -> ShadowSession | None:
+        """Fail only the still-current prepare operation.
+
+        A delayed Driver error must not fault an activated session or unbind a
+        replacement session for the same robot.
+        """
+
+        async with self._lock:
+            self._expire_due_locked(self._monotonic())
+            session = self._sessions.get(session_id)
+            if session is None:
+                return None
+            if (
+                session.operation_generation != operation_generation
+                or session.state != 'preparing'
+                or not self._is_current_locked(session)
+            ):
+                return None
+            session.state = 'faulted'
+            session.operation_state = 'failed'
+            self._unbind_robot_locked(session)
+            self._prune_terminal_locked()
+            return session
+
+    async def fault(
+        self,
+        session_id: str,
+        operation_generation: int | None = None,
+    ) -> ShadowSession | None:
+        """Conditionally fault and release any current, non-terminal session.
+
+        The heartbeat worker uses this after a Driver failure. Supplying an
+        operation generation additionally protects against a delayed worker from
+        an obsolete reservation.
+        """
+
+        async with self._lock:
+            self._expire_due_locked(self._monotonic())
+            session = self._sessions.get(session_id)
+            if session is None or not self._is_current_locked(session):
+                return None
+            if session.state in _TERMINAL_STATES:
+                return None
+            if (
+                operation_generation is not None
+                and session.operation_generation != operation_generation
+            ):
+                return None
+            session.state = 'faulted'
+            session.operation_state = 'failed'
+            self._unbind_robot_locked(session)
+            self._prune_terminal_locked()
+            return session
+
+    async def get(self, session_id: str) -> ShadowSession | None:
+        async with self._lock:
+            self._expire_due_locked(self._monotonic())
+            return self._sessions.get(session_id)
+
+    async def get_current(self, session_id: str) -> ShadowSession | None:
+        async with self._lock:
+            self._expire_due_locked(self._monotonic())
+            session = self._sessions.get(session_id)
+            if session is None or not self._is_current_locked(session):
+                return None
+            if session.state in _TERMINAL_STATES:
+                return None
+            return session
+
+    async def authorize(
+        self,
+        session_id: str,
+        principal_id: str,
+        owner: bool = False,
+    ) -> ShadowSession:
+        return await self.get_authorized(session_id, principal_id, owner=owner)
+
+    async def get_authorized(
+        self,
+        session_id: str,
+        principal_id: str,
+        owner: bool = False,
+        include_terminal: bool = False,
+        *,
+        client_id: str = '',
+        require_client: bool = False,
+    ) -> ShadowSession:
+        """Read an authorized session without renewing or changing its lease."""
+
+        async with self._lock:
+            self._expire_due_locked(self._monotonic())
+            if include_terminal:
+                session = self._sessions.get(session_id)
+                if session is None:
+                    raise SessionNotFound(session_id)
+                if session.state not in _TERMINAL_STATES and not self._is_current_locked(session):
+                    raise SessionNotFound(session_id)
+            else:
+                session = self._require_current_locked(session_id)
+            self._authorize_locked(session, principal_id, owner)
+            if require_client:
+                self._authorize_client_locked(session, client_id, owner)
+            return session
+
+    async def active_for_robot(self, robot_id: str) -> ShadowSession | None:
+        async with self._lock:
+            self._expire_due_locked(self._monotonic())
+            session_id = self._robot_sessions.get(robot_id)
+            session = self._sessions.get(session_id) if session_id else None
+            if session is None or session.state in _TERMINAL_STATES:
+                if self._robot_sessions.get(robot_id) == session_id:
+                    self._robot_sessions.pop(robot_id, None)
+                return None
+            return session
+
+    async def list_visible(
+        self,
+        principal_id: str,
+        owner: bool = False,
+    ) -> list[ShadowSession]:
+        async with self._lock:
+            self._expire_due_locked(self._monotonic())
+            sessions = list(self._sessions.values())
+            if owner:
+                return sessions
+            return [s for s in sessions if s.principal_id == principal_id]
+
+    async def expire_due(self) -> list[ShadowSession]:
+        async with self._lock:
+            self._expire_due_locked(self._monotonic())
+            expired = list(self._pending_expired.values())
+            self._pending_expired.clear()
+            self._prune_terminal_locked()
+            return expired
+
+    async def retained_session_ids(self) -> set[str]:
+        async with self._lock:
+            self._prune_terminal_locked()
+            return set(self._sessions)
+
+    async def reset(self) -> None:
+        """Clear ephemeral ownership; persisted driver epochs are untouched."""
+
+        async with self._lock:
+            self._sessions.clear()
+            self._robot_sessions.clear()
+            self._pending_expired.clear()
+            self._operation_sequence = 0
+
+    def public_dict(self, session: ShadowSession) -> dict:
+        return session.public_dict(
+            monotonic_now=self._monotonic(),
+            wall_now=self._wall_clock(),
+        )
+
+    def _require_current_locked(self, session_id: str) -> ShadowSession:
+        session = self._sessions.get(session_id)
+        if (
+            session is None
+            or session.state in _TERMINAL_STATES
+            or not self._is_current_locked(session)
+        ):
+            raise SessionNotFound(session_id)
+        return session
+
+    @staticmethod
+    def _authorize_locked(
+        session: ShadowSession,
+        principal_id: str,
+        owner: bool,
+    ) -> None:
+        if not owner and session.principal_id != principal_id:
+            raise SessionForbidden(session.id)
+
+    @staticmethod
+    def _authorize_client_locked(
+        session: ShadowSession,
+        client_id: str,
+        owner: bool,
+    ) -> None:
+        if not owner and session.client_id != client_id:
+            raise SessionClientMismatch(session.id)
+
+
+manager = ShadowSessionManager()

--- a/agent-core/src/tls_config.py
+++ b/agent-core/src/tls_config.py
@@ -1,0 +1,328 @@
+"""Resolve the TLS certificate pair used by the Agent Core web server.
+
+Importing this module has no filesystem or process side effects.  Certificate
+generation happens only when :func:`resolve_tls_certificates` is called with no
+explicit certificate configuration and neither compatibility file exists.
+"""
+
+from __future__ import annotations
+
+import os
+import pathlib
+import re
+import ssl
+import stat
+import subprocess
+from collections.abc import Mapping
+
+TLS_CERT_FILE_ENV = 'MOTUS_TLS_CERT_FILE'
+TLS_KEY_FILE_ENV = 'MOTUS_TLS_KEY_FILE'
+DEFAULT_CERT_DIR = pathlib.Path('./resource/certs')
+MAX_PUBLIC_CERTIFICATE_CHAIN_BYTES = 32 * 1024
+
+_CERTIFICATE_BLOCK = re.compile(
+    r'-----BEGIN CERTIFICATE-----\s*'
+    r'(?P<body>[A-Za-z0-9+/=\r\n]+?)\s*'
+    r'-----END CERTIFICATE-----'
+)
+
+
+class TLSConfigurationError(RuntimeError):
+    """Raised when TLS files are incomplete or unusable."""
+
+
+def project_public_certificate_chain(pem: str) -> str:
+    """Return a bounded, certificate-only normalized PEM chain.
+
+    The configured server certfile can contain a full public chain, but it is
+    never safe to expose that file verbatim: an operator could accidentally
+    append unrelated material to it. Only complete parseable CERTIFICATE
+    blocks survive this projection. Paths, comments, and all key material are
+    rejected instead of being reflected into the capture bootstrap response.
+    """
+
+    if not isinstance(pem, str):
+        raise TLSConfigurationError('TLS public certificate chain must be text')
+    try:
+        encoded = pem.encode('ascii')
+    except UnicodeEncodeError as exc:
+        raise TLSConfigurationError(
+            'TLS public certificate chain must contain ASCII PEM only'
+        ) from exc
+    if not encoded or len(encoded) > MAX_PUBLIC_CERTIFICATE_CHAIN_BYTES:
+        raise TLSConfigurationError(
+            'TLS public certificate chain exceeds the capture bootstrap limit'
+        )
+    if 'PRIVATE KEY' in pem or '\x00' in pem:
+        raise TLSConfigurationError(
+            'TLS public certificate chain contains forbidden material'
+        )
+
+    normalized_blocks: list[str] = []
+    cursor = 0
+    for match in _CERTIFICATE_BLOCK.finditer(pem):
+        if pem[cursor:match.start()].strip():
+            raise TLSConfigurationError(
+                'TLS public certificate file must contain certificates only'
+            )
+        body = ''.join(match.group('body').split())
+        if not body:
+            raise TLSConfigurationError('TLS public certificate block is empty')
+        wrapped = '\n'.join(body[index:index + 64] for index in range(0, len(body), 64))
+        block = (
+            '-----BEGIN CERTIFICATE-----\n'
+            f'{wrapped}\n'
+            '-----END CERTIFICATE-----'
+        )
+        try:
+            der = ssl.PEM_cert_to_DER_cert(block)
+        except ValueError as exc:
+            raise TLSConfigurationError(
+                'TLS public certificate chain contains malformed PEM'
+            ) from exc
+        if not der or der[0] != 0x30:
+            raise TLSConfigurationError(
+                'TLS public certificate chain contains malformed DER'
+            )
+        normalized_blocks.append(block)
+        cursor = match.end()
+
+    if pem[cursor:].strip() or not normalized_blocks:
+        raise TLSConfigurationError(
+            'TLS public certificate file must contain certificates only'
+        )
+    normalized = '\n'.join(normalized_blocks) + '\n'
+    if len(normalized.encode('ascii')) > MAX_PUBLIC_CERTIFICATE_CHAIN_BYTES:
+        raise TLSConfigurationError(
+            'TLS public certificate chain exceeds the capture bootstrap limit'
+        )
+    return normalized
+
+
+def load_public_certificate_chain(cert_file: str | pathlib.Path) -> str:
+    """Read and project the public chain used by the running HTTPS server."""
+
+    path = pathlib.Path(cert_file)
+    _require_regular_file(path, TLS_CERT_FILE_ENV)
+    try:
+        with path.open('rb') as certificate_stream:
+            raw = certificate_stream.read(MAX_PUBLIC_CERTIFICATE_CHAIN_BYTES + 1)
+    except OSError as exc:
+        raise TLSConfigurationError(
+            'TLS public certificate chain could not be read safely'
+        ) from exc
+    if len(raw) > MAX_PUBLIC_CERTIFICATE_CHAIN_BYTES:
+        raise TLSConfigurationError(
+            'TLS public certificate chain exceeds the capture bootstrap limit'
+        )
+    try:
+        pem = raw.decode('ascii')
+    except UnicodeDecodeError as exc:
+        raise TLSConfigurationError(
+            'TLS public certificate chain must contain ASCII PEM only'
+        ) from exc
+    return project_public_certificate_chain(pem)
+
+
+def _explicit_path(environ: Mapping[str, str], name: str) -> str:
+    value = environ.get(name, '')
+    return value.strip() if isinstance(value, str) else ''
+
+
+def _require_regular_file(path: pathlib.Path, setting: str) -> None:
+    if not path.is_file():
+        raise TLSConfigurationError(
+            f'{setting} must point to an existing regular file inside the Core runtime'
+        )
+
+
+def _require_distinct_files(cert_path: pathlib.Path, key_path: pathlib.Path) -> None:
+    try:
+        same_file = cert_path.samefile(key_path)
+    except OSError as exc:
+        raise TLSConfigurationError(
+            'TLS certificate and private-key files could not be compared safely'
+        ) from exc
+    if same_file:
+        raise TLSConfigurationError(
+            'TLS certificate and private key must be different files'
+        )
+
+
+def _private_key_mode(key_path: pathlib.Path) -> int:
+    try:
+        return stat.S_IMODE(key_path.stat().st_mode)
+    except OSError as exc:
+        raise TLSConfigurationError(
+            'TLS private-key permissions could not be inspected safely'
+        ) from exc
+
+
+def _require_private_key_permissions(key_path: pathlib.Path) -> None:
+    if os.name == 'posix' and _private_key_mode(key_path) & 0o077:
+        raise TLSConfigurationError(
+            'TLS private key must not be accessible by group or other users; '
+            'set its mode to 0600 or 0400'
+        )
+
+
+def _secure_compatibility_key(key_path: pathlib.Path) -> None:
+    if os.name != 'posix' or not (_private_key_mode(key_path) & 0o077):
+        return
+    if key_path.is_symlink():
+        raise TLSConfigurationError(
+            'a linked compatibility TLS private key has broad permissions; '
+            'fix the managed target or configure the explicit TLS pair'
+        )
+
+    flags = os.O_RDONLY
+    flags |= getattr(os, 'O_CLOEXEC', 0)
+    flags |= getattr(os, 'O_NOFOLLOW', 0)
+    try:
+        key_fd = os.open(key_path, flags)
+    except OSError as exc:
+        raise TLSConfigurationError(
+            'the compatibility TLS private key could not be opened safely'
+        ) from exc
+    try:
+        metadata = os.fstat(key_fd)
+        if not stat.S_ISREG(metadata.st_mode) or metadata.st_nlink != 1:
+            raise TLSConfigurationError(
+                'a multiply-linked compatibility TLS private key cannot be modified; '
+                'fix the managed target or configure the explicit TLS pair'
+            )
+        os.fchmod(key_fd, 0o600)
+    except OSError as exc:
+        raise TLSConfigurationError(
+            'the compatibility TLS private key could not be restricted to mode 0600'
+        ) from exc
+    finally:
+        os.close(key_fd)
+    _require_private_key_permissions(key_path)
+
+
+def _validate_certificate_pair(cert_path: pathlib.Path, key_path: pathlib.Path) -> None:
+    """Prove that Python's server TLS stack can load this matching pair."""
+
+    try:
+        context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+        context.load_cert_chain(
+            certfile=str(cert_path),
+            keyfile=str(key_path),
+            # Core has no interactive secret-input path. An encrypted key must
+            # fail immediately instead of blocking startup on an OpenSSL prompt.
+            password=lambda: b'',
+        )
+    except (OSError, ssl.SSLError) as exc:
+        raise TLSConfigurationError(
+            'TLS certificate and private key must be a parseable matching server pair'
+        ) from exc
+
+
+def _resolve_explicit_pair(environ: Mapping[str, str]) -> tuple[str, str] | None:
+    cert_value = _explicit_path(environ, TLS_CERT_FILE_ENV)
+    key_value = _explicit_path(environ, TLS_KEY_FILE_ENV)
+
+    if bool(cert_value) != bool(key_value):
+        raise TLSConfigurationError(
+            f'{TLS_CERT_FILE_ENV} and {TLS_KEY_FILE_ENV} must be configured together'
+        )
+    if not cert_value:
+        return None
+
+    cert_path = pathlib.Path(cert_value)
+    key_path = pathlib.Path(key_value)
+    _require_regular_file(cert_path, TLS_CERT_FILE_ENV)
+    _require_regular_file(key_path, TLS_KEY_FILE_ENV)
+    _require_distinct_files(cert_path, key_path)
+    _require_private_key_permissions(key_path)
+    _validate_certificate_pair(cert_path, key_path)
+    print(
+        '[tls] Using explicitly configured certificate files; '
+        'browser trust is determined independently by the client.'
+    )
+    return str(cert_path), str(key_path)
+
+
+def _ensure_compatibility_pair(cert_dir: str | pathlib.Path) -> tuple[str, str]:
+    directory = pathlib.Path(cert_dir)
+    cert_path = directory / 'cert.pem'
+    key_path = directory / 'key.pem'
+
+    # A broken symlink is still an occupied deployment path. Treat it as an
+    # invalid existing file so openssl can never follow or replace it.
+    cert_exists = cert_path.exists() or cert_path.is_symlink()
+    key_exists = key_path.exists() or key_path.is_symlink()
+    if cert_exists or key_exists:
+        if cert_path.is_file() and key_path.is_file():
+            _require_distinct_files(cert_path, key_path)
+            _secure_compatibility_key(key_path)
+            _validate_certificate_pair(cert_path, key_path)
+            print(
+                '[tls] Using the existing compatibility certificate pair; '
+                'browser trust is not inferred.'
+            )
+            return str(cert_path), str(key_path)
+        raise TLSConfigurationError(
+            'the compatibility TLS certificate pair is incomplete or not made of '
+            f'regular files: {cert_path} and {key_path}'
+        )
+
+    directory.mkdir(parents=True, exist_ok=True)
+    try:
+        # OpenSSL truncates this existing file without widening its mode.  The
+        # private key therefore never has a group/world-readable creation
+        # window, even when the host process umask is permissive.
+        key_fd = os.open(key_path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        os.close(key_fd)
+    except OSError as exc:
+        raise TLSConfigurationError(
+            'failed to reserve the compatibility TLS private key securely'
+        ) from exc
+    try:
+        subprocess.run(
+            [
+                'openssl', 'req', '-x509', '-newkey', 'rsa:2048',
+                '-keyout', str(key_path), '-out', str(cert_path),
+                '-days', '3650', '-nodes',
+                '-subj', '/CN=phanthy-motus',
+            ],
+            check=True,
+            capture_output=True,
+        )
+    except (OSError, subprocess.CalledProcessError) as exc:
+        raise TLSConfigurationError(
+            'failed to generate the self-signed compatibility TLS certificate pair'
+        ) from exc
+
+    if not cert_path.is_file() or not key_path.is_file():
+        raise TLSConfigurationError(
+            'openssl completed without creating both compatibility TLS files'
+        )
+    _require_distinct_files(cert_path, key_path)
+    _require_private_key_permissions(key_path)
+    _validate_certificate_pair(cert_path, key_path)
+
+    print(
+        '[tls] Generated a self-signed compatibility fallback certificate; '
+        'this does not establish browser trust or Quest WebXR readiness.'
+    )
+    return str(cert_path), str(key_path)
+
+
+def resolve_tls_certificates(
+    *,
+    environ: Mapping[str, str] | None = None,
+    cert_dir: str | pathlib.Path = DEFAULT_CERT_DIR,
+) -> tuple[str, str]:
+    """Return the certificate and private-key paths for Uvicorn.
+
+    An explicit pair is fail-closed and is never generated or modified.  With
+    no explicit pair, the historical ``resource/certs`` behavior remains, but
+    a partial or non-file default pair is rejected instead of overwritten.
+    """
+
+    configured = _resolve_explicit_pair(os.environ if environ is None else environ)
+    if configured is not None:
+        return configured
+    return _ensure_compatibility_pair(cert_dir)

--- a/agent-core/tests/teleop/conftest.py
+++ b/agent-core/tests/teleop/conftest.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+import asyncio
+import os
+from pathlib import Path
+import sys
+import tempfile
+
+import pytest
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+from fastapi.testclient import TestClient
+
+
+# config seeds SQLite at import time.  Point that bootstrap write at an isolated
+# temporary location before importing Agent Core modules.
+_AGENT_CORE = Path(__file__).resolve().parents[2]
+_SRC = _AGENT_CORE / 'src'
+sys.path.insert(0, str(_SRC))
+_BOOTSTRAP = Path(tempfile.mkdtemp(prefix='motus-core-c1-bootstrap-'))
+os.environ['DB_PATH'] = str(_BOOTSTRAP / 'data.db')
+
+import auth  # noqa: E402
+import config  # noqa: E402
+import mcp_client  # noqa: E402
+from api import canvas, config as config_api, inspection, mcp_manage, motus_stream, teleop  # noqa: E402
+from teleop import authority_guard  # noqa: E402
+
+
+HUMAN_AUTH = {
+    'ACCESS_TOKEN': 'owner-token',
+    'MOTUS_OPERATOR_TOKENS': '{"alice":"operator-token"}',
+    'MOTUS_VIEWER_TOKENS': '{"auditor":"viewer-token"}',
+    'MOTUS_DRIVER_TOKEN': 'test-only-legacy-driver-fallback',
+    'MOTUS_TELEOP_TICKET_SECRET': 'test-only-ticket-secret-000000000',
+}
+
+TEST_CAPTURE_CA_CERTIFICATE_PEM = (
+    '-----BEGIN CERTIFICATE-----\n'
+    'MAMCAQE=\n'
+    '-----END CERTIFICATE-----\n'
+)
+
+
+@pytest.fixture(autouse=True)
+def isolated_core_state(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(config, 'DB_PATH', str(tmp_path / 'data.db'))
+    config._seed_defaults()
+    config.main['services'] = {'mcp': []}
+    config.main['canvas_layout'] = {
+        'cards': [], 'connections': [], 'execConnections': [], 'transform': {},
+    }
+    config.main['event'] = {'llm': {}, 'subscribe_topics': []}
+
+    auth.init(HUMAN_AUTH)
+    mcp_client.registry.clear()
+    mcp_manage._last_tool_names.clear()
+    mcp_manage._ping_generations.clear()
+    target_mutation_lock = asyncio.Lock()
+    monkeypatch.setattr(authority_guard, 'target_mutation_lock', target_mutation_lock)
+    monkeypatch.setattr(mcp_manage, '_mcp_write_lock', target_mutation_lock)
+    canvas._editor_session = None
+    canvas._editor_last_seen = 0.0
+    config_api._clear_project_residual()
+    motus_stream._clients.clear()
+    yield
+    motus_stream._clients.clear()
+    mcp_client.registry.clear()
+    config_api._clear_project_residual()
+    auth.init({})
+
+
+@pytest.fixture
+def client():
+    api_app = FastAPI()
+    api_app.include_router(mcp_manage.router)
+    api_app.include_router(canvas.router)
+    api_app.include_router(teleop.router)
+    api_app.state.teleop_capture_ca_certificate_pem = (
+        TEST_CAPTURE_CA_CERTIFICATE_PEM
+    )
+
+    @api_app.get('/auth/verify')
+    async def auth_verify(request: Request):
+        if not auth.is_enabled():
+            return {'valid': True, 'auth_required': False, 'principal': None}
+        principal = auth.authenticate(auth._extract_token(request))
+        if principal:
+            return {
+                'valid': True,
+                'auth_required': True,
+                'principal': principal.as_dict(),
+            }
+        return JSONResponse(
+            status_code=401,
+            content={'valid': False, 'auth_required': True, 'principal': None},
+        )
+
+    app = FastAPI()
+    app.middleware('http')(auth.auth_middleware)
+    app.mount('/api', api_app)
+    app.include_router(motus_stream.router)
+    app.include_router(inspection.ws_router)
+    app.include_router(teleop.ws_router)
+
+    with TestClient(app) as test_client:
+        yield test_client
+
+
+@pytest.fixture
+def auth_headers():
+    client_header = {
+        'X-Motus-Teleop-Client': '7dbabfca-15c1-43ca-b600-75e7682c21d0',
+    }
+    return {
+        'owner': {'Authorization': 'Bearer owner-token', **client_header},
+        'operator': {'Authorization': 'Bearer operator-token', **client_header},
+        'viewer': {'Authorization': 'Bearer viewer-token', **client_header},
+    }
+
+
+@pytest.fixture
+def shadow_session_tool():
+    """Producer-shaped fixture mirrored from Driver teleop_shadow.tool_definitions."""
+    identity = {
+        'boot_id': {'type': 'string', 'format': 'uuid'},
+        'session_id': {'type': 'string', 'format': 'uuid'},
+        'epoch': {'type': 'integer', 'minimum': 1},
+        'fence': {'type': 'string', 'minLength': 24},
+    }
+    actions = {
+        'start': {'params': [], 'description': 'Passive lifecycle readiness check'},
+        'stop': {'params': [], 'description': 'Stop lifecycle and release Shadow'},
+        'prepare_shadow': {
+            'params': ['session_id', 'epoch', 'fence'],
+            'description': 'Install a new Core-issued epoch/fence',
+        },
+        'heartbeat': {'params': list(identity), 'description': 'Renew lease'},
+        'pause': {'params': list(identity), 'description': 'Pause diagnostics'},
+        'release': {'params': list(identity), 'description': 'Release session'},
+        'soft_stop': {'params': list(identity), 'description': 'Enter HOLD'},
+        'status': {'params': [], 'description': 'Read diagnostics'},
+        'submit_shadow_frame': {'params': ['frame'], 'description': 'Submit Frame v1'},
+    }
+    return {
+        'name': 'teleop_session',
+        'type': 'actuator',
+        'multiInstance': False,
+        'description': 'Robot-free Quest/WebRTC Shadow session diagnostics.',
+        'annotations': {'destructiveHint': False, 'idempotentHint': False},
+        'inputSchema': {
+            'type': 'object',
+            'additionalProperties': False,
+            'properties': {
+                'action': {'type': 'string', 'enum': list(actions)},
+                **identity,
+                'frame': {'type': 'object', 'description': 'Strict Teleop Frame v1 object'},
+            },
+            'required': ['action'],
+            'x-action-params': actions,
+        },
+        'x-teleop': {
+            'protocol': 'motus.teleop.shadow.v1',
+            'driver_id': 'teleop-shadow-driver',
+            'driver_name': 'Generic Teleop Shadow Diagnostics',
+            'robot_id': 'robot-fixture',
+            'mode': 'shadow',
+            'actuation_enabled': False,
+            'capability_digest': '0123456789abcdef' * 4,
+            'dispatch_contract': 'motus.teleop.dispatch.recording.v1',
+            'dry_run_profile': 'recording',
+            'signaling': {
+                'protocol': 'motus.teleop.webrtc-offer-answer.v1',
+                'path': '/offer',
+                'access': 'authenticated-core-proxy-only',
+            },
+        },
+    }

--- a/agent-core/tests/teleop/test_auth_rbac.py
+++ b/agent-core/tests/teleop/test_auth_rbac.py
@@ -1,0 +1,499 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from starlette.websockets import WebSocketDisconnect
+
+import auth
+
+
+@pytest.mark.parametrize('role', ['owner', 'operator', 'viewer'])
+@pytest.mark.parametrize('path', ['/api/teleop/me', '/api/teleop/robots'])
+def test_all_human_roles_can_read_teleop_directory(client, auth_headers, role, path):
+    response = client.get(path, headers=auth_headers[role])
+    assert response.status_code == 200
+
+
+@pytest.mark.parametrize('role', ['operator', 'viewer'])
+@pytest.mark.parametrize(
+    ('method', 'path', 'json_body'),
+    [
+        ('get', '/api/mcp', None),
+        ('get', '/api/canvas/layout', None),
+        (
+            'post',
+            '/api/mcp/agentcore/call',
+            {'tool': 'remote_message', 'arguments': {'action': 'stop'}},
+        ),
+        (
+            'post',
+            '/api/mcp',
+            {
+                'id': 'human-must-not-register-driver',
+                'name': 'Human Registration',
+                'url': 'http://human.invalid/mcp',
+            },
+        ),
+    ],
+)
+def test_non_owners_cannot_reach_existing_api_authority(
+    client, auth_headers, role, method, path, json_body,
+):
+    response = client.request(method, path, headers=auth_headers[role], json=json_body)
+    assert response.status_code == 403
+    assert response.json()['detail'] == 'Owner role required'
+
+
+def test_owner_keeps_existing_api_and_canvas_compatibility(client, auth_headers):
+    assert client.get('/api/mcp', headers=auth_headers['owner']).status_code == 200
+    assert client.get('/api/canvas/layout', headers=auth_headers['owner']).status_code == 200
+
+    call = client.post(
+        '/api/mcp/agentcore/call',
+        headers=auth_headers['owner'],
+        json={'tool': 'remote_message', 'arguments': {'action': 'stop'}},
+    )
+    assert call.status_code == 200
+    assert call.json()['data']['state'] == 'idle'
+
+
+def test_missing_or_invalid_human_token_is_rejected(client):
+    assert client.get('/api/teleop/robots').status_code == 401
+    assert client.get(
+        '/api/teleop/robots',
+        headers={'Authorization': 'Bearer not-a-token'},
+    ).status_code == 401
+    assert client.get('/api/mcp').status_code == 401
+
+
+@pytest.mark.parametrize(
+    ('role', 'token', 'principal_id'),
+    [
+        ('owner', 'owner-token', 'owner:legacy'),
+        ('operator', 'operator-token', 'operator:alice'),
+        ('viewer', 'viewer-token', 'viewer:auditor'),
+    ],
+)
+def test_auth_verify_returns_role_namespaced_principal(
+    client, role, token, principal_id,
+):
+    response = client.get(
+        '/api/auth/verify', headers={'Authorization': f'Bearer {token}'},
+    )
+    assert response.status_code == 200
+    assert response.json()['principal'] == {'id': principal_id, 'role': role}
+
+
+def test_invalid_auth_verify_is_401(client):
+    response = client.get('/api/auth/verify')
+    assert response.status_code == 401
+    assert response.json() == {
+        'valid': False, 'auth_required': True, 'principal': None,
+    }
+
+
+@pytest.mark.parametrize(
+    'service_settings',
+    [
+        {'MOTUS_DRIVER_TOKEN': 'legacy-driver-service-token'},
+        {
+            'MOTUS_DRIVER_TOKENS': json.dumps({
+                'driver-a': 'dedicated-driver-service-token-a',
+            }),
+        },
+        {'MOTUS_TELEOP_TICKET_SECRET': 't' * 32},
+        {
+            'MOTUS_TELEOP_TICKET_SECRETS': json.dumps({
+                'driver-a': 's' * 32,
+            }),
+        },
+    ],
+)
+def test_service_credentials_without_human_principal_lock_management_api(
+    client, service_settings,
+):
+    auth.init(service_settings)
+
+    assert auth.is_enabled() is True
+    assert client.get('/api/auth/verify').status_code == 401
+    assert client.get('/api/mcp').status_code == 401
+    assert client.post('/api/config', json={'mcp_list': []}).status_code == 401
+    assert client.post('/api/mcp/driver-a/ping').status_code == 401
+
+
+def test_duplicate_human_token_fails_closed():
+    with pytest.raises(ValueError, match='assigned to both'):
+        auth.init({
+            'MOTUS_OPERATOR_TOKENS': '{"alice":"same-token"}',
+            'MOTUS_VIEWER_TOKENS': '{"bob":"same-token"}',
+        })
+
+
+def test_duplicate_role_principal_id_fails_closed():
+    with pytest.raises(ValueError, match='principal id is configured more than once'):
+        auth.init({'MOTUS_OPERATOR_TOKENS': 'alice:first,alice:second'})
+
+
+def test_exact_duplicate_token_assignment_also_fails_closed():
+    with pytest.raises(ValueError, match='authentication token is configured more than once'):
+        auth.init({'MOTUS_OPERATOR_TOKENS': 'alice:same,alice:same'})
+
+
+def test_duplicate_json_principal_name_fails_closed():
+    with pytest.raises(ValueError, match='principal id is configured more than once'):
+        auth.init({'MOTUS_VIEWER_TOKENS': '{"alice":"first","alice":"second"}'})
+
+
+def test_same_name_in_distinct_role_namespaces_is_valid():
+    auth.init({
+        'MOTUS_OPERATOR_TOKENS': '{"sam":"operator-secret"}',
+        'MOTUS_VIEWER_TOKENS': '{"sam":"viewer-secret"}',
+    })
+    assert auth.authenticate('operator-secret').id == 'operator:sam'
+    assert auth.authenticate('viewer-secret').id == 'viewer:sam'
+
+
+def test_driver_token_cannot_reuse_human_token():
+    with pytest.raises(ValueError, match='must not reuse a human access token'):
+        auth.init({'ACCESS_TOKEN': 'collision', 'MOTUS_DRIVER_TOKEN': 'collision'})
+
+
+def test_rejected_auth_reload_atomically_preserves_last_valid_snapshot():
+    auth.init({
+        'ACCESS_TOKEN': 'old-owner-token',
+        'MOTUS_DRIVER_TOKEN': 'old-driver-token',
+        'MOTUS_TELEOP_TICKET_SECRET': 'o' * 32,
+    })
+
+    with pytest.raises(ValueError, match='must not reuse a human access token'):
+        auth.init({
+            'ACCESS_TOKEN': 'rejected-collision-token',
+            'MOTUS_DRIVER_TOKEN': 'rejected-collision-token',
+            'MOTUS_TELEOP_TICKET_SECRET': 'n' * 32,
+        })
+
+    assert auth.authenticate('old-owner-token').id == 'owner:legacy'
+    assert auth.verify_driver_token('old-driver-token', 'legacy-driver') is True
+    assert auth.teleop_ticket_secret('legacy-driver') == b'o' * 32
+    assert auth.authenticate('rejected-collision-token') is None
+    assert auth.verify_driver_token(
+        'rejected-collision-token', 'legacy-driver',
+    ) is False
+
+
+def test_driver_enforcement_requires_driver_token():
+    with pytest.raises(ValueError, match='requires MOTUS_DRIVER_TOKEN'):
+        auth.init({'MOTUS_ENFORCE_DRIVER_AUTH': 'true'})
+
+
+def test_dedicated_driver_and_ticket_credentials_select_exact_identity():
+    driver_a = 'driver-a-token-that-is-private'
+    driver_b = 'driver-b-token-that-is-private'
+    ticket_a = 'a' * 32
+    ticket_b = 'b' * 32
+    auth.init({
+        'MOTUS_DRIVER_TOKEN': 'legacy-driver-fallback',
+        'MOTUS_DRIVER_TOKENS': json.dumps({
+            'driver-a': driver_a,
+            'driver-b': driver_b,
+        }),
+        'MOTUS_TELEOP_TICKET_SECRET': 'l' * 32,
+        'MOTUS_TELEOP_TICKET_SECRETS': json.dumps({
+            'driver-a': ticket_a,
+            'driver-b': ticket_b,
+        }),
+    })
+
+    assert auth.verify_driver_token(driver_a, 'driver-a') is True
+    assert auth.verify_driver_token(driver_a, 'driver-b') is False
+    assert auth.driver_token_identity(driver_a) == 'driver-a'
+    assert auth.driver_request_headers('driver-a') == {
+        'Authorization': f'Bearer {driver_a}',
+    }
+    assert auth.driver_request_headers('driver-b') == {
+        'Authorization': f'Bearer {driver_b}',
+    }
+    assert auth.driver_request_headers('legacy-driver') == {
+        'Authorization': 'Bearer legacy-driver-fallback',
+    }
+    assert auth.teleop_ticket_secret('driver-a') == ticket_a.encode()
+    assert auth.teleop_ticket_secret('driver-b') == ticket_b.encode()
+    assert auth.teleop_ticket_secret('legacy-driver') == b'l' * 32
+    assert auth.teleop_ticket_credential_available('driver-a') is True
+    assert auth.teleop_ticket_credential_available('legacy-driver') is True
+
+
+def test_dedicated_driver_credentials_enable_enforcement_without_global_token():
+    auth.init({
+        'MOTUS_DRIVER_TOKENS': '{"driver-a":"private-driver-a-token-0001"}',
+        'MOTUS_ENFORCE_DRIVER_AUTH': 'true',
+    })
+
+    assert auth.is_driver_auth_enforced() is True
+    assert auth.driver_runtime_credential_available('driver-a') is True
+    assert auth.driver_runtime_credential_available('driver-b') is False
+
+
+def test_dedicated_driver_bearer_requires_24_url_safe_ascii_characters():
+    with pytest.raises(ValueError, match='at least 24 bytes'):
+        auth.init({'MOTUS_DRIVER_TOKENS': json.dumps({'driver-a': 'a' * 23})})
+
+    auth.init({'MOTUS_DRIVER_TOKENS': json.dumps({'driver-a': 'a' * 24})})
+    assert auth.verify_driver_token('a' * 24, 'driver-a') is True
+
+
+def test_removing_every_driver_credential_quarantines_persisted_trust():
+    auth.init({})
+
+    assert auth.has_any_driver_credentials() is False
+    assert auth.driver_runtime_credential_available('persisted-driver') is False
+
+
+def test_driver_credential_selectors_reject_missing_or_invalid_identity():
+    auth.init({
+        'MOTUS_DRIVER_TOKEN': 'legacy-driver-fallback',
+        'MOTUS_TELEOP_TICKET_SECRET': 't' * 32,
+    })
+
+    for invalid_id in ('', ' bad-id', 'driver/id', None):
+        assert auth.is_driver_auth_configured(invalid_id) is False
+        assert auth.driver_runtime_credential_available(invalid_id) is False
+        assert auth.driver_request_headers(invalid_id) == {}
+        assert auth.teleop_ticket_secret(invalid_id) == b''
+        assert auth.teleop_ticket_credential_available(invalid_id) is False
+        assert auth.verify_driver_token('legacy-driver-fallback', invalid_id) is False
+
+
+def test_ticket_readiness_is_exact_per_driver_and_does_not_use_another_map_entry():
+    auth.init({
+        'MOTUS_TELEOP_TICKET_SECRETS': json.dumps({'driver-a': 'a' * 32}),
+    })
+
+    assert auth.teleop_ticket_credential_available('driver-a') is True
+    assert auth.teleop_ticket_credential_available('driver-b') is False
+
+
+def test_dedicated_credential_binding_requires_fresh_registration_after_rotation():
+    old_token = 'private-driver-a-token-old-0001'
+    new_token = 'private-driver-a-token-new-0002'
+    auth.init({
+        'MOTUS_DRIVER_TOKEN': 'legacy-driver-fallback',
+        'MOTUS_DRIVER_TOKENS': json.dumps({'driver-a': old_token}),
+    })
+    old_binding = auth.driver_credential_binding('driver-a')
+
+    assert old_binding.startswith('sha256:')
+    assert old_token not in old_binding
+    assert auth.driver_record_credential_available('driver-a', old_binding) is True
+    assert auth.driver_record_credential_available('driver-a', '') is False
+
+    auth.init({
+        'MOTUS_DRIVER_TOKEN': 'legacy-driver-fallback',
+        'MOTUS_DRIVER_TOKENS': json.dumps({'driver-a': new_token}),
+    })
+    new_binding = auth.driver_credential_binding('driver-a')
+    assert new_binding != old_binding
+    assert auth.driver_record_credential_available('driver-a', old_binding) is False
+    assert auth.driver_record_credential_available('driver-a', new_binding) is True
+
+    auth.init({'MOTUS_DRIVER_TOKEN': 'legacy-driver-fallback'})
+    assert auth.driver_record_credential_available('driver-a', old_binding) is False
+    assert auth.driver_record_credential_available('driver-a', None) is True
+
+
+@pytest.mark.parametrize(
+    ('settings', 'message'),
+    [
+        (
+            {
+                'MOTUS_DRIVER_TOKENS': (
+                    '{"driver-a":"same-secret-value-1234567890",'
+                    '"driver-b":"same-secret-value-1234567890"}'
+                ),
+            },
+            'more than one id',
+        ),
+        (
+            {
+                'ACCESS_TOKEN': 'same-secret-value-1234567890',
+                'MOTUS_DRIVER_TOKENS': (
+                    '{"driver-a":"same-secret-value-1234567890"}'
+                ),
+            },
+            'human access token',
+        ),
+        (
+            {
+                'MOTUS_DRIVER_TOKEN': 'same-secret-value-1234567890',
+                'MOTUS_DRIVER_TOKENS': (
+                    '{"driver-a":"same-secret-value-1234567890"}'
+                ),
+            },
+            'reuse dedicated credential',
+        ),
+        (
+            {'MOTUS_DRIVER_TOKENS': '{"bad id":"private"}'},
+            'invalid driver credential id',
+        ),
+        (
+            {
+                'MOTUS_TELEOP_TICKET_SECRETS': (
+                    '{"driver-a":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",'
+                    '"driver-b":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}'
+                ),
+            },
+            'more than one id',
+        ),
+        (
+            {
+                'MOTUS_TELEOP_TICKET_SECRET': 'a' * 32,
+                'MOTUS_TELEOP_TICKET_SECRETS': (
+                    '{"driver-a":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}'
+                ),
+            },
+            'reuse dedicated secret',
+        ),
+        (
+            {
+                'MOTUS_DRIVER_TOKENS': (
+                    '{"driver-a":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}'
+                ),
+                'MOTUS_TELEOP_TICKET_SECRETS': (
+                    '{"driver-b":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}'
+                ),
+            },
+            'reuse dedicated Driver credential',
+        ),
+        (
+            {
+                'ACCESS_TOKEN': 'h' * 32,
+                'MOTUS_TELEOP_TICKET_SECRET': 'h' * 32,
+            },
+            'reuse a human access token',
+        ),
+        (
+            {
+                'MOTUS_DRIVER_TOKEN': 'l' * 32,
+                'MOTUS_TELEOP_TICKET_SECRET': 'l' * 32,
+            },
+            'reuse legacy Driver credential',
+        ),
+        (
+            {
+                'MOTUS_DRIVER_TOKEN': '遥' * 11,
+                'MOTUS_TELEOP_TICKET_SECRET': '遥' * 11,
+            },
+            'reuse legacy Driver credential',
+        ),
+    ],
+)
+def test_driver_credential_maps_reject_ambiguous_or_reused_secrets(
+    settings,
+    message,
+):
+    with pytest.raises(ValueError, match=message):
+        auth.init(settings)
+
+
+def test_teleop_ticket_secret_requires_at_least_32_utf8_bytes():
+    with pytest.raises(ValueError, match='at least 32 bytes'):
+        auth.init({'MOTUS_TELEOP_TICKET_SECRET': 'x' * 31})
+
+    auth.init({'MOTUS_TELEOP_TICKET_SECRET': '遥' * 11})
+    assert auth.teleop_ticket_secret('legacy-driver') == ('遥' * 11).encode('utf-8')
+
+
+def test_dedicated_bearer_rejects_unicode_but_ticket_secret_supports_it():
+    with pytest.raises(ValueError, match='restricted ASCII Bearer'):
+        auth.init({
+            'MOTUS_DRIVER_TOKENS': json.dumps({'driver-a': '密' * 24}),
+        })
+
+    unicode_ticket = '遥' * 11
+    auth.init({
+        'MOTUS_TELEOP_TICKET_SECRETS': json.dumps({
+            'driver-a': unicode_ticket,
+        }),
+    })
+    assert auth.teleop_ticket_secret('driver-a') == unicode_ticket.encode('utf-8')
+
+    with pytest.raises(ValueError, match='reuse a human access token'):
+        auth.init({
+            'ACCESS_TOKEN': unicode_ticket,
+            'MOTUS_TELEOP_TICKET_SECRETS': json.dumps({
+                'driver-a': unicode_ticket,
+            }),
+        })
+
+
+def test_teleop_ticket_secret_loads_from_deployment_env(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    deployment_env = tmp_path / 'deployment.env'
+    deployment_env.write_text(
+        f'MOTUS_TELEOP_TICKET_SECRET={"s" * 32}\n',
+        encoding='utf-8',
+    )
+    monkeypatch.delenv('MOTUS_TELEOP_TICKET_SECRET', raising=False)
+    monkeypatch.setattr(auth, '_ENV_PATH', deployment_env)
+    monkeypatch.setattr(auth, '_ENV_PATH_DEV', tmp_path / 'missing.env')
+
+    auth.init()
+
+    assert auth.teleop_ticket_secret('legacy-driver') == b's' * 32
+
+
+def test_per_driver_credentials_load_from_deployment_env(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    deployment_env = tmp_path / 'deployment.env'
+    deployment_env.write_text(
+        'MOTUS_DRIVER_TOKENS={"driver-a":"private-driver-a-token-0001"}\n'
+        f'MOTUS_TELEOP_TICKET_SECRETS={{"driver-a":"{"t" * 32}"}}\n'
+        'MOTUS_ENFORCE_DRIVER_AUTH=true\n',
+        encoding='utf-8',
+    )
+    for key in (
+        'MOTUS_DRIVER_TOKEN',
+        'MOTUS_DRIVER_TOKENS',
+        'MOTUS_TELEOP_TICKET_SECRET',
+        'MOTUS_TELEOP_TICKET_SECRETS',
+        'MOTUS_ENFORCE_DRIVER_AUTH',
+    ):
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setattr(auth, '_ENV_PATH', deployment_env)
+    monkeypatch.setattr(auth, '_ENV_PATH_DEV', tmp_path / 'missing.env')
+
+    auth.init()
+
+    assert auth.driver_request_headers('driver-a') == {
+        'Authorization': 'Bearer private-driver-a-token-0001',
+    }
+    assert auth.teleop_ticket_secret('driver-a') == b't' * 32
+    assert auth.is_driver_auth_enforced() is True
+
+
+@pytest.mark.parametrize('path', ['/ws/motus', '/ws/bus/unregistered'])
+def test_non_owner_websocket_is_closed(client, path):
+    with pytest.raises(WebSocketDisconnect) as exc:
+        with client.websocket_connect(f'{path}?token=viewer-token'):
+            pass
+    assert exc.value.code in (4001, 4003)
+
+
+def test_owner_websocket_remains_usable(client):
+    with client.websocket_connect('/ws/motus?token=owner-token') as websocket:
+        message = websocket.receive_json()
+    assert message['type'] == 'status'
+    assert message['payload']['connected'] is True
+
+
+def test_owner_can_open_bus_websocket(client):
+    with client.websocket_connect('/ws/bus/unregistered?token=owner-token') as websocket:
+        message = websocket.receive_json()
+    assert message['type'] == 'error'
+    assert 'not registered' in message['message']

--- a/agent-core/tests/teleop/test_authority_guard.py
+++ b/agent-core/tests/teleop/test_authority_guard.py
@@ -1,0 +1,363 @@
+from __future__ import annotations
+
+import asyncio
+import math
+import sqlite3
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import fields
+
+import pytest
+
+import config
+from teleop import authority_guard
+from teleop.authority_guard import (
+    MAX_DRIVER_EPOCH,
+    MAX_SQLITE_INTEGER,
+    AuthorityGuard,
+    AuthorityGuardNotFound,
+    AuthorityGuardSchemaError,
+    AuthorityGuardStateConflict,
+)
+
+SESSION_A = "11111111-1111-4111-8111-111111111111"
+SESSION_B = "22222222-2222-4222-8222-222222222222"
+BOOT_A = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+
+
+def guard_values(index: int = 1, **overrides: object) -> dict[str, object]:
+    values: dict[str, object] = {
+        "robot_id": f"robot-{index}",
+        "driver_id": f"driver-{index}",
+        "session_id": SESSION_A if index == 1 else SESSION_B,
+        "boot_id": BOOT_A,
+        "epoch": index,
+        "capability_digest": "a" * 64,
+        "target_fingerprint": "b" * 64,
+        "dispatch_generation": index,
+        "phase": "preparing",
+        "created_at": 100.0 + index,
+        "updated_at": 100.0 + index,
+    }
+    values.update(overrides)
+    return values
+
+
+def make_guard(index: int = 1, **overrides: object) -> AuthorityGuard:
+    return AuthorityGuard(**guard_values(index, **overrides))
+
+
+def test_guard_round_trip_list_order_and_thread_entrypoints():
+    async def scenario():
+        second = make_guard(2)
+        first = make_guard(1)
+        await asyncio.to_thread(authority_guard.create_guard, second)
+        await asyncio.to_thread(authority_guard.create_guard, first)
+
+        loaded = await asyncio.to_thread(authority_guard.get_guard, first.robot_id)
+        listed = await asyncio.to_thread(authority_guard.list_guards)
+        missing = await asyncio.to_thread(authority_guard.get_guard, "robot-missing")
+        return loaded, listed, missing
+
+    loaded, listed, missing = asyncio.run(scenario())
+
+    assert loaded == make_guard(1)
+    assert listed == [make_guard(1), make_guard(2)]
+    assert missing is None
+
+
+def test_insert_never_replaces_robot_driver_or_session_aliases():
+    original = authority_guard.create_guard(make_guard())
+
+    aliases = [
+        make_guard(
+            2,
+            robot_id=original.robot_id,
+            session_id=SESSION_B,
+        ),
+        make_guard(
+            2,
+            driver_id=original.driver_id,
+            session_id=SESSION_B,
+        ),
+        make_guard(
+            2,
+            session_id=original.session_id,
+        ),
+    ]
+    for alias in aliases:
+        with pytest.raises(sqlite3.IntegrityError):
+            authority_guard.create_guard(alias)
+
+    assert authority_guard.list_guards() == [original]
+
+
+def test_concurrent_alias_inserts_have_one_winner_and_do_not_replace():
+    candidates = [
+        make_guard(
+            1,
+            robot_id="shared-robot",
+            driver_id=f"driver-{index}",
+            session_id=f"00000000-0000-4000-8000-{index:012d}",
+            epoch=index,
+        )
+        for index in range(1, 9)
+    ]
+
+    def insert(candidate: AuthorityGuard) -> tuple[str, AuthorityGuard | None]:
+        try:
+            return "created", authority_guard.create_guard(candidate)
+        except sqlite3.IntegrityError:
+            return "conflict", None
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        results = list(pool.map(insert, candidates))
+
+    assert [result[0] for result in results].count("created") == 1
+    assert [result[0] for result in results].count("conflict") == 7
+    stored = authority_guard.list_guards()
+    assert len(stored) == 1
+    assert stored[0] in candidates
+
+
+def test_update_and_delete_compare_the_exact_robot_session_pair(monkeypatch):
+    first = authority_guard.create_guard(make_guard(1))
+    second = authority_guard.create_guard(make_guard(2))
+
+    with pytest.raises(AuthorityGuardNotFound):
+        authority_guard.update_guard(
+            first.robot_id,
+            second.session_id,
+            phase="active",
+            dispatch_generation=2,
+        )
+    assert authority_guard.delete_guard(first.robot_id, second.session_id) is False
+    assert authority_guard.get_guard(first.robot_id) == first
+    assert authority_guard.get_guard(second.robot_id) == second
+
+    updated = authority_guard.update_guard(
+        first.robot_id,
+        first.session_id,
+        phase="active",
+        dispatch_generation=2,
+        updated_at=110.0,
+    )
+    assert updated.phase == "active"
+    assert updated.dispatch_generation == 2
+    assert updated.updated_at == 110.0
+    assert updated.created_at == first.created_at
+
+    monkeypatch.setattr(authority_guard.time, "time", lambda: 1.0)
+    after_clock_rollback = authority_guard.update_guard(
+        first.robot_id,
+        first.session_id,
+        phase="stopping",
+        dispatch_generation=3,
+    )
+    assert after_clock_rollback.updated_at == 110.0
+
+    assert authority_guard.delete_guard(first.robot_id, first.session_id) is True
+    assert authority_guard.delete_guard(first.robot_id, first.session_id) is False
+    assert authority_guard.list_guards() == [second]
+
+
+def test_update_rejects_generation_and_timestamp_regression_atomically():
+    original = authority_guard.create_guard(
+        make_guard(dispatch_generation=10, updated_at=200.0)
+    )
+
+    with pytest.raises(AuthorityGuardStateConflict, match="dispatch_generation"):
+        authority_guard.update_guard(
+            original.robot_id,
+            original.session_id,
+            phase="active",
+            dispatch_generation=9,
+            updated_at=201.0,
+        )
+    with pytest.raises(AuthorityGuardStateConflict, match="updated_at"):
+        authority_guard.update_guard(
+            original.robot_id,
+            original.session_id,
+            phase="active",
+            dispatch_generation=11,
+            updated_at=199.0,
+        )
+
+    assert authority_guard.get_guard(original.robot_id) == original
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"robot_id": ""},
+        {"robot_id": "r" * 65},
+        {"robot_id": "robot/unsafe"},
+        {"driver_id": ""},
+        {"driver_id": " driver"},
+        {"session_id": "not-a-uuid"},
+        {"session_id": "00000000-0000-0000-0000-000000000000"},
+        {"session_id": "AAAAAAAA-AAAA-4AAA-8AAA-AAAAAAAAAAAA"},
+        {"boot_id": "not-a-uuid"},
+        {"capability_digest": "A" * 64},
+        {"capability_digest": "a" * 63},
+        {"target_fingerprint": "g" * 64},
+        {"epoch": True},
+        {"epoch": 0},
+        {"epoch": MAX_DRIVER_EPOCH + 1},
+        {"dispatch_generation": False},
+        {"dispatch_generation": -1},
+        {"dispatch_generation": MAX_SQLITE_INTEGER + 1},
+        {"phase": "released"},
+        {"created_at": math.nan},
+        {"created_at": math.inf},
+        {"created_at": -1},
+        {"updated_at": 0},
+    ],
+)
+def test_guard_rejects_invalid_or_out_of_range_fields(overrides):
+    with pytest.raises((TypeError, ValueError)):
+        make_guard(**overrides)
+
+
+def test_mutation_rolls_back_when_sqlite_rejects_the_write():
+    original = authority_guard.create_guard(make_guard())
+    with config._get_conn() as conn:
+        conn.execute("""
+            CREATE TRIGGER reject_guard_updates
+            BEFORE UPDATE ON teleop_authority_guards
+            BEGIN
+                SELECT RAISE(ABORT, 'simulated durable write failure');
+            END
+        """)
+        conn.commit()
+
+    with pytest.raises(sqlite3.IntegrityError, match="durable write failure"):
+        authority_guard.update_guard(
+            original.robot_id,
+            original.session_id,
+            phase="active",
+            dispatch_generation=2,
+            updated_at=150.0,
+        )
+
+    assert authority_guard.get_guard(original.robot_id) == original
+
+
+@pytest.mark.parametrize(
+    "operation",
+    [
+        lambda guard: authority_guard.create_guard(guard),
+        lambda guard: authority_guard.get_guard(guard.robot_id),
+        lambda guard: authority_guard.list_guards(),
+        lambda guard: authority_guard.update_guard(
+            guard.robot_id,
+            guard.session_id,
+            phase="active",
+            dispatch_generation=2,
+        ),
+        lambda guard: authority_guard.delete_guard(guard.robot_id, guard.session_id),
+    ],
+)
+def test_database_open_failures_propagate_fail_closed(monkeypatch, operation):
+    def unavailable():
+        raise OSError("database unavailable")
+
+    monkeypatch.setattr(config, "_get_conn", unavailable)
+    with pytest.raises(OSError, match="database unavailable"):
+        operation(make_guard())
+
+
+def test_corrupt_raw_row_causes_reads_to_fail_instead_of_appearing_unlocked():
+    guard = authority_guard.create_guard(make_guard())
+    with config._get_conn() as conn:
+        conn.execute(
+            """UPDATE teleop_authority_guards
+               SET target_fingerprint=? WHERE robot_id=?""",
+            ("not-a-fingerprint", guard.robot_id),
+        )
+        conn.commit()
+
+    with pytest.raises(ValueError, match="target_fingerprint"):
+        authority_guard.get_guard(guard.robot_id)
+    with pytest.raises(ValueError, match="target_fingerprint"):
+        authority_guard.list_guards()
+
+
+def test_incompatible_preexisting_schema_is_rejected():
+    with config._get_conn() as conn:
+        conn.execute("""
+            CREATE TABLE teleop_authority_guards (
+                robot_id TEXT PRIMARY KEY,
+                fence TEXT
+            )
+        """)
+        conn.commit()
+
+    with pytest.raises(AuthorityGuardSchemaError):
+        authority_guard.list_guards()
+
+
+def test_raw_schema_and_dataclass_contain_only_secret_free_guard_evidence():
+    authority_guard.create_guard(make_guard())
+
+    expected_fields = [
+        "robot_id",
+        "driver_id",
+        "session_id",
+        "boot_id",
+        "epoch",
+        "capability_digest",
+        "target_fingerprint",
+        "dispatch_generation",
+        "phase",
+        "created_at",
+        "updated_at",
+    ]
+    assert [field.name for field in fields(AuthorityGuard)] == expected_fields
+
+    with config._get_conn() as conn:
+        columns = [
+            row[1]
+            for row in conn.execute(
+                "PRAGMA table_info(teleop_authority_guards)"
+            ).fetchall()
+        ]
+        create_sql = conn.execute(
+            "SELECT sql FROM sqlite_master WHERE type='table' AND name=?",
+            ("teleop_authority_guards",),
+        ).fetchone()[0]
+        row = conn.execute("SELECT * FROM teleop_authority_guards").fetchone()
+
+    assert columns == expected_fields
+    normalized = " ".join(columns).lower()
+    schema_lower = create_sql.lower()
+    for secret_name in (
+        "fence",
+        "token",
+        "client",
+        "principal",
+        "credential",
+        "password",
+    ):
+        assert secret_name not in normalized
+        assert secret_name not in schema_lower
+    assert len(row) == len(expected_fields)
+
+
+def test_raw_schema_enforces_phase_and_integer_ranges():
+    authority_guard.create_guard(make_guard())
+    with config._get_conn() as conn:
+        with pytest.raises(sqlite3.IntegrityError):
+            conn.execute(
+                """UPDATE teleop_authority_guards SET phase='released'
+                   WHERE robot_id='robot-1' """
+            )
+        conn.rollback()
+
+        with pytest.raises(sqlite3.IntegrityError):
+            conn.execute(
+                """UPDATE teleop_authority_guards SET dispatch_generation=-1
+                   WHERE robot_id='robot-1' """
+            )
+        conn.rollback()
+
+    assert authority_guard.get_guard("robot-1") == make_guard()

--- a/agent-core/tests/teleop/test_capture_api.py
+++ b/agent-core/tests/teleop/test_capture_api.py
@@ -1,0 +1,666 @@
+from __future__ import annotations
+
+import asyncio
+import base64
+import gc
+import json
+
+import pytest
+
+from api import teleop
+from teleop.capture_manager import CaptureConnection, CaptureManager
+from teleop.service import TeleopServiceError
+from teleop.session_manager import SessionClientMismatch, SessionStateConflict
+
+CLIENT_ID = '7dbabfca-15c1-43ca-b600-75e7682c21d0'
+REFRESHED_CLIENT_ID = '68991413-d37a-4603-9f07-3e25219d6d96'
+SESSION_ID = 'd097eb8f-b386-455f-9e2b-23f1ad6a1ee3'
+DIGEST = '0123456789abcdef' * 4
+CAPTURE_METADATA = {
+    'capture_protocol': 'motus.teleop.capture.v1',
+    'frame_protocol': 'motus.teleop.rtc-frame.v1',
+    'client_kind': 'browser_webxr',
+    'app_version': '1.0.0-test',
+}
+
+
+class _CaptureApiCoordinator:
+    def __init__(self, *, fail_signaling: bool = False):
+        self.capture_manager = CaptureManager()
+        self.fail_signaling = fail_signaling
+        self.session_state = 'active'
+        self.soft_stop_count = 0
+
+    async def _complete_loss(self, lost_assignment):
+        if lost_assignment is None:
+            return
+        self.soft_stop_count += 1
+        self.session_state = 'hold'
+        assert await self.capture_manager.complete_assignment_loss(
+            lost_assignment,
+        ) is True
+
+    async def create_capture_pairing(self, principal_id, client_id, *, label):
+        return await self.capture_manager.create_pairing(
+            principal_id,
+            client_id,
+            label=label,
+        )
+
+    async def list_captures(self, principal_id):
+        return await self.capture_manager.list_for_supervisor(principal_id)
+
+    async def revoke_capture(self, capture_id, principal_id):
+        return await self.capture_manager.revoke_capture(capture_id, principal_id)
+
+    async def attach_capture(
+        self,
+        session_id,
+        principal_id,
+        client_id,
+        *,
+        capture_id,
+        mode,
+        profile_id,
+        capability_digest,
+    ):
+        if principal_id != 'operator:alice':
+            raise SessionStateConflict(session_id)
+        if client_id != CLIENT_ID:
+            raise SessionClientMismatch(session_id)
+        if (
+            self.session_state != 'active'
+            or session_id != SESSION_ID
+            or mode != 'shadow'
+            or profile_id != 'recording'
+            or capability_digest != DIGEST
+        ):
+            raise SessionStateConflict(session_id)
+        return await self.capture_manager.attach(
+            capture_id=capture_id,
+            principal_id=principal_id,
+            session_id=session_id,
+            operation_generation=3,
+            mode=mode,
+            profile_id=profile_id,
+            capability_digest=capability_digest,
+            capabilities={
+                'profile_id': 'recording',
+                'input_bindings': {},
+                'outputs': {'dual_arm': {'enabled': True, 'joint_count': 10}},
+                'effectors': ['dual_arm'],
+            },
+            effectors=['dual_arm'],
+        )
+
+    async def connect_capture_with_pairing(
+        self,
+        pairing_id,
+        pairing_code,
+        **metadata,
+    ):
+        return await self.capture_manager.connect_with_pairing(
+            pairing_id,
+            pairing_code,
+            **metadata,
+        )
+
+    async def connect_capture_with_credential(
+        self,
+        capture_id,
+        capture_credential,
+        **metadata,
+    ):
+        return await self.capture_manager.connect_with_credential(
+            capture_id,
+            capture_credential,
+            **metadata,
+        )
+
+    async def disconnect_capture(self, capture_id, connection_id):
+        lost_assignment = await self.capture_manager.disconnect(
+            capture_id,
+            connection_id,
+        )
+        await self._complete_loss(lost_assignment)
+
+    async def capture_presence(
+        self,
+        capture_id,
+        connection_id,
+        *,
+        state,
+        assignment_id,
+    ):
+        presence, lost_assignment = await self.capture_manager.update_presence(
+            capture_id,
+            connection_id,
+            state=state,
+            assignment_id=assignment_id,
+        )
+        await self._complete_loss(lost_assignment)
+        return presence
+
+    async def expire_capture_connection(self, capture_id, connection_id):
+        stale, lost_assignment = await self.capture_manager.expire_stale_connection(
+            capture_id,
+            connection_id,
+        )
+        await self._complete_loss(lost_assignment)
+        return stale
+
+    async def capture_signaling_offer(
+        self,
+        capture_id,
+        connection_id,
+        assignment_id,
+        offer,
+    ):
+        assert offer == {'type': 'offer', 'sdp': 'v=0\r\no=quest-capture'}
+        await self.capture_manager.claim_offer(
+            capture_id,
+            connection_id,
+            assignment_id,
+        )
+        if self.fail_signaling:
+            lost_assignment = await self.capture_manager.fail_offer(
+                capture_id,
+                assignment_id,
+            )
+            await self._complete_loss(lost_assignment)
+            raise TeleopServiceError('driver_unreachable', 503)
+        assert await self.capture_manager.complete_offer(
+            capture_id,
+            connection_id,
+            assignment_id,
+        ) is True
+        return {'type': 'answer', 'sdp': f'v=0\r\na={assignment_id}'}
+
+
+def _operator_headers(client_id: str = CLIENT_ID) -> dict[str, str]:
+    return {
+        'Authorization': 'Bearer operator-token',
+        'X-Motus-Teleop-Client': client_id,
+    }
+
+
+def _pairing(client, *, label: str = 'Quest 3') -> dict:
+    response = client.post(
+        '/api/teleop/capture-pairings',
+        headers=_operator_headers(),
+        json={'label': label},
+    )
+    assert response.status_code == 201
+    assert response.headers['cache-control'] == 'no-store'
+    return response.json()['data']
+
+
+def _pair_message(pairing: dict) -> dict:
+    return {
+        'type': 'pair',
+        'pairing_id': pairing['pairing_id'],
+        'pairing_code': pairing['pairing_code'],
+        **CAPTURE_METADATA,
+    }
+
+
+def test_pairing_returns_only_bounded_public_tls_bootstrap(
+    client,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    coordinator = _CaptureApiCoordinator()
+    monkeypatch.setattr(teleop, 'coordinator', coordinator)
+
+    pairing = _pairing(client)
+
+    assert pairing['websocket_path'] == '/ws/teleop-capture'
+    assert pairing['ca_certificate_pem'].startswith(
+        '-----BEGIN CERTIFICATE-----\n'
+    )
+    assert pairing['ca_certificate_pem'].endswith(
+        '-----END CERTIFICATE-----\n'
+    )
+    assert base64.b64decode(
+        pairing['ca_certificate_base64'],
+        validate=True,
+    ).decode('ascii') == pairing['ca_certificate_pem']
+    serialized = json.dumps(pairing, sort_keys=True)
+    assert 'PRIVATE KEY' not in serialized
+    assert 'cert.pem' not in serialized
+    assert 'key.pem' not in serialized
+
+
+def test_pairing_tls_bootstrap_is_not_visible_to_viewers(client):
+    response = client.post(
+        '/api/teleop/capture-pairings',
+        headers={
+            'Authorization': 'Bearer viewer-token',
+            'X-Motus-Teleop-Client': CLIENT_ID,
+        },
+        json={'label': 'Quest 3'},
+    )
+
+    assert response.status_code == 403
+    serialized = response.text
+    assert 'BEGIN CERTIFICATE' not in serialized
+    assert 'pairing_code' not in serialized
+
+
+def test_pairing_fails_before_issuing_secret_without_safe_tls_bootstrap(
+    client,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    coordinator = _CaptureApiCoordinator()
+    monkeypatch.setattr(teleop, 'coordinator', coordinator)
+    api_mount = next(route for route in client.app.routes if route.path == '/api')
+    api_mount.app.state.teleop_capture_ca_certificate_pem = (
+        '-----BEGIN PRIVATE KEY-----\nsecret\n-----END PRIVATE KEY-----\n'
+    )
+
+    response = client.post(
+        '/api/teleop/capture-pairings',
+        headers=_operator_headers(),
+        json={'label': 'Quest 3'},
+    )
+
+    assert response.status_code == 503
+    assert response.headers['cache-control'] == 'no-store'
+    assert response.json()['detail']['code'] == 'capture_tls_bootstrap_unavailable'
+    assert coordinator.capture_manager._pairings == {}
+
+
+def test_capture_secret_models_hide_credentials_from_repr():
+    pairing_code = 'pairing-secret-' + ('x' * 32)
+    credential = 'credential-secret-' + ('y' * 32)
+    pair = teleop.CapturePairMessage.model_validate({
+        'type': 'pair',
+        'pairing_id': 'd097eb8f-b386-455f-9e2b-23f1ad6a1ee3',
+        'pairing_code': pairing_code,
+        **CAPTURE_METADATA,
+    })
+    reconnect = teleop.CaptureCredentialMessage.model_validate({
+        'type': 'credential',
+        'capture_id': '79def5a3-85e9-48b0-9220-8e730e2944c1',
+        'capture_credential': credential,
+        **CAPTURE_METADATA,
+    })
+
+    assert pairing_code not in repr(pair)
+    assert credential not in repr(reconnect)
+
+
+def test_pairing_is_in_band_and_enrollment_survives_pc_tab_refresh(
+    client,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    coordinator = _CaptureApiCoordinator()
+    monkeypatch.setattr(teleop, 'coordinator', coordinator)
+    pairing = _pairing(client)
+
+    with client.websocket_connect('/ws/teleop-capture') as websocket:
+        websocket.send_json(_pair_message(pairing))
+        paired = websocket.receive_json()
+        credential = paired['capture_credential']
+        capture_id = paired['capture_id']
+        assert paired == {
+            'type': 'paired',
+            'capture_id': capture_id,
+            'capture_credential': credential,
+            'capture_protocol': CAPTURE_METADATA['capture_protocol'],
+            'frame_protocol': CAPTURE_METADATA['frame_protocol'],
+            'presence_interval_ms': 2_000,
+            'presence_timeout_ms': 5_000,
+        }
+
+        websocket.send_json({
+            'type': 'presence',
+            'state': 'xr_standby',
+            'assignment_id': None,
+        })
+        assert websocket.receive_json() == {
+            'type': 'presence_ack',
+            'state': 'xr_standby',
+        }
+
+        refreshed = client.get(
+            '/api/teleop/captures',
+            headers=_operator_headers(REFRESHED_CLIENT_ID),
+        )
+        assert refreshed.status_code == 200
+        public_capture = refreshed.json()['data'][0]
+        assert public_capture['id'] == capture_id
+        assert public_capture['connected'] is True
+        assert public_capture['observed_state'] == 'xr_standby'
+        for key, value in CAPTURE_METADATA.items():
+            assert public_capture[key] == value
+
+        serialized = json.dumps(public_capture, sort_keys=True)
+        for secret in (
+            pairing['pairing_code'],
+            credential,
+            CLIENT_ID,
+            REFRESHED_CLIENT_ID,
+        ):
+            assert secret not in serialized
+
+        other_principal = client.get(
+            '/api/teleop/captures',
+            headers={
+                'Authorization': 'Bearer owner-token',
+                'X-Motus-Teleop-Client': REFRESHED_CLIENT_ID,
+            },
+        )
+        assert other_principal.status_code == 200
+        assert other_principal.json()['data'] == []
+
+        revoked = client.delete(
+            f'/api/teleop/captures/{capture_id}',
+            headers=_operator_headers(REFRESHED_CLIENT_ID),
+        )
+        assert revoked.status_code == 200
+        assert websocket.receive_json() == {
+            'type': 'capture_revoked',
+            'reason': 'operator_revoked',
+        }
+
+
+def test_original_session_tab_attaches_and_wss_receives_only_safe_assignment(
+    client,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    coordinator = _CaptureApiCoordinator()
+    monkeypatch.setattr(teleop, 'coordinator', coordinator)
+    pairing = _pairing(client)
+
+    with client.websocket_connect('/ws/teleop-capture') as websocket:
+        websocket.send_json(_pair_message(pairing))
+        paired = websocket.receive_json()
+        websocket.send_json({
+            'type': 'presence',
+            'state': 'xr_standby',
+            'assignment_id': None,
+        })
+        assert websocket.receive_json()['type'] == 'presence_ack'
+
+        wrong_tab = client.post(
+            f'/api/teleop/sessions/{SESSION_ID}/capture-attachment',
+            headers=_operator_headers(REFRESHED_CLIENT_ID),
+            json={
+                'capture_id': paired['capture_id'],
+                'mode': 'shadow',
+                'profile_id': 'recording',
+                'capability_digest': DIGEST,
+            },
+        )
+        assert wrong_tab.status_code == 403
+        assert wrong_tab.json()['detail']['code'] == 'session_client_mismatch'
+
+        attached = client.post(
+            f'/api/teleop/sessions/{SESSION_ID}/capture-attachment',
+            headers=_operator_headers(),
+            json={
+                'capture_id': paired['capture_id'],
+                'mode': 'shadow',
+                'profile_id': 'recording',
+                'capability_digest': DIGEST,
+            },
+        )
+        assert attached.status_code == 200
+        assignment = websocket.receive_json()
+        assert assignment['type'] == 'assignment'
+        assert assignment['assignment'] == attached.json()['data']
+        assignment_id = assignment['assignment']['id']
+
+        public_wire = json.dumps(assignment, sort_keys=True)
+        for secret in (
+            paired['capture_credential'],
+            pairing['pairing_code'],
+            CLIENT_ID,
+            'private-fence',
+            'teleop-ticket',
+        ):
+            assert secret not in public_wire
+
+        websocket.send_json({
+            'type': 'signaling_offer',
+            'assignment_id': assignment_id,
+            'offer': {'type': 'offer', 'sdp': 'v=0\r\no=quest-capture'},
+        })
+        assert websocket.receive_json() == {
+            'type': 'signaling_answer',
+            'assignment_id': assignment_id,
+            'answer': {
+                'type': 'answer',
+                'sdp': f'v=0\r\na={assignment_id}',
+            },
+        }
+
+        still_attached = client.delete(
+            f"/api/teleop/captures/{paired['capture_id']}",
+            headers=_operator_headers(),
+        )
+        assert still_attached.status_code == 409
+        assert still_attached.json()['detail']['code'] == 'capture_attached'
+
+        websocket.send_json({
+            'type': 'presence',
+            'state': 'xr_ended',
+            'assignment_id': None,
+        })
+        assert websocket.receive_json() == {
+            'type': 'presence_ack',
+            'state': 'xr_ended',
+        }
+        assert websocket.receive_json() == {
+            'type': 'assignment_revoked',
+            'assignment_id': assignment_id,
+            'reason': 'capture_xr_ended',
+        }
+
+        revoked = client.delete(
+            f"/api/teleop/captures/{paired['capture_id']}",
+            headers=_operator_headers(),
+        )
+        assert revoked.status_code == 200
+        assert websocket.receive_json() == {
+            'type': 'capture_revoked',
+            'reason': 'operator_revoked',
+        }
+
+
+def test_real_wss_offer_error_closes_and_holds_exactly_once(
+    client,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    coordinator = _CaptureApiCoordinator(fail_signaling=True)
+    monkeypatch.setattr(teleop, 'coordinator', coordinator)
+    pairing = _pairing(client)
+
+    with client.websocket_connect('/ws/teleop-capture') as websocket:
+        websocket.send_json(_pair_message(pairing))
+        paired = websocket.receive_json()
+        websocket.send_json({
+            'type': 'presence',
+            'state': 'xr_standby',
+            'assignment_id': None,
+        })
+        assert websocket.receive_json()['type'] == 'presence_ack'
+        attached = client.post(
+            f'/api/teleop/sessions/{SESSION_ID}/capture-attachment',
+            headers=_operator_headers(),
+            json={
+                'capture_id': paired['capture_id'],
+                'mode': 'shadow',
+                'profile_id': 'recording',
+                'capability_digest': DIGEST,
+            },
+        )
+        assert attached.status_code == 200
+        assignment = websocket.receive_json()['assignment']
+
+        websocket.send_json({
+            'type': 'signaling_offer',
+            'assignment_id': assignment['id'],
+            'offer': {'type': 'offer', 'sdp': 'v=0\r\no=quest-capture'},
+        })
+        assert websocket.receive_json() == {
+            'type': 'error',
+            'code': 'driver_unreachable',
+        }
+
+    assert coordinator.session_state == 'hold'
+    assert coordinator.soft_stop_count == 1
+    captures = asyncio.run(coordinator.list_captures('operator:alice'))
+    assert captures[0]['assignment'] is None
+
+
+class _SimultaneousTerminalWebSocket:
+    def __init__(self, first_message: dict):
+        self._first_message = first_message
+        self._receive_count = 0
+        self.peer_disconnect_ready = asyncio.Event()
+        self.sent: list[dict] = []
+        self.closed: list[tuple[int, str]] = []
+
+    async def accept(self):
+        return None
+
+    async def receive(self):
+        self._receive_count += 1
+        if self._receive_count == 1:
+            return {
+                'type': 'websocket.receive',
+                'text': json.dumps(self._first_message),
+            }
+        self.peer_disconnect_ready.set()
+        return {'type': 'websocket.disconnect', 'code': 1000}
+
+    async def send_json(self, value):
+        self.sent.append(value)
+
+    async def close(self, *, code, reason):
+        self.closed.append((code, reason))
+
+
+class _TerminalAfterPeerDisconnectEvents:
+    def __init__(self, websocket: _SimultaneousTerminalWebSocket):
+        self.websocket = websocket
+
+    async def get(self):
+        await self.websocket.peer_disconnect_ready.wait()
+        # Let the receive task turn the disconnect packet into its terminal
+        # exception before the event task completes in the same wait cycle.
+        await asyncio.sleep(0)
+        return {'type': 'capture_revoked', 'reason': 'operator_revoked'}
+
+
+class _SimultaneousTerminalCoordinator:
+    def __init__(self, websocket: _SimultaneousTerminalWebSocket):
+        self.websocket = websocket
+        self.capture_manager = CaptureManager()
+        self.disconnects = []
+
+    async def connect_capture_with_pairing(self, *_args, **_kwargs):
+        return CaptureConnection(
+            capture_id='79def5a3-85e9-48b0-9220-8e730e2944c1',
+            connection_id='29656917-6e93-40ae-9476-0a532787d752',
+            events=_TerminalAfterPeerDisconnectEvents(self.websocket),
+            capture_credential='capture-credential-that-is-private-000000',
+        )
+
+    async def disconnect_capture(self, capture_id, connection_id):
+        self.disconnects.append((capture_id, connection_id))
+
+
+def test_simultaneous_terminal_event_and_peer_disconnect_consumes_both_tasks(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    async def scenario():
+        websocket = _SimultaneousTerminalWebSocket({
+            'type': 'pair',
+            'pairing_id': 'd097eb8f-b386-455f-9e2b-23f1ad6a1ee3',
+            'pairing_code': 'x' * 32,
+            **CAPTURE_METADATA,
+        })
+        coordinator = _SimultaneousTerminalCoordinator(websocket)
+        monkeypatch.setattr(teleop, 'coordinator', coordinator)
+        loop = asyncio.get_running_loop()
+        unhandled = []
+        previous_handler = loop.get_exception_handler()
+        loop.set_exception_handler(
+            lambda _loop, context: unhandled.append(context),
+        )
+        try:
+            await teleop.teleop_capture_websocket(websocket)
+            gc.collect()
+            await asyncio.sleep(0)
+        finally:
+            loop.set_exception_handler(previous_handler)
+        return websocket, coordinator, unhandled
+
+    websocket, coordinator, unhandled = asyncio.run(scenario())
+
+    assert [message['type'] for message in websocket.sent] == [
+        'paired',
+        'capture_revoked',
+    ]
+    assert websocket.closed == [(4403, 'operator_revoked')]
+    assert coordinator.disconnects == [(
+        '79def5a3-85e9-48b0-9220-8e730e2944c1',
+        '29656917-6e93-40ae-9476-0a532787d752',
+    )]
+    assert unhandled == []
+
+
+@pytest.mark.parametrize(
+    'message',
+    [
+        {
+            'type': 'pair',
+            'pairing_id': 'd097eb8f-b386-455f-9e2b-23f1ad6a1ee3',
+            'pairing_code': 'x' * 32,
+        },
+        {
+            'type': 'pair',
+            'pairing_id': 'd097eb8f-b386-455f-9e2b-23f1ad6a1ee3',
+            'pairing_code': 'x' * 32,
+            **CAPTURE_METADATA,
+            'frame_protocol': 'motus.teleop.rtc-frame.v2',
+        },
+        {
+            'type': 'pair',
+            'pairing_id': 'd097eb8f-b386-455f-9e2b-23f1ad6a1ee3',
+            'pairing_code': 'x' * 32,
+            **CAPTURE_METADATA,
+            'app_version': 'x' * 33,
+        },
+    ],
+)
+def test_wss_rejects_capture_with_unknown_frame_contract(
+    client,
+    monkeypatch: pytest.MonkeyPatch,
+    message,
+):
+    monkeypatch.setattr(teleop, 'coordinator', _CaptureApiCoordinator())
+    with client.websocket_connect('/ws/teleop-capture') as websocket:
+        websocket.send_json(message)
+        assert websocket.receive_json() == {
+            'type': 'error',
+            'code': 'capture_message_invalid',
+        }
+
+
+def test_capture_secrets_are_never_accepted_in_url(
+    client,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(teleop, 'coordinator', _CaptureApiCoordinator())
+    pairing = _pairing(client)
+    with client.websocket_connect(
+        f"/ws/teleop-capture?pairing_code={pairing['pairing_code']}",
+    ) as websocket:
+        websocket.send_json(_pair_message(pairing))
+        assert websocket.receive_json() == {
+            'type': 'error',
+            'code': 'capture_query_forbidden',
+        }

--- a/agent-core/tests/teleop/test_capture_console.mjs
+++ b/agent-core/tests/teleop/test_capture_console.mjs
@@ -1,0 +1,86 @@
+import assert from 'node:assert/strict';
+
+import {
+  captureAssignmentForSession,
+  captureAttachEligibility,
+  captureBootstrapFields,
+} from '../../web/js/teleop/capture-console.js';
+
+const DIGEST = '0123456789abcdef'.repeat(4);
+const readySession = {
+  id: 'd097eb8f-b386-455f-9e2b-23f1ad6a1ee3',
+  owned_by_client: true,
+  state: 'active',
+  mode: 'shadow',
+  live_confirmed: true,
+  profile_id: 'recording',
+  capability_digest: DIGEST,
+};
+const readyCapture = {
+  id: '79def5a3-85e9-48b0-9220-8e730e2944c1',
+  connected: true,
+  observed_state: 'xr_standby',
+  capture_protocol: 'motus.teleop.capture.v1',
+  frame_protocol: 'motus.teleop.rtc-frame.v1',
+  assignment: null,
+};
+
+assert.deepEqual(
+  captureAttachEligibility(readySession, readyCapture),
+  { allowed: true, code: 'ready' },
+);
+assert.deepEqual(
+  captureAttachEligibility(
+    {
+      ...readySession,
+      mode: 'live',
+      state: 'awaiting_confirmation',
+      live_confirmed: false,
+    },
+    readyCapture,
+  ),
+  { allowed: false, code: 'capture_live_confirmation_required' },
+);
+assert.deepEqual(
+  captureAttachEligibility(
+    { ...readySession, mode: 'live', live_confirmed: false },
+    readyCapture,
+  ),
+  { allowed: false, code: 'capture_live_confirmation_required' },
+);
+assert.deepEqual(
+  captureAttachEligibility(readySession, { ...readyCapture, observed_state: 'streaming' }),
+  { allowed: false, code: 'capture_not_ready' },
+);
+assert.deepEqual(
+  captureAttachEligibility(readySession, {
+    ...readyCapture,
+    assignment: { session_id: readySession.id },
+  }),
+  { allowed: false, code: 'capture_assignment_conflict' },
+);
+
+const bootstrap = captureBootstrapFields({
+  websocket_path: '/ws/teleop-capture',
+  pairing_id: '9878dc06-cfa9-40f2-9739-62db01165ce9',
+  pairing_code: 'one-time-secret-that-is-never-stored',
+  ca_certificate_base64: 'TUFNQ0FRRT0=',
+  expires_at: 1_800_000_000,
+}, { host: 'core.lab.example:15678' });
+assert.equal(bootstrap.coreWssUrl, 'wss://core.lab.example:15678/ws/teleop-capture');
+assert.equal(bootstrap.pairingCode, 'one-time-secret-that-is-never-stored');
+assert.throws(() => captureBootstrapFields({
+  websocket_path: '/ws/teleop-capture?pairing_code=secret',
+  pairing_id: 'x',
+  pairing_code: 'y',
+  ca_certificate_base64: 'TUFNQ0FRRT0=',
+}, { host: 'core.lab.example' }));
+
+const assignment = { session_id: readySession.id, state: 'negotiated' };
+assert.equal(
+  captureAssignmentForSession([{ ...readyCapture, assignment }], readySession.id),
+  assignment,
+);
+assert.equal(captureAssignmentForSession([], readySession.id), null);
+
+console.log('capture-console contract tests passed');

--- a/agent-core/tests/teleop/test_capture_manager.py
+++ b/agent-core/tests/teleop/test_capture_manager.py
@@ -1,0 +1,471 @@
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+
+import pytest
+
+from teleop.capture_manager import MAX_CAPTURE_RECORDS, CaptureError, CaptureManager
+
+PRINCIPAL = 'operator:alice'
+CLIENT_ID = '7dbabfca-15c1-43ca-b600-75e7682c21d0'
+OTHER_CLIENT_ID = '68991413-d37a-4603-9f07-3e25219d6d96'
+SESSION_ID = 'd097eb8f-b386-455f-9e2b-23f1ad6a1ee3'
+DIGEST = '0123456789abcdef' * 4
+CLIENT_METADATA = {
+    'capture_protocol': 'motus.teleop.capture.v1',
+    'frame_protocol': 'motus.teleop.rtc-frame.v1',
+    'client_kind': 'browser_webxr',
+    'app_version': '1.0.0-test',
+}
+
+
+@dataclass
+class _Clock:
+    monotonic: float = 10.0
+    wall: float = 1_700_000_000.0
+
+    def advance(self, seconds: float) -> None:
+        self.monotonic += seconds
+        self.wall += seconds
+
+
+async def _connected_capture(
+    manager: CaptureManager,
+    *,
+    label: str = 'Quest 3',
+):
+    pairing = await manager.create_pairing(PRINCIPAL, CLIENT_ID, label=label)
+    connection = await manager.connect_with_pairing(
+        pairing.pairing_id,
+        pairing.pairing_code,
+        **CLIENT_METADATA,
+    )
+    return pairing, connection
+
+
+async def _pairing_is_single_use_bounded_and_secrets_never_enter_repr():
+    clock = _Clock()
+    manager = CaptureManager(monotonic=lambda: clock.monotonic, wall_clock=lambda: clock.wall)
+
+    pairing = await manager.create_pairing(PRINCIPAL, CLIENT_ID, label=' Quest 3 ')
+    assert pairing.expires_at == clock.wall + 60.0
+    assert pairing.pairing_code not in repr(pairing)
+
+    connection = await manager.connect_with_pairing(
+        pairing.pairing_id,
+        pairing.pairing_code,
+        **CLIENT_METADATA,
+    )
+    assert connection.capture_credential is not None
+    assert connection.capture_credential not in repr(connection)
+    with pytest.raises(CaptureError, match='capture_pairing_invalid'):
+        await manager.connect_with_pairing(
+            pairing.pairing_id,
+            pairing.pairing_code,
+            **CLIENT_METADATA,
+        )
+
+    captures = await manager.list_for_supervisor(PRINCIPAL)
+    assert captures == [{
+        'id': connection.capture_id,
+        'label': 'Quest 3',
+        **CLIENT_METADATA,
+        'connected': True,
+        'observed_state': 'browser_ready',
+        'created_at': clock.wall,
+        'connected_at': clock.wall,
+        'last_seen_at': clock.wall,
+        'assignment': None,
+    }]
+    serialized = repr(captures)
+    assert CLIENT_ID not in serialized
+    assert pairing.pairing_code not in serialized
+    assert connection.capture_credential not in serialized
+
+
+async def _expired_pairing_and_wrong_supervisor_fail_closed():
+    clock = _Clock()
+    manager = CaptureManager(monotonic=lambda: clock.monotonic, wall_clock=lambda: clock.wall)
+    pairing = await manager.create_pairing(PRINCIPAL, CLIENT_ID, label='Quest 3')
+    clock.advance(60.0)
+
+    with pytest.raises(CaptureError, match='capture_pairing_invalid'):
+        await manager.connect_with_pairing(
+            pairing.pairing_id,
+            pairing.pairing_code,
+            **CLIENT_METADATA,
+        )
+
+    _, connection = await _connected_capture(manager)
+    assert len(await manager.list_for_supervisor(PRINCIPAL)) == 1
+    with pytest.raises(CaptureError, match='capture_forbidden'):
+        await manager.revoke_capture(connection.capture_id, 'operator:bob')
+
+
+async def _pairing_limit_is_principal_scoped_across_refreshed_clients():
+    manager = CaptureManager()
+    for index in range(4):
+        await manager.create_pairing(
+            PRINCIPAL,
+            f'00000000-0000-4000-8000-{index:012d}',
+            label=f'Quest {index}',
+        )
+    with pytest.raises(CaptureError, match='capture_pairing_limit'):
+        await manager.create_pairing(
+            PRINCIPAL,
+            OTHER_CLIENT_ID,
+            label='Quest after refresh',
+        )
+
+    # Another principal retains an independent bounded enrollment window.
+    await manager.create_pairing('operator:bob', OTHER_CLIENT_ID, label='Bob Quest')
+
+
+async def _operator_revoke_deletes_tombstone_and_releases_global_capacity():
+    manager = CaptureManager()
+    first_capture_id = ''
+    first_credential = ''
+    for index in range(MAX_CAPTURE_RECORDS + 1):
+        pairing = await manager.create_pairing(
+            PRINCIPAL,
+            CLIENT_ID,
+            label=f'Quest {index}',
+        )
+        connection = await manager.connect_with_pairing(
+            pairing.pairing_id,
+            pairing.pairing_code,
+            **CLIENT_METADATA,
+        )
+        if index == 0:
+            first_capture_id = connection.capture_id
+            first_credential = connection.capture_credential or ''
+        revoked = await manager.revoke_capture(connection.capture_id, PRINCIPAL)
+        assert revoked['revoked'] is True
+        assert await connection.events.get() == {
+            'type': 'capture_revoked',
+            'reason': 'operator_revoked',
+        }
+
+    assert await manager.list_for_supervisor(PRINCIPAL) == []
+    with pytest.raises(CaptureError, match='capture_auth_invalid'):
+        await manager.connect_with_credential(
+            first_capture_id,
+            first_credential,
+            **CLIENT_METADATA,
+        )
+
+    # A different principal can still enroll after more than the former global
+    # tombstone limit worth of successful pair+revoke cycles.
+    pairing = await manager.create_pairing(
+        'operator:bob',
+        OTHER_CLIENT_ID,
+        label='Bob Quest',
+    )
+    connection = await manager.connect_with_pairing(
+        pairing.pairing_id,
+        pairing.pairing_code,
+        **CLIENT_METADATA,
+    )
+    assert connection.capture_id
+
+
+async def _attach_requires_xr_standby_and_binds_exact_session_contract():
+    manager = CaptureManager()
+    _, connection = await _connected_capture(manager)
+
+    with pytest.raises(CaptureError, match='capture_not_ready'):
+        await manager.attach(
+            capture_id=connection.capture_id,
+            principal_id=PRINCIPAL,
+            session_id=SESSION_ID,
+            operation_generation=3,
+            mode='live',
+            profile_id='dual_arm_v1',
+            capability_digest=DIGEST,
+            capabilities={'profile_id': 'dual_arm_v1'},
+            effectors=['dual_arm'],
+        )
+
+    await manager.update_presence(
+        connection.capture_id,
+        connection.connection_id,
+        state='xr_standby',
+        assignment_id=None,
+    )
+    assignment = await manager.attach(
+        capture_id=connection.capture_id,
+        principal_id=PRINCIPAL,
+        session_id=SESSION_ID,
+        operation_generation=3,
+        mode='live',
+        profile_id='dual_arm_v1',
+        capability_digest=DIGEST,
+        capabilities={'profile_id': 'dual_arm_v1'},
+        effectors=['dual_arm'],
+    )
+    pushed = connection.events.get_nowait()
+    assert pushed['type'] == 'assignment'
+    assert pushed['assignment']['id'] == assignment.id
+    assert pushed['assignment']['mode'] == 'live'
+    assert 'operation_generation' not in pushed['assignment']
+
+    duplicate = await manager.attach(
+        capture_id=connection.capture_id,
+        principal_id=PRINCIPAL,
+        session_id=SESSION_ID,
+        operation_generation=3,
+        mode='live',
+        profile_id='dual_arm_v1',
+        capability_digest=DIGEST,
+        capabilities={'profile_id': 'dual_arm_v1'},
+        effectors=['dual_arm'],
+    )
+    assert duplicate.id == assignment.id
+    assert connection.events.empty()
+
+
+async def _offer_failure_creates_loss_fence_instead_of_same_session_retry():
+    manager = CaptureManager()
+    _, connection = await _connected_capture(manager)
+    await manager.update_presence(
+        connection.capture_id,
+        connection.connection_id,
+        state='xr_standby',
+        assignment_id=None,
+    )
+    values = {
+        'capture_id': connection.capture_id,
+        'principal_id': PRINCIPAL,
+        'session_id': SESSION_ID,
+        'operation_generation': 3,
+        'mode': 'shadow',
+        'profile_id': 'recording',
+        'capability_digest': DIGEST,
+        'capabilities': {'profile_id': 'recording'},
+        'effectors': ['dual_arm'],
+    }
+    assignment = await manager.attach(**values)
+    connection.events.get_nowait()
+
+    claimed = await manager.claim_offer(
+        connection.capture_id,
+        connection.connection_id,
+        assignment.id,
+    )
+    assert claimed.state == 'offer_consumed'
+    with pytest.raises(CaptureError, match='capture_offer_already_consumed'):
+        await manager.claim_offer(
+            connection.capture_id,
+            connection.connection_id,
+            assignment.id,
+        )
+
+    lost = await manager.fail_offer(connection.capture_id, assignment.id)
+    assert lost is not None
+    assert lost.id == assignment.id
+    assert lost.failure_code == 'capture_signaling_failed'
+    revoked = connection.events.get_nowait()
+    assert revoked == {
+        'type': 'assignment_revoked',
+        'assignment_id': assignment.id,
+        'reason': 'capture_signaling_failed',
+    }
+    assert await manager.assignment_loss_is_pending(lost) is True
+    with pytest.raises(CaptureError, match='capture_loss_pending'):
+        await manager.attach(**values)
+    assert await manager.complete_assignment_loss(lost) is True
+
+
+async def _disconnect_and_session_terminalization_revoke_assignment():
+    manager = CaptureManager()
+    _, connection = await _connected_capture(manager)
+    await manager.update_presence(
+        connection.capture_id,
+        connection.connection_id,
+        state='xr_standby',
+        assignment_id=None,
+    )
+    assignment = await manager.attach(
+        capture_id=connection.capture_id,
+        principal_id=PRINCIPAL,
+        session_id=SESSION_ID,
+        operation_generation=3,
+        mode='shadow',
+        profile_id='recording',
+        capability_digest=DIGEST,
+        capabilities={'profile_id': 'recording'},
+        effectors=[],
+    )
+    connection.events.get_nowait()
+
+    await manager.revoke_for_session(SESSION_ID, 'operator_pause')
+    event = connection.events.get_nowait()
+    assert event == {
+        'type': 'assignment_revoked',
+        'assignment_id': assignment.id,
+        'reason': 'operator_pause',
+    }
+    captures = await manager.list_for_supervisor(PRINCIPAL)
+    assert captures[0]['assignment'] is None
+
+    await manager.disconnect(connection.capture_id, connection.connection_id)
+    captures = await manager.list_for_supervisor(PRINCIPAL)
+    assert captures[0]['connected'] is False
+    assert captures[0]['observed_state'] == 'offline'
+
+
+async def _reset_drops_all_ephemeral_capture_authority():
+    manager = CaptureManager()
+    pairing, connection = await _connected_capture(manager)
+    credential = connection.capture_credential
+    await manager.reset()
+
+    assert await manager.list_for_supervisor(PRINCIPAL) == []
+    with pytest.raises(CaptureError, match='capture_auth_invalid'):
+        await manager.connect_with_credential(
+            connection.capture_id,
+            credential or '',
+            **CLIENT_METADATA,
+        )
+    with pytest.raises(CaptureError, match='capture_pairing_invalid'):
+        await manager.connect_with_pairing(
+            pairing.pairing_id,
+            pairing.pairing_code,
+            **CLIENT_METADATA,
+        )
+    # The reset notification is queued before the in-memory connection owner is dropped.
+    assert await asyncio.wait_for(connection.events.get(), timeout=0.1) == {
+        'type': 'capture_revoked',
+        'reason': 'core_stopped',
+    }
+
+
+async def _terminal_presence_and_stale_heartbeat_revoke_assignment():
+    clock = _Clock()
+    manager = CaptureManager(monotonic=lambda: clock.monotonic, wall_clock=lambda: clock.wall)
+    _, connection = await _connected_capture(manager)
+    await manager.update_presence(
+        connection.capture_id,
+        connection.connection_id,
+        state='xr_standby',
+        assignment_id=None,
+    )
+    assignment = await manager.attach(
+        capture_id=connection.capture_id,
+        principal_id=PRINCIPAL,
+        session_id=SESSION_ID,
+        operation_generation=3,
+        mode='shadow',
+        profile_id='recording',
+        capability_digest=DIGEST,
+        capabilities={'profile_id': 'recording'},
+        effectors=[],
+    )
+    connection.events.get_nowait()
+
+    _presence, ended_loss = await manager.update_presence(
+        connection.capture_id,
+        connection.connection_id,
+        state='xr_ended',
+        assignment_id=None,
+    )
+    assert ended_loss is not None
+    assert connection.events.get_nowait() == {
+        'type': 'assignment_revoked',
+        'assignment_id': assignment.id,
+        'reason': 'capture_xr_ended',
+    }
+    assert (await manager.list_for_supervisor(PRINCIPAL))[0]['assignment'] is None
+    with pytest.raises(CaptureError, match='capture_loss_pending'):
+        await manager.attach(
+            capture_id=connection.capture_id,
+            principal_id=PRINCIPAL,
+            session_id=SESSION_ID,
+            operation_generation=3,
+            mode='shadow',
+            profile_id='recording',
+            capability_digest=DIGEST,
+            capabilities={'profile_id': 'recording'},
+            effectors=[],
+        )
+    assert await manager.complete_assignment_loss(ended_loss) is True
+
+    await manager.update_presence(
+        connection.capture_id,
+        connection.connection_id,
+        state='xr_standby',
+        assignment_id=None,
+    )
+    replacement = await manager.attach(
+        capture_id=connection.capture_id,
+        principal_id=PRINCIPAL,
+        session_id=SESSION_ID,
+        operation_generation=3,
+        mode='shadow',
+        profile_id='recording',
+        capability_digest=DIGEST,
+        capabilities={'profile_id': 'recording'},
+        effectors=[],
+    )
+    connection.events.get_nowait()
+    clock.advance(5.0)
+    stale, lost_assignment = await manager.expire_stale_connection(
+        connection.capture_id,
+        connection.connection_id,
+    )
+    assert stale is True
+    assert lost_assignment is not None
+    assert lost_assignment.id == replacement.id
+    assert lost_assignment.failure_code == 'capture_presence_timeout'
+    assert await manager.assignment_loss_is_pending(lost_assignment) is True
+    assert connection.events.get_nowait() == {
+        'type': 'assignment_revoked',
+        'assignment_id': replacement.id,
+        'reason': 'capture_presence_timeout',
+    }
+    assert connection.events.get_nowait() == {
+        'type': 'capture_stale',
+        'reason': 'capture_presence_timeout',
+    }
+    public = (await manager.list_for_supervisor(PRINCIPAL))[0]
+    assert public['connected'] is False
+    assert public['observed_state'] == 'offline'
+    assert public['assignment'] is None
+    assert await manager.complete_assignment_loss(lost_assignment) is True
+
+
+def test_pairing_is_single_use_bounded_and_secrets_never_enter_repr():
+    asyncio.run(_pairing_is_single_use_bounded_and_secrets_never_enter_repr())
+
+
+def test_expired_pairing_and_wrong_supervisor_fail_closed():
+    asyncio.run(_expired_pairing_and_wrong_supervisor_fail_closed())
+
+
+def test_pairing_limit_is_principal_scoped_across_refreshed_clients():
+    asyncio.run(_pairing_limit_is_principal_scoped_across_refreshed_clients())
+
+
+def test_operator_revoke_deletes_tombstone_and_releases_global_capacity():
+    asyncio.run(_operator_revoke_deletes_tombstone_and_releases_global_capacity())
+
+
+def test_attach_requires_xr_standby_and_binds_exact_session_contract():
+    asyncio.run(_attach_requires_xr_standby_and_binds_exact_session_contract())
+
+
+def test_offer_failure_creates_loss_fence_instead_of_same_session_retry():
+    asyncio.run(_offer_failure_creates_loss_fence_instead_of_same_session_retry())
+
+
+def test_disconnect_and_session_terminalization_revoke_assignment():
+    asyncio.run(_disconnect_and_session_terminalization_revoke_assignment())
+
+
+def test_reset_drops_all_ephemeral_capture_authority():
+    asyncio.run(_reset_drops_all_ephemeral_capture_authority())
+
+
+def test_terminal_presence_and_stale_heartbeat_revoke_assignment():
+    asyncio.run(_terminal_presence_and_stale_heartbeat_revoke_assignment())

--- a/agent-core/tests/teleop/test_command_broker.py
+++ b/agent-core/tests/teleop/test_command_broker.py
@@ -1,0 +1,2343 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from copy import deepcopy
+
+import fastapi
+import httpx
+import pytest
+
+import client as client_mod
+import config
+import mcp_client
+from api import canvas, config as config_api, mcp_manage
+from teleop import audit
+from teleop.command_broker import (
+    CommandBroker,
+    CommandDrainTimeout,
+    TeleopCommandBlocked,
+    classify_tool_access,
+)
+from teleop.service import coordinator
+
+
+@pytest.mark.parametrize(
+    ('tool_type', 'annotations', 'action', 'action_declared', 'read_only'),
+    [
+        ('sensor', {}, None, False, True),
+        ('resource', {}, None, False, True),
+        ('actuator', {'readOnlyHint': True}, None, False, True),
+        ('actuator', {'readOnlyHint': True}, 'move', True, False),
+        ('processor', {}, 'status', True, True),
+        ('processor', {}, 'STATUS', True, False),
+        ('actuator', {}, 'info', True, True),
+        ('actuator', {}, 'info', False, False),
+        ('actuator', {}, 'get_up', True, False),
+        ('processor', {}, 'move', True, False),
+        ('sensor', {}, 'calibrate', True, False),
+        ('resource', {}, 'delete', True, False),
+        (None, {}, None, False, False),
+        ('sensor', {}, 'start', True, False),
+        ('resource', {'readOnlyHint': True}, 'config', True, False),
+    ],
+)
+def test_tool_access_classifier_is_fail_closed(
+    tool_type,
+    annotations,
+    action,
+    action_declared,
+    read_only,
+):
+    access = classify_tool_access(
+        tool_type=tool_type,
+        annotations=annotations,
+        action=action,
+        action_declared=action_declared,
+    )
+
+    assert access.read_only is read_only
+
+
+def test_authority_timeout_removes_provisional_claim():
+    async def scenario() -> None:
+        broker = CommandBroker()
+        write_entered = asyncio.Event()
+        finish_write = asyncio.Event()
+
+        async def write() -> None:
+            async with broker.ordinary_command(
+                'robot-a',
+                read_only=False,
+                source='test',
+                tool='drive',
+                action='move',
+            ):
+                write_entered.set()
+                await finish_write.wait()
+
+        write_task = asyncio.create_task(write())
+        await write_entered.wait()
+        try:
+            with pytest.raises(CommandDrainTimeout):
+                await broker.begin_authority(
+                    'robot-a',
+                    'claim-timeout',
+                    drain_timeout_seconds=0,
+                )
+            assert await broker.authority_for('robot-a') is None
+        finally:
+            finish_write.set()
+            await write_task
+
+    asyncio.run(scenario())
+
+
+def test_same_token_authority_waits_for_the_original_command_drain():
+    async def scenario() -> None:
+        broker = CommandBroker()
+        write_entered = asyncio.Event()
+        finish_write = asyncio.Event()
+
+        async def write() -> None:
+            async with broker.ordinary_command(
+                'robot-a',
+                read_only=False,
+                source='test',
+                tool='drive',
+                action='move',
+            ):
+                write_entered.set()
+                await finish_write.wait()
+
+        write_task = asyncio.create_task(write())
+        await write_entered.wait()
+        first = asyncio.create_task(broker.begin_authority('robot-a', 'same-token'))
+        while await broker.authority_for('robot-a') is None:
+            await asyncio.sleep(0)
+        second = asyncio.create_task(broker.begin_authority('robot-a', 'same-token'))
+        await asyncio.sleep(0)
+        assert first.done() is False
+        assert second.done() is False
+
+        finish_write.set()
+        first_claim, second_claim = await asyncio.gather(first, second)
+        assert first_claim == second_claim
+        assert first_claim.state == 'acquiring'
+        await broker.release_authority('robot-a', 'same-token')
+        await write_task
+
+    asyncio.run(scenario())
+
+
+def test_broker_rebinds_conditions_between_event_loops_after_state_drains():
+    broker = CommandBroker()
+
+    async def contention_cycle(token: str) -> None:
+        entered = asyncio.Event()
+        finish = asyncio.Event()
+
+        async def write() -> None:
+            async with broker.ordinary_command(
+                'robot-loop',
+                read_only=False,
+                source='test',
+                tool='drive',
+                action='move',
+            ):
+                entered.set()
+                await finish.wait()
+
+        writer = asyncio.create_task(write())
+        await entered.wait()
+        claim = asyncio.create_task(broker.begin_authority('robot-loop', token))
+        await asyncio.sleep(0)
+        finish.set()
+        await claim
+        await writer
+        assert await broker.release_authority('robot-loop', token) is True
+
+    asyncio.run(contention_cycle('loop-one'))
+    asyncio.run(contention_cycle('loop-two'))
+
+
+def test_double_cancelled_ordinary_command_cannot_leak_inflight_admission():
+    async def scenario() -> None:
+        broker = CommandBroker()
+        entered = asyncio.Event()
+        cleanup_started = asyncio.Event()
+        finish_cleanup = asyncio.Event()
+        original_finish = broker._finish_ordinary
+
+        async def delayed_finish(robot_id: str) -> None:
+            cleanup_started.set()
+            await finish_cleanup.wait()
+            await original_finish(robot_id)
+
+        broker._finish_ordinary = delayed_finish  # type: ignore[method-assign]
+
+        async def write() -> None:
+            async with broker.ordinary_command(
+                'robot-cancel',
+                read_only=False,
+                source='test',
+                tool='drive',
+                action='move',
+            ):
+                entered.set()
+                await asyncio.Event().wait()
+
+        task = asyncio.create_task(write())
+        await entered.wait()
+        task.cancel()
+        await cleanup_started.wait()
+        task.cancel()
+        await asyncio.sleep(0)
+        assert task.done() is False
+        finish_cleanup.set()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        claim = await broker.begin_authority(
+            'robot-cancel',
+            'after-cancel',
+            drain_timeout_seconds=0.1,
+        )
+        assert claim.token == 'after-cancel'
+        await broker.release_authority('robot-cancel', 'after-cancel')
+
+    asyncio.run(scenario())
+
+
+def test_blocked_audit_redacts_unverified_tool_and_action(monkeypatch):
+    async def scenario() -> None:
+        broker = CommandBroker()
+        events = []
+
+        async def capture(event_type, **fields):
+            events.append({'event_type': event_type, **fields})
+
+        monkeypatch.setattr(audit, 'emit', capture)
+        await broker.begin_authority('robot-secret', 'claim')
+        await broker.update_authority(
+            'robot-secret',
+            'claim',
+            session_id='safe-session',
+            state='active',
+        )
+        secret = 'fence-token-must-not-be-audited'
+        with pytest.raises(TeleopCommandBlocked):
+            async with broker.ordinary_command(
+                'robot-secret',
+                read_only=False,
+                source='test',
+                tool=secret,
+                action=secret,
+            ):
+                raise AssertionError('blocked call entered')
+        serialized = json.dumps(events)
+        assert secret not in serialized
+        assert events[0]['tool'] == '<unverified>'
+        assert events[0]['action'] == '<unverified>'
+        await broker.release_authority('robot-secret', 'claim')
+
+    asyncio.run(scenario())
+
+
+class _FakeResponse:
+    def __init__(self, payload: dict, status: int = 200):
+        self._payload = payload
+        self.status = status
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    def __await__(self):
+        async def resolve():
+            return self
+
+        return resolve().__await__()
+
+    async def json(self, content_type=None):
+        return deepcopy(self._payload)
+
+
+class _RecordingSession:
+    def __init__(self, records: list[dict], *args, **kwargs):
+        self.records = records
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    def post(self, url, *, json, headers, **kwargs):
+        self.records.append(deepcopy(json))
+        if json['method'] == 'initialize':
+            result = {'serverInfo': {'name': 'broker-test-driver'}}
+        elif json['method'] == 'tools/call':
+            result = {
+                'content': [{
+                    'type': 'text',
+                    'text': '{"state":"observed"}',
+                }],
+            }
+        else:
+            raise AssertionError(f'unexpected method: {json["method"]}')
+        payload = {'jsonrpc': '2.0', 'id': json['id'], 'result': result}
+        return _FakeResponse(payload)
+
+
+def _session_factory(records: list[dict]):
+    def factory(*args, **kwargs):
+        return _RecordingSession(records, *args, **kwargs)
+
+    return factory
+
+
+def _tool_result_session_factory(records: list[dict], tool_result: dict):
+    class ScriptedSession(_RecordingSession):
+        def post(self, url, *, json, headers, **kwargs):
+            self.records.append(deepcopy(json))
+            if json['method'] == 'initialize':
+                result = {'serverInfo': {'name': 'broker-test-driver'}}
+            elif json['method'] == 'tools/call':
+                result = deepcopy(tool_result)
+            else:
+                raise AssertionError(f'unexpected method: {json["method"]}')
+            payload = {'jsonrpc': '2.0', 'id': json['id'], 'result': result}
+            return _FakeResponse(payload)
+
+    def factory(*args, **kwargs):
+        return ScriptedSession(records, *args, **kwargs)
+
+    return factory
+
+
+def _ordinary_control_tool() -> dict:
+    return {
+        'name': 'robot_control',
+        'type': 'actuator',
+        'annotations': {'destructiveHint': True},
+        'configSchema': {'type': 'object', 'properties': {}},
+        'inputSchema': {
+            'type': 'object',
+            'properties': {
+                'action': {
+                    'type': 'string',
+                    'enum': ['config', 'info', 'move', 'status'],
+                },
+            },
+            'required': ['action'],
+        },
+    }
+
+
+def test_active_authority_blocks_every_core_write_lane_but_allows_diagnostics(
+    monkeypatch,
+):
+    async def scenario() -> None:
+        driver_id = 'broker-entry-driver'
+        session_id = 'e9b5fd2a-e24e-46da-bf98-fe10dbbff862'
+        claim_token = 'broker-entry-claim'
+        tool = _ordinary_control_tool()
+        full_name = f'mcp__{driver_id}__{tool["name"]}'
+        record = {
+            'id': driver_id,
+            'name': 'Broker Entry Driver',
+            'transport': 'http',
+            'url': 'http://broker-entry.invalid/mcp',
+            'trust_state': 'trusted',
+            'tools': [deepcopy(tool)],
+        }
+        config.main['services'] = {'mcp': [record]}
+        config.main[f'tool_config:{driver_id}:{tool["name"]}'] = {
+            'configured': True,
+        }
+        mcp_client.registry[driver_id] = {
+            'name': record['name'],
+            'url': record['url'],
+            'online': True,
+            'trusted': True,
+            'transport': 'http',
+            'schemas': {},
+            'split_map': {},
+            'input_schemas': {full_name: tool['inputSchema']},
+            'tool_meta': {
+                full_name: {
+                    'type': 'actuator',
+                    'action_enum': ['config', 'info', 'move', 'status'],
+                    'annotations': tool['annotations'],
+                    'has_config_schema': True,
+                },
+            },
+        }
+
+        audit_events: list[dict] = []
+
+        async def capture_audit(event_type, **fields):
+            audit_events.append({'event_type': event_type, **deepcopy(fields)})
+            return audit_events[-1]
+
+        monkeypatch.setattr(audit, 'emit', capture_audit)
+        rpc_records: list[dict] = []
+
+        async def fake_jrpc(
+            session, url, method, params, *, trusted=False, driver_id='',
+        ):
+            rpc_records.append({
+                'method': method,
+                'params': deepcopy(params),
+                'trusted': trusted,
+            })
+            return {
+                'content': [{
+                    'type': 'text',
+                    'text': '{"state":"observed"}',
+                }],
+            }
+
+        monkeypatch.setattr(mcp_client, '_jrpc', fake_jrpc)
+        monkeypatch.setattr(
+            mcp_client.aiohttp,
+            'ClientSession',
+            _session_factory([]),
+        )
+        api_records: list[dict] = []
+        monkeypatch.setattr(
+            mcp_manage.aiohttp,
+            'ClientSession',
+            _session_factory(api_records),
+        )
+
+        await coordinator.command_broker.begin_authority(driver_id, claim_token)
+        await coordinator.command_broker.update_authority(
+            driver_id,
+            claim_token,
+            session_id=session_id,
+            principal_id='operator:alice',
+            state='active',
+        )
+        try:
+            llm_result = await mcp_client.call_tool(full_name, {'action': 'move'})
+            assert json.loads(llm_result) == {
+                'error': {
+                    'code': 'teleop_command_blocked',
+                    'reason': 'teleop_session_active',
+                    'robot_id': driver_id,
+                    'session_id': session_id,
+                    'state': 'active',
+                },
+            }
+            assert rpc_records == []
+
+            with pytest.raises(fastapi.HTTPException) as blocked_api:
+                await mcp_manage.mcp_call_tool(
+                    driver_id,
+                    mcp_manage.MCPCallRequest(
+                        tool=tool['name'],
+                        arguments={'action': 'move'},
+                    ),
+                )
+            assert blocked_api.value.status_code == 409
+            assert blocked_api.value.detail['code'] == 'teleop_command_blocked'
+            assert api_records == []
+
+            deferred = await canvas.save_tool_config(
+                driver_id,
+                tool['name'],
+                {'gain': 0.5},
+            )
+            deferred_body = json.loads(deferred.body)
+            assert deferred.status_code == 202
+            assert deferred_body['data'] == {
+                'saved': True,
+                'applied': False,
+                'deferred': True,
+                'reason': 'teleop_session_active',
+            }
+            deferred_instance = await canvas.save_instance_config(
+                driver_id,
+                tool['name'],
+                'canvas-card-1',
+                {'gain': 0.75},
+            )
+            assert deferred_instance.status_code == 202
+            assert json.loads(deferred_instance.body)['data']['deferred'] is True
+            assert api_records == []
+
+            config.main['canvas_layout'] = {
+                'cards': [{
+                    'id': 'canvas-card-1',
+                    'mcpId': driver_id,
+                    'toolName': tool['name'],
+                }],
+                'connections': [],
+                'revision': 7,
+            }
+            assert (await canvas.claim_edit({'session_id': 'canvas-editor'}))['code'] == 200
+            project_start = await config_api.api_start_project(
+                config_api.ProjectStartRequest(
+                    session_id='canvas-editor',
+                    layout_revision=7,
+                ),
+            )
+            project_body = json.loads(project_start.body)
+            assert project_start.status_code == 409
+            assert project_body['detail']['code'] == 'teleop_command_blocked'
+            assert project_body['detail']['session_id'] == session_id
+            assert api_records == []
+
+            config_api._set_project_state('running')
+            project_stop = await config_api.api_stop_project()
+            stop_body = json.loads(project_stop.body)
+            assert project_stop.status_code == 409
+            assert stop_body['detail']['code'] == 'teleop_command_blocked'
+            assert stop_body['detail']['session_id'] == session_id
+            assert api_records == []
+
+            await mcp_manage._restore_saved_configs(
+                driver_id,
+                record['url'],
+                [tool],
+                trusted=True,
+            )
+            assert api_records == []
+
+            diagnostic = await mcp_client.call_tool(full_name, {'action': 'info'})
+            assert json.loads(diagnostic) == {'state': 'observed'}
+            assert len(rpc_records) == 1
+            assert rpc_records[0]['params']['arguments'] == {'action': 'info'}
+
+            api_diagnostic = await mcp_manage.mcp_call_tool(
+                driver_id,
+                mcp_manage.MCPCallRequest(
+                    tool=tool['name'],
+                    arguments={'action': 'info'},
+                ),
+            )
+            assert api_diagnostic['code'] == 200
+            assert [record['method'] for record in api_records] == [
+                'initialize', 'tools/call',
+            ]
+            api_status = await mcp_manage.mcp_call_tool(
+                driver_id,
+                mcp_manage.MCPCallRequest(
+                    tool=tool['name'],
+                    arguments={'action': 'status'},
+                ),
+            )
+            assert api_status['code'] == 200
+            assert [record['method'] for record in api_records] == [
+                'initialize', 'tools/call', 'initialize', 'tools/call',
+            ]
+            assert [
+                record['params']['arguments']['action']
+                for record in api_records
+                if record['method'] == 'tools/call'
+            ] == ['info', 'status']
+
+            blocked_events = [
+                event for event in audit_events
+                if event['event_type'] == 'teleop.command.blocked'
+            ]
+            assert {event['source'] for event in blocked_events} == {
+                'config_restore', 'mcp_api', 'mcp_client',
+            }
+            assert all(event['session_id'] == session_id for event in blocked_events)
+            assert all(event['tool'] == tool['name'] for event in blocked_events)
+            assert {event['action'] for event in blocked_events} == {
+                '<unverified>', 'config', 'move',
+            }
+            scan = json.dumps(blocked_events, sort_keys=True)
+            assert 'arguments' not in scan
+            assert 'fence' not in scan
+        finally:
+            await coordinator.command_broker.release_authority(
+                driver_id,
+                claim_token,
+            )
+        try:
+            resumed = await mcp_client.call_tool(full_name, {'action': 'move'})
+            assert json.loads(resumed) == {'state': 'observed'}
+            assert len(rpc_records) == 2
+        finally:
+            mcp_client.registry.pop(driver_id, None)
+
+    asyncio.run(scenario())
+
+
+def test_owner_bound_adapter_and_actuator_share_one_robot_gate(monkeypatch):
+    async def scenario() -> None:
+        robot_id = 'g1-lab-a'
+        adapter_id = 'teleop-shadow-lab-a'
+        session_id = 'a9abdaaf-318f-4a52-849c-f55a77b0c1bd'
+        tool = _ordinary_control_tool()
+        full_name = f'mcp__{robot_id}__{tool["name"]}'
+        config.main['services'] = {'mcp': [{
+            'id': adapter_id,
+            'name': 'Standalone Teleop Adapter',
+            'transport': 'http',
+            'category': 'driver',
+            'url': 'http://teleop-adapter.invalid/mcp',
+            'trust_state': 'trusted',
+            'reported_robot_id': robot_id,
+            'authority_domain': robot_id,
+            'authority_binding_required': True,
+            'tools': [{
+                'name': 'teleop_session',
+                'type': 'actuator',
+                'x-teleop': {'robot_id': robot_id},
+            }],
+        }, {
+            'id': robot_id,
+            'name': 'G1 Actuator',
+            'transport': 'http',
+            'category': 'driver',
+            'url': 'http://g1.invalid/mcp',
+            'trust_state': 'trusted',
+            'tools': [deepcopy(tool)],
+        }]}
+        mcp_client.registry[robot_id] = {
+            'name': 'G1 Actuator',
+            'url': 'http://g1.invalid/mcp',
+            'online': True,
+            'trusted': True,
+            'schemas': {},
+            'split_map': {},
+            'input_schemas': {full_name: tool['inputSchema']},
+            'tool_meta': {
+                full_name: {
+                    'type': 'actuator',
+                    'action_enum': ['config', 'info', 'move', 'status'],
+                    'annotations': {},
+                },
+            },
+        }
+        calls = []
+
+        async def fake_jrpc(
+            session, url, method, params, *, trusted=False, driver_id='',
+        ):
+            calls.append(deepcopy(params))
+            return {
+                'content': [{
+                    'type': 'text',
+                    'text': '{"state":"observed"}',
+                }],
+            }
+
+        monkeypatch.setattr(mcp_client, '_jrpc', fake_jrpc)
+        await coordinator.command_broker.begin_authority(robot_id, 'adapter-claim')
+        await coordinator.command_broker.update_authority(
+            robot_id,
+            'adapter-claim',
+            session_id=session_id,
+            state='active',
+        )
+        try:
+            blocked = json.loads(await mcp_client.call_tool(
+                full_name,
+                {'action': 'move'},
+            ))
+            assert blocked['error']['code'] == 'teleop_command_blocked'
+            assert blocked['error']['robot_id'] == robot_id
+            assert calls == []
+
+            diagnostic = await mcp_client.call_tool(full_name, {'action': 'status'})
+            assert json.loads(diagnostic) == {'state': 'observed'}
+            assert len(calls) == 1
+        finally:
+            await coordinator.command_broker.release_authority(
+                robot_id,
+                'adapter-claim',
+            )
+            mcp_client.registry.pop(robot_id, None)
+
+    asyncio.run(scenario())
+
+
+def test_reserved_and_unknown_tools_fail_before_network_with_stale_registry(
+    monkeypatch,
+):
+    async def scenario() -> None:
+        driver_id = 'stale-registry-driver'
+        config.main['services'] = {'mcp': [{
+            'id': driver_id,
+            'name': 'Stale Registry Driver',
+            'transport': 'http',
+            'url': 'http://stale.invalid/mcp',
+            'trust_state': 'trusted',
+            'tools': [],
+        }]}
+        mcp_client.registry[driver_id] = {
+            'name': 'Stale Registry Driver',
+            'url': 'http://stale.invalid/mcp',
+            'online': True,
+            'trusted': True,
+            'schemas': {},
+            'split_map': {},
+            'tool_meta': {
+                f'mcp__{driver_id}__unknown_tool': {
+                    'type': 'actuator',
+                    'action_enum': ['move'],
+                    'annotations': {},
+                },
+            },
+        }
+        network = []
+        monkeypatch.setattr(
+            mcp_manage.aiohttp,
+            'ClientSession',
+            _session_factory(network),
+        )
+
+        reserved = await mcp_client.call_tool(
+            f'mcp__{driver_id}__teleop_session',
+            {'action': 'status'},
+        )
+        assert reserved == 'Teleop tools are reserved for the dedicated teleop API'
+        unknown = await mcp_client.call_tool(
+            f'mcp__{driver_id}__unknown_tool',
+            {'action': 'move'},
+        )
+        assert unknown == 'MCP tool not found'
+
+        with pytest.raises(fastapi.HTTPException) as reserved_api:
+            await mcp_manage.mcp_call_tool(
+                driver_id,
+                mcp_manage.MCPCallRequest(
+                    tool='teleop_session',
+                    arguments={'action': 'status'},
+                ),
+            )
+        assert reserved_api.value.status_code == 403
+        with pytest.raises(fastapi.HTTPException) as unknown_api:
+            await mcp_manage.mcp_call_tool(
+                driver_id,
+                mcp_manage.MCPCallRequest(
+                    tool='unknown_tool',
+                    arguments={'action': 'move'},
+                ),
+            )
+        assert unknown_api.value.status_code == 404
+        assert network == []
+        mcp_client.registry.pop(driver_id, None)
+
+    asyncio.run(scenario())
+
+
+def test_broken_explicit_authority_binding_fails_closed_without_network(
+    monkeypatch,
+):
+    async def scenario() -> None:
+        mcp_id = 'bound-but-broken'
+        tool = _ordinary_control_tool()
+        full_name = f'mcp__{mcp_id}__{tool["name"]}'
+        config.main['services'] = {'mcp': [{
+            'id': mcp_id,
+            'name': 'Broken Binding',
+            'transport': 'http',
+            'url': 'http://broken.invalid/mcp',
+            'trust_state': 'trusted',
+            'authority_domain': 'missing-root',
+            'authority_binding_required': True,
+            'tools': [deepcopy(tool)],
+        }]}
+        mcp_client.registry[mcp_id] = {
+            'name': 'Broken Binding',
+            'url': 'http://broken.invalid/mcp',
+            'online': True,
+            'trusted': True,
+            'schemas': {},
+            'split_map': {},
+            'tool_meta': {
+                full_name: {
+                    'type': 'actuator',
+                    'action_enum': ['move'],
+                    'annotations': {},
+                },
+            },
+        }
+        records = []
+        monkeypatch.setattr(
+            mcp_manage.aiohttp,
+            'ClientSession',
+            _session_factory(records),
+        )
+
+        llm_result = json.loads(await mcp_client.call_tool(
+            full_name,
+            {'action': 'move'},
+        ))
+        assert llm_result['error']['code'] == 'authority_binding_invalid'
+        with pytest.raises(fastapi.HTTPException) as api_error:
+            await mcp_manage.mcp_call_tool(
+                mcp_id,
+                mcp_manage.MCPCallRequest(
+                    tool=tool['name'],
+                    arguments={'action': 'move'},
+                ),
+            )
+        assert api_error.value.status_code == 409
+        assert api_error.value.detail['code'] == 'authority_binding_invalid'
+        assert records == []
+        mcp_client.registry.pop(mcp_id, None)
+
+    asyncio.run(scenario())
+
+
+def test_inflight_ping_cannot_restore_an_owner_retargeted_url(monkeypatch):
+    async def scenario() -> None:
+        mcp_id = 'retargeted-driver'
+        old_url = 'http://old.invalid/mcp'
+        new_url = 'http://new.invalid/mcp'
+        config.main['services'] = {'mcp': [{
+            'id': mcp_id,
+            'name': 'Retargeted Driver',
+            'transport': 'http',
+            'url': old_url,
+            'trust_state': 'trusted',
+            'tools': [],
+        }]}
+        ping_entered = asyncio.Event()
+        finish_ping = asyncio.Event()
+        restores = []
+
+        async def delayed_ping(url, *, trusted=False, driver_id=''):
+            assert url == old_url
+            ping_entered.set()
+            await finish_ping.wait()
+            return {
+                'server_name': 'old-driver',
+                'tools': [_ordinary_control_tool()],
+                'resources': [],
+                'device_type': '',
+                'topic_out': [],
+                'topic_in': [],
+            }
+
+        async def record_restore(*args, **kwargs):
+            restores.append((args, kwargs))
+
+        monkeypatch.setattr(mcp_manage, '_ping_mcp_http', delayed_ping)
+        monkeypatch.setattr(mcp_manage, '_restore_saved_configs', record_restore)
+
+        task = asyncio.create_task(mcp_manage._do_ping(mcp_id))
+        await asyncio.wait_for(ping_entered.wait(), timeout=0.5)
+        config.main['services'] = {'mcp': [{
+            'id': mcp_id,
+            'name': 'Retargeted Driver',
+            'transport': 'http',
+            'url': new_url,
+            'trust_state': 'trusted',
+            'tools': [],
+            'resources': [],
+            'server_name': '',
+            'capability_refresh_required': True,
+        }]}
+        mcp_client.registry.pop(mcp_id, None)
+        finish_ping.set()
+
+        result = await asyncio.wait_for(task, timeout=0.5)
+        await asyncio.sleep(0)
+
+        persisted = config.main['services']['mcp'][0]
+        assert result['error'] == 'ping target changed; stale result discarded'
+        assert persisted['url'] == new_url
+        assert persisted['tools'] == []
+        assert persisted['capability_refresh_required'] is True
+        assert mcp_id not in mcp_client.registry
+        assert restores == []
+
+    asyncio.run(scenario())
+
+
+def test_background_config_restore_rechecks_target_before_network(monkeypatch):
+    async def scenario() -> None:
+        mcp_id = 'restore-retarget-driver'
+        old_url = 'http://restore-old.invalid/mcp'
+        new_url = 'http://restore-new.invalid/mcp'
+        tool = _ordinary_control_tool()
+        config.main['services'] = {'mcp': [{
+            'id': mcp_id,
+            'name': 'Restore Driver',
+            'transport': 'http',
+            'url': old_url,
+            'trust_state': 'trusted',
+            'tools': [deepcopy(tool)],
+        }]}
+        config.main[f'tool_config:{mcp_id}:{tool["name"]}'] = {'gain': 0.4}
+        session_entered = asyncio.Event()
+        continue_restore = asyncio.Event()
+        records = []
+
+        class DelayedSession(_RecordingSession):
+            async def __aenter__(self):
+                session_entered.set()
+                await continue_restore.wait()
+                return self
+
+        monkeypatch.setattr(
+            mcp_manage.aiohttp,
+            'ClientSession',
+            lambda *args, **kwargs: DelayedSession(records, *args, **kwargs),
+        )
+
+        task = asyncio.create_task(mcp_manage._restore_saved_configs(
+            mcp_id,
+            old_url,
+            [tool],
+            trusted=True,
+        ))
+        await asyncio.wait_for(session_entered.wait(), timeout=0.5)
+        config.main['services'] = {'mcp': [{
+            'id': mcp_id,
+            'name': 'Restore Driver',
+            'transport': 'http',
+            'url': new_url,
+            'trust_state': 'trusted',
+            'tools': [],
+            'capability_refresh_required': True,
+        }]}
+        continue_restore.set()
+        await asyncio.wait_for(task, timeout=0.5)
+
+        assert records == []
+
+    asyncio.run(scenario())
+
+
+def test_background_config_restore_rejects_same_url_capability_generation(
+    monkeypatch,
+):
+    async def scenario() -> None:
+        mcp_id = 'restore-capability-refresh-driver'
+        url = 'http://restore-same-url.invalid/mcp'
+        tool = _ordinary_control_tool()
+        target = {
+            'id': mcp_id,
+            'name': 'Capability Refresh Driver',
+            'transport': 'http',
+            'url': url,
+            'trust_state': 'trusted',
+            'tools': [deepcopy(tool)],
+        }
+        config.main['services'] = {'mcp': [target]}
+        config.main[f'tool_config:{mcp_id}:{tool["name"]}'] = {'gain': 0.4}
+        mcp_manage._ping_generations[mcp_id] = 1
+        target_fingerprint = mcp_manage._ping_target_fingerprint(target)
+        session_entered = asyncio.Event()
+        continue_restore = asyncio.Event()
+        records = []
+
+        class DelayedSession(_RecordingSession):
+            async def __aenter__(self):
+                session_entered.set()
+                await continue_restore.wait()
+                return self
+
+        monkeypatch.setattr(
+            mcp_manage.aiohttp,
+            'ClientSession',
+            lambda *args, **kwargs: DelayedSession(records, *args, **kwargs),
+        )
+
+        task = asyncio.create_task(mcp_manage._restore_saved_configs(
+            mcp_id,
+            url,
+            [tool],
+            trusted=True,
+            target_fingerprint=target_fingerprint,
+            ping_generation=1,
+        ))
+        await asyncio.wait_for(session_entered.wait(), timeout=0.5)
+
+        reserved = deepcopy(tool)
+        reserved['x-teleop'] = {
+            'protocol': 'motus.teleop.shadow.v1',
+            'mode': 'shadow',
+        }
+        config.main['services'] = {'mcp': [{**target, 'tools': [reserved]}]}
+        mcp_manage._ping_generations[mcp_id] = 2
+        continue_restore.set()
+        await asyncio.wait_for(task, timeout=0.5)
+
+        assert records == []
+
+    asyncio.run(scenario())
+
+
+def test_running_project_rejects_active_target_delete_and_can_still_stop(
+    monkeypatch,
+):
+    async def scenario() -> None:
+        mcp_id = 'active-delete-driver'
+        tool = _ordinary_control_tool()
+        target = {
+            'id': mcp_id,
+            'name': 'Active Delete Driver',
+            'transport': 'http',
+            'url': 'http://active-delete.invalid/mcp',
+            'trust_state': 'trusted',
+            'tools': [deepcopy(tool)],
+        }
+        card = {'id': 'card-delete', 'mcpId': mcp_id, 'toolName': tool['name']}
+        config.main['services'] = {'mcp': [target]}
+        config_api._set_project_state('running', cards=[card])
+        records = []
+        monkeypatch.setattr(
+            mcp_manage.aiohttp,
+            'ClientSession',
+            _session_factory(records),
+        )
+
+        response = await mcp_manage.mcp_delete(mcp_id)
+
+        assert response.status_code == 409
+        body = json.loads(response.body)
+        assert body['data']['code'] == 'project_target_locked'
+        assert body['data']['mcp_ids'] == [mcp_id]
+        assert config.main['services']['mcp'][0]['id'] == mcp_id
+        assert await config_api._do_stop_project() is True
+        assert records[-1]['params']['arguments'] == {
+            'action': 'stop',
+            'instance_id': card['id'],
+        }
+
+    asyncio.run(scenario())
+
+
+def test_running_project_rejects_retarget_with_zero_hidden_config_writes(
+    monkeypatch,
+):
+    async def scenario() -> None:
+        mcp_id = 'active-retarget-driver'
+        old_url = 'http://active-retarget-old.invalid/mcp'
+        tool = _ordinary_control_tool()
+        target = {
+            'id': mcp_id,
+            'name': 'Active Retarget Driver',
+            'transport': 'http',
+            'url': old_url,
+            'trust_state': 'trusted',
+            'tools': [deepcopy(tool)],
+        }
+        card = {'id': 'card-retarget', 'mcpId': mcp_id, 'toolName': tool['name']}
+        config.main['services'] = {
+            'llm': {'url': 'http://old-llm.invalid/v1', 'key': 'old', 'model': 'old'},
+            'mcp': [target],
+        }
+        config.main['client'] = {'llm': [{
+            'url': 'http://old-llm.invalid/v1',
+            'key': 'old',
+            'model': 'old',
+        }]}
+        config_api._set_project_state('running', cards=[card])
+        before_services = config.main['services']
+        before_client = config.main['client']
+        runtime_client = client_mod.llm
+        records = []
+        monkeypatch.setattr(
+            mcp_manage.aiohttp,
+            'ClientSession',
+            _session_factory(records),
+        )
+        request = config_api.ConfigSaveRequest(
+            services={'llm': {
+                'url': 'http://hidden-new-llm.invalid',
+                'key': 'hidden-new-key',
+                'model': 'hidden-new-model',
+            }},
+            mcp_list=[{
+                'id': mcp_id,
+                'name': target['name'],
+                'transport': 'http',
+                'url': 'http://active-retarget-new.invalid/mcp',
+            }],
+        )
+
+        with pytest.raises(fastapi.HTTPException) as error:
+            await config_api.config_save(request)
+
+        assert error.value.status_code == 409
+        assert error.value.detail['code'] == 'project_target_locked'
+        assert config.main['services'] == before_services
+        assert config.main['client'] == before_client
+        assert client_mod.llm is runtime_client
+        assert await config_api._do_stop_project() is True
+        assert records[-1]['params']['arguments']['action'] == 'stop'
+
+    asyncio.run(scenario())
+
+
+def test_running_project_rejects_same_url_capability_removal_and_can_stop(
+    monkeypatch,
+):
+    async def scenario() -> None:
+        mcp_id = 'active-capability-driver'
+        tool = _ordinary_control_tool()
+        target = {
+            'id': mcp_id,
+            'name': 'Active Capability Driver',
+            'transport': 'http',
+            'url': 'http://active-capability.invalid/mcp',
+            'trust_state': 'trusted',
+            'tools': [deepcopy(tool)],
+        }
+        card = {'id': 'card-capability', 'mcpId': mcp_id, 'toolName': tool['name']}
+        config.main['services'] = {'mcp': [target]}
+        config_api._set_project_state('running', cards=[card])
+        mcp_client.registry[mcp_id] = {'online': True}
+
+        async def removed_capabilities(url, *, trusted=False, driver_id=''):
+            return {
+                'server_name': 'active-capability-driver',
+                'tools': [],
+                'resources': [],
+                'device_type': '',
+                'topic_out': [],
+                'topic_in': [],
+            }
+
+        monkeypatch.setattr(mcp_manage, '_ping_mcp_http', removed_capabilities)
+        result = await mcp_manage._do_ping(mcp_id)
+
+        assert result['detail']['code'] == 'project_target_locked'
+        assert config.main['services']['mcp'][0]['tools'] == [tool]
+
+        records = []
+        monkeypatch.setattr(
+            mcp_manage.aiohttp,
+            'ClientSession',
+            _session_factory(records),
+        )
+        assert await config_api._do_stop_project() is True
+        assert records[-1]['params']['arguments']['action'] == 'stop'
+
+    asyncio.run(scenario())
+
+
+def test_running_project_locks_authority_root_target(monkeypatch):
+    async def scenario() -> None:
+        adapter_id = 'active-alias-adapter'
+        root_id = 'active-alias-root'
+        tool = _ordinary_control_tool()
+        adapter = {
+            'id': adapter_id,
+            'name': 'Active Alias Adapter',
+            'transport': 'http',
+            'url': 'http://active-alias.invalid/mcp',
+            'category': 'driver',
+            'trust_state': 'trusted',
+            'authority_domain': root_id,
+            'tools': [deepcopy(tool)],
+        }
+        root = {
+            'id': root_id,
+            'name': 'Active Alias Root',
+            'transport': 'http',
+            'url': 'http://active-root-old.invalid/mcp',
+            'category': 'driver',
+            'trust_state': 'trusted',
+            'tools': [deepcopy(tool)],
+        }
+        card = {'id': 'card-alias', 'mcpId': adapter_id, 'toolName': tool['name']}
+        config.main['services'] = {'mcp': [adapter, root]}
+        config_api._set_project_state('running', cards=[card])
+        request = config_api.ConfigSaveRequest(mcp_list=[{
+            'id': adapter_id,
+            'name': adapter['name'],
+            'transport': 'http',
+            'url': adapter['url'],
+        }, {
+            'id': root_id,
+            'name': root['name'],
+            'transport': 'http',
+            'url': 'http://active-root-new.invalid/mcp',
+        }])
+
+        with pytest.raises(fastapi.HTTPException) as error:
+            await config_api.config_save(request)
+
+        assert error.value.status_code == 409
+        assert error.value.detail['code'] == 'project_target_locked'
+        assert error.value.detail['mcp_ids'] == [root_id]
+
+        async def fake_call(mcp_id, call):
+            return {'code': 200, 'data': {'state': 'idle'}}
+
+        monkeypatch.setattr(mcp_manage, 'mcp_call_tool', fake_call)
+        assert await config_api._do_stop_project() is True
+
+    asyncio.run(scenario())
+
+
+def test_project_transition_rejects_target_delete_before_running_commit(
+    monkeypatch,
+):
+    async def scenario() -> None:
+        mcp_id = 'transition-delete-driver'
+        tool = _ordinary_control_tool()
+        target = {
+            'id': mcp_id,
+            'name': 'Transition Delete Driver',
+            'transport': 'http',
+            'url': 'http://transition-delete.invalid/mcp',
+            'trust_state': 'trusted',
+            'tools': [deepcopy(tool)],
+        }
+        card = {'id': 'card-transition', 'mcpId': mcp_id, 'toolName': tool['name']}
+        config.main['services'] = {'mcp': [target]}
+        config.main['canvas_layout'] = {'cards': [card], 'connections': []}
+        start_entered = asyncio.Event()
+        finish_start = asyncio.Event()
+
+        async def delayed_call(driver_id, request):
+            action = request.arguments.get('action')
+            if action == 'start':
+                start_entered.set()
+                await finish_start.wait()
+                return {'code': 200, 'data': {'state': 'running'}}
+            if action == 'info':
+                return {'code': 200, 'data': {}}
+            return {'code': 200, 'data': {'state': 'idle'}}
+
+        monkeypatch.setattr(mcp_manage, 'mcp_call_tool', delayed_call)
+        start_task = asyncio.create_task(config_api._do_start_project())
+        await asyncio.wait_for(start_entered.wait(), timeout=0.5)
+        assert config_api._project_transition_lock.locked() is True
+
+        response = await mcp_manage.mcp_delete(mcp_id)
+
+        assert response.status_code == 409
+        assert json.loads(response.body)['data']['project_state'] == 'transitioning'
+        finish_start.set()
+        assert await asyncio.wait_for(start_task, timeout=0.5) is True
+        assert config.main['services']['mcp'][0]['id'] == mcp_id
+        assert await config_api._do_stop_project() is True
+
+    asyncio.run(scenario())
+
+
+def test_rejected_duplicate_config_save_never_switches_hidden_llm_route():
+    async def scenario() -> None:
+        config.main['services'] = {
+            'llm': {'url': 'http://old.invalid/v1', 'key': 'old', 'model': 'old'},
+            'mcp': [],
+        }
+        config.main['client'] = {'llm': [{
+            'url': 'http://old.invalid/v1',
+            'key': 'old',
+            'model': 'old',
+        }]}
+        before_services = config.main['services']
+        before_client = config.main['client']
+        runtime_client = client_mod.llm
+        request = config_api.ConfigSaveRequest(
+            services={'llm': {
+                'url': 'http://new.invalid',
+                'key': 'new-secret',
+                'model': 'new-model',
+            }},
+            mcp_list=[
+                {'id': 'duplicate', 'url': 'http://one.invalid/mcp'},
+                {'id': 'duplicate', 'url': 'http://two.invalid/mcp'},
+            ],
+        )
+
+        with pytest.raises(fastapi.HTTPException) as error:
+            await config_api.config_save(request)
+
+        assert error.value.status_code == 409
+        assert config.main['services'] == before_services
+        assert config.main['client'] == before_client
+        assert client_mod.llm is runtime_client
+
+    asyncio.run(scenario())
+
+
+def test_config_save_persists_related_keys_atomically_before_runtime_swap(
+    monkeypatch,
+):
+    async def scenario() -> None:
+        old_values = {
+            'services': {
+                'llm': {'url': 'http://old.invalid/v1', 'key': 'old', 'model': 'old'},
+                'mcp': [],
+            },
+            'client': {'llm': [{
+                'url': 'http://old.invalid/v1',
+                'key': 'old',
+                'model': 'old',
+            }]},
+            'desktop_tools': {'search': {
+                'type': 'none',
+                'base_url': '',
+                'api_key': '',
+            }},
+            'core': {'configured': False},
+        }
+        config.main.set_many(old_values)
+        runtime_client = client_mod.llm
+        real_get_conn = config._get_conn
+        fault = {'enabled': True, 'writes': 0}
+
+        class FaultyConnection:
+            def __init__(self):
+                self.connection = real_get_conn()
+
+            def __enter__(self):
+                self.connection.__enter__()
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return self.connection.__exit__(exc_type, exc, tb)
+
+            def execute(self, sql, parameters=()):
+                if fault['enabled'] and sql.startswith('INSERT OR REPLACE'):
+                    fault['writes'] += 1
+                    if fault['writes'] == 3:
+                        fault['enabled'] = False
+                        raise OSError('simulated third config write failure')
+                return self.connection.execute(sql, parameters)
+
+            def commit(self):
+                return self.connection.commit()
+
+            def rollback(self):
+                return self.connection.rollback()
+
+        monkeypatch.setattr(config, '_get_conn', FaultyConnection)
+        request = config_api.ConfigSaveRequest(
+            services={
+                'llm': {
+                    'url': 'http://new.invalid',
+                    'key': 'new-secret',
+                    'model': 'new-model',
+                },
+                'search': {
+                    'type': 'baidu_search',
+                    'base_url': 'http://search.invalid',
+                    'api_key': 'search-secret',
+                },
+            },
+            mcp_list=[],
+        )
+
+        with pytest.raises(OSError, match='third config write failure'):
+            await config_api.config_save(request)
+
+        for key, value in old_values.items():
+            assert config.main[key] == value
+        assert client_mod.llm is runtime_client
+
+    asyncio.run(scenario())
+
+
+def test_invalid_config_runtime_candidate_is_zero_write_and_keeps_registry(
+    monkeypatch,
+):
+    async def scenario() -> None:
+        mcp_id = 'candidate-retarget-driver'
+        old_values = {
+            'services': {
+                'llm': {'url': 'http://old.invalid/v1', 'key': 'old', 'model': 'old'},
+                'mcp': [{
+                    'id': mcp_id,
+                    'name': 'Candidate Retarget Driver',
+                    'transport': 'http',
+                    'url': 'http://candidate-old.invalid/mcp',
+                    'trust_state': 'trusted',
+                    'tools': [deepcopy(_ordinary_control_tool())],
+                }],
+            },
+            'client': {'llm': [{
+                'url': 'http://old.invalid/v1',
+                'key': 'old',
+                'model': 'old',
+            }]},
+            'desktop_tools': {'search': {'type': 'none'}},
+            'core': {'configured': False},
+        }
+        config.main.set_many(old_values)
+        registry_entry = {'online': True, 'url': 'http://candidate-old.invalid/mcp'}
+        mcp_client.registry[mcp_id] = deepcopy(registry_entry)
+        runtime_client = client_mod.llm
+        request = config_api.ConfigSaveRequest(
+            services={'llm': {
+                'url': '::::',
+                'key': 'new-secret',
+                'model': 'new-model',
+            }},
+            mcp_list=[{
+                'id': mcp_id,
+                'name': 'Candidate Retarget Driver',
+                'transport': 'http',
+                'url': 'http://candidate-new.invalid/mcp',
+            }],
+        )
+
+        with pytest.raises(httpx.InvalidURL):
+            await config_api.config_save(request)
+
+        for key, value in old_values.items():
+            assert config.main[key] == value
+        assert client_mod.llm is runtime_client
+        assert mcp_client.registry[mcp_id] == registry_entry
+
+    asyncio.run(scenario())
+
+
+def test_successful_config_commit_swaps_runtime_and_invalidates_target_registry(
+    monkeypatch,
+):
+    async def scenario() -> None:
+        mcp_id = 'candidate-success-driver'
+        config.main['services'] = {'mcp': [{
+            'id': mcp_id,
+            'name': 'Candidate Success Driver',
+            'transport': 'http',
+            'url': 'http://candidate-success-old.invalid/mcp',
+            'trust_state': 'trusted',
+            'tools': [deepcopy(_ordinary_control_tool())],
+        }]}
+        mcp_client.registry[mcp_id] = {'online': True}
+        previous_runtime = client_mod.llm
+        monkeypatch.setattr(client_mod, 'llm', previous_runtime)
+        request = config_api.ConfigSaveRequest(
+            services={'llm': {
+                'url': 'http://candidate-llm.invalid',
+                'key': 'candidate-secret',
+                'model': 'candidate-model',
+            }},
+            mcp_list=[{
+                'id': mcp_id,
+                'name': 'Candidate Success Driver',
+                'transport': 'http',
+                'url': 'http://candidate-success-new.invalid/mcp',
+            }],
+        )
+
+        response = await config_api.config_save(request)
+
+        assert response['code'] == 200
+        candidate_runtime = client_mod.llm
+        assert candidate_runtime is not previous_runtime
+        assert config.main['client']['llm'][0]['url'] == 'http://candidate-llm.invalid/v1'
+        assert config.main['services']['mcp'][0]['tools'] == []
+        assert mcp_id not in mcp_client.registry
+        await candidate_runtime.aclose()
+
+    asyncio.run(scenario())
+
+
+def test_agentcore_invalid_runtime_candidate_is_atomic_zero_write():
+    async def scenario() -> None:
+        old_values = {
+            'client': {'llm': [{
+                'url': 'http://old-agentcore.invalid/v1',
+                'key': 'old',
+                'model': 'old',
+            }]},
+            'event': {
+                'llm': {'trigger_interval_ms': 1000},
+                'subscribe_topics': [],
+            },
+            'desktop_tools': {'search': {
+                'type': 'none',
+                'base_url': '',
+                'api_key': '',
+            }},
+        }
+        config.main.set_many(old_values)
+        runtime_client = client_mod.llm
+        request = mcp_manage.MCPCallRequest(
+            tool='decision_core',
+            arguments={
+                'action': 'config',
+                'llm_url': '::::',
+                'llm_key': 'new-secret',
+                'llm_model': 'new-model',
+                'trigger_interval_ms': 25,
+                'search_type': 'baidu_search',
+                'search_base_url': 'http://new-search.invalid',
+                'search_api_key': 'new-search-secret',
+            },
+        )
+
+        with pytest.raises(httpx.InvalidURL):
+            await mcp_manage._handle_agentcore_call(request)
+
+        for key, value in old_values.items():
+            assert config.main[key] == value
+        assert client_mod.llm is runtime_client
+
+    asyncio.run(scenario())
+
+
+def test_degraded_persist_failure_latches_residual_targets_until_retry_stop(
+    monkeypatch,
+):
+    async def scenario() -> None:
+        tool = _ordinary_control_tool()
+        cards = [{
+            'id': 'residual-card-a',
+            'mcpId': 'residual-driver-a',
+            'toolName': tool['name'],
+        }, {
+            'id': 'residual-card-b',
+            'mcpId': 'residual-driver-b',
+            'toolName': tool['name'],
+        }]
+        config.main['services'] = {'mcp': [{
+            'id': card['mcpId'],
+            'name': card['mcpId'],
+            'transport': 'http',
+            'url': f'http://{card["mcpId"]}.invalid/mcp',
+            'trust_state': 'trusted',
+            'tools': [deepcopy(tool)],
+        } for card in cards]}
+        config.main['canvas_layout'] = {'cards': cards, 'connections': []}
+        calls = []
+        fail_stops = {'enabled': True}
+
+        async def fake_call(mcp_id, request):
+            action = request.arguments['action']
+            calls.append((mcp_id, action))
+            if action == 'start' and mcp_id == 'residual-driver-b':
+                return {'code': 500, 'message': 'start failed'}
+            if action == 'info':
+                return {'code': 200, 'data': {}}
+            if action == 'stop' and fail_stops['enabled']:
+                return {'code': 500, 'message': 'stop failed'}
+            return {
+                'code': 200,
+                'data': {'state': 'running' if action == 'start' else 'idle'},
+            }
+
+        original_set_state = config_api._set_project_state
+
+        def fail_degraded_commit(state, *, cards=None):
+            if state == 'degraded':
+                raise OSError('simulated degraded state commit failure')
+            return original_set_state(state, cards=cards)
+
+        monkeypatch.setattr(mcp_manage, 'mcp_call_tool', fake_call)
+        monkeypatch.setattr(config_api, '_set_project_state', fail_degraded_commit)
+
+        result = await config_api._do_start_project()
+
+        assert result['status_code'] == 500
+        assert result['detail']['rollback_incomplete'] is True
+        assert await config_api.get_project_running() == {
+            'running': True,
+            'state': 'degraded',
+            'transitioning': False,
+        }
+        assert config.main['core'].get('active_project_cards') is None
+
+        delete = await mcp_manage.mcp_delete('residual-driver-a')
+        assert delete.status_code == 409
+        assert json.loads(delete.body)['data']['project_state'] == 'degraded'
+        restart = await config_api._do_start_project()
+        assert restart['detail']['code'] == 'project_degraded_requires_stop'
+
+        fail_stops['enabled'] = False
+        assert await config_api._do_stop_project() is True
+        assert calls.count(('residual-driver-a', 'stop')) == 2
+        assert calls.count(('residual-driver-b', 'stop')) == 2
+        assert await config_api.get_project_running() == {
+            'running': False,
+            'state': 'stopped',
+            'transitioning': False,
+        }
+        assert config_api._project_residual_latched is False
+
+    asyncio.run(scenario())
+
+
+def test_canvas_config_response_confirms_driver_apply_before_success(monkeypatch):
+    async def scenario() -> None:
+        mcp_id = 'config-apply-driver'
+        tool = _ordinary_control_tool()
+        config.main['services'] = {'mcp': [{
+            'id': mcp_id,
+            'name': 'Config Apply Driver',
+            'transport': 'http',
+            'url': 'http://config-apply.invalid/mcp',
+            'trust_state': 'trusted',
+            'tools': [deepcopy(tool)],
+        }]}
+        records = []
+        monkeypatch.setattr(
+            mcp_manage.aiohttp,
+            'ClientSession',
+            _session_factory(records),
+        )
+
+        response = await canvas.save_tool_config(
+            mcp_id,
+            tool['name'],
+            {'gain': 0.5},
+        )
+
+        assert response == {
+            'code': 200,
+            'data': {'saved': True, 'applied': True, 'deferred': False},
+        }
+        assert [record['method'] for record in records] == [
+            'initialize', 'tools/call',
+        ]
+        assert records[-1]['params']['arguments'] == {
+            'action': 'config',
+            'gain': 0.5,
+        }
+
+    asyncio.run(scenario())
+
+
+@pytest.mark.parametrize(
+    'tool_result',
+    [
+        {
+            'isError': True,
+            'content': [{'type': 'text', 'text': '{"message":"rejected"}'}],
+        },
+        {
+            'content': [{'type': 'text', 'text': '{"adapter_ok":false}'}],
+        },
+        {
+            'content': [{
+                'type': 'text',
+                'text': '{"error":"Missing input_topic"}',
+            }],
+        },
+        {
+            'content': [{}],
+        },
+        {
+            'content': [{'type': 'text', 'text': 'configured'}],
+        },
+        {
+            'content': [{
+                'type': 'text',
+                'text': '{"configured":true,"gain":NaN}',
+            }],
+        },
+        {
+            'content': [{
+                'type': 'image',
+                'data': 'aW1hZ2U=',
+                'mimeType': 'image/png',
+            }],
+        },
+        {
+            'content': [],
+        },
+        {},
+    ],
+    ids=[
+        'mcp-is-error',
+        'adapter-rejected',
+        'explicit-error-ack',
+        'invalid-content-block',
+        'unstructured-text-ack',
+        'non-finite-json-ack',
+        'image-only-ack',
+        'empty-ack',
+        'invalid-result',
+    ],
+)
+def test_canvas_config_driver_rejection_is_saved_but_not_reported_applied(
+    monkeypatch,
+    tool_result,
+):
+    async def scenario() -> None:
+        mcp_id = 'config-reject-driver'
+        tool = _ordinary_control_tool()
+        config.main['services'] = {'mcp': [{
+            'id': mcp_id,
+            'name': 'Config Reject Driver',
+            'transport': 'http',
+            'url': 'http://config-reject.invalid/mcp',
+            'trust_state': 'trusted',
+            'tools': [deepcopy(tool)],
+        }]}
+        records = []
+        monkeypatch.setattr(
+            mcp_manage.aiohttp,
+            'ClientSession',
+            _tool_result_session_factory(records, tool_result),
+        )
+
+        response = await canvas.save_tool_config(
+            mcp_id,
+            tool['name'],
+            {'gain': 0.5},
+        )
+
+        assert response.status_code == 502
+        body = json.loads(response.body)
+        assert body['data'] == {
+            'saved': True,
+            'applied': False,
+            'deferred': False,
+            'reason': 'driver_apply_failed',
+        }
+        assert config.main[f'tool_config:{mcp_id}:{tool["name"]}'] == {
+            'gain': 0.5,
+        }
+        assert records[-1]['params']['arguments'] == {
+            'gain': 0.5,
+            'action': 'config',
+        }
+
+    asyncio.run(scenario())
+
+
+def test_generic_mcp_call_accepts_a_valid_non_text_content_block(monkeypatch):
+    async def scenario() -> None:
+        mcp_id = 'image-result-driver'
+        tool = _ordinary_control_tool()
+        tool.pop('configSchema')
+        config.main['services'] = {'mcp': [{
+            'id': mcp_id,
+            'name': 'Image Result Driver',
+            'transport': 'http',
+            'url': 'http://image-result.invalid/mcp',
+            'trust_state': 'trusted',
+            'tools': [deepcopy(tool)],
+        }]}
+        image_block = {
+            'type': 'image',
+            'data': 'aW1hZ2U=',
+            'mimeType': 'image/png',
+        }
+        monkeypatch.setattr(
+            mcp_manage.aiohttp,
+            'ClientSession',
+            _tool_result_session_factory([], {'content': [image_block]}),
+        )
+
+        result = await mcp_manage.mcp_call_tool(
+            mcp_id,
+            mcp_manage.MCPCallRequest(
+                tool=tool['name'],
+                arguments={'action': 'info'},
+            ),
+        )
+
+        assert result == {'code': 200, 'data': [image_block]}
+
+    asyncio.run(scenario())
+
+
+def test_llm_dispatch_requires_config_ack_but_keeps_generic_images(monkeypatch):
+    async def scenario() -> None:
+        mcp_id = 'llm-config-ack-driver'
+        tool = _ordinary_control_tool()
+        tool['inputSchema']['properties']['action']['enum'].append('start')
+        full_name = f'mcp__{mcp_id}__{tool["name"]}'
+        config.main['services'] = {'mcp': [{
+            'id': mcp_id,
+            'name': 'LLM Config Ack Driver',
+            'transport': 'http',
+            'url': 'http://llm-config.invalid/mcp',
+            'trust_state': 'trusted',
+            'tools': [deepcopy(tool)],
+        }]}
+        config.main[f'tool_config:{mcp_id}:{tool["name"]}'] = {'gain': 0.5}
+        mcp_client.registry[mcp_id] = {
+            'name': 'LLM Config Ack Driver',
+            'url': 'http://llm-config.invalid/mcp',
+            'online': True,
+            'trusted': True,
+            'schemas': {},
+            'split_map': {},
+            'input_schemas': {full_name: tool['inputSchema']},
+            'tool_meta': {
+                full_name: {
+                    'type': 'actuator',
+                    'action_enum': tool['inputSchema']['properties']['action']['enum'],
+                    'annotations': {},
+                    'has_config_schema': True,
+                },
+            },
+        }
+        calls = []
+        image_block = {
+            'type': 'image',
+            'data': 'aW1hZ2U=',
+            'mimeType': 'image/png',
+        }
+
+        async def image_result(session, url, method, params, **kwargs):
+            calls.append(deepcopy(params['arguments']))
+            return {'content': [deepcopy(image_block)]}
+
+        monkeypatch.setattr(mcp_client, '_jrpc', image_result)
+
+        rejected = await mcp_client.call_tool(full_name, {'action': 'start'})
+        assert rejected == f'[{tool["name"]}] Driver 拒绝配置，启动已取消。'
+        assert calls == [{'gain': 0.5, 'action': 'config'}]
+
+        observed = await mcp_client.call_tool(full_name, {'action': 'info'})
+        assert observed == [{
+            'type': 'image_url',
+            'image_url': 'data:image/png;base64,aW1hZ2U=',
+        }]
+        assert calls[-1] == {'action': 'info'}
+
+    asyncio.run(scenario())
+
+
+def test_generic_result_can_observe_error_state_without_becoming_rpc_failure():
+    result = {
+        'content': [{
+            'type': 'text',
+            'text': '{"state":"error","message":"sensor unavailable"}',
+        }],
+    }
+
+    assert mcp_manage._tool_result_error(result) is None
+    assert mcp_manage._tool_result_error(
+        result,
+        require_structured_ack=True,
+    ) == 'sensor unavailable'
+
+    explicit_error = {
+        'content': [{
+            'type': 'text',
+            'text': '{"error":"Missing input_topic"}',
+        }],
+    }
+    assert mcp_manage._tool_result_error(explicit_error) is None
+    assert mcp_manage._tool_result_error(
+        explicit_error,
+        require_structured_ack=True,
+    ) == 'Missing input_topic'
+    assert config_api._project_tool_ack_error({
+        'code': 200,
+        'data': explicit_error['content'],
+    }) == 'Missing input_topic'
+
+
+@pytest.mark.parametrize(
+    'body',
+    [
+        {'action': 'move', 'gain': 0.5},
+        {'instance_id': 'another-card', 'gain': 0.5},
+        ['not', 'an', 'object'],
+    ],
+    ids=['action', 'instance-id', 'non-object'],
+)
+def test_canvas_config_rejects_protocol_owned_fields_before_persisting(body):
+    async def scenario() -> None:
+        key = 'tool_config:config-safe-driver:robot_control'
+        with pytest.raises(fastapi.HTTPException) as error:
+            await canvas.save_tool_config(
+                'config-safe-driver',
+                'robot_control',
+                body,
+            )
+        assert error.value.status_code == 422
+        assert config.main.get(key, None) is None
+
+    asyncio.run(scenario())
+
+
+def test_legacy_saved_config_cannot_override_restore_protocol_fields(monkeypatch):
+    async def scenario() -> None:
+        mcp_id = 'legacy-config-driver'
+        tool = _ordinary_control_tool()
+        config.main['services'] = {'mcp': [{
+            'id': mcp_id,
+            'name': 'Legacy Config Driver',
+            'transport': 'http',
+            'url': 'http://legacy-config.invalid/mcp',
+            'trust_state': 'trusted',
+            'tools': [deepcopy(tool)],
+        }]}
+        config.main[f'tool_config:{mcp_id}:{tool["name"]}'] = {
+            'action': 'move',
+            'instance_id': 'victim-card',
+            'gain': 0.25,
+        }
+        records = []
+        monkeypatch.setattr(
+            mcp_manage.aiohttp,
+            'ClientSession',
+            _session_factory(records),
+        )
+
+        await mcp_manage._restore_saved_configs(
+            mcp_id,
+            'http://legacy-config.invalid/mcp',
+            [tool],
+            trusted=True,
+        )
+
+        assert records[-1]['params']['arguments'] == {
+            'gain': 0.25,
+            'action': 'config',
+        }
+
+    asyncio.run(scenario())
+
+
+def test_empty_canvas_start_is_a_visible_conflict():
+    async def scenario() -> None:
+        assert (await canvas.claim_edit({'session_id': 'canvas-editor'}))['code'] == 200
+        response = await config_api.api_start_project(
+            config_api.ProjectStartRequest(
+                session_id='canvas-editor',
+                layout_revision=0,
+            ),
+        )
+
+        assert response.status_code == 409
+        body = json.loads(response.body)
+        assert body['detail'] == {
+            'code': 'project_empty',
+            'reason': 'no_canvas_cards',
+        }
+        state = await config_api.get_project_running()
+        assert state == {
+            'running': False,
+            'state': 'stopped',
+            'transitioning': False,
+        }
+
+    asyncio.run(scenario())
+
+
+def test_degraded_project_must_be_stopped_before_another_start():
+    async def scenario() -> None:
+        config_api._set_project_state('degraded', cards=[{
+            'id': 'card-a',
+            'mcpId': 'driver-a',
+            'toolName': 'tool-a',
+        }])
+
+        result = await config_api._do_start_project()
+
+        assert result == {
+            'status_code': 409,
+            'detail': {
+                'code': 'project_degraded_requires_stop',
+                'reason': 'residual_control_must_be_stopped_before_start',
+                'project_state': 'degraded',
+            },
+            'errors': [],
+        }
+
+    asyncio.run(scenario())
+
+
+def test_canvas_revision_cas_rejects_a_stale_visible_layout():
+    async def scenario() -> None:
+        assert (await canvas.claim_edit({'session_id': 'editor-a'}))['code'] == 200
+        initial = await canvas.get_layout()
+        assert initial['data']['revision'] == 0
+
+        saved = await canvas.save_layout(canvas.CanvasLayout(
+            cards=[{'id': 'card-a', 'mcpId': 'driver-a', 'toolName': 'tool-a'}],
+            connections=[],
+            session_id='editor-a',
+            revision=0,
+        ))
+        assert saved == {'code': 200, 'data': {'revision': 1}}
+
+        stale = await canvas.save_layout(canvas.CanvasLayout(
+            cards=[{'id': 'stale-card', 'mcpId': 'driver-b', 'toolName': 'tool-b'}],
+            connections=[],
+            session_id='editor-a',
+            revision=0,
+        ))
+        assert stale.status_code == 409
+        assert json.loads(stale.body)['detail'] == {
+            'code': 'canvas_revision_conflict',
+            'expected_revision': 0,
+            'current_revision': 1,
+        }
+        assert config.main['canvas_layout']['cards'][0]['id'] == 'card-a'
+
+    asyncio.run(scenario())
+
+
+def test_project_start_requires_current_editor_and_visible_revision(monkeypatch):
+    async def scenario() -> None:
+        config.main['canvas_layout'] = {
+            'cards': [{'id': 'card-a', 'mcpId': 'driver-a', 'toolName': 'tool-a'}],
+            'connections': [],
+            'revision': 4,
+        }
+        assert (await canvas.claim_edit({'session_id': 'editor-a'}))['code'] == 200
+        calls = []
+
+        async def fake_call(mcp_id, request):
+            calls.append((mcp_id, request.tool, request.arguments['action']))
+            if request.arguments['action'] == 'info':
+                return {'code': 200, 'data': {}}
+            return {'code': 200, 'data': {'state': 'running'}}
+
+        monkeypatch.setattr(mcp_manage, 'mcp_call_tool', fake_call)
+
+        wrong_editor = await config_api.api_start_project(
+            config_api.ProjectStartRequest(
+                session_id='editor-b',
+                layout_revision=4,
+            ),
+        )
+        assert wrong_editor.status_code == 409
+        assert json.loads(wrong_editor.body)['detail']['code'] == 'project_editor_required'
+        assert calls == []
+
+        stale = await config_api.api_start_project(
+            config_api.ProjectStartRequest(
+                session_id='editor-a',
+                layout_revision=3,
+            ),
+        )
+        assert stale.status_code == 409
+        assert json.loads(stale.body)['detail'] == {
+            'code': 'project_layout_revision_conflict',
+            'expected_revision': 3,
+            'current_revision': 4,
+        }
+        assert calls == []
+
+        started = await config_api.api_start_project(
+            config_api.ProjectStartRequest(
+                session_id='editor-a',
+                layout_revision=4,
+            ),
+        )
+        assert started == {'ok': True}
+        assert calls == [
+            ('driver-a', 'tool-a', 'start'),
+            ('driver-a', 'tool-a', 'info'),
+        ]
+
+    asyncio.run(scenario())
+
+
+def test_project_running_exposes_an_inflight_start_transition(monkeypatch):
+    async def scenario() -> None:
+        config.main['canvas_layout'] = {
+            'cards': [{'id': 'card-a', 'mcpId': 'driver-a', 'toolName': 'tool-a'}],
+            'connections': [],
+            'revision': 2,
+        }
+        assert (await canvas.claim_edit({'session_id': 'editor-a'}))['code'] == 200
+        start_entered = asyncio.Event()
+        finish_start = asyncio.Event()
+
+        async def fake_call(mcp_id, request):
+            if request.arguments['action'] == 'start':
+                start_entered.set()
+                await finish_start.wait()
+                return {'code': 200, 'data': {'state': 'running'}}
+            return {'code': 200, 'data': {}}
+
+        monkeypatch.setattr(mcp_manage, 'mcp_call_tool', fake_call)
+        task = asyncio.create_task(config_api.api_start_project(
+            config_api.ProjectStartRequest(
+                session_id='editor-a',
+                layout_revision=2,
+            ),
+        ))
+        await asyncio.wait_for(start_entered.wait(), timeout=0.5)
+
+        assert await config_api.get_project_running() == {
+            'running': False,
+            'state': 'stopped',
+            'transitioning': True,
+        }
+        finish_start.set()
+        assert await asyncio.wait_for(task, timeout=0.5) == {'ok': True}
+        assert await config_api.get_project_running() == {
+            'running': True,
+            'state': 'running',
+            'transitioning': False,
+        }
+
+    asyncio.run(scenario())
+
+
+def test_project_start_reports_degraded_when_rollback_is_incomplete(monkeypatch):
+    async def scenario() -> None:
+        config.main['canvas_layout'] = {
+            'cards': [
+                {'id': 'card-a', 'mcpId': 'driver-a', 'toolName': 'tool-a'},
+                {'id': 'card-b', 'mcpId': 'driver-b', 'toolName': 'tool-b'},
+            ],
+            'connections': [],
+        }
+        calls = []
+
+        async def fake_call(mcp_id, request):
+            action = request.arguments['action']
+            calls.append((mcp_id, request.tool, action))
+            if action == 'info':
+                return {'code': 200, 'data': {}}
+            if action == 'start' and request.tool == 'tool-b':
+                return {'code': 500, 'message': 'start rejected', 'data': None}
+            if action == 'stop' and request.tool == 'tool-a':
+                return {'code': 500, 'message': 'stop rejected', 'data': None}
+            return {'code': 200, 'data': {'state': 'running'}}
+
+        monkeypatch.setattr(mcp_manage, 'mcp_call_tool', fake_call)
+        result = await config_api._do_start_project()
+
+        assert result['status_code'] == 500
+        assert result['detail']['rollback_incomplete'] is True
+        assert result['detail']['project_state'] == 'degraded'
+        assert result['detail']['started_card_ids'] == ['card-a']
+        assert result['detail']['attempted_card_ids'] == ['card-a', 'card-b']
+        assert ('driver-a', 'tool-a', 'stop') in calls
+        assert ('driver-b', 'tool-b', 'stop') in calls
+        assert await config_api.get_project_running() == {
+            'running': True,
+            'state': 'degraded',
+            'transitioning': False,
+        }
+
+    asyncio.run(scenario())
+
+
+def test_project_start_never_marks_running_without_structured_driver_ack(monkeypatch):
+    async def scenario() -> None:
+        config.main['canvas_layout'] = {
+            'cards': [{'id': 'card-a', 'mcpId': 'driver-a', 'toolName': 'tool-a'}],
+            'connections': [],
+        }
+        calls = []
+
+        async def fake_call(mcp_id, request):
+            action = request.arguments['action']
+            calls.append(action)
+            if action == 'start':
+                return {
+                    'code': 200,
+                    'data': [{
+                        'type': 'image',
+                        'data': 'aW1hZ2U=',
+                        'mimeType': 'image/png',
+                    }],
+                }
+            return {'code': 200, 'data': {'state': 'idle'}}
+
+        monkeypatch.setattr(mcp_manage, 'mcp_call_tool', fake_call)
+        result = await config_api._do_start_project()
+
+        assert result['status_code'] == 500
+        assert result['detail']['code'] == 'project_start_failed'
+        assert result['detail']['rollback_incomplete'] is False
+        assert calls == ['start', 'stop']
+        assert await config_api.get_project_running() == {
+            'running': False,
+            'state': 'stopped',
+            'transitioning': False,
+        }
+
+    asyncio.run(scenario())
+
+
+def test_project_running_state_commit_failure_stops_started_drivers(monkeypatch):
+    async def scenario() -> None:
+        config.main['canvas_layout'] = {
+            'cards': [{'id': 'card-a', 'mcpId': 'driver-a', 'toolName': 'tool-a'}],
+            'connections': [],
+        }
+        calls = []
+
+        async def fake_call(mcp_id, request):
+            action = request.arguments['action']
+            calls.append(action)
+            if action == 'info':
+                return {'code': 200, 'data': {}}
+            return {'code': 200, 'data': {'state': 'running' if action == 'start' else 'idle'}}
+
+        original_set_state = config_api._set_project_state
+
+        def fail_running_commit(state, *, cards=None):
+            if state == 'running':
+                raise OSError('simulated SQLite commit failure')
+            return original_set_state(state, cards=cards)
+
+        monkeypatch.setattr(mcp_manage, 'mcp_call_tool', fake_call)
+        monkeypatch.setattr(config_api, '_set_project_state', fail_running_commit)
+
+        result = await config_api._do_start_project()
+
+        assert result['status_code'] == 500
+        assert result['detail']['code'] == 'project_state_commit_failed'
+        assert result['detail']['rollback_incomplete'] is False
+        assert calls == ['start', 'info', 'stop']
+        assert config.main['core']['project_running'] is False
+
+    asyncio.run(scenario())
+
+
+def test_agentcore_decision_card_has_structured_project_lifecycle_ack():
+    async def scenario() -> None:
+        config.main['canvas_layout'] = {
+            'cards': [{
+                'id': 'decision-card',
+                'mcpId': 'agentcore',
+                'toolName': 'decision_core',
+            }],
+            'connections': [],
+        }
+
+        assert await config_api._do_start_project() is True
+        assert config.main['core']['project_state'] == 'running'
+        assert await config_api._do_stop_project() is True
+        assert config.main['core']['project_state'] == 'stopped'
+
+    asyncio.run(scenario())
+
+
+def test_cancelled_project_start_finishes_rollback_despite_recancellation(monkeypatch):
+    async def scenario() -> None:
+        config.main['canvas_layout'] = {
+            'cards': [
+                {'id': 'card-a', 'mcpId': 'driver-a', 'toolName': 'tool-a'},
+                {'id': 'card-b', 'mcpId': 'driver-b', 'toolName': 'tool-b'},
+            ],
+            'connections': [],
+        }
+        calls = []
+        second_start = asyncio.Event()
+        rollback_started = asyncio.Event()
+        finish_rollback = asyncio.Event()
+
+        async def fake_call(mcp_id, request):
+            action = request.arguments['action']
+            calls.append((request.tool, action))
+            if action == 'info':
+                return {'code': 200, 'data': {}}
+            if action == 'start' and request.tool == 'tool-b':
+                second_start.set()
+                await asyncio.Event().wait()
+            if action == 'stop':
+                rollback_started.set()
+                await finish_rollback.wait()
+                return {'code': 200, 'data': {'state': 'idle'}}
+            return {'code': 200, 'data': {'state': 'running'}}
+
+        monkeypatch.setattr(mcp_manage, 'mcp_call_tool', fake_call)
+        task = asyncio.create_task(config_api._do_start_project())
+        await asyncio.wait_for(second_start.wait(), timeout=0.5)
+        task.cancel()
+        await asyncio.wait_for(rollback_started.wait(), timeout=0.5)
+        task.cancel()
+        await asyncio.sleep(0)
+        assert task.done() is False
+        finish_rollback.set()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        assert ('tool-a', 'stop') in calls
+        assert ('tool-b', 'stop') in calls
+        assert await config_api.get_project_running() == {
+            'running': False,
+            'state': 'stopped',
+            'transitioning': False,
+        }
+
+    asyncio.run(scenario())
+
+
+def test_cancelled_project_stop_finishes_all_stops_before_propagating(monkeypatch):
+    async def scenario() -> None:
+        config.main['canvas_layout'] = {
+            'cards': [
+                {'id': 'card-a', 'mcpId': 'driver-a', 'toolName': 'tool-a'},
+                {'id': 'card-b', 'mcpId': 'driver-b', 'toolName': 'tool-b'},
+                {'id': 'card-c', 'mcpId': 'driver-c', 'toolName': 'tool-c'},
+            ],
+            'connections': [],
+        }
+        config_api._set_project_state('running')
+        calls = []
+        second_stop = asyncio.Event()
+        finish_second_stop = asyncio.Event()
+
+        async def fake_call(mcp_id, request):
+            calls.append((request.tool, request.arguments['action']))
+            if request.tool == 'tool-b':
+                second_stop.set()
+                await finish_second_stop.wait()
+            return {'code': 200, 'data': {'state': 'idle'}}
+
+        monkeypatch.setattr(mcp_manage, 'mcp_call_tool', fake_call)
+        task = asyncio.create_task(config_api._do_stop_project())
+        await asyncio.wait_for(second_stop.wait(), timeout=0.5)
+        task.cancel()
+        task.cancel()
+        await asyncio.sleep(0)
+        assert task.done() is False
+        finish_second_stop.set()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        assert calls == [
+            ('tool-a', 'stop'),
+            ('tool-b', 'stop'),
+            ('tool-c', 'stop'),
+        ]
+        assert await config_api.get_project_running() == {
+            'running': False,
+            'state': 'stopped',
+            'transitioning': False,
+        }
+
+    asyncio.run(scenario())
+
+
+def test_project_stop_uses_active_snapshot_even_if_canvas_layout_changes(monkeypatch):
+    async def scenario() -> None:
+        card = {'id': 'card-a', 'mcpId': 'driver-a', 'toolName': 'tool-a'}
+        config.main['canvas_layout'] = {
+            'cards': [deepcopy(card)],
+            'connections': [],
+        }
+        calls = []
+
+        async def fake_call(mcp_id, request):
+            calls.append((request.tool, request.arguments['action']))
+            if request.arguments['action'] == 'info':
+                return {'code': 200, 'data': {}}
+            return {'code': 200, 'data': {'state': 'running'}}
+
+        monkeypatch.setattr(mcp_manage, 'mcp_call_tool', fake_call)
+        assert await config_api._do_start_project() is True
+        assert config.main['core']['active_project_cards'] == [card]
+
+        rejected = await canvas.save_layout(canvas.CanvasLayout(
+            cards=[],
+            connections=[],
+        ))
+        assert rejected.status_code == 409
+        assert json.loads(rejected.body)['detail']['code'] == 'project_topology_locked'
+
+        # Even a stale/external write cannot change the target of the active
+        # stop transaction because it uses the independent runtime snapshot.
+        config.main['canvas_layout'] = {'cards': [], 'connections': []}
+        assert await config_api._do_stop_project() is True
+        assert ('tool-a', 'stop') in calls
+        assert 'active_project_cards' not in config.main['core']
+        assert await config_api.get_project_running() == {
+            'running': False,
+            'state': 'stopped',
+            'transitioning': False,
+        }
+
+    asyncio.run(scenario())

--- a/agent-core/tests/teleop/test_descriptor_and_reservation.py
+++ b/agent-core/tests/teleop/test_descriptor_and_reservation.py
@@ -1,0 +1,476 @@
+from __future__ import annotations
+
+import asyncio
+from copy import deepcopy
+from types import SimpleNamespace
+
+import auth
+import config
+import mcp_client
+import pytest
+from api import mcp_manage, teleop
+from teleop.service import TeleopServiceError, _driver_descriptor
+
+
+def _trusted_robot(tool: dict, **overrides) -> dict:
+    tool = deepcopy(tool)
+    record = {
+        'id': 'teleop-robot',
+        'name': 'Teleop Robot',
+        'server_name': 'teleop-shadow',
+        'url': 'http://127.0.0.1:15711/mcp',
+        'transport': 'http',
+        'category': 'driver',
+        'trust_state': 'trusted',
+        'tools': [tool],
+    }
+    record.update(overrides)
+    if isinstance(tool.get('x-teleop'), dict):
+        tool['x-teleop']['driver_id'] = record['id']
+        tool['x-teleop']['robot_id'] = record['id']
+    return record
+
+
+def _invalidate(tool: dict, case: str) -> None:
+    descriptor = tool.get('x-teleop')
+    if case == 'missing-descriptor':
+        tool.pop('x-teleop')
+    elif case == 'null-descriptor':
+        tool['x-teleop'] = None
+    elif case == 'missing-protocol':
+        descriptor.pop('protocol')
+    elif case == 'wrong-protocol':
+        descriptor['protocol'] = 'motus.teleop.live.v1'
+    elif case == 'missing-dispatch-contract':
+        descriptor.pop('dispatch_contract')
+    elif case == 'wrong-dispatch-contract':
+        descriptor['dispatch_contract'] = 'motus.teleop.dispatch.live.v1'
+    elif case == 'wrong-dry-run-profile':
+        descriptor['dry_run_profile'] = 'go1_live'
+    elif case == 'non-string-dry-run-profile':
+        descriptor['dry_run_profile'] = ['unitree_go1_high_level']
+    elif case == 'missing-signaling':
+        descriptor.pop('signaling')
+    elif case == 'wrong-signaling-protocol':
+        descriptor['signaling']['protocol'] = 'motus.teleop.websocket.v1'
+    elif case == 'wrong-signaling-path':
+        descriptor['signaling']['path'] = '/unsafe-offer'
+    elif case == 'wrong-signaling-access':
+        descriptor['signaling']['access'] = 'browser-direct'
+    elif case == 'wrong-mode':
+        descriptor['mode'] = 'live'
+    elif case == 'missing-actuation-flag':
+        descriptor.pop('actuation_enabled')
+    elif case == 'actuation-enabled':
+        descriptor['actuation_enabled'] = True
+    elif case == 'falsey-integer-is-not-false':
+        descriptor['actuation_enabled'] = 0
+    elif case == 'missing-digest':
+        descriptor.pop('capability_digest')
+    elif case == 'short-digest':
+        descriptor['capability_digest'] = 'a' * 63
+    elif case == 'uppercase-digest':
+        descriptor['capability_digest'] = 'A' * 64
+    elif case == 'old-prepare-action':
+        actions = tool['inputSchema']['properties']['action']['enum']
+        actions[actions.index('prepare_shadow')] = 'prepare'
+    elif case == 'input-schema-string':
+        tool['inputSchema'] = 'not-an-object'
+    elif case == 'properties-list':
+        tool['inputSchema']['properties'] = []
+    elif case == 'action-schema-string':
+        tool['inputSchema']['properties']['action'] = 'not-an-object'
+    elif case == 'wrong-tool-type':
+        tool['type'] = 'resource'
+    else:  # pragma: no cover - protects the parameter table itself
+        raise AssertionError(f'unknown invalid descriptor case: {case}')
+
+
+def test_driver_producer_fixture_satisfies_exact_shadow_contract(shadow_session_tool):
+    assert teleop._valid_shadow_descriptor(shadow_session_tool) is True
+
+
+@pytest.mark.parametrize(
+    'case',
+    [
+        'missing-descriptor',
+        'null-descriptor',
+        'missing-protocol',
+        'wrong-protocol',
+        'missing-dispatch-contract',
+        'wrong-dispatch-contract',
+        'wrong-dry-run-profile',
+        'non-string-dry-run-profile',
+        'missing-signaling',
+        'wrong-signaling-protocol',
+        'wrong-signaling-path',
+        'wrong-signaling-access',
+        'wrong-mode',
+        'missing-actuation-flag',
+        'actuation-enabled',
+        'falsey-integer-is-not-false',
+        'missing-digest',
+        'short-digest',
+        'uppercase-digest',
+        'old-prepare-action',
+        'input-schema-string',
+        'properties-list',
+        'action-schema-string',
+        'wrong-tool-type',
+    ],
+)
+def test_shadow_descriptor_rejects_every_malformed_contract_field(
+    shadow_session_tool, case,
+):
+    tool = deepcopy(shadow_session_tool)
+    _invalidate(tool, case)
+    assert teleop._valid_shadow_descriptor(tool) is False
+
+
+@pytest.mark.parametrize(
+    ('trust_state', 'online', 'ready', 'reason'),
+    [
+        ('trusted', True, True, 'ready'),
+        ('trusted', False, False, 'driver_offline'),
+        ('untrusted', True, False, 'driver_registration_not_trusted'),
+        ('quarantined', True, False, 'driver_registration_not_trusted'),
+    ],
+)
+def test_teleop_ready_requires_valid_descriptor_trust_and_runtime_online(
+    shadow_session_tool, trust_state, online, ready, reason,
+):
+    record = _trusted_robot(deepcopy(shadow_session_tool), trust_state=trust_state)
+    mcp_client.registry[record['id']] = {
+        'online': online,
+        'trusted': True,
+        'url': record['url'],
+        'teleop_fingerprint': mcp_client.teleop_tool_fingerprint(record['tools'][0]),
+    }
+
+    view = teleop._robot_view(record)
+
+    assert view['descriptor_valid'] is True
+    assert view['teleop_ready'] is ready
+    assert view['reason'] == reason
+
+
+def test_invalid_descriptor_is_visible_but_never_ready(shadow_session_tool):
+    tool = deepcopy(shadow_session_tool)
+    tool['x-teleop']['mode'] = 'active'
+    record = _trusted_robot(tool)
+    mcp_client.registry[record['id']] = {
+        'online': True,
+        'trusted': True,
+        'url': record['url'],
+        'teleop_fingerprint': mcp_client.teleop_tool_fingerprint(record['tools'][0]),
+    }
+
+    view = teleop._robot_view(record)
+
+    assert view['teleop_declared'] is True
+    assert view['descriptor_valid'] is False
+    assert view['teleop_ready'] is False
+    assert view['reason'] == 'teleop_descriptor_invalid'
+
+
+def test_missing_exact_ticket_secret_is_visible_and_blocks_acquire_preflight(
+    shadow_session_tool,
+):
+    auth.init({'MOTUS_DRIVER_TOKEN': 'driver-secret'})
+    record = _trusted_robot(deepcopy(shadow_session_tool))
+    config.main['services'] = {'mcp': [record]}
+    mcp_client.registry[record['id']] = {
+        'online': True,
+        'trusted': True,
+        'url': record['url'],
+        'teleop_fingerprint': mcp_client.teleop_tool_fingerprint(record['tools'][0]),
+    }
+
+    view = teleop._robot_view(record)
+
+    assert view['teleop_ready'] is False
+    assert view['reason'] == 'teleop_signaling_unavailable'
+    with pytest.raises(TeleopServiceError) as raised:
+        _driver_descriptor(record['id'])
+    assert raised.value.code == 'teleop_signaling_unavailable'
+
+
+def test_teleop_directory_sanitizes_untrusted_metadata_and_internal_url(
+    client, auth_headers, shadow_session_tool,
+):
+    tool = deepcopy(shadow_session_tool)
+    tool['x-teleop'].update({
+        'access_token': 'do-not-return-token',
+        'nested': {
+            'fence': 'do-not-return-fence',
+            'private_key': 'do-not-return-key',
+            'privateKey': 'do-not-return-camel-key',
+            'apiKey': 'do-not-return-api-key',
+            'api-key-id': 'do-not-return-hyphen-key',
+            'public_label': 'safe',
+        },
+    })
+    record = _trusted_robot(tool)
+    config.main['services'] = {'mcp': [record]}
+    mcp_client.registry[record['id']] = {
+        'online': True,
+        'trusted': True,
+        'url': record['url'],
+        'teleop_fingerprint': mcp_client.teleop_tool_fingerprint(record['tools'][0]),
+    }
+
+    response = client.get('/api/teleop/robots', headers=auth_headers['viewer'])
+
+    assert response.status_code == 200
+    robot = response.json()['data'][0]
+    assert robot['descriptor_valid'] is False
+    assert robot['teleop_ready'] is False
+    assert robot['reason'] == 'teleop_descriptor_invalid'
+    assert 'url' not in robot
+    assert robot['teleop']['nested'] == {'public_label': 'safe'}
+    assert 'access_token' not in robot['teleop']
+    assert 'do-not-return' not in response.text
+
+
+def test_non_finite_metadata_cannot_take_down_other_robot_directory_entries(
+    client, auth_headers, shadow_session_tool,
+):
+    malformed = deepcopy(shadow_session_tool)
+    malformed['x-teleop']['diagnostics'] = {
+        'nan': float('nan'),
+        'positive_infinity': float('inf'),
+        'negative_infinity': float('-inf'),
+    }
+    malformed['annotations']['non_finite'] = [
+        float('nan'), float('inf'), float('-inf'),
+    ]
+    bad_record = _trusted_robot(
+        malformed,
+        id='robot-with-non-finite-metadata',
+        name='A Robot With Bad Metadata',
+    )
+    good_record = _trusted_robot(
+        deepcopy(shadow_session_tool),
+        id='unaffected-robot',
+        name='B Unaffected Robot',
+    )
+    config.main['services'] = {'mcp': [bad_record, good_record]}
+    for record in (bad_record, good_record):
+        mcp_client.registry[record['id']] = {
+            'online': True,
+            'trusted': True,
+            'url': record['url'],
+            'teleop_fingerprint': mcp_client.teleop_tool_fingerprint(record['tools'][0]),
+        }
+
+    response = client.get('/api/teleop/robots', headers=auth_headers['viewer'])
+
+    assert response.status_code == 200
+    robots = {robot['id']: robot for robot in response.json()['data']}
+    assert set(robots) == {bad_record['id'], good_record['id']}
+    assert robots[bad_record['id']]['teleop']['diagnostics'] == {
+        'nan': None,
+        'positive_infinity': None,
+        'negative_infinity': None,
+    }
+    assert robots[bad_record['id']]['descriptor_valid'] is False
+    assert robots[bad_record['id']]['reason'] == 'teleop_descriptor_invalid'
+    assert robots[bad_record['id']]['annotations']['non_finite'] == [None, None, None]
+    assert robots[good_record['id']]['teleop_ready'] is True
+
+
+def test_teleop_directory_uses_bound_robot_domain_for_busy_session(
+    client,
+    auth_headers,
+    shadow_session_tool,
+    monkeypatch,
+):
+    adapter_id = 'teleop-shadow-lab-a'
+    robot_id = 'g1-lab-a'
+    adapter = _trusted_robot(
+        deepcopy(shadow_session_tool),
+        id=adapter_id,
+        name='Standalone Teleop Adapter',
+        reported_robot_id=robot_id,
+        authority_domain=robot_id,
+        authority_binding_required=True,
+    )
+    adapter['tools'][0]['x-teleop']['robot_id'] = robot_id
+    root = {
+        'id': robot_id,
+        'name': 'G1 Lab A',
+        'url': 'http://g1.invalid/mcp',
+        'transport': 'http',
+        'category': 'driver',
+        'trust_state': 'trusted',
+        'tools': [{'name': 'locomotion', 'type': 'actuator'}],
+    }
+    config.main['services'] = {'mcp': [adapter, root]}
+    mcp_client.registry[adapter_id] = {
+        'online': True,
+        'trusted': True,
+        'url': adapter['url'],
+        'teleop_fingerprint': mcp_client.teleop_tool_fingerprint(
+            adapter['tools'][0],
+        ),
+    }
+    looked_up = []
+    session = SimpleNamespace(
+        id='bound-session',
+        principal_id='operator:alice',
+        client_id='other-client',
+        state='active',
+    )
+
+    async def active_for_robot(requested_robot_id):
+        looked_up.append(requested_robot_id)
+        return session if requested_robot_id == robot_id else None
+
+    monkeypatch.setattr(
+        teleop.coordinator.manager,
+        'active_for_robot',
+        active_for_robot,
+    )
+    monkeypatch.setattr(
+        teleop.coordinator.manager,
+        'public_dict',
+        lambda current: {
+            'id': current.id,
+            'robot_id': robot_id,
+            'remaining_seconds': 10.0,
+        },
+    )
+
+    response = client.get('/api/teleop/robots', headers=auth_headers['viewer'])
+
+    assert response.status_code == 200
+    robots = {robot['id']: robot for robot in response.json()['data']}
+    view = robots[adapter_id]
+    assert view['driver_id'] == adapter_id
+    assert view['robot_id'] == robot_id
+    assert view['teleop_ready'] is True
+    assert view['session']['busy'] is True
+    assert robot_id in looked_up
+
+
+def test_canvas_and_generic_mcp_endpoints_hide_reserved_tools(
+    client, auth_headers, shadow_session_tool,
+):
+    ordinary = {
+        'name': 'camera_info',
+        'type': 'resource',
+        'inputSchema': {'type': 'object', 'properties': {}},
+    }
+    record = _trusted_robot(
+        deepcopy(shadow_session_tool),
+        transport='internal',
+        url='',
+    )
+    record['tools'] = [ordinary, deepcopy(shadow_session_tool)]
+    config.main['services'] = {'mcp': [record]}
+
+    listing = client.get('/api/mcp', headers=auth_headers['owner'])
+    details = client.get(
+        f'/api/mcp/{record["id"]}/tools', headers=auth_headers['owner'],
+    )
+    rejected = client.post(
+        f'/api/mcp/{record["id"]}/call',
+        headers=auth_headers['owner'],
+        json={'tool': 'teleop_session', 'arguments': {'action': 'status'}},
+    )
+
+    assert [tool['name'] for tool in listing.json()['data'][0]['tools']] == ['camera_info']
+    assert [tool['name'] for tool in details.json()['data']] == ['camera_info']
+    assert rejected.status_code == 403
+    assert rejected.json()['detail'] == 'Teleop tools are reserved for the dedicated teleop API'
+
+
+def test_any_x_teleop_presence_is_reserved_even_when_descriptor_is_null(
+    client, auth_headers,
+):
+    suspicious = {
+        'name': 'maybe_teleop',
+        'type': 'actuator',
+        'inputSchema': {'type': 'object', 'properties': {}},
+        'x-teleop': None,
+    }
+    record = _trusted_robot(suspicious, transport='internal', url='')
+    config.main['services'] = {'mcp': [record]}
+
+    listing = client.get('/api/mcp', headers=auth_headers['owner'])
+    rejected = client.post(
+        f'/api/mcp/{record["id"]}/call',
+        headers=auth_headers['owner'],
+        json={'tool': 'maybe_teleop', 'arguments': {}},
+    )
+
+    assert listing.json()['data'][0]['tools'] == []
+    assert rejected.status_code == 403
+
+
+def test_ping_preserves_raw_descriptor_but_excludes_it_from_llm_registry(
+    monkeypatch, shadow_session_tool,
+):
+    ordinary = {
+        'name': 'camera_info',
+        'description': 'ordinary camera status',
+        'type': 'resource',
+        'inputSchema': {'type': 'object', 'properties': {}},
+        'annotations': {'readOnlyHint': True},
+    }
+    robot = _trusted_robot(deepcopy(shadow_session_tool))
+    config.main['services'] = {'mcp': [robot]}
+
+    async def fake_ping(url, *, trusted=False, driver_id=''):
+        assert trusted is True
+        return {
+            'server_name': 'teleop-shadow',
+            'tools': [ordinary, deepcopy(shadow_session_tool)],
+            'resources': [],
+            'device_type': '',
+            'topic_out': [],
+            'topic_in': [],
+        }
+
+    async def no_op(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(mcp_manage, '_ping_mcp_http', fake_ping)
+    monkeypatch.setattr(mcp_manage, '_notify_inspector', no_op)
+    monkeypatch.setattr(mcp_manage, '_restore_saved_configs', no_op)
+
+    async def run_ping():
+        result = await mcp_manage._do_ping(robot['id'])
+        await asyncio.sleep(0)
+        return result
+
+    result = asyncio.run(run_ping())
+
+    persisted = config.main['services']['mcp'][0]['tools']
+    persisted_teleop = next(tool for tool in persisted if tool['name'] == 'teleop_session')
+    assert persisted_teleop['x-teleop']['protocol'] == 'motus.teleop.shadow.v1'
+    assert persisted_teleop['annotations']['destructiveHint'] is False
+    assert result['tools'][1]['name'] == 'teleop_session'
+
+    runtime = mcp_client.registry[robot['id']]
+    assert runtime['tools'] == ['camera_info']
+    assert set(runtime['schemas']) == {'mcp__teleop-robot__camera_info'}
+    assert all('teleop_session' not in schema['name'] for schema in mcp_client.all_schemas())
+
+
+def test_llm_transport_refuses_reserved_tool_before_network(shadow_session_tool):
+    robot = _trusted_robot(deepcopy(shadow_session_tool))
+    config.main['services'] = {'mcp': [robot]}
+    mcp_client.registry[robot['id']] = {
+        'online': True,
+        'url': robot['url'],
+        'trusted': True,
+        'schemas': {},
+        'split_map': {},
+    }
+
+    result = asyncio.run(mcp_client.call_tool(
+        'mcp__teleop-robot__teleop_session', {'action': 'status'},
+    ))
+
+    assert result == 'Teleop tools are reserved for the dedicated teleop API'

--- a/agent-core/tests/teleop/test_desktop_security.py
+++ b/agent-core/tests/teleop/test_desktop_security.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import asyncio
+import importlib
+from pathlib import Path
+
+import pytest
+
+import auth
+import config
+from event.desktop import DesktopTools
+
+
+event_llm = importlib.import_module('event.llm')
+
+
+def _desktop_tool_names() -> set[str]:
+    return {
+        name
+        for name, _function in event_llm._desktop_tool_functions(DesktopTools())
+    }
+
+
+def test_authenticated_deployment_exposes_only_read_only_local_file_tools():
+    auth.init({
+        'ACCESS_TOKEN': 'owner-token',
+        'MOTUS_DRIVER_TOKEN': 'driver-token',
+        'MOTUS_TELEOP_TICKET_SECRET': 't' * 32,
+    })
+
+    names = _desktop_tool_names()
+
+    assert {'Read', 'Glob', 'Grep'} <= names
+    assert {'Bash', 'PythonExec', 'Write', 'Edit', 'WebFetch'}.isdisjoint(names)
+
+
+def test_unsafe_code_and_mutation_tools_require_explicit_secret_free_opt_in():
+    auth.init({'MOTUS_ENABLE_UNSAFE_DESKTOP_CODE_TOOLS': 'true'})
+    assert {
+        'Bash', 'PythonExec', 'Write', 'Edit', 'WebFetch',
+    } <= _desktop_tool_names()
+    auth.init({})
+
+    for secret_settings in (
+        {'ACCESS_TOKEN': 'owner-token'},
+        {'MOTUS_DRIVER_TOKEN': 'driver-token'},
+        {'MOTUS_TELEOP_TICKET_SECRET': 't' * 32},
+    ):
+        with pytest.raises(ValueError, match='cannot be enabled'):
+            auth.init({
+                **secret_settings,
+                'MOTUS_ENABLE_UNSAFE_DESKTOP_CODE_TOOLS': 'true',
+            })
+        assert auth.unsafe_desktop_code_tools_enabled() is False
+
+
+def test_file_tools_hide_dotenv_runtime_database_and_symlink_targets(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    public = tmp_path / 'notes.txt'
+    dotenv = tmp_path / '.env'
+    database = tmp_path / 'runtime.db'
+    dotenv_link = tmp_path / 'innocent-looking.txt'
+    tls_key = tmp_path / 'server-material'
+    tls_key_link = tmp_path / 'server-material-link'
+    public.write_text('public marker', encoding='utf-8')
+    dotenv.write_text('DRIVER_SENTINEL=must-not-leak', encoding='utf-8')
+    database.write_text('DATABASE_SENTINEL=must-not-leak', encoding='utf-8')
+    dotenv_link.symlink_to(dotenv)
+    tls_key.write_text('TLS_KEY_SENTINEL=must-not-leak', encoding='utf-8')
+    tls_key_link.hardlink_to(tls_key)
+    monkeypatch.setattr(config, 'DB_PATH', str(database))
+    monkeypatch.setenv('MOTUS_TLS_KEY_FILE', str(tls_key))
+
+    tools = DesktopTools()
+    monkeypatch.setattr(
+        importlib.import_module('event.desktop'),
+        '_ALLOWED_DIRS',
+        [str(tmp_path)],
+    )
+
+    assert 'protected credential' in asyncio.run(tools.Read(str(dotenv)))
+    assert 'protected credential' in asyncio.run(tools.Read(str(database)))
+    assert 'protected credential' in asyncio.run(tools.Read(str(dotenv_link)))
+    assert 'protected credential' in asyncio.run(tools.Read(str(tls_key_link)))
+
+    grep = asyncio.run(tools.Grep('SENTINEL|public marker', str(tmp_path)))
+    assert 'public marker' in grep
+    assert 'DRIVER_SENTINEL' not in grep
+    assert 'DATABASE_SENTINEL' not in grep
+    assert 'TLS_KEY_SENTINEL' not in grep
+
+    glob = asyncio.run(tools.Glob('*', str(tmp_path)))
+    assert str(public) in glob
+    assert str(dotenv) not in glob
+    assert str(database) not in glob
+    assert str(dotenv_link) not in glob
+    assert str(tls_key) not in glob
+    assert str(tls_key_link) not in glob
+
+
+def test_python_exec_does_not_publish_open_builtin_even_in_unsafe_mode():
+    tools = DesktopTools()
+
+    result = asyncio.run(tools.PythonExec("print('open' in __builtins__)"))
+
+    assert result.strip() == 'False'

--- a/agent-core/tests/teleop/test_driver_headers.py
+++ b/agent-core/tests/teleop/test_driver_headers.py
@@ -1,0 +1,548 @@
+from __future__ import annotations
+
+import asyncio
+from copy import deepcopy
+
+import pytest
+
+import auth
+import config
+import mcp_client
+from api import mcp_manage
+
+
+class FakeResponse:
+    def __init__(self, payload: dict, status: int = 200):
+        self._payload = payload
+        self.status = status
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    def __await__(self):
+        async def resolve():
+            return self
+
+        return resolve().__await__()
+
+    async def json(self, content_type=None):
+        return deepcopy(self._payload)
+
+
+class RecordingSession:
+    def __init__(self, records: list, *args, tools=None, **kwargs):
+        self.records = records
+        self.tools = tools or [
+            {
+                'name': 'ordinary_tool',
+                'description': 'ordinary',
+                'inputSchema': {'type': 'object', 'properties': {}},
+            },
+        ]
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    def post(self, url, *, json, headers, **kwargs):
+        self.records.append({
+            'url': url,
+            'method': json['method'],
+            'headers': dict(headers),
+            'payload': deepcopy(json),
+        })
+        method = json['method']
+        if method == 'initialize':
+            result = {'serverInfo': {'name': 'test-driver'}}
+        elif method == 'tools/list':
+            result = {'tools': deepcopy(self.tools)}
+        elif method == 'resources/list':
+            result = {'resources': []}
+        elif method == 'tools/call':
+            result = {'content': [{'type': 'text', 'text': 'ok'}]}
+        else:  # pragma: no cover - fails loudly for an unexpected RPC
+            raise AssertionError(f'unexpected RPC method {method}')
+        payload = {'jsonrpc': '2.0', 'id': json['id'], 'result': result}
+        return FakeResponse(payload)
+
+
+class CancelledSseResponse:
+    async def __aenter__(self):
+        raise asyncio.CancelledError
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+class RecordingSseSession:
+    def __init__(self, records: list, *args, **kwargs):
+        self.records = records
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    def get(self, url, *, headers, **kwargs):
+        self.records.append({'url': url, 'headers': dict(headers)})
+        return CancelledSseResponse()
+
+
+def _session_factory(records, *, tools=None):
+    def factory(*args, **kwargs):
+        return RecordingSession(records, *args, tools=tools, **kwargs)
+
+    return factory
+
+
+@pytest.mark.parametrize('method', ['initialize', 'tools/list', 'tools/call'])
+def test_jrpc_sends_driver_bearer_on_every_trusted_rpc(method):
+    secret = 'trusted-driver-secret'
+    auth.init({'MOTUS_DRIVER_TOKEN': secret})
+    records = []
+    session = RecordingSession(records)
+
+    asyncio.run(mcp_client._jrpc(
+        session,
+        'http://trusted.local/mcp',
+        method,
+        {},
+        trusted=True,
+        driver_id='legacy-driver',
+    ))
+
+    assert len(records) == 1
+    assert records[0]['method'] == method
+    assert records[0]['headers']['Authorization'] == f'Bearer {secret}'
+    assert records[0]['headers']['Content-Type'] == 'application/json'
+
+
+@pytest.mark.parametrize('method', ['initialize', 'tools/list', 'tools/call'])
+def test_jrpc_never_leaks_driver_bearer_to_untrusted_rpc(method):
+    secret = 'trusted-driver-secret'
+    auth.init({'MOTUS_DRIVER_TOKEN': secret})
+    records = []
+    session = RecordingSession(records)
+
+    asyncio.run(mcp_client._jrpc(
+        session,
+        'http://legacy.local/mcp',
+        method,
+        {},
+        trusted=False,
+    ))
+
+    assert len(records) == 1
+    assert 'Authorization' not in records[0]['headers']
+    assert secret not in str(records[0])
+
+
+@pytest.mark.parametrize('trusted', [True, False])
+def test_capability_discovery_authenticates_only_trusted_driver(
+    monkeypatch, trusted,
+):
+    secret = 'trusted-driver-secret'
+    auth.init({'MOTUS_DRIVER_TOKEN': secret})
+    records = []
+    monkeypatch.setattr(
+        mcp_manage.aiohttp,
+        'ClientSession',
+        _session_factory(records),
+    )
+
+    result = asyncio.run(mcp_manage._ping_mcp_http(
+        'http://driver.local/mcp',
+        trusted=trusted,
+        driver_id='legacy-driver',
+    ))
+
+    assert result['server_name'] == 'test-driver'
+    assert [record['method'] for record in records] == [
+        'initialize', 'tools/list', 'resources/list',
+    ]
+    for record in records:
+        if trusted:
+            assert record['headers']['Authorization'] == f'Bearer {secret}'
+        else:
+            assert 'Authorization' not in record['headers']
+
+
+def test_capability_discovery_never_calls_reserved_info_tools(
+    monkeypatch, shadow_session_tool,
+):
+    named_info = deepcopy(shadow_session_tool)
+    named_info['name'] = 'teleop_info'
+    action_info = deepcopy(shadow_session_tool)
+    action_info['inputSchema']['properties']['action']['enum'].append('info')
+    records = []
+    monkeypatch.setattr(
+        mcp_manage.aiohttp,
+        'ClientSession',
+        _session_factory(records, tools=[named_info, action_info]),
+    )
+
+    result = asyncio.run(mcp_manage._ping_mcp_http(
+        'http://trusted.local/mcp',
+        trusted=True,
+        driver_id='legacy-driver',
+    ))
+
+    assert [record['method'] for record in records] == [
+        'initialize', 'tools/list', 'resources/list',
+    ]
+    assert all(record['method'] != 'tools/call' for record in records)
+    assert [tool['name'] for tool in result['tools']] == [
+        'teleop_info', 'teleop_session',
+    ]
+
+
+def test_capability_discovery_selects_only_the_exact_driver_credential(monkeypatch):
+    token_a = 'private-driver-token-a-0001'
+    token_b = 'private-driver-token-b-0002'
+    auth.init({
+        'MOTUS_DRIVER_TOKENS': (
+            f'{{"driver-a":"{token_a}","driver-b":"{token_b}"}}'
+        ),
+    })
+    records = []
+    monkeypatch.setattr(
+        mcp_manage.aiohttp,
+        'ClientSession',
+        _session_factory(records),
+    )
+
+    asyncio.run(mcp_manage._ping_mcp_http(
+        'http://driver-b.local/mcp',
+        trusted=True,
+        driver_id='driver-b',
+    ))
+
+    assert len(records) == 3
+    assert all(
+        record['headers'].get('Authorization') == f'Bearer {token_b}'
+        for record in records
+    )
+    assert token_a not in str(records)
+
+
+def test_sse_selects_only_the_exact_driver_credential(monkeypatch):
+    token_a = 'private-driver-token-a-0001'
+    token_b = 'private-driver-token-b-0002'
+    auth.init({
+        'MOTUS_DRIVER_TOKENS': (
+            f'{{"driver-a":"{token_a}","driver-b":"{token_b}"}}'
+        ),
+    })
+    records = []
+    monkeypatch.setattr(
+        mcp_client.aiohttp,
+        'ClientSession',
+        lambda *args, **kwargs: RecordingSseSession(records),
+    )
+
+    asyncio.run(mcp_client._subscribe_sse(
+        'driver-b',
+        'http://driver-b.local/mcp',
+        trusted=True,
+    ))
+
+    assert records == [{
+        'url': 'http://driver-b.local/mcp/sse',
+        'headers': {'Authorization': f'Bearer {token_b}'},
+    }]
+    assert token_a not in str(records)
+
+
+def test_trusted_outbound_helpers_fail_before_network_without_exact_identity(
+    monkeypatch,
+):
+    auth.init({'MOTUS_DRIVER_TOKEN': 'trusted-driver-secret'})
+    jrpc_records = []
+    with pytest.raises(PermissionError, match='exact credential'):
+        asyncio.run(mcp_client._jrpc(
+            RecordingSession(jrpc_records),
+            'http://trusted.local/mcp',
+            'initialize',
+            {},
+            trusted=True,
+        ))
+    assert jrpc_records == []
+
+    ping_records = []
+    monkeypatch.setattr(
+        mcp_manage.aiohttp,
+        'ClientSession',
+        _session_factory(ping_records),
+    )
+    with pytest.raises(PermissionError, match='exact credential'):
+        asyncio.run(mcp_manage._ping_mcp_http(
+            'http://trusted.local/mcp',
+            trusted=True,
+        ))
+    assert ping_records == []
+
+
+def test_startup_never_sends_rotated_bearer_to_stale_persisted_endpoint(
+    monkeypatch,
+):
+    old_token = 'private-driver-token-old-0001'
+    new_token = 'private-driver-token-new-0002'
+    auth.init({
+        'MOTUS_DRIVER_TOKENS': f'{{"driver-a":"{old_token}"}}',
+    })
+    old_binding = auth.driver_credential_binding('driver-a')
+    config.main['services'] = {'mcp': [{
+        'id': 'driver-a',
+        'name': 'Persisted Driver A',
+        'url': 'http://stale-driver-a.local/mcp',
+        'transport': 'http',
+        'trust_state': 'trusted',
+        'credential_binding': old_binding,
+        'tools': [],
+    }]}
+    auth.init({
+        'MOTUS_DRIVER_TOKENS': f'{{"driver-a":"{new_token}"}}',
+    })
+    attempted = []
+
+    async def record_connect(*args, **kwargs):
+        attempted.append((args, kwargs))
+
+    monkeypatch.setattr(mcp_client, '_connect_one', record_connect)
+
+    asyncio.run(mcp_client.init_all())
+
+    assert attempted == []
+
+
+def test_config_restore_never_calls_reserved_tool(
+    monkeypatch, shadow_session_tool,
+):
+    records = []
+    config.main['services'] = {'mcp': [{
+        'id': 'teleop-robot',
+        'name': 'Teleop Robot',
+        'url': 'http://trusted.local/mcp',
+        'transport': 'http',
+        'trust_state': 'trusted',
+        'authority_domain': 'teleop-robot',
+        'tools': [],
+    }]}
+    config.main['tool_config:teleop-robot:teleop_session'] = {'configured': True}
+    reserved = deepcopy(shadow_session_tool)
+    reserved['configSchema'] = {'type': 'object', 'properties': {}}
+    monkeypatch.setattr(
+        mcp_manage.aiohttp,
+        'ClientSession',
+        _session_factory(records),
+    )
+
+    asyncio.run(mcp_manage._restore_saved_configs(
+        'teleop-robot',
+        'http://trusted.local/mcp',
+        [reserved],
+        trusted=True,
+    ))
+
+    assert records == []
+
+
+def test_config_restore_selects_only_the_exact_driver_credential(monkeypatch):
+    token_a = 'private-driver-token-a-0001'
+    token_b = 'private-driver-token-b-0002'
+    auth.init({
+        'MOTUS_DRIVER_TOKENS': (
+            f'{{"driver-a":"{token_a}","driver-b":"{token_b}"}}'
+        ),
+    })
+    tool = {
+        'name': 'ordinary_tool',
+        'type': 'actuator',
+        'configSchema': {'type': 'object', 'properties': {'speed': {'type': 'number'}}},
+        'inputSchema': {
+            'type': 'object',
+            'properties': {'action': {'type': 'string', 'enum': ['config']}},
+            'required': ['action'],
+        },
+    }
+    config.main['services'] = {'mcp': [{
+        'id': 'driver-b',
+        'name': 'Driver B',
+        'url': 'http://driver-b.local/mcp',
+        'transport': 'http',
+        'trust_state': 'trusted',
+        'credential_binding': auth.driver_credential_binding('driver-b'),
+        'authority_domain': 'driver-b',
+        'tools': [tool],
+    }]}
+    config.main['tool_config:driver-b:ordinary_tool'] = {'speed': 0.5}
+    records = []
+    monkeypatch.setattr(
+        mcp_manage.aiohttp,
+        'ClientSession',
+        _session_factory(records),
+    )
+
+    asyncio.run(mcp_manage._restore_saved_configs(
+        'driver-b',
+        'http://driver-b.local/mcp',
+        [tool],
+        trusted=True,
+    ))
+
+    assert [record['method'] for record in records] == ['tools/call']
+    assert records[0]['headers']['Authorization'] == f'Bearer {token_b}'
+    assert token_a not in str(records)
+
+
+def test_tools_and_rest_call_select_only_the_exact_driver_credential(monkeypatch):
+    token_a = 'private-driver-token-a-0001'
+    token_b = 'private-driver-token-b-0002'
+    auth.init({
+        'MOTUS_DRIVER_TOKENS': (
+            f'{{"driver-a":"{token_a}","driver-b":"{token_b}"}}'
+        ),
+    })
+    tool = {
+        'name': 'ordinary_tool',
+        'type': 'sensor',
+        'inputSchema': {'type': 'object', 'properties': {}},
+    }
+    config.main['services'] = {'mcp': [{
+        'id': 'driver-b',
+        'name': 'Driver B',
+        'url': 'http://driver-b.local/mcp',
+        'transport': 'http',
+        'trust_state': 'trusted',
+        'credential_binding': auth.driver_credential_binding('driver-b'),
+        'authority_domain': 'driver-b',
+        'tools': [tool],
+    }]}
+    records = []
+    monkeypatch.setattr(
+        mcp_manage.aiohttp,
+        'ClientSession',
+        _session_factory(records, tools=[tool]),
+    )
+
+    tools_result = asyncio.run(mcp_manage.mcp_get_tools('driver-b'))
+    call_result = asyncio.run(mcp_manage.mcp_call_tool(
+        'driver-b',
+        mcp_manage.MCPCallRequest(tool='ordinary_tool', arguments={}),
+    ))
+
+    assert tools_result['code'] == 200
+    assert call_result['code'] == 200
+    assert [record['method'] for record in records] == [
+        'initialize', 'tools/list', 'initialize', 'tools/call',
+    ]
+    assert all(
+        record['headers'].get('Authorization') == f'Bearer {token_b}'
+        for record in records
+    )
+    assert token_a not in str(records)
+
+
+def test_connect_and_llm_call_keep_trust_on_all_rpc_hops(monkeypatch):
+    secret = 'trusted-driver-secret-0001'
+    other_secret = 'other-driver-secret-000002'
+    auth.init({
+        'MOTUS_DRIVER_TOKENS': (
+            f'{{"other-robot":"{other_secret}","trusted-robot":"{secret}"}}'
+        ),
+    })
+    config.main['services'] = {'mcp': [{
+        'id': 'trusted-robot',
+        'name': 'Trusted Robot',
+        'url': 'http://trusted.local/mcp',
+        'transport': 'http',
+        'trust_state': 'trusted',
+        'credential_binding': auth.driver_credential_binding('trusted-robot'),
+        'tools': [{'name': 'ordinary_tool', 'type': 'actuator'}],
+    }]}
+    records = []
+    monkeypatch.setattr(
+        mcp_client.aiohttp,
+        'ClientSession',
+        _session_factory(records),
+    )
+
+    async def no_sse(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(mcp_client, '_subscribe_sse', no_sse)
+
+    async def connect_and_call():
+        await mcp_client._connect_one(
+            'trusted-robot',
+            'Trusted Robot',
+            'http://trusted.local/mcp',
+            '',
+            trusted=True,
+        )
+        await asyncio.sleep(0)
+        return await mcp_client.call_tool(
+            'mcp__trusted-robot__ordinary_tool', {},
+        )
+
+    result = asyncio.run(connect_and_call())
+
+    assert result == 'ok'
+    assert [record['method'] for record in records] == [
+        'initialize', 'tools/list', 'tools/call',
+    ]
+    assert all(
+        record['headers'].get('Authorization') == f'Bearer {secret}'
+        for record in records
+    )
+    assert other_secret not in str(records)
+
+
+def test_legacy_runtime_call_does_not_receive_global_driver_secret(monkeypatch):
+    secret = 'trusted-driver-secret'
+    auth.init({'MOTUS_DRIVER_TOKEN': secret})
+    records = []
+    monkeypatch.setattr(
+        mcp_client.aiohttp,
+        'ClientSession',
+        _session_factory(records),
+    )
+    config.main['services'] = {'mcp': [{
+        'id': 'legacy-driver',
+        'name': 'Legacy Driver',
+        'url': 'http://legacy.local/mcp',
+        'transport': 'http',
+        'trust_state': 'untrusted',
+        'tools': [{'name': 'ordinary_tool'}],
+    }]}
+    mcp_client.registry['legacy-driver'] = {
+        'name': 'Legacy Driver',
+        'url': 'http://legacy.local/mcp',
+        'online': True,
+        'trusted': False,
+        'schemas': {},
+        'input_schemas': {},
+        'split_map': {},
+        'tool_meta': {
+            'mcp__legacy-driver__ordinary_tool': {
+                'type': 'actuator',
+                'action_enum': None,
+                'annotations': {},
+            },
+        },
+    }
+
+    result = asyncio.run(mcp_client.call_tool(
+        'mcp__legacy-driver__ordinary_tool', {},
+    ))
+
+    assert result == 'ok'
+    assert [record['method'] for record in records] == ['tools/call']
+    assert 'Authorization' not in records[0]['headers']
+    assert secret not in str(records)

--- a/agent-core/tests/teleop/test_driver_trust.py
+++ b/agent-core/tests/teleop/test_driver_trust.py
@@ -1,0 +1,1574 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from copy import deepcopy
+
+import fastapi
+import pytest
+
+import auth
+import config
+import mcp_client
+from api import config as config_api
+from api import mcp_manage
+from teleop import authority_guard
+
+
+def _persist_authority_guard(driver_id: str, robot_id: str):
+    return authority_guard.create_guard(authority_guard.AuthorityGuard(
+        robot_id=robot_id,
+        driver_id=driver_id,
+        session_id='f43d94e5-fdea-44d9-a11e-61723387b3a4',
+        boot_id='8ee5e121-78d9-47cb-91f6-cf9134973677',
+        epoch=7,
+        capability_digest='0' * 64,
+        target_fingerprint='a' * 64,
+        dispatch_generation=3,
+        phase='recovery_required',
+        created_at=1_000.0,
+        updated_at=1_001.0,
+    ))
+
+
+def _registration(**overrides):
+    body = {
+        'id': 'robot-stable-id',
+        'name': 'Robot Driver',
+        'transport': 'http',
+        'url': 'http://robot.local/mcp',
+        'category': 'driver',
+    }
+    body.update(overrides)
+    return body
+
+
+@pytest.mark.parametrize(
+    ('settings', 'expected_state', 'should_schedule'),
+    [
+        ({}, 'untrusted', True),
+        ({'MOTUS_DRIVER_TOKEN': 'driver-secret'}, 'untrusted', True),
+        (
+            {
+                'MOTUS_DRIVER_TOKEN': 'driver-secret',
+                'MOTUS_ENFORCE_DRIVER_AUTH': 'true',
+            },
+            'quarantined',
+            False,
+        ),
+    ],
+)
+def test_unauthenticated_driver_three_state_rollout(
+    client, monkeypatch, settings, expected_state, should_schedule,
+):
+    auth.init(settings)
+    scheduled = []
+
+    def fake_ping(mcp_id):
+        scheduled.append(mcp_id)
+
+        async def done():
+            return {}
+
+        return done()
+
+    monkeypatch.setattr(mcp_manage, '_do_ping', fake_ping)
+    response = client.post('/api/mcp', json=_registration())
+
+    assert response.status_code == 200
+    data = response.json()['data']
+    assert data['trust_state'] == expected_state
+    assert bool(scheduled) is should_schedule
+    record = config.main['services']['mcp'][0]
+    assert record['trust_state'] == expected_state
+    assert mcp_manage._runtime_registration_allowed(record) is should_schedule
+    if expected_state == 'quarantined':
+        assert data['id'] not in mcp_client.registry
+
+
+def test_valid_driver_token_creates_trusted_stable_identity(client, monkeypatch):
+    auth.init({'MOTUS_DRIVER_TOKEN': 'driver-secret'})
+    scheduled = []
+
+    def fake_ping(mcp_id):
+        scheduled.append(mcp_id)
+
+        async def done():
+            return {}
+
+        return done()
+
+    monkeypatch.setattr(mcp_manage, '_do_ping', fake_ping)
+    response = client.post(
+        '/api/mcp',
+        headers={'X-Motus-Driver-Token': 'driver-secret'},
+        json=_registration(),
+    )
+
+    assert response.status_code == 200
+    assert response.json()['data'] == {
+        'id': 'robot-stable-id', 'trust_state': 'trusted',
+    }
+    assert scheduled == ['robot-stable-id']
+    assert config.main['services']['mcp'][0]['trust_state'] == 'trusted'
+
+
+def test_driver_registration_never_accepts_credential_in_query_string(
+    client,
+    monkeypatch,
+):
+    token = 'private-driver-a-token-0001'
+    auth.init({
+        'MOTUS_DRIVER_TOKENS': json.dumps({'driver-a': token}),
+        'MOTUS_ENFORCE_DRIVER_AUTH': 'true',
+    })
+    scheduled = []
+    monkeypatch.setattr(
+        mcp_manage,
+        '_do_ping',
+        lambda mcp_id: scheduled.append(mcp_id) or asyncio.sleep(0),
+    )
+
+    response = client.post(
+        f'/api/mcp?token={token}',
+        json=_registration(id='driver-a', url='http://driver-a.local/mcp'),
+    )
+
+    assert response.status_code == 401
+    assert config.main['services']['mcp'] == []
+    assert scheduled == []
+    assert token not in json.dumps(response.json())
+
+
+def test_dedicated_driver_token_cannot_register_another_driver_identity(
+    client,
+    monkeypatch,
+):
+    token_a = 'private-driver-a-token-0001'
+    token_b = 'private-driver-b-token-0002'
+    auth.init({
+        'MOTUS_DRIVER_TOKENS': json.dumps({
+            'driver-a': token_a,
+            'driver-b': token_b,
+        }),
+        'MOTUS_ENFORCE_DRIVER_AUTH': 'true',
+    })
+    scheduled = []
+
+    def fake_ping(mcp_id):
+        scheduled.append(mcp_id)
+        return asyncio.sleep(0)
+
+    monkeypatch.setattr(mcp_manage, '_do_ping', fake_ping)
+    accepted_a = client.post(
+        '/api/mcp',
+        headers={'X-Motus-Driver-Token': token_a},
+        json=_registration(
+            id='driver-a',
+            url='http://driver-a.local/mcp',
+        ),
+    )
+    before_rejections = deepcopy(config.main['services']['mcp'])
+
+    cross_identity = client.post(
+        '/api/mcp',
+        headers={'X-Motus-Driver-Token': token_a},
+        json=_registration(
+            id='driver-b',
+            url='http://driver-b.local/mcp',
+        ),
+    )
+    wrong_for_dedicated = client.post(
+        '/api/mcp',
+        headers={'X-Motus-Driver-Token': 'unknown-token'},
+        json=_registration(
+            id='driver-b',
+            url='http://driver-b.local/mcp',
+        ),
+    )
+
+    assert accepted_a.status_code == 200
+    assert accepted_a.json()['data']['trust_state'] == 'trusted'
+    assert cross_identity.status_code == 403
+    assert wrong_for_dedicated.status_code == 401
+    assert config.main['services']['mcp'] == before_rejections
+    assert scheduled == ['driver-a']
+    public_scan = json.dumps(
+        [
+            cross_identity.json(),
+            wrong_for_dedicated.json(),
+            config.main['services'],
+        ],
+        ensure_ascii=False,
+    )
+    assert token_a not in public_scan
+    assert token_b not in public_scan
+
+    accepted_b = client.post(
+        '/api/mcp',
+        headers={'X-Motus-Driver-Token': token_b},
+        json=_registration(
+            id='driver-b',
+            url='http://driver-b.local/mcp',
+        ),
+    )
+    assert accepted_b.status_code == 200
+    assert accepted_b.json()['data']['trust_state'] == 'trusted'
+    assert scheduled == ['driver-a', 'driver-b']
+
+
+def test_dedicated_credential_rotation_quarantines_until_new_inbound_registration(
+    client,
+    monkeypatch,
+):
+    old_token = 'private-driver-a-token-old-0001'
+    new_token = 'private-driver-a-token-new-0002'
+    scheduled = []
+    monkeypatch.setattr(
+        mcp_manage,
+        '_do_ping',
+        lambda mcp_id: scheduled.append(mcp_id) or asyncio.sleep(0),
+    )
+    auth.init({
+        'MOTUS_DRIVER_TOKENS': json.dumps({'driver-a': old_token}),
+        'MOTUS_ENFORCE_DRIVER_AUTH': 'true',
+    })
+    first = client.post(
+        '/api/mcp',
+        headers={'Authorization': f'Bearer {old_token}'},
+        json=_registration(id='driver-a', url='http://driver-a.local/mcp'),
+    )
+    assert first.status_code == 200
+    persisted = config.main['services']['mcp'][0]
+    old_binding = persisted['credential_binding']
+    assert old_token not in old_binding
+
+    auth.init({
+        'MOTUS_DRIVER_TOKENS': json.dumps({'driver-a': new_token}),
+        'MOTUS_ENFORCE_DRIVER_AUTH': 'true',
+    })
+    assert mcp_manage._effective_trust_state(persisted) == 'quarantined'
+    assert mcp_manage._runtime_registration_allowed(persisted) is False
+    before_revalidation = deepcopy(config.main['services']['mcp'])
+    stale = client.post(
+        '/api/mcp',
+        headers={'Authorization': f'Bearer {old_token}'},
+        json=_registration(id='driver-a', url='http://driver-a.local/mcp'),
+    )
+    assert stale.status_code == 401
+    assert config.main['services']['mcp'] == before_revalidation
+
+    refreshed = client.post(
+        '/api/mcp',
+        headers={'Authorization': f'Bearer {new_token}'},
+        json=_registration(id='driver-a', url='http://driver-a.local/mcp'),
+    )
+    assert refreshed.status_code == 200
+    rebound = config.main['services']['mcp'][0]
+    assert rebound['credential_binding'] != old_binding
+    assert mcp_manage._effective_trust_state(rebound) == 'trusted'
+    assert scheduled == ['driver-a', 'driver-a']
+
+
+def test_stale_dedicated_binding_cannot_silently_downgrade_to_legacy_fallback(
+    client,
+    monkeypatch,
+):
+    dedicated = 'private-driver-a-token-old-0001'
+    legacy = 'legacy-driver-fallback'
+    scheduled = []
+    monkeypatch.setattr(
+        mcp_manage,
+        '_do_ping',
+        lambda mcp_id: scheduled.append(mcp_id) or asyncio.sleep(0),
+    )
+    auth.init({
+        'MOTUS_DRIVER_TOKEN': legacy,
+        'MOTUS_DRIVER_TOKENS': json.dumps({'driver-a': dedicated}),
+    })
+    assert client.post(
+        '/api/mcp',
+        headers={'Authorization': f'Bearer {dedicated}'},
+        json=_registration(id='driver-a', url='http://driver-a.local/mcp'),
+    ).status_code == 200
+    bound = config.main['services']['mcp'][0]
+    assert 'credential_binding' in bound
+
+    auth.init({'MOTUS_DRIVER_TOKEN': legacy})
+    assert mcp_manage._effective_trust_state(bound) == 'quarantined'
+
+    rebound = client.post(
+        '/api/mcp',
+        headers={'Authorization': f'Bearer {legacy}'},
+        json=_registration(id='driver-a', url='http://driver-a.local/mcp'),
+    )
+    assert rebound.status_code == 200
+    record = config.main['services']['mcp'][0]
+    assert record['trust_state'] == 'trusted'
+    assert 'credential_binding' not in record
+    assert mcp_manage._effective_trust_state(record) == 'trusted'
+    assert scheduled == ['driver-a', 'driver-a']
+
+
+def test_persisted_trusted_driver_without_selected_credential_is_quarantined(
+    client,
+    auth_headers,
+    shadow_session_tool,
+):
+    auth.init({
+        'ACCESS_TOKEN': 'owner-token',
+        'MOTUS_DRIVER_TOKENS': '{"driver-a":"private-driver-a-token-0001"}',
+        'MOTUS_ENFORCE_DRIVER_AUTH': 'true',
+    })
+    tool = deepcopy(shadow_session_tool)
+    tool['x-teleop']['driver_id'] = 'driver-b'
+    tool['x-teleop']['robot_id'] = 'driver-b'
+    target = {
+        'id': 'driver-b',
+        'name': 'Persisted Driver B',
+        'url': 'http://localhost:15712/mcp',
+        'transport': 'http',
+        'category': 'driver',
+        'trust_state': 'trusted',
+        'tools': [tool],
+    }
+    config.main['services'] = {'mcp': [target]}
+    mcp_client.registry['driver-b'] = {
+        'online': True,
+        'trusted': True,
+        'url': target['url'],
+        'teleop_fingerprint': mcp_client.teleop_tool_fingerprint(tool),
+    }
+
+    response = client.get('/api/teleop/robots', headers=auth_headers['owner'])
+
+    assert response.status_code == 200
+    robot = response.json()['data'][0]
+    assert robot['driver_id'] == 'driver-b'
+    assert robot['trust_state'] == 'quarantined'
+    assert robot['teleop_ready'] is False
+    assert robot['reason'] == 'driver_credential_unavailable'
+    assert mcp_manage._runtime_registration_allowed(target) is False
+    with pytest.raises(
+        mcp_client.TrustedShadowTransportError,
+        match='driver_auth_unavailable',
+    ):
+        mcp_client._trusted_shadow_target('driver-b', 'status')
+
+
+def test_driver_reported_robot_id_cannot_create_an_authority_binding(
+    client,
+    monkeypatch,
+):
+    auth.init({
+        'ACCESS_TOKEN': 'owner-token',
+        'MOTUS_DRIVER_TOKEN': 'driver-secret',
+    })
+    monkeypatch.setattr(mcp_manage, '_do_ping', lambda _mcp_id: asyncio.sleep(0))
+
+    rejected = client.post(
+        '/api/mcp',
+        headers={'X-Motus-Driver-Token': 'driver-secret'},
+        json=_registration(
+            id='standalone-teleop',
+            robot_id='victim-robot',
+            authority_domain='victim-robot',
+        ),
+    )
+    assert rejected.status_code == 422
+    assert config.main['services']['mcp'] == []
+
+    response = client.post(
+        '/api/mcp',
+        headers={'X-Motus-Driver-Token': 'driver-secret'},
+        json=_registration(
+            id='standalone-teleop',
+            robot_id='victim-robot',
+        ),
+    )
+
+    assert response.status_code == 200
+    record = config.main['services']['mcp'][0]
+    assert record['reported_robot_id'] == 'victim-robot'
+    assert 'authority_domain' not in record
+    assert 'pending_authority_domain' not in record
+
+
+def test_authority_binding_is_owner_only_and_activates_at_restart_boundary(
+    client,
+    auth_headers,
+    shadow_session_tool,
+):
+    root_id = 'g1-lab-a'
+    adapter_id = 'teleop-shadow-lab-a'
+    teleop_tool = deepcopy(shadow_session_tool)
+    teleop_tool['x-teleop']['driver_id'] = adapter_id
+    teleop_tool['x-teleop']['robot_id'] = root_id
+    config.main['services'] = {'mcp': [{
+        'id': adapter_id,
+        'name': 'Standalone Teleop Adapter',
+        'url': 'http://teleop.invalid/mcp',
+        'transport': 'http',
+        'category': 'driver',
+        'trust_state': 'trusted',
+        'reported_robot_id': root_id,
+        'tools': [teleop_tool],
+    }, {
+        'id': root_id,
+        'name': 'G1 Lab A',
+        'url': 'http://g1.invalid/mcp',
+        'transport': 'http',
+        'category': 'driver',
+        'trust_state': 'trusted',
+        'tools': [{
+            'name': 'locomotion',
+            'type': 'actuator',
+            'inputSchema': {'type': 'object'},
+        }],
+    }]}
+
+    forbidden = client.put(
+        f'/api/mcp/{adapter_id}/authority-domain',
+        headers=auth_headers['operator'],
+        json={'root_mcp_id': root_id},
+    )
+    assert forbidden.status_code == 403
+
+    staged = client.put(
+        f'/api/mcp/{adapter_id}/authority-domain',
+        headers=auth_headers['owner'],
+        json={'root_mcp_id': root_id},
+    )
+    assert staged.status_code == 202
+    assert staged.json()['data']['restart_required'] is True
+    record = config.main['services']['mcp'][0]
+    assert record['pending_authority_domain'] == root_id
+    assert 'authority_domain' not in record
+
+    asyncio.run(mcp_manage.activate_pending_authority_bindings())
+    record = config.main['services']['mcp'][0]
+    assert record['authority_domain'] == root_id
+    assert record['authority_binding_required'] is True
+    assert 'pending_authority_domain' not in record
+
+    auth.init({})
+    unavailable = client.delete(f'/api/mcp/{adapter_id}/authority-domain')
+    assert unavailable.status_code == 503
+
+
+def test_persistent_guard_locks_delete_retarget_and_binding_changes(
+    client,
+    auth_headers,
+    shadow_session_tool,
+    monkeypatch,
+):
+    adapter_id = 'teleop-shadow-guarded'
+    root_id = 'robot-guarded'
+    teleop_tool = deepcopy(shadow_session_tool)
+    teleop_tool['x-teleop'].update({
+        'driver_id': adapter_id,
+        'robot_id': root_id,
+    })
+    original_targets = [{
+        'id': adapter_id,
+        'name': 'Guarded Teleop Adapter',
+        'url': 'http://guarded-teleop.invalid/mcp',
+        'transport': 'http',
+        'category': 'driver',
+        'trust_state': 'trusted',
+        'reported_robot_id': root_id,
+        'authority_domain': root_id,
+        'tools': [teleop_tool],
+    }, {
+        'id': root_id,
+        'name': 'Guarded Robot',
+        'url': 'http://guarded-robot.invalid/mcp',
+        'transport': 'http',
+        'category': 'driver',
+        'trust_state': 'trusted',
+        'tools': [{
+            'name': 'locomotion',
+            'type': 'actuator',
+            'inputSchema': {'type': 'object'},
+        }],
+    }]
+    config.main['services'] = {'mcp': deepcopy(original_targets)}
+    _persist_authority_guard(adapter_id, root_id)
+
+    for locked_id in (adapter_id, root_id):
+        response = client.delete(
+            f'/api/mcp/{locked_id}',
+            headers=auth_headers['owner'],
+        )
+        assert response.status_code == 409
+        assert response.json()['data'] == {
+            'code': 'authority_target_locked',
+            'reason': 'persistent_authority_guard_requires_stable_target',
+            'project_state': 'running',
+            'mcp_ids': [locked_id],
+        }
+
+    unbind = client.delete(
+        f'/api/mcp/{adapter_id}/authority-domain',
+        headers=auth_headers['owner'],
+    )
+    assert unbind.status_code == 409
+    assert unbind.json()['data']['code'] == 'authority_target_locked'
+    assert unbind.json()['data']['mcp_ids'] == [adapter_id]
+
+    auth.init({
+        'ACCESS_TOKEN': 'owner-token',
+        'MOTUS_DRIVER_TOKEN': 'driver-secret',
+    })
+
+    async def forbidden_ping(_mcp_id):
+        raise AssertionError('locked retarget must not schedule discovery')
+
+    monkeypatch.setattr(mcp_manage, '_do_ping', forbidden_ping)
+    retarget = client.post(
+        '/api/mcp',
+        headers={
+            'Authorization': 'Bearer owner-token',
+            'X-Motus-Driver-Token': 'driver-secret',
+        },
+        json=_registration(
+            id=adapter_id,
+            name='Guarded Teleop Adapter',
+            url='http://guarded-teleop.invalid/mcp',
+            transport='stdio',
+            robot_id=root_id,
+        ),
+    )
+    assert retarget.status_code == 409
+    assert retarget.json()['data']['code'] == 'authority_target_locked'
+    assert retarget.json()['data']['mcp_ids'] == [adapter_id]
+    assert config.main['services']['mcp'] == original_targets
+
+
+def test_startup_defers_pending_unbind_until_persistent_guard_is_cleared(
+    shadow_session_tool,
+):
+    async def scenario() -> None:
+        adapter_id = 'teleop-shadow-deferred-unbind'
+        root_id = 'robot-deferred-unbind'
+        teleop_tool = deepcopy(shadow_session_tool)
+        teleop_tool['x-teleop'].update({
+            'driver_id': adapter_id,
+            'robot_id': root_id,
+        })
+        config.main['services'] = {'mcp': [{
+            'id': adapter_id,
+            'name': 'Deferred Unbind Adapter',
+            'url': 'http://deferred-unbind.invalid/mcp',
+            'transport': 'http',
+            'category': 'driver',
+            'trust_state': 'trusted',
+            'reported_robot_id': root_id,
+            'authority_domain': root_id,
+            'pending_authority_domain': adapter_id,
+            'tools': [teleop_tool],
+        }, {
+            'id': root_id,
+            'name': 'Deferred Unbind Robot',
+            'url': 'http://deferred-robot.invalid/mcp',
+            'transport': 'http',
+            'category': 'driver',
+            'trust_state': 'trusted',
+            'tools': [{
+                'name': 'locomotion',
+                'type': 'actuator',
+                'inputSchema': {'type': 'object'},
+            }],
+        }]}
+        guard = _persist_authority_guard(adapter_id, root_id)
+
+        await mcp_manage.activate_pending_authority_bindings()
+        deferred = config.main['services']['mcp'][0]
+        assert deferred['authority_domain'] == root_id
+        assert deferred['pending_authority_domain'] == adapter_id
+
+        assert authority_guard.delete_guard(root_id, guard.session_id) is True
+        await mcp_manage.activate_pending_authority_bindings()
+        activated = config.main['services']['mcp'][0]
+        assert 'authority_domain' not in activated
+        assert 'pending_authority_domain' not in activated
+
+    asyncio.run(scenario())
+
+
+def test_config_save_cannot_retarget_guarded_authority_root(
+    shadow_session_tool,
+):
+    async def scenario() -> None:
+        adapter_id = 'teleop-shadow-config-guarded'
+        root_id = 'robot-config-guarded'
+        teleop_tool = deepcopy(shadow_session_tool)
+        teleop_tool['x-teleop'].update({
+            'driver_id': adapter_id,
+            'robot_id': root_id,
+        })
+        services = {'mcp': [{
+            'id': adapter_id,
+            'name': 'Config Guarded Adapter',
+            'url': 'http://config-guarded-adapter.invalid/mcp',
+            'transport': 'http',
+            'category': 'driver',
+            'trust_state': 'trusted',
+            'reported_robot_id': root_id,
+            'authority_domain': root_id,
+            'tools': [teleop_tool],
+        }, {
+            'id': root_id,
+            'name': 'Config Guarded Root',
+            'url': 'http://config-guarded-root.invalid/mcp',
+            'transport': 'http',
+            'category': 'driver',
+            'trust_state': 'trusted',
+            'tools': [{
+                'name': 'locomotion',
+                'type': 'actuator',
+                'inputSchema': {'type': 'object'},
+            }],
+        }]}
+        config.main['services'] = deepcopy(services)
+        _persist_authority_guard(adapter_id, root_id)
+        request = config_api.ConfigSaveRequest(mcp_list=[{
+            'id': adapter_id,
+            'name': 'Config Guarded Adapter',
+            'transport': 'http',
+            'url': 'http://config-guarded-adapter.invalid/mcp',
+        }, {
+            'id': root_id,
+            'name': 'Config Guarded Root',
+            'transport': 'http',
+            'url': 'http://replacement-root.invalid/mcp',
+        }])
+
+        with pytest.raises(fastapi.HTTPException) as raised:
+            await config_api.config_save(request)
+        assert raised.value.status_code == 409
+        assert raised.value.detail == {
+            'code': 'authority_target_locked',
+            'reason': 'persistent_authority_guard_requires_stable_target',
+            'project_state': 'running',
+            'mcp_ids': [root_id],
+        }
+        assert config.main['services'] == services
+
+    asyncio.run(scenario())
+
+
+def test_persistent_guard_does_not_lock_unrelated_target():
+    async def scenario() -> None:
+        guarded_id = 'guarded-standalone'
+        unrelated_id = 'unrelated-sensor'
+        guarded = {
+            'id': guarded_id,
+            'name': 'Guarded Standalone',
+            'url': 'http://guarded-standalone.invalid/mcp',
+            'transport': 'http',
+            'category': 'driver',
+            'trust_state': 'trusted',
+            'tools': [],
+        }
+        unrelated = {
+            'id': unrelated_id,
+            'name': 'Unrelated Sensor',
+            'url': 'http://unrelated.invalid/mcp',
+            'transport': 'http',
+            'category': 'sensor',
+            'trust_state': 'trusted',
+            'tools': [],
+        }
+        config.main['services'] = {'mcp': [guarded, unrelated]}
+        _persist_authority_guard(guarded_id, guarded_id)
+
+        response = await mcp_manage.mcp_delete(unrelated_id)
+        assert response == {'code': 200}
+        assert config.main['services']['mcp'] == [guarded]
+        assert authority_guard.get_guard(guarded_id) is not None
+
+    asyncio.run(scenario())
+
+
+def test_unreadable_guard_store_rejects_target_mutation_and_defers_activation(
+    shadow_session_tool,
+    monkeypatch,
+):
+    async def scenario() -> None:
+        adapter_id = 'teleop-shadow-store-down'
+        root_id = 'robot-store-down'
+        teleop_tool = deepcopy(shadow_session_tool)
+        teleop_tool['x-teleop'].update({
+            'driver_id': adapter_id,
+            'robot_id': root_id,
+        })
+        targets = [{
+            'id': adapter_id,
+            'name': 'Store Down Adapter',
+            'url': 'http://store-down.invalid/mcp',
+            'transport': 'http',
+            'category': 'driver',
+            'trust_state': 'trusted',
+            'reported_robot_id': root_id,
+            'authority_domain': root_id,
+            'pending_authority_domain': adapter_id,
+            'tools': [teleop_tool],
+        }, {
+            'id': root_id,
+            'name': 'Store Down Robot',
+            'url': 'http://store-down-robot.invalid/mcp',
+            'transport': 'http',
+            'category': 'driver',
+            'trust_state': 'trusted',
+            'tools': [{
+                'name': 'locomotion',
+                'type': 'actuator',
+                'inputSchema': {'type': 'object'},
+            }],
+        }]
+        config.main['services'] = {'mcp': deepcopy(targets)}
+
+        def unavailable():
+            raise OSError('simulated authority guard store failure')
+
+        monkeypatch.setattr(authority_guard, 'list_guards', unavailable)
+        renamed = deepcopy(targets)
+        renamed[0]['name'] = 'Changed While Guard Store Is Unknown'
+        assert await config_api._project_target_mutation_error(targets, renamed) == {
+            'code': 'authority_guard_persistence_error',
+            'reason': 'authority_guard_store_unavailable',
+            'project_state': 'running',
+            'mcp_ids': [adapter_id],
+        }
+        response = await mcp_manage.mcp_delete(adapter_id)
+        assert response.status_code == 409
+        assert json.loads(response.body)['data'] == {
+            'code': 'authority_guard_persistence_error',
+            'reason': 'authority_guard_store_unavailable',
+            'project_state': 'running',
+            'mcp_ids': [adapter_id],
+        }
+        await mcp_manage.activate_pending_authority_bindings()
+        assert config.main['services']['mcp'] == targets
+
+    asyncio.run(scenario())
+
+
+def test_guard_store_contention_does_not_block_event_loop():
+    async def scenario() -> None:
+        target_id = 'contention-target'
+        config.main['services'] = {'mcp': [{
+            'id': target_id,
+            'name': 'Contention Target',
+            'url': 'http://contention.invalid/mcp',
+            'transport': 'http',
+            'category': 'sensor',
+            'trust_state': 'trusted',
+            'tools': [],
+        }]}
+        blocker = config._get_conn()
+        blocker.execute('BEGIN IMMEDIATE')
+        ticks = 0
+        ticker_done = asyncio.Event()
+
+        async def ticker() -> None:
+            nonlocal ticks
+            while not ticker_done.is_set():
+                ticks += 1
+                await asyncio.sleep(0.005)
+
+        ticker_task = asyncio.create_task(ticker())
+        delete_task = asyncio.create_task(mcp_manage.mcp_delete(target_id))
+        try:
+            await asyncio.sleep(0.06)
+            assert ticks >= 5
+            assert not delete_task.done()
+            blocker.rollback()
+            response = await asyncio.wait_for(delete_task, timeout=0.5)
+            assert response == {'code': 200}
+        finally:
+            ticker_done.set()
+            blocker.rollback()
+            blocker.close()
+            await asyncio.gather(ticker_task, return_exceptions=True)
+            if not delete_task.done():
+                delete_task.cancel()
+            await asyncio.gather(delete_task, return_exceptions=True)
+
+    asyncio.run(scenario())
+
+
+def test_startup_migration_preserves_mcp_snapshot_while_guard_is_pending():
+    guarded_id = 'guarded-migration-target'
+    duplicate_url = 'http://duplicate-during-recovery.invalid/mcp'
+    targets = [{
+        'id': guarded_id,
+        'name': 'Guarded Migration Target',
+        'url': duplicate_url,
+        'transport': 'http',
+        'category': 'driver',
+        'trust_state': 'trusted',
+        'tools': [],
+    }, {
+        'id': 'legacy-duplicate-target',
+        'name': 'Legacy Duplicate Target',
+        'url': duplicate_url,
+        'transport': 'http',
+        'category': 'sensor',
+        'trust_state': 'untrusted',
+        'tools': [],
+    }]
+    config.main['services'] = {'mcp': deepcopy(targets)}
+    _persist_authority_guard(guarded_id, guarded_id)
+
+    config._migrate()
+
+    assert config.main['services']['mcp'] == targets
+
+
+def test_staged_unbind_keeps_active_binding_valid_for_driver_heartbeats(
+    client,
+    monkeypatch,
+):
+    adapter_id = 'teleop-shadow-lab-a'
+    root_id = 'g1-lab-a'
+    auth.init({'MOTUS_DRIVER_TOKEN': 'driver-secret'})
+    monkeypatch.setattr(mcp_manage, '_do_ping', lambda _mcp_id: asyncio.sleep(0))
+    config.main['services'] = {'mcp': [{
+        'id': adapter_id,
+        'name': 'Standalone Teleop Adapter',
+        'url': 'http://teleop.invalid/mcp',
+        'transport': 'http',
+        'category': 'driver',
+        'trust_state': 'trusted',
+        'reported_robot_id': root_id,
+        'authority_domain': root_id,
+        'pending_authority_domain': adapter_id,
+        'tools': [],
+    }]}
+
+    response = client.post(
+        '/api/mcp',
+        headers={'X-Motus-Driver-Token': 'driver-secret'},
+        json=_registration(
+            id=adapter_id,
+            name='Standalone Teleop Adapter',
+            url='http://teleop.invalid/mcp',
+            robot_id=root_id,
+        ),
+    )
+
+    assert response.status_code == 200
+    record = config.main['services']['mcp'][0]
+    assert record['authority_domain'] == root_id
+    assert record['pending_authority_domain'] == adapter_id
+
+
+def test_shared_driver_token_cannot_retarget_or_omit_bound_identity(
+    client,
+    monkeypatch,
+):
+    adapter_id = 'teleop-shadow-secure'
+    root_id = 'robot-secure'
+    auth.init({'MOTUS_DRIVER_TOKEN': 'driver-secret'})
+    monkeypatch.setattr(mcp_manage, '_do_ping', lambda _mcp_id: asyncio.sleep(0))
+    original = {
+        'id': adapter_id,
+        'name': 'Secure Adapter',
+        'url': 'http://secure-adapter.invalid/mcp',
+        'transport': 'http',
+        'category': 'driver',
+        'trust_state': 'trusted',
+        'reported_robot_id': root_id,
+        'authority_domain': root_id,
+        'tools': [],
+    }
+    config.main['services'] = {'mcp': [deepcopy(original)]}
+
+    retarget = client.post(
+        '/api/mcp',
+        headers={'X-Motus-Driver-Token': 'driver-secret'},
+        json=_registration(
+            id=adapter_id,
+            name='Attacker',
+            url='http://attacker.invalid/mcp',
+        ),
+    )
+    assert retarget.status_code == 409
+    assert config.main['services']['mcp'][0] == original
+
+    omitted_identity = client.post(
+        '/api/mcp',
+        headers={'X-Motus-Driver-Token': 'driver-secret'},
+        json=_registration(
+            id=adapter_id,
+            name='Attacker',
+            url=original['url'],
+        ),
+    )
+    assert omitted_identity.status_code == 409
+    assert config.main['services']['mcp'][0] == original
+
+
+def test_cross_id_binding_requires_descriptor_robot_identity(
+    client,
+    auth_headers,
+    shadow_session_tool,
+):
+    adapter_id = 'teleop-shadow-missing-robot'
+    root_id = 'robot-root'
+    teleop_tool = deepcopy(shadow_session_tool)
+    teleop_tool['x-teleop']['driver_id'] = adapter_id
+    teleop_tool['x-teleop'].pop('robot_id')
+    config.main['services'] = {'mcp': [{
+        'id': adapter_id,
+        'name': 'Missing Robot Adapter',
+        'url': 'http://missing-robot.invalid/mcp',
+        'transport': 'http',
+        'category': 'driver',
+        'trust_state': 'trusted',
+        'reported_robot_id': root_id,
+        'tools': [teleop_tool],
+    }, {
+        'id': root_id,
+        'name': 'Robot Root',
+        'url': 'http://robot-root.invalid/mcp',
+        'transport': 'http',
+        'category': 'driver',
+        'trust_state': 'trusted',
+        'tools': [{
+            'name': 'locomotion',
+            'type': 'actuator',
+            'inputSchema': {'type': 'object'},
+        }],
+    }]}
+
+    response = client.put(
+        f'/api/mcp/{adapter_id}/authority-domain',
+        headers=auth_headers['owner'],
+        json={'root_mcp_id': root_id},
+    )
+
+    assert response.status_code == 409
+    assert response.json()['detail'] == {
+        'code': 'authority_binding_invalid',
+        'reason': 'descriptor_robot_id_mismatch',
+    }
+    assert 'pending_authority_domain' not in config.main['services']['mcp'][0]
+
+
+def test_config_save_cannot_remove_active_root_while_unbind_is_pending(
+    shadow_session_tool,
+):
+    async def scenario() -> None:
+        adapter_id = 'teleop-shadow-pending-unbind'
+        root_id = 'robot-active-root'
+        teleop_tool = deepcopy(shadow_session_tool)
+        teleop_tool['x-teleop'].update({
+            'driver_id': adapter_id,
+            'robot_id': root_id,
+        })
+        config.main['services'] = {'mcp': [{
+            'id': adapter_id,
+            'name': 'Pending Unbind Adapter',
+            'url': 'http://pending-unbind.invalid/mcp',
+            'transport': 'http',
+            'category': 'driver',
+            'trust_state': 'trusted',
+            'reported_robot_id': root_id,
+            'authority_domain': root_id,
+            'pending_authority_domain': adapter_id,
+            'tools': [teleop_tool],
+        }, {
+            'id': root_id,
+            'name': 'Active Root',
+            'url': 'http://active-root.invalid/mcp',
+            'transport': 'http',
+            'category': 'driver',
+            'trust_state': 'trusted',
+            'tools': [{
+                'name': 'locomotion',
+                'type': 'actuator',
+                'inputSchema': {'type': 'object'},
+            }],
+        }]}
+        request = config_api.ConfigSaveRequest(mcp_list=[{
+            'id': adapter_id,
+            'name': 'Pending Unbind Adapter',
+            'transport': 'http',
+            'url': 'http://pending-unbind.invalid/mcp',
+        }])
+
+        with pytest.raises(fastapi.HTTPException) as error:
+            await config_api.config_save(request)
+
+        assert getattr(error.value, 'status_code', None) == 409
+        assert error.value.detail['reason'] == 'authority_root_would_be_removed'
+        assert config.main['services']['mcp'][1]['id'] == root_id
+
+    asyncio.run(scenario())
+
+
+def test_owner_target_change_invalidates_old_capability_snapshot():
+    async def scenario() -> None:
+        mcp_id = 'owner-retargeted-driver'
+        config.main['services'] = {'mcp': [{
+            'id': mcp_id,
+            'name': 'Owner Retargeted Driver',
+            'url': 'http://old-target.invalid/mcp',
+            'transport': 'http',
+            'category': 'driver',
+            'trust_state': 'trusted',
+            'tools': [{
+                'name': 'locomotion',
+                'type': 'actuator',
+                'inputSchema': {'type': 'object'},
+            }],
+            'resources': [{'uri': 'robot://state'}],
+        }]}
+        mcp_client.registry[mcp_id] = {
+            'url': 'http://old-target.invalid/mcp',
+            'online': True,
+        }
+        request = config_api.ConfigSaveRequest(mcp_list=[{
+            'id': mcp_id,
+            'name': 'Owner Retargeted Driver',
+            'transport': 'http',
+            'url': 'http://new-target.invalid/mcp',
+        }])
+
+        response = await config_api.config_save(request)
+
+        assert response['code'] == 200
+        record = config.main['services']['mcp'][0]
+        assert record['url'] == 'http://new-target.invalid/mcp'
+        assert record['tools'] == []
+        assert record['resources'] == []
+        assert record['capability_refresh_required'] is True
+        assert mcp_id not in mcp_client.registry
+
+    asyncio.run(scenario())
+
+
+def test_settings_save_preserves_internal_credential_binding():
+    async def scenario() -> None:
+        import client as client_mod
+
+        mcp_id = 'driver-with-dedicated-binding'
+        auth.init({
+            'MOTUS_DRIVER_TOKENS': json.dumps({
+                mcp_id: 'private-driver-token-bound-0001',
+            }),
+        })
+        binding = auth.driver_credential_binding(mcp_id)
+        config.main['services'] = {'mcp': [{
+            'id': mcp_id,
+            'name': 'Bound Driver',
+            'url': 'http://bound-driver.invalid/mcp',
+            'transport': 'http',
+            'category': 'driver',
+            'trust_state': 'trusted',
+            'credential_binding': binding,
+            'tools': [],
+        }]}
+        previous_client = client_mod.llm
+        try:
+            response = await config_api.config_save(config_api.ConfigSaveRequest(
+                mcp_list=[{
+                    'id': mcp_id,
+                    'name': 'Bound Driver',
+                    'url': 'http://bound-driver.invalid/mcp',
+                    'transport': 'http',
+                }],
+            ))
+            assert response['code'] == 200
+            record = config.main['services']['mcp'][0]
+            assert record['credential_binding'] == binding
+            assert mcp_manage._effective_trust_state(record) == 'trusted'
+        finally:
+            replacement = client_mod.llm
+            client_mod.llm = previous_client
+            if replacement is not previous_client:
+                await replacement.aclose()
+
+    asyncio.run(scenario())
+
+
+def test_retargeted_authority_root_cannot_reuse_old_actuator_proof(
+    shadow_session_tool,
+):
+    async def scenario() -> None:
+        adapter_id = 'retarget-binding-adapter'
+        root_id = 'retarget-binding-root'
+        teleop_tool = deepcopy(shadow_session_tool)
+        teleop_tool['x-teleop'].update({
+            'driver_id': adapter_id,
+            'robot_id': root_id,
+        })
+        services = {'mcp': [{
+            'id': adapter_id,
+            'name': 'Retarget Binding Adapter',
+            'url': 'http://binding-adapter.invalid/mcp',
+            'transport': 'http',
+            'category': 'driver',
+            'trust_state': 'trusted',
+            'reported_robot_id': root_id,
+            'authority_domain': root_id,
+            'tools': [teleop_tool],
+        }, {
+            'id': root_id,
+            'name': 'Retarget Binding Root',
+            'url': 'http://binding-root-old.invalid/mcp',
+            'transport': 'http',
+            'category': 'driver',
+            'trust_state': 'trusted',
+            'tools': [{
+                'name': 'locomotion',
+                'type': 'actuator',
+                'inputSchema': {'type': 'object'},
+            }],
+        }]}
+        config.main['services'] = services
+        request = config_api.ConfigSaveRequest(mcp_list=[{
+            'id': adapter_id,
+            'name': 'Retarget Binding Adapter',
+            'transport': 'http',
+            'url': 'http://binding-adapter.invalid/mcp',
+        }, {
+            'id': root_id,
+            'name': 'Retarget Binding Root',
+            'transport': 'http',
+            'url': 'http://binding-root-new.invalid/mcp',
+        }])
+
+        with pytest.raises(fastapi.HTTPException) as error:
+            await config_api.config_save(request)
+
+        assert error.value.status_code == 409
+        assert error.value.detail['reason'] == 'authority_binding_would_be_invalidated'
+        assert error.value.detail['bindings'] == [{
+            'mcp_id': adapter_id,
+            'root_mcp_id': root_id,
+            'reason': 'root_missing_ordinary_actuator',
+        }]
+        assert config.main['services'] == services
+
+    asyncio.run(scenario())
+
+
+def test_active_project_registration_cannot_change_stop_target(
+    client,
+    monkeypatch,
+):
+    auth.init({'MOTUS_DRIVER_TOKEN': 'driver-secret'})
+    mcp_id = 'active-registration-driver'
+    target = {
+        'id': mcp_id,
+        'name': 'Active Registration Driver',
+        'url': 'http://active-registration.invalid/mcp',
+        'transport': 'http',
+        'category': 'driver',
+        'trust_state': 'trusted',
+        'tools': [{
+            'name': 'locomotion',
+            'type': 'actuator',
+            'inputSchema': {'type': 'object'},
+        }],
+    }
+    config.main['services'] = {'mcp': [target]}
+    config_api._set_project_state('running', cards=[{
+        'id': 'active-registration-card',
+        'mcpId': mcp_id,
+        'toolName': 'locomotion',
+    }])
+
+    async def forbidden_ping(_mcp_id):
+        raise AssertionError('rejected registration must not schedule a ping')
+
+    monkeypatch.setattr(mcp_manage, '_do_ping', forbidden_ping)
+    response = client.post(
+        '/api/mcp',
+        headers={'X-Motus-Driver-Token': 'driver-secret'},
+        json=_registration(
+            id=mcp_id,
+            name='Active Registration Driver',
+            url=target['url'],
+            transport='stdio',
+        ),
+    )
+
+    assert response.status_code == 409
+    assert response.json()['data'] == {
+        'code': 'project_target_locked',
+        'reason': 'active_project_requires_stable_stop_targets',
+        'project_state': 'running',
+        'mcp_ids': [mcp_id],
+    }
+    assert config.main['services']['mcp'] == [target]
+
+
+@pytest.mark.parametrize(
+    ('reserved_id', 'settings', 'headers'),
+    [
+        (
+            'agentcore',
+            {'MOTUS_DRIVER_TOKEN': 'driver-secret'},
+            {'X-Motus-Driver-Token': 'driver-secret'},
+        ),
+        (
+            'channel',
+            {'MOTUS_DRIVER_TOKEN': 'driver-secret'},
+            {'X-Motus-Driver-Token': 'driver-secret'},
+        ),
+        ('agentcore', {}, {}),
+        (
+            'agentcore',
+            {
+                'MOTUS_DRIVER_TOKEN': 'driver-secret',
+                'MOTUS_ENFORCE_DRIVER_AUTH': 'true',
+            },
+            {},
+        ),
+    ],
+    ids=['trusted-agentcore', 'trusted-channel', 'untrusted', 'quarantined'],
+)
+def test_external_registration_cannot_claim_reserved_internal_id(
+    client, monkeypatch, reserved_id, settings, headers,
+):
+    auth.init(settings)
+    internal_records = [
+        {
+            'id': 'agentcore',
+            'name': 'Agent Core',
+            'transport': 'internal',
+            'url': '',
+            'server_name': 'AgentCore',
+            'category': 'controller',
+            'trust_state': 'internal',
+            'online': True,
+            'tools': [{'name': 'decision_core'}],
+        },
+        {
+            'id': 'channel',
+            'name': 'Channel',
+            'transport': 'internal',
+            'url': '',
+            'server_name': 'Channel',
+            'category': 'controller',
+            'trust_state': 'internal',
+            'online': True,
+            'tools': [{'name': 'channel_request'}],
+        },
+    ]
+    config.main['services'] = {'mcp': deepcopy(internal_records)}
+
+    def forbidden_ping(mcp_id):  # pragma: no cover - invocation fails the test
+        raise AssertionError(f'internal collision scheduled ping for {mcp_id}')
+
+    monkeypatch.setattr(mcp_manage, '_do_ping', forbidden_ping)
+    before = json.dumps(config.main['services'], sort_keys=True)
+
+    response = client.post(
+        '/api/mcp',
+        headers=headers,
+        json=_registration(
+            id=reserved_id,
+            name='External Driver',
+            url='http://external.local/mcp',
+        ),
+    )
+
+    assert response.status_code == 409
+    assert response.json()['data'] == {
+        'id': reserved_id, 'trust_state': 'internal',
+    }
+    assert json.dumps(config.main['services'], sort_keys=True) == before
+    assert config.main['services']['mcp'] == internal_records
+
+
+@pytest.mark.parametrize(
+    'registration_fields',
+    [
+        {'name': 'Agent Core', 'url': 'http://external.local/mcp'},
+        {'name': 'External Driver', 'url': 'internal://agent-core'},
+        {'name': 'AgentCore', 'url': 'http://external.local/mcp'},
+    ],
+    ids=['same-name', 'same-url', 'same-server-name'],
+)
+def test_external_registration_descriptors_cannot_merge_internal_record(
+    client, monkeypatch, registration_fields,
+):
+    internal = {
+        'id': 'custom-internal',
+        'name': 'Agent Core',
+        'transport': 'internal',
+        'url': 'internal://agent-core',
+        'server_name': 'AgentCore',
+        'category': 'controller',
+        'trust_state': 'internal',
+        'tools': [{'name': 'decision_core'}],
+    }
+    config.main['services'] = {'mcp': [deepcopy(internal)]}
+    auth.init({'MOTUS_DRIVER_TOKEN': 'driver-secret'})
+
+    def forbidden_ping(mcp_id):  # pragma: no cover - invocation fails the test
+        raise AssertionError(f'internal collision scheduled ping for {mcp_id}')
+
+    monkeypatch.setattr(mcp_manage, '_do_ping', forbidden_ping)
+    response = client.post(
+        '/api/mcp',
+        headers={'X-Motus-Driver-Token': 'driver-secret'},
+        json=_registration(id='external-driver', **registration_fields),
+    )
+
+    assert response.status_code == 409
+    assert config.main['services']['mcp'] == [internal]
+
+
+@pytest.mark.parametrize('bad_id', ['', 'spaces are invalid', '../robot'])
+def test_trusted_registration_requires_valid_stable_id(client, bad_id):
+    auth.init({'MOTUS_DRIVER_TOKEN': 'driver-secret'})
+    response = client.post(
+        '/api/mcp',
+        headers={'Authorization': 'Bearer driver-secret'},
+        json=_registration(id=bad_id),
+    )
+    assert response.status_code == 422
+    assert config.main['services']['mcp'] == []
+
+
+@pytest.mark.parametrize(
+    'attacker_overrides',
+    [
+        {'name': 'Trusted Robot', 'url': 'http://attacker.local/mcp'},
+        {'name': 'Attacker', 'url': 'http://trusted.local/mcp'},
+        {'name': 'TrustedServerName', 'url': 'http://attacker.local/mcp'},
+    ],
+    ids=['same-name', 'same-url', 'same-server-name'],
+)
+def test_untrusted_registration_cannot_merge_trusted_identity(
+    client, attacker_overrides,
+):
+    auth.init({'MOTUS_DRIVER_TOKEN': 'driver-secret'})
+    trusted = {
+        'id': 'trusted-robot',
+        'name': 'Trusted Robot',
+        'server_name': 'TrustedServerName',
+        'url': 'http://trusted.local/mcp',
+        'transport': 'http',
+        'category': 'driver',
+        'trust_state': 'trusted',
+        'tools': [{'name': 'safe-tool'}],
+    }
+    config.main['services'] = {'mcp': [deepcopy(trusted)]}
+
+    response = client.post('/api/mcp', json=_registration(**attacker_overrides))
+
+    assert response.status_code == 403
+    assert config.main['services']['mcp'] == [trusted]
+
+
+def test_untrusted_initialize_name_spoof_cannot_touch_trusted_record(
+    monkeypatch,
+):
+    auth.init({'MOTUS_DRIVER_TOKEN': 'driver-secret'})
+    trusted = {
+        'id': 'trusted-robot',
+        'name': 'Trusted Robot',
+        'server_name': 'SharedServerName',
+        'url': 'http://trusted.local/mcp',
+        'transport': 'http',
+        'category': 'driver',
+        'trust_state': 'trusted',
+        'tools': [{'name': 'safe-tool'}],
+    }
+    attacker = {
+        'id': 'legacy-attacker',
+        'name': 'Different Registration Name',
+        'url': 'http://attacker.local/mcp',
+        'transport': 'http',
+        'category': 'driver',
+        'trust_state': 'untrusted',
+    }
+    config.main['services'] = {'mcp': [deepcopy(trusted), attacker]}
+    trusted_runtime = {'online': True, 'url': trusted['url'], 'sentinel': 'unchanged'}
+    mcp_client.registry.update({
+        trusted['id']: deepcopy(trusted_runtime),
+        attacker['id']: {'online': False, 'url': attacker['url']},
+    })
+
+    async def fake_ping(url, *, trusted=False, driver_id=''):
+        assert url == attacker['url']
+        assert trusted is False
+        return {
+            'server_name': trusted_record_name,
+            'tools': [{'name': 'attacker-tool'}],
+            'resources': [],
+            'device_type': '',
+            'topic_out': [],
+            'topic_in': [],
+        }
+
+    trusted_record_name = trusted['server_name']
+    monkeypatch.setattr(mcp_manage, '_ping_mcp_http', fake_ping)
+    result = asyncio.run(mcp_manage._do_ping(attacker['id']))
+
+    assert result['online'] is False
+    assert result['error'] == 'untrusted duplicate of trusted service'
+    assert config.main['services']['mcp'] == [trusted]
+    assert mcp_client.registry[trusted['id']] == trusted_runtime
+    assert attacker['id'] not in mcp_client.registry
+
+
+def test_external_ping_server_name_cannot_affect_internal_identity(
+    monkeypatch, shadow_session_tool,
+):
+    auth.init({'MOTUS_DRIVER_TOKEN': 'driver-secret'})
+    internal = {
+        'id': 'agentcore',
+        'name': 'Agent Core',
+        'server_name': 'AgentCore',
+        'url': '',
+        'transport': 'internal',
+        'category': 'controller',
+        'trust_state': 'internal',
+        'tools': [{'name': 'decision_core'}],
+    }
+    external = {
+        'id': 'external-driver',
+        'name': 'Non-Colliding Registration Name',
+        'url': 'http://external.local/mcp',
+        'transport': 'http',
+        'category': 'driver',
+        'trust_state': 'trusted',
+    }
+    config.main['services'] = {'mcp': [deepcopy(internal), external]}
+    internal_runtime = {'online': True, 'transport': 'internal', 'sentinel': 'unchanged'}
+    mcp_client.registry.update({
+        internal['id']: deepcopy(internal_runtime),
+        external['id']: {'online': False, 'url': external['url']},
+    })
+
+    async def spoofed_ping(url, *, trusted=False, driver_id=''):
+        assert trusted is True
+        return {
+            'server_name': 'AgentCore',
+            'tools': [deepcopy(shadow_session_tool)],
+            'resources': [],
+            'device_type': '',
+            'topic_out': [],
+            'topic_in': [],
+        }
+
+    monkeypatch.setattr(mcp_manage, '_ping_mcp_http', spoofed_ping)
+    result = asyncio.run(mcp_manage._do_ping(external['id']))
+
+    assert result['online'] is False
+    assert result['error'] == 'external duplicate of internal service'
+    assert config.main['services']['mcp'] == [internal]
+    assert mcp_client.registry[internal['id']] == internal_runtime
+    assert external['id'] not in mcp_client.registry
+
+
+def test_two_trusted_instances_with_same_server_name_remain_distinct(
+    client, monkeypatch, shadow_session_tool,
+):
+    auth.init({'MOTUS_DRIVER_TOKEN': 'driver-secret'})
+    scheduled = []
+
+    def registration_ping(mcp_id):
+        scheduled.append(mcp_id)
+
+        async def done():
+            return {}
+
+        return done()
+
+    real_do_ping = mcp_manage._do_ping
+    monkeypatch.setattr(mcp_manage, '_do_ping', registration_ping)
+    headers = {'X-Motus-Driver-Token': 'driver-secret'}
+    for robot_id in ('robot-a', 'robot-b'):
+        response = client.post(
+            '/api/mcp',
+            headers=headers,
+            json=_registration(
+                id=robot_id,
+                name='Generic Teleop Shadow Diagnostics',
+                url=f'http://{robot_id}.local/mcp',
+            ),
+        )
+        assert response.status_code == 200
+        assert response.json()['data']['id'] == robot_id
+
+    assert scheduled == ['robot-a', 'robot-b']
+    assert [item['id'] for item in config.main['services']['mcp']] == ['robot-a', 'robot-b']
+
+    async def same_server_name(url, *, trusted=False, driver_id=''):
+        assert trusted is True
+        return {
+            'server_name': 'teleop-shadow',
+            'tools': [deepcopy(shadow_session_tool)],
+            'resources': [],
+            'device_type': '',
+            'topic_out': [],
+            'topic_in': [],
+        }
+
+    async def no_op(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(mcp_manage, '_do_ping', real_do_ping)
+    monkeypatch.setattr(mcp_manage, '_ping_mcp_http', same_server_name)
+    monkeypatch.setattr(mcp_manage, '_notify_inspector', no_op)
+    monkeypatch.setattr(mcp_manage, '_restore_saved_configs', no_op)
+
+    async def ping_both():
+        await mcp_manage._do_ping('robot-a')
+        await mcp_manage._do_ping('robot-b')
+        await asyncio.sleep(0)
+
+    asyncio.run(ping_both())
+
+    records = config.main['services']['mcp']
+    assert {record['id'] for record in records} == {'robot-a', 'robot-b'}
+    assert {record['server_name'] for record in records} == {'teleop-shadow'}
+    assert {record['url'] for record in records} == {
+        'http://robot-a.local/mcp', 'http://robot-b.local/mcp',
+    }
+    assert mcp_client.registry['robot-a']['online'] is True
+    assert mcp_client.registry['robot-b']['online'] is True
+
+
+def test_driver_secret_is_neither_persisted_nor_returned_or_logged(
+    client, monkeypatch, capsys,
+):
+    secret = 'driver-secret-never-persist'
+    auth.init({
+        'ACCESS_TOKEN': 'owner-token-for-secret-proof',
+        'MOTUS_DRIVER_TOKEN': secret,
+    })
+
+    def fake_ping(mcp_id):
+        async def done():
+            return {}
+
+        return done()
+
+    monkeypatch.setattr(mcp_manage, '_do_ping', fake_ping)
+    response = client.post(
+        '/api/mcp',
+        headers={'X-Motus-Driver-Token': secret},
+        json=_registration(),
+    )
+    listing = client.get(
+        '/api/mcp',
+        headers={'Authorization': 'Bearer owner-token-for-secret-proof'},
+    )
+
+    assert response.status_code == 200
+    assert listing.status_code == 200
+    assert secret not in json.dumps(config.main['services'])
+    assert secret not in response.text
+    assert secret not in listing.text
+    assert secret not in capsys.readouterr().out

--- a/agent-core/tests/teleop/test_live_contract.py
+++ b/agent-core/tests/teleop/test_live_contract.py
@@ -1,0 +1,1110 @@
+from __future__ import annotations
+
+import asyncio
+import threading
+from collections import defaultdict, deque
+from copy import deepcopy
+from typing import Any
+
+import aiohttp
+import pytest
+
+import config
+import mcp_client
+from api import teleop
+from teleop import authority_guard
+from teleop.command_broker import CommandBroker
+from teleop.service import TeleopCoordinator, TeleopServiceError
+from teleop.session_manager import SessionStateConflict, ShadowSessionManager
+
+CLIENT_ID = '7dbabfca-15c1-43ca-b600-75e7682c21d0'
+
+
+def _live_tool(shadow_session_tool: dict) -> dict:
+    tool = deepcopy(shadow_session_tool)
+    actions = tool['inputSchema']['x-action-params']
+    prepare = actions.pop('prepare_shadow')
+    actions['prepare_live'] = prepare
+    action_enum = tool['inputSchema']['properties']['action']['enum']
+    action_enum[action_enum.index('prepare_shadow')] = 'prepare_live'
+    descriptor = tool['x-teleop']
+    descriptor.pop('dry_run_profile')
+    descriptor.update({
+        'protocol': 'motus.teleop.live.v1',
+        'mode': 'live',
+        'actuation_enabled': True,
+        'dispatch_contract': 'motus.teleop.dispatch.hardware.v1',
+        'profile_id': 'dual_arm_profile_v1',
+        'capabilities': {
+            'profile_id': 'dual_arm_profile_v1',
+            'input_bindings': {
+                'head': {'required': True, 'role': 'reference'},
+                'left_controller': {
+                    'required': True,
+                    'role': 'left_end_effector',
+                },
+                'right_controller': {
+                    'required': True,
+                    'role': 'right_end_effector',
+                },
+            },
+            'outputs': {
+                'dual_arm': {'enabled': True, 'joint_count': 10},
+                'base': {'enabled': False},
+                'hands': {'enabled': False},
+            },
+            'effectors': ['dual_arm'],
+        },
+    })
+    descriptor['signaling']['audience'] = 'motus-teleop-rtc'
+    return tool
+
+
+def _trusted_record(tool: dict) -> dict:
+    tool = deepcopy(tool)
+    record = {
+        'id': 'live-teleop-driver',
+        'name': 'Live Teleop Driver',
+        'server_name': 'teleop',
+        'url': 'http://127.0.0.1:15711/mcp',
+        'transport': 'http',
+        'category': 'driver',
+        'trust_state': 'trusted',
+        'tools': [tool],
+    }
+    tool['x-teleop']['driver_id'] = record['id']
+    tool['x-teleop']['robot_id'] = record['id']
+    return record
+
+
+def _install_live(tool: dict) -> dict:
+    record = _trusted_record(tool)
+    config.main['services'] = {'mcp': [record]}
+    mcp_client.registry[record['id']] = {
+        'online': True,
+        'trusted': True,
+        'url': record['url'],
+        'teleop_fingerprint': mcp_client.teleop_tool_fingerprint(record['tools'][0]),
+    }
+    return record
+
+
+def _empty_latency() -> dict[str, Any]:
+    return {'last': None, 'p50': None, 'p95': None, 'p99': None, 'count': 0}
+
+
+class _LiveCaller:
+    def __init__(self, driver_id: str):
+        self.driver_id = driver_id
+        self.robot_id = driver_id
+        self.boot_id = 'f77787b9-c5d2-465a-b4b4-e74f61f35e30'
+        self.epoch = 7
+        self.session_id: str | None = None
+        self.fence: str | None = None
+        self.state = 'idle'
+        self.reason: str | None = None
+        self.authority_valid = False
+        self.dispatch_generation = 0
+        self.calls: list[dict[str, Any]] = []
+        self.script: dict[str, deque[Any]] = defaultdict(deque)
+
+    def queue(self, action: str, *outcomes: Any) -> None:
+        self.script[action].extend(outcomes)
+
+    def count(self, action: str) -> int:
+        return sum(call['action'] == action for call in self.calls)
+
+    def latch_live_fault(self) -> None:
+        self.session_id = None
+        self.fence = None
+        self.state = 'fault'
+        self.reason = 'dispatch_fault'
+        self.authority_valid = False
+        self.dispatch_generation += 1
+
+    def snapshot(self) -> dict[str, Any]:
+        dispatch_state = {
+            'idle': 'safe_unarmed',
+            'prepared_live': 'safe_waiting_frame',
+            'active_live': 'motion_eligible',
+            'paused': 'safe_latched',
+            'released': 'safe_revoked',
+            'fault': 'fault_latched',
+        }.get(self.state, 'safe_reclutch_required')
+        if self.state == 'hold' and self.reason == 'soft_stop':
+            dispatch_state = 'safe_latched'
+        decision = {
+            'idle': 'startup_safe_ack',
+            'prepared_live': 'prepared_after_stop_ack',
+            'active_live': 'motion_committed',
+            'fault': 'async_fault:arm_sdk_async_fault',
+        }.get(self.state, f'would_stop:{self.reason}')
+        admitted = 1 if self.state in {'active_live', 'fault'} else None
+        joints = [0.0] * 10 if self.authority_valid or self.state == 'fault' else []
+        return {
+            'driver_id': self.driver_id,
+            'driver_type': 'teleop',
+            'robot_id': self.robot_id,
+            'mode': 'live',
+            'actuation_enabled': True,
+            'boot_id': self.boot_id,
+            'session_id': self.session_id,
+            'epoch': self.epoch,
+            'state': self.state,
+            'reason': self.reason,
+            'authority_valid': self.authority_valid,
+            'capability_digest': '0123456789abcdef' * 4,
+            'lease': {
+                'source': 'agent-core-mcp-heartbeat-only',
+                'timeout_ms': 1_000.0,
+                'age_ms': 0.0 if self.authority_valid else None,
+                'fresh': self.authority_valid,
+                'authority_valid': self.authority_valid,
+                'expired_latched': False,
+            },
+            'pose': {
+                'timeout_ms': 250.0,
+                'age_ms': None,
+                'fresh': False,
+                'latest_sequence': None,
+            },
+            'rtc': {
+                'connected': False,
+                'channels': {'teleop-control': False, 'teleop-pose': False},
+                'renews_lease': False,
+            },
+            'dispatch': {
+                'kind': 'hardware',
+                'state': dispatch_state,
+                'ready': self.state != 'fault',
+                'generation': self.dispatch_generation,
+                'mailbox_depth': 0,
+                'stop_queue_depth': 0,
+                'last_admitted_sequence': admitted,
+                'last_published_sequence': admitted,
+                'last_decision': decision,
+                'stop_acknowledged': self.state != 'fault',
+                'fault_code': 'arm_sdk_async_fault' if self.state == 'fault' else None,
+                'io_inflight': None,
+                'counters': {'startup_safe_acks': 1, 'stop_acks': 1},
+            },
+            'diagnostics': {
+                'transport': {
+                    'rtc_rtt_ms': None,
+                    'pose_age_ms': None,
+                    'frame_rate_hz': None,
+                    'frames_received': 0,
+                    'frames_rejected': 0,
+                    'sequence_gaps': 0,
+                    'mailbox_replacements': 0,
+                },
+                'latency_ms': {
+                    stage: _empty_latency()
+                    for stage in (
+                        'receive_to_admit', 'mailbox_wait', 'ik',
+                        'adapter_apply', 'robot_follow',
+                    )
+                },
+            },
+            'output': {
+                'profile_id': 'dual_arm_profile_v1',
+                'hardware_output': True,
+                'state': self.state,
+                'target_joint_positions_rad': joints,
+                'measured_joint_positions_rad': list(joints),
+                'max_abs_error_rad': None,
+                'arm_sdk_weight': 0.0,
+                'command_age_ms': None,
+                'fault_reason': 'arm_sdk_async_fault' if self.state == 'fault' else None,
+            },
+            'counters': {},
+        }
+
+    async def __call__(
+        self,
+        driver_id: str,
+        action: str,
+        arguments: dict[str, Any] | None,
+        *,
+        timeout_seconds: float,
+        session: aiohttp.ClientSession,
+        target: mcp_client.TrustedShadowTarget | None = None,
+    ) -> dict[str, Any]:
+        assert driver_id == self.driver_id
+        assert timeout_seconds > 0
+        assert not session.closed
+        self.calls.append({
+            'action': action,
+            'arguments': deepcopy(arguments),
+            'target': target,
+        })
+        if self.script[action]:
+            outcome = self.script[action].popleft()
+            if callable(outcome):
+                outcome = outcome(self, arguments)
+                if asyncio.iscoroutine(outcome):
+                    outcome = await outcome
+            if isinstance(outcome, BaseException):
+                raise outcome
+            return deepcopy(outcome)
+        if action == 'status':
+            return self.snapshot()
+        if self.state == 'fault' and action in {'heartbeat', 'release', 'soft_stop'}:
+            raise RuntimeError('fault-latched Driver requires process restart')
+        if action == 'prepare_live':
+            assert arguments is not None
+            self.session_id = arguments['session_id']
+            self.epoch = arguments['epoch']
+            self.fence = arguments['fence']
+            self.state = 'prepared_live'
+            self.authority_valid = True
+            self.dispatch_generation += 1
+            return self.snapshot()
+        if action == 'heartbeat':
+            assert arguments is not None and arguments['fence'] == self.fence
+            return self.snapshot()
+        if action == 'release':
+            self.session_id = None
+            self.fence = None
+            self.state = 'released'
+            self.reason = 'operator_release'
+            self.authority_valid = False
+            self.dispatch_generation += 1
+            return self.snapshot()
+        if action == 'soft_stop':
+            self.state = 'hold'
+            self.reason = 'soft_stop'
+            self.dispatch_generation += 1
+            return self.snapshot()
+        raise AssertionError(f'unexpected live action {action}')
+
+
+async def _wait_until(predicate, *, timeout: float = 1.0) -> None:
+    deadline = asyncio.get_running_loop().time() + timeout
+    while not predicate():
+        if asyncio.get_running_loop().time() >= deadline:
+            raise AssertionError('condition was not reached before the test deadline')
+        await asyncio.sleep(0.01)
+
+
+def _pin_injected_live_target(
+    coordinator: TeleopCoordinator,
+    record: dict,
+    session_id: str,
+    capability_digest: str,
+) -> mcp_client.TrustedShadowTarget:
+    target = mcp_client.TrustedShadowTarget(
+        mcp_id=record['id'],
+        url=record['url'],
+        capability_digest=capability_digest,
+        descriptor_fingerprint=mcp_client.teleop_tool_fingerprint(
+            record['tools'][0],
+        ),
+        actions=frozenset(
+            record['tools'][0]['inputSchema']['properties']['action']['enum'],
+        ),
+    )
+    coordinator._pinned_targets[session_id] = target
+    coordinator._uses_pinned_targets = True
+    return target
+
+
+def test_live_descriptor_is_explicit_and_adapter_neutral(shadow_session_tool):
+    tool = _live_tool(shadow_session_tool)
+
+    assert teleop._valid_teleop_descriptor(tool) is True
+    assert teleop._valid_shadow_descriptor(tool) is False
+
+    for path, value in (
+        (('actuation_enabled',), False),
+        (('protocol',), 'motus.teleop.shadow.v1'),
+        (('dispatch_contract',), 'motus.teleop.dispatch.recording.v1'),
+        (('signaling', 'audience'), 'teleop-shadow-rtc'),
+    ):
+        malformed = deepcopy(tool)
+        target = malformed['x-teleop']
+        for key in path[:-1]:
+            target = target[key]
+        target[path[-1]] = value
+        assert teleop._valid_teleop_descriptor(malformed) is False
+
+
+@pytest.mark.parametrize('malformation', ['duplicate', 'non_string', 'undeclared'])
+def test_live_descriptor_rejects_ambiguous_action_declarations(
+    shadow_session_tool,
+    malformation,
+):
+    tool = _live_tool(shadow_session_tool)
+    action_enum = tool['inputSchema']['properties']['action']['enum']
+    if malformation == 'duplicate':
+        action_enum.append(action_enum[0])
+    elif malformation == 'non_string':
+        action_enum.append(7)
+    else:
+        action_enum.append('adapter_private_action')
+
+    assert teleop._valid_teleop_descriptor(tool) is False
+
+
+def test_base_speed_can_only_come_from_bounded_capability_binding(
+    shadow_session_tool,
+):
+    tool = _live_tool(shadow_session_tool)
+    descriptor = tool['x-teleop']
+    descriptor['capabilities']['outputs']['base']['enabled'] = True
+    descriptor['capabilities']['input_bindings']['base_twist'] = {
+        'linear_x': {
+            'hand': 'left', 'axis': 3, 'scale': 0.5,
+            'deadzone': 0.2, 'direction': -1,
+        },
+        'linear_y': {
+            'hand': 'left', 'axis': 2, 'scale': 0.3,
+            'deadzone': 0.2, 'direction': -1,
+        },
+        'angular_z': {
+            'hand': 'right', 'axis': 2, 'scale': 0.6,
+            'deadzone': 0.2, 'direction': -1,
+        },
+    }
+    descriptor['capabilities']['effectors'].append('base')
+    assert teleop._valid_teleop_descriptor(tool) is True
+
+    tool['x-teleop']['capabilities']['input_bindings']['base_twist'][
+        'linear_x'
+    ]['scale'] = 100
+    assert teleop._valid_teleop_descriptor(tool) is False
+
+
+def test_live_manager_defers_identity_and_requires_one_confirmation():
+    async def scenario():
+        manager = ShadowSessionManager()
+        capabilities = {
+            'profile_id': 'dual_arm_profile_v1',
+            'input_bindings': {},
+            'outputs': {'dual_arm': {'enabled': True, 'joint_count': 10}},
+            'effectors': ['dual_arm'],
+        }
+        session = await manager.reserve(
+            'robot-live',
+            'operator:alice',
+            driver_id='driver-live',
+            boot_id='',
+            capability_digest='a' * 64,
+            client_id=CLIENT_ID,
+            mode='live',
+            profile_id='dual_arm_profile_v1',
+            capabilities=capabilities,
+            effectors=['dual_arm'],
+            signaling_audience='motus-teleop-rtc',
+            defer_identity=True,
+        )
+        capabilities['outputs']['dual_arm']['joint_count'] = 99
+        assert session.state == 'awaiting_confirmation'
+        assert session.epoch == 0
+        assert session.boot_id == ''
+        assert session.live_confirmed is False
+        assert session.capabilities['outputs']['dual_arm']['joint_count'] == 10
+
+        confirmed = await manager.confirm_live_identity(
+            session.id,
+            'operator:alice',
+            CLIENT_ID,
+            boot_id='driver-boot-live',
+            minimum_epoch=4,
+        )
+        assert confirmed.state == 'preparing'
+        assert confirmed.epoch >= 4
+        assert confirmed.live_confirmed is True
+        with pytest.raises(SessionStateConflict):
+            await manager.confirm_live_identity(
+                session.id,
+                'operator:alice',
+                CLIENT_ID,
+                boot_id='driver-boot-live',
+                minimum_epoch=5,
+            )
+
+    asyncio.run(scenario())
+
+
+@pytest.mark.parametrize(
+    ('override', 'message'),
+    [
+        ({'signaling_audience': 'teleop-shadow-rtc'}, 'signaling_audience'),
+        ({'profile_id': 'other_profile'}, 'capabilities.profile_id'),
+        ({'effectors': []}, 'effectors'),
+    ],
+)
+def test_live_manager_rejects_contradictory_contract_projection(override, message):
+    async def scenario():
+        manager = ShadowSessionManager()
+        capabilities = {
+            'profile_id': 'dual_arm_profile_v1',
+            'input_bindings': {},
+            'outputs': {'dual_arm': {'enabled': True, 'joint_count': 10}},
+            'effectors': ['dual_arm'],
+        }
+        arguments = {
+            'driver_id': 'driver-live',
+            'boot_id': '',
+            'capability_digest': 'a' * 64,
+            'client_id': CLIENT_ID,
+            'mode': 'live',
+            'profile_id': 'dual_arm_profile_v1',
+            'capabilities': capabilities,
+            'effectors': ['dual_arm'],
+            'signaling_audience': 'motus-teleop-rtc',
+            'defer_identity': True,
+        }
+        arguments.update(override)
+        with pytest.raises(ValueError, match=message):
+            await manager.reserve(
+                'robot-live',
+                'operator:alice',
+                **arguments,
+            )
+        assert await manager.active_for_robot('robot-live') is None
+
+    asyncio.run(scenario())
+
+
+def test_live_acquire_and_release_never_contact_driver_before_confirmation(
+    shadow_session_tool,
+):
+    async def scenario():
+        record = _trusted_record(_live_tool(shadow_session_tool))
+        config.main['services'] = {'mcp': [record]}
+        mcp_client.registry[record['id']] = {
+            'online': True,
+            'trusted': True,
+            'url': record['url'],
+            'teleop_fingerprint': mcp_client.teleop_tool_fingerprint(
+                record['tools'][0],
+            ),
+        }
+        calls = []
+
+        async def caller(*args, **kwargs):
+            calls.append((args, kwargs))
+            raise AssertionError('Driver must not be contacted before live confirmation')
+
+        broker = CommandBroker()
+        coordinator = TeleopCoordinator(
+            session_manager=ShadowSessionManager(),
+            caller=caller,
+            command_broker=broker,
+        )
+        result = await coordinator.acquire(
+            record['id'],
+            'operator:alice',
+            CLIENT_ID,
+            mode='live',
+        )
+        assert result.disposition == 'confirmation_required'
+        assert result.session.state == 'awaiting_confirmation'
+        assert calls == []
+        assert coordinator.list_authority_guards() == []
+        assert authority_guard.get_guard(record['id']) is None
+        assert record['id'] not in coordinator._authority_guards
+        claim = await broker.authority_for(record['id'])
+        assert claim is not None
+        assert claim.state == 'awaiting_confirmation'
+
+        released, acknowledged = await coordinator.release(
+            result.session.id,
+            'operator:alice',
+            CLIENT_ID,
+            owner=False,
+        )
+        assert acknowledged is True
+        assert released.state == 'released'
+        assert calls == []
+        assert await broker.authority_for(record['id']) is None
+
+    asyncio.run(scenario())
+
+
+def test_confirm_live_happy_path_is_ordered_and_idempotent(shadow_session_tool):
+    async def scenario():
+        record = _install_live(_live_tool(shadow_session_tool))
+        caller = _LiveCaller(record['id'])
+        broker = CommandBroker()
+        coordinator = TeleopCoordinator(
+            session_manager=ShadowSessionManager(),
+            caller=caller,
+            command_broker=broker,
+        )
+        acquired = await coordinator.acquire(
+            record['id'], 'operator:alice', CLIENT_ID, mode='live',
+        )
+        assert caller.calls == []
+
+        confirmed = await coordinator.confirm_live(
+            acquired.session.id,
+            'operator:alice',
+            CLIENT_ID,
+            profile_id='dual_arm_profile_v1',
+        )
+        assert confirmed.disposition == 'created'
+        assert confirmed.session.state == 'active'
+        assert confirmed.session.live_confirmed is True
+        assert [call['action'] for call in caller.calls[:3]] == [
+            'status', 'prepare_live', 'heartbeat',
+        ]
+        assert coordinator.public_session(confirmed.session)['driver']['mode'] == 'live'
+        assert coordinator.public_session(confirmed.session)['driver'][
+            'output'
+        ]['hardware_output'] is True
+        persisted_guard = authority_guard.get_guard(record['id'])
+        assert persisted_guard is not None
+        assert persisted_guard.session_id == confirmed.session.id
+        assert persisted_guard.phase == 'active'
+        assert coordinator._authority_guards[record['id']].phase == 'active'
+
+        prepare_count = caller.count('prepare_live')
+        retried = await coordinator.confirm_live(
+            acquired.session.id,
+            'operator:alice',
+            CLIENT_ID,
+            profile_id='dual_arm_profile_v1',
+        )
+        assert retried.disposition == 'existing'
+        assert caller.count('prepare_live') == prepare_count
+
+        await coordinator.release(
+            acquired.session.id,
+            'operator:alice',
+            CLIENT_ID,
+            owner=False,
+        )
+        await coordinator.stop()
+
+    asyncio.run(scenario())
+
+
+def test_live_status_preserves_strict_driver_fault_evidence_for_console(
+    shadow_session_tool,
+):
+    async def scenario():
+        record = _install_live(_live_tool(shadow_session_tool))
+        caller = _LiveCaller(record['id'])
+        coordinator = TeleopCoordinator(
+            session_manager=ShadowSessionManager(),
+            caller=caller,
+            command_broker=CommandBroker(),
+        )
+        acquired = await coordinator.acquire(
+            record['id'], 'operator:alice', CLIENT_ID, mode='live',
+        )
+        confirmed = await coordinator.confirm_live(
+            acquired.session.id,
+            'operator:alice',
+            CLIENT_ID,
+            profile_id='dual_arm_profile_v1',
+        )
+        caller.latch_live_fault()
+
+        public = await coordinator.status(
+            confirmed.session.id,
+            'operator:alice',
+            owner=False,
+        )
+
+        assert public['state'] == 'faulted'
+        assert public['driver']['state'] == 'fault'
+        assert public['driver']['reason'] == 'dispatch_fault'
+        assert public['driver']['authority_valid'] is False
+        assert public['driver']['session_id'] is None
+        assert public['driver']['dispatch']['state'] == 'fault_latched'
+        assert public['driver']['dispatch']['fault_code'] == 'arm_sdk_async_fault'
+        assert public['driver']['dispatch']['stop_acknowledged'] is False
+        assert public['driver']['output']['state'] == 'fault'
+        assert public['driver']['output']['arm_sdk_weight'] == 0.0
+        assert authority_guard.get_guard(record['id']) is not None
+        await coordinator.stop()
+
+    asyncio.run(scenario())
+
+
+def test_terminal_heartbeat_rpc_captures_one_strict_fault_status_for_console(
+    shadow_session_tool,
+):
+    async def scenario():
+        record = _install_live(_live_tool(shadow_session_tool))
+        caller = _LiveCaller(record['id'])
+        coordinator = TeleopCoordinator(
+            session_manager=ShadowSessionManager(),
+            caller=caller,
+            command_broker=CommandBroker(),
+        )
+        acquired = await coordinator.acquire(
+            record['id'], 'operator:alice', CLIENT_ID, mode='live',
+        )
+        confirmed = await coordinator.confirm_live(
+            acquired.session.id,
+            'operator:alice',
+            CLIENT_ID,
+            profile_id='dual_arm_profile_v1',
+        )
+        status_before = caller.count('status')
+        heartbeat_before = caller.count('heartbeat')
+        pinned_target = _pin_injected_live_target(
+            coordinator,
+            record,
+            confirmed.session.id,
+            confirmed.session.capability_digest,
+        )
+        caller.latch_live_fault()
+        caller.queue(
+            'heartbeat',
+            mcp_client.TrustedShadowTransportError(
+                'rpc_error',
+                rpc_code=-32602,
+                rpc_data_code='session_inactive',
+            ),
+        )
+
+        await _wait_until(lambda: confirmed.session.state == 'faulted')
+
+        public = coordinator.public_session(confirmed.session)
+        assert caller.count('heartbeat') == heartbeat_before + 1
+        assert caller.count('status') == status_before + 1
+        terminal_status = [
+            call for call in caller.calls if call['action'] == 'status'
+        ][-1]
+        assert terminal_status['arguments'] is None
+        assert terminal_status['target'] is pinned_target
+        assert public['state'] == 'faulted'
+        assert public['driver']['state'] == 'fault'
+        assert public['driver']['dispatch']['fault_code'] == 'arm_sdk_async_fault'
+        assert public['driver']['output']['fault_reason'] == 'arm_sdk_async_fault'
+        assert public['driver_heartbeat']['state'] == 'faulted'
+        assert authority_guard.get_guard(record['id']) is not None
+        await coordinator.stop()
+
+    asyncio.run(scenario())
+
+
+def test_terminal_heartbeat_status_failure_keeps_original_fail_closed_path(
+    shadow_session_tool,
+):
+    async def scenario():
+        record = _install_live(_live_tool(shadow_session_tool))
+        caller = _LiveCaller(record['id'])
+        coordinator = TeleopCoordinator(
+            session_manager=ShadowSessionManager(),
+            caller=caller,
+            command_broker=CommandBroker(),
+        )
+        acquired = await coordinator.acquire(
+            record['id'], 'operator:alice', CLIENT_ID, mode='live',
+        )
+        confirmed = await coordinator.confirm_live(
+            acquired.session.id,
+            'operator:alice',
+            CLIENT_ID,
+            profile_id='dual_arm_profile_v1',
+        )
+        healthy = deepcopy(coordinator.public_session(confirmed.session)['driver'])
+        status_before = caller.count('status')
+        heartbeat_before = caller.count('heartbeat')
+        heartbeat_task = coordinator._heartbeat_tasks[confirmed.session.id]
+        _pin_injected_live_target(
+            coordinator,
+            record,
+            confirmed.session.id,
+            confirmed.session.capability_digest,
+        )
+        caller.latch_live_fault()
+        caller.queue(
+            'heartbeat',
+            mcp_client.TrustedShadowTransportError(
+                'rpc_error',
+                rpc_code=-32602,
+                rpc_data_code='session_inactive',
+            ),
+        )
+        caller.queue(
+            'status',
+            mcp_client.TrustedShadowTransportError('timeout'),
+        )
+
+        # ``faulted`` publishes Core's local revoke immediately; the background
+        # heartbeat task remains the completion signal for remote safety cleanup.
+        await asyncio.wait_for(asyncio.shield(heartbeat_task), timeout=1.0)
+
+        public = coordinator.public_session(confirmed.session)
+        assert caller.count('heartbeat') == heartbeat_before + 1
+        assert caller.count('status') == status_before + 1
+        assert caller.count('soft_stop') == 1
+        assert caller.count('release') == 1
+        assert public['state'] == 'faulted'
+        assert public['driver'] == healthy
+        assert public['driver']['dispatch']['fault_code'] is None
+        assert public['driver_heartbeat']['state'] == 'faulted'
+        assert authority_guard.get_guard(record['id']) is not None
+        await coordinator.stop()
+
+    asyncio.run(scenario())
+
+
+def test_confirm_live_rejects_wrong_profile_and_tab_without_driver_contact(
+    shadow_session_tool,
+):
+    async def scenario():
+        record = _install_live(_live_tool(shadow_session_tool))
+        caller = _LiveCaller(record['id'])
+        coordinator = TeleopCoordinator(
+            session_manager=ShadowSessionManager(),
+            caller=caller,
+            command_broker=CommandBroker(),
+        )
+        acquired = await coordinator.acquire(
+            record['id'], 'operator:alice', CLIENT_ID, mode='live',
+        )
+        with pytest.raises(TeleopServiceError) as wrong_profile:
+            await coordinator.confirm_live(
+                acquired.session.id,
+                'operator:alice',
+                CLIENT_ID,
+                profile_id='different_profile',
+            )
+        assert wrong_profile.value.code == 'live_confirmation_mismatch'
+        with pytest.raises(Exception) as wrong_tab:
+            await coordinator.confirm_live(
+                acquired.session.id,
+                'operator:alice',
+                '68991413-d37a-4603-9f07-3e25219d6d96',
+                profile_id='dual_arm_profile_v1',
+            )
+        assert wrong_tab.type.__name__ == 'SessionClientMismatch'
+        assert caller.calls == []
+        await coordinator.release(
+            acquired.session.id,
+            'operator:alice',
+            CLIENT_ID,
+            owner=False,
+        )
+
+    asyncio.run(scenario())
+
+
+def test_waiting_live_blocks_every_driver_facing_operation(shadow_session_tool):
+    async def scenario():
+        record = _install_live(_live_tool(shadow_session_tool))
+        caller = _LiveCaller(record['id'])
+        coordinator = TeleopCoordinator(
+            session_manager=ShadowSessionManager(),
+            caller=caller,
+            command_broker=CommandBroker(),
+        )
+        acquired = await coordinator.acquire(
+            record['id'], 'operator:alice', CLIENT_ID, mode='live',
+        )
+        operations = (
+            coordinator.heartbeat(
+                acquired.session.id, 'operator:alice', CLIENT_ID,
+            ),
+            coordinator.status(
+                acquired.session.id, 'operator:alice', owner=False,
+            ),
+            coordinator.signaling_offer(
+                acquired.session.id,
+                'operator:alice',
+                CLIENT_ID,
+                {'type': 'offer', 'sdp': 'v=0'},
+            ),
+            coordinator.pause(
+                acquired.session.id,
+                'operator:alice',
+                CLIENT_ID,
+                owner=False,
+            ),
+            coordinator.soft_stop(
+                acquired.session.id,
+                'operator:alice',
+                CLIENT_ID,
+                owner=False,
+            ),
+        )
+        for operation in operations:
+            with pytest.raises(SessionStateConflict):
+                await operation
+        assert caller.calls == []
+        await coordinator.release(
+            acquired.session.id,
+            'operator:alice',
+            CLIENT_ID,
+            owner=False,
+        )
+
+    asyncio.run(scenario())
+
+
+def test_unconfirmed_live_expiry_never_contacts_driver(shadow_session_tool):
+    async def scenario():
+        record = _install_live(_live_tool(shadow_session_tool))
+        caller = _LiveCaller(record['id'])
+        broker = CommandBroker()
+        manager = ShadowSessionManager()
+        coordinator = TeleopCoordinator(
+            session_manager=manager,
+            caller=caller,
+            command_broker=broker,
+        )
+        acquired = await coordinator.acquire(
+            record['id'], 'operator:alice', CLIENT_ID, mode='live',
+        )
+        acquired.session.deadline_monotonic = 0.0
+        expired = await manager.expire_due()
+        assert expired == [acquired.session]
+        await coordinator._complete_expiry_cleanup(
+            acquired.session,
+            origin_task=asyncio.current_task(),
+        )
+        assert caller.calls == []
+        assert await broker.authority_for(record['id']) is None
+
+    asyncio.run(scenario())
+
+
+def test_live_guard_failure_releases_memory_authority_without_driver_prepare(
+    shadow_session_tool,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    async def scenario():
+        record = _install_live(_live_tool(shadow_session_tool))
+        caller = _LiveCaller(record['id'])
+        broker = CommandBroker()
+        coordinator = TeleopCoordinator(
+            session_manager=ShadowSessionManager(),
+            caller=caller,
+            command_broker=broker,
+        )
+        acquired = await coordinator.acquire(
+            record['id'], 'operator:alice', CLIENT_ID, mode='live',
+        )
+
+        def reject_guard(_guard):
+            raise OSError('simulated durable guard failure')
+
+        monkeypatch.setattr(authority_guard, 'create_guard', reject_guard)
+        with pytest.raises(TeleopServiceError) as raised:
+            await coordinator.confirm_live(
+                acquired.session.id,
+                'operator:alice',
+                CLIENT_ID,
+                profile_id='dual_arm_profile_v1',
+            )
+        assert raised.value.code == 'authority_guard_persistence_error'
+        assert caller.count('status') == 1
+        assert caller.count('prepare_live') == 0
+        assert acquired.session.state == 'faulted'
+        assert await broker.authority_for(record['id']) is None
+        assert coordinator.list_authority_guards() == []
+        assert authority_guard.get_guard(record['id']) is None
+        assert record['id'] not in coordinator._authority_guards
+        await coordinator.stop()
+
+    asyncio.run(scenario())
+
+
+def test_cancelled_live_status_keeps_confirmation_pending_and_driver_unarmed(
+    shadow_session_tool,
+):
+    async def scenario():
+        record = _install_live(_live_tool(shadow_session_tool))
+        caller = _LiveCaller(record['id'])
+        broker = CommandBroker()
+        coordinator = TeleopCoordinator(
+            session_manager=ShadowSessionManager(),
+            caller=caller,
+            command_broker=broker,
+        )
+        acquired = await coordinator.acquire(
+            record['id'], 'operator:alice', CLIENT_ID, mode='live',
+        )
+        status_started = asyncio.Event()
+
+        async def slow_status(_producer, _arguments):
+            status_started.set()
+            await asyncio.Event().wait()
+
+        caller.queue('status', slow_status)
+        confirmation = asyncio.create_task(coordinator.confirm_live(
+            acquired.session.id,
+            'operator:alice',
+            CLIENT_ID,
+            profile_id='dual_arm_profile_v1',
+        ))
+        await asyncio.wait_for(status_started.wait(), timeout=0.8)
+        confirmation.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await confirmation
+
+        assert acquired.session.state == 'awaiting_confirmation'
+        assert acquired.session.live_confirmed is False
+        assert acquired.session.epoch == 0
+        assert caller.count('prepare_live') == 0
+        assert authority_guard.get_guard(record['id']) is None
+        claim = await broker.authority_for(record['id'])
+        assert claim is not None and claim.state == 'awaiting_confirmation'
+        await coordinator.release(
+            acquired.session.id,
+            'operator:alice',
+            CLIENT_ID,
+            owner=False,
+        )
+        assert await broker.authority_for(record['id']) is None
+        await coordinator.stop()
+
+    asyncio.run(scenario())
+
+
+def test_cancel_after_live_identity_commit_abandons_reservation_without_prepare(
+    shadow_session_tool,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    async def scenario():
+        record = _install_live(_live_tool(shadow_session_tool))
+        caller = _LiveCaller(record['id'])
+        broker = CommandBroker()
+        manager = ShadowSessionManager()
+        coordinator = TeleopCoordinator(
+            session_manager=manager,
+            caller=caller,
+            command_broker=broker,
+        )
+        acquired = await coordinator.acquire(
+            record['id'], 'operator:alice', CLIENT_ID, mode='live',
+        )
+        original = manager.confirm_live_identity
+
+        async def commit_then_cancel(*args, **kwargs):
+            await original(*args, **kwargs)
+            raise asyncio.CancelledError
+
+        monkeypatch.setattr(manager, 'confirm_live_identity', commit_then_cancel)
+        with pytest.raises(asyncio.CancelledError):
+            await coordinator.confirm_live(
+                acquired.session.id,
+                'operator:alice',
+                CLIENT_ID,
+                profile_id='dual_arm_profile_v1',
+            )
+
+        assert acquired.session.live_confirmed is True
+        assert acquired.session.state == 'faulted'
+        assert caller.count('status') == 1
+        assert caller.count('prepare_live') == 0
+        assert await broker.authority_for(record['id']) is None
+        assert authority_guard.get_guard(record['id']) is None
+        assert coordinator._command_claims == {}
+        await coordinator.stop()
+
+    asyncio.run(scenario())
+
+
+def test_cancel_after_live_guard_commit_discards_guard_without_driver_prepare(
+    shadow_session_tool,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    async def scenario():
+        record = _install_live(_live_tool(shadow_session_tool))
+        caller = _LiveCaller(record['id'])
+        broker = CommandBroker()
+        coordinator = TeleopCoordinator(
+            session_manager=ShadowSessionManager(),
+            caller=caller,
+            command_broker=broker,
+        )
+        acquired = await coordinator.acquire(
+            record['id'], 'operator:alice', CLIENT_ID, mode='live',
+        )
+        guard_started = threading.Event()
+        allow_guard = threading.Event()
+        original = authority_guard.create_guard
+
+        def commit_guard_then_wait(guard):
+            created = original(guard)
+            guard_started.set()
+            assert allow_guard.wait(timeout=2.0)
+            return created
+
+        monkeypatch.setattr(authority_guard, 'create_guard', commit_guard_then_wait)
+        confirmation = asyncio.create_task(coordinator.confirm_live(
+            acquired.session.id,
+            'operator:alice',
+            CLIENT_ID,
+            profile_id='dual_arm_profile_v1',
+        ))
+        await asyncio.wait_for(
+            asyncio.to_thread(guard_started.wait, 0.8),
+            timeout=1.0,
+        )
+        confirmation.cancel()
+        allow_guard.set()
+        with pytest.raises(asyncio.CancelledError):
+            await confirmation
+
+        assert acquired.session.state == 'faulted'
+        assert caller.count('prepare_live') == 0
+        assert authority_guard.get_guard(record['id']) is None
+        assert record['id'] not in coordinator._authority_guards
+        assert await broker.authority_for(record['id']) is None
+        await coordinator.stop()
+
+    asyncio.run(scenario())
+
+
+def test_cancel_after_live_prepare_applies_revokes_driver_and_guard(
+    shadow_session_tool,
+):
+    async def scenario():
+        record = _install_live(_live_tool(shadow_session_tool))
+        caller = _LiveCaller(record['id'])
+        broker = CommandBroker()
+        coordinator = TeleopCoordinator(
+            session_manager=ShadowSessionManager(),
+            caller=caller,
+            command_broker=broker,
+        )
+        acquired = await coordinator.acquire(
+            record['id'], 'operator:alice', CLIENT_ID, mode='live',
+        )
+        prepare_applied = asyncio.Event()
+
+        async def apply_then_wait(producer, arguments):
+            assert arguments is not None
+            producer.session_id = arguments['session_id']
+            producer.epoch = arguments['epoch']
+            producer.fence = arguments['fence']
+            producer.state = 'prepared_live'
+            producer.authority_valid = True
+            producer.dispatch_generation += 1
+            prepare_applied.set()
+            await asyncio.Event().wait()
+
+        caller.queue('prepare_live', apply_then_wait)
+        confirmation = asyncio.create_task(coordinator.confirm_live(
+            acquired.session.id,
+            'operator:alice',
+            CLIENT_ID,
+            profile_id='dual_arm_profile_v1',
+        ))
+        await asyncio.wait_for(prepare_applied.wait(), timeout=0.8)
+        confirmation.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await confirmation
+
+        assert acquired.session.state == 'faulted'
+        assert caller.count('prepare_live') == 1
+        assert caller.count('release') == 1
+        assert caller.authority_valid is False
+        assert caller.session_id is None
+        assert authority_guard.get_guard(record['id']) is None
+        assert record['id'] not in coordinator._authority_guards
+        assert await broker.authority_for(record['id']) is None
+        await coordinator.stop()
+
+    asyncio.run(scenario())

--- a/agent-core/tests/teleop/test_session_manager.py
+++ b/agent-core/tests/teleop/test_session_manager.py
@@ -1,0 +1,456 @@
+from __future__ import annotations
+
+import asyncio
+import math
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import fields
+
+import pytest
+
+from teleop.models import _public_value
+from teleop.session_manager import (
+    MAX_DRIVER_EPOCH,
+    EpochExhausted,
+    SessionNotFound,
+    SessionStateConflict,
+    ShadowSessionManager,
+)
+
+CLIENT_ID = '7dbabfca-15c1-43ca-b600-75e7682c21d0'
+OTHER_CLIENT_ID = '68991413-d37a-4603-9f07-3e25219d6d96'
+
+
+class MutableClock:
+    def __init__(self, *, monotonic: float = 100.0, wall: float = 1_000.0):
+        self.monotonic = monotonic
+        self.wall = wall
+
+    def monotonic_now(self) -> float:
+        return self.monotonic
+
+    def wall_now(self) -> float:
+        return self.wall
+
+
+def make_manager(clock: MutableClock | None = None) -> ShadowSessionManager:
+    clock = clock or MutableClock()
+    return ShadowSessionManager(
+        monotonic=clock.monotonic_now,
+        wall_clock=clock.wall_now,
+    )
+
+
+async def reserve(
+    manager: ShadowSessionManager,
+    *,
+    robot_id: str = 'robot-1',
+    driver_id: str = 'driver-1',
+    lease_seconds: float = 15.0,
+    minimum_epoch: int = 1,
+):
+    return await manager.reserve(
+        robot_id,
+        'alice',
+        driver_id=driver_id,
+        boot_id='driver-boot-1',
+        capability_digest='a' * 64,
+        client_id=CLIENT_ID,
+        lease_seconds=lease_seconds,
+        minimum_epoch=minimum_epoch,
+    )
+
+
+def test_shadow_session_repr_and_public_snapshot_never_expose_fence():
+    async def scenario():
+        manager = make_manager()
+        session = await reserve(manager)
+
+        assert next(item for item in fields(session) if item.name == 'fence').repr is False
+        assert session.fence not in repr(session)
+        assert 'fence' not in repr(session).lower()
+
+        public = manager.public_dict(session)
+        assert session.fence not in repr(public)
+        assert 'fence' not in repr(public).lower()
+        assert 'token' not in repr(public).lower()
+        assert public['boot_id'] == 'driver-boot-1'
+        assert public['epoch'] == 1
+        assert public['capability_digest'] == 'a' * 64
+        assert public['configured_dry_run_profile'] == 'recording'
+        assert public['operation'] == {'generation': 1, 'state': 'pending'}
+
+    asyncio.run(scenario())
+
+
+def test_session_pins_adapter_neutral_profile_and_limits_legacy_alias():
+    async def scenario():
+        manager = make_manager()
+        session = await manager.reserve(
+            'arm-robot',
+            'alice',
+            driver_id='arm-teleop',
+            boot_id='arm-boot',
+            capability_digest='b' * 64,
+            client_id=CLIENT_ID,
+            profile_id='dual_arm_profile_v1',
+        )
+        assert session.profile_id == 'dual_arm_profile_v1'
+        assert manager.public_dict(session)['profile_id'] == 'dual_arm_profile_v1'
+
+        with pytest.raises(ValueError, match='dry_run_profile'):
+            await manager.reserve(
+                'live-robot',
+                'alice',
+                driver_id='live-driver',
+                boot_id='live-boot',
+                capability_digest='c' * 64,
+                client_id=CLIENT_ID,
+                dry_run_profile='vendor_live_profile',
+            )
+
+        with pytest.raises(ValueError, match='profile_id'):
+            await manager.reserve(
+                'malformed-robot',
+                'alice',
+                driver_id='malformed-driver',
+                boot_id='malformed-boot',
+                capability_digest='d' * 64,
+                client_id=CLIENT_ID,
+                profile_id=['malformed_profile'],
+            )
+
+    asyncio.run(scenario())
+
+
+def test_public_snapshot_sanitizer_recursively_removes_secret_shaped_keys():
+    sanitized = _public_value({
+        'safe': {
+            'items': [
+                {
+                    'fence': 'hidden',
+                    'accessToken': 'hidden',
+                    'private_key': 'hidden',
+                    'state': 'active',
+                },
+            ],
+        },
+    })
+    assert sanitized == {'safe': {'items': [{'state': 'active'}]}}
+
+
+def test_monotonic_deadline_survives_wall_clock_rollback():
+    async def scenario():
+        clock = MutableClock()
+        manager = make_manager(clock)
+        session = await reserve(manager, lease_seconds=15)
+        await manager.activate(session.id, session.operation_generation)
+
+        clock.monotonic += 10
+        clock.wall = 10  # wall clock rolled back by much more than the lease
+        public = manager.public_dict(session)
+        assert public['remaining_seconds'] == 5
+        assert public['expires_at'] == 15
+        assert await manager.active_for_robot('robot-1') is session
+
+        clock.monotonic += 5.001
+        clock.wall = -50_000
+        assert await manager.active_for_robot('robot-1') is None
+        assert session.state == 'expired'
+        assert session.operation_state == 'expired'
+
+    asyncio.run(scenario())
+
+
+@pytest.mark.parametrize(
+    ('requested', 'expected'),
+    [
+        (0, 15.0),
+        (-100, 15.0),
+        (5, 15.0),
+        (15, 15.0),
+        (120, 120.0),
+        (999, 120.0),
+        (math.nan, 15.0),
+        (math.inf, 15.0),
+    ],
+)
+def test_ownership_lease_is_bounded(requested, expected):
+    async def scenario():
+        session = await reserve(make_manager(), lease_seconds=requested)
+        assert session.lease_seconds == expected
+
+    asyncio.run(scenario())
+
+
+def test_driver_epoch_persists_across_manager_instances_and_is_per_driver():
+    async def scenario():
+        first = await reserve(make_manager(), robot_id='r1', driver_id='driver-a')
+        after_restart = await reserve(
+            make_manager(),
+            robot_id='r2',
+            driver_id='driver-a',
+        )
+        independent = await reserve(
+            make_manager(),
+            robot_id='r3',
+            driver_id='driver-b',
+        )
+        assert (first.epoch, after_restart.epoch, independent.epoch) == (1, 2, 1)
+
+    asyncio.run(scenario())
+
+
+def test_driver_reported_epoch_sets_a_persisted_allocation_floor():
+    async def scenario():
+        recovered = await reserve(
+            make_manager(),
+            robot_id='r1',
+            driver_id='driver-a',
+            minimum_epoch=42,
+        )
+        next_session = await reserve(
+            make_manager(),
+            robot_id='r2',
+            driver_id='driver-a',
+            minimum_epoch=3,
+        )
+        raised_again = await reserve(
+            make_manager(),
+            robot_id='r3',
+            driver_id='driver-a',
+            minimum_epoch=100,
+        )
+        assert (recovered.epoch, next_session.epoch, raised_again.epoch) == (42, 43, 100)
+
+    asyncio.run(scenario())
+
+
+def test_driver_epoch_exhaustion_is_detected_before_sqlite_overflow():
+    async def scenario():
+        final = await reserve(
+            make_manager(),
+            robot_id='last-safe-robot',
+            driver_id='exhausted-driver',
+            minimum_epoch=MAX_DRIVER_EPOCH,
+        )
+        assert final.epoch == MAX_DRIVER_EPOCH
+
+        with pytest.raises(EpochExhausted):
+            await reserve(
+                make_manager(),
+                robot_id='must-not-wrap',
+                driver_id='exhausted-driver',
+            )
+
+        with pytest.raises(EpochExhausted):
+            await reserve(
+                make_manager(),
+                robot_id='out-of-range-floor',
+                driver_id='fresh-driver',
+                minimum_epoch=MAX_DRIVER_EPOCH + 1,
+            )
+
+    asyncio.run(scenario())
+
+
+def test_driver_epoch_allocation_is_atomic_across_concurrent_managers():
+    def reserve_in_thread(index: int) -> int:
+        async def scenario():
+            session = await reserve(
+                make_manager(),
+                robot_id=f'robot-{index}',
+                driver_id='shared-driver',
+            )
+            return session.epoch
+
+        return asyncio.run(scenario())
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        epochs = list(pool.map(reserve_in_thread, range(12)))
+
+    assert sorted(epochs) == list(range(1, 13))
+
+
+def test_terminal_session_history_is_bounded():
+    async def scenario():
+        manager = make_manager()
+        sessions = []
+        for index in range(300):
+            session = await reserve(
+                manager,
+                robot_id=f'robot-{index}',
+                driver_id='history-driver',
+            )
+            await manager.release(
+                session.id,
+                'alice',
+                CLIENT_ID,
+            )
+            sessions.append(session)
+
+        retained = await manager.retained_session_ids()
+        assert len(retained) == 256
+        assert sessions[0].id not in retained
+        assert await manager.get(sessions[0].id) is None
+        assert sessions[-1].id in retained
+        assert await manager.get(sessions[-1].id) is sessions[-1]
+
+    asyncio.run(scenario())
+
+
+def test_delayed_prepare_failure_cannot_fault_an_activated_session():
+    async def scenario():
+        manager = make_manager()
+        session = await reserve(manager)
+        generation = session.operation_generation
+        await manager.activate(session.id, generation)
+
+        assert await manager.fail_reservation(session.id, generation) is None
+        assert session.state == 'active'
+        assert session.operation_state == 'succeeded'
+        assert await manager.active_for_robot(session.robot_id) is session
+
+    asyncio.run(scenario())
+
+
+def test_heartbeat_worker_fault_is_generation_guarded_and_conditionally_unbinds():
+    async def scenario():
+        manager = make_manager()
+        session = await reserve(manager)
+        await manager.activate(session.id, session.operation_generation)
+
+        assert await manager.fault(session.id, session.operation_generation + 1) is None
+        assert await manager.get_current(session.id) is session
+        assert await manager.authorize(session.id, 'alice') is session
+
+        faulted = await manager.fault(session.id, session.operation_generation)
+        assert faulted is session
+        assert session.state == 'faulted'
+        assert session.operation_state == 'failed'
+        assert await manager.get_current(session.id) is None
+        assert await manager.active_for_robot(session.robot_id) is None
+        assert await manager.get_authorized(
+            session.id,
+            'alice',
+            include_terminal=True,
+        ) is session
+
+    asyncio.run(scenario())
+
+
+def test_old_async_failure_and_completion_cannot_clear_or_revive_replacement():
+    async def scenario():
+        clock = MutableClock()
+        manager = make_manager(clock)
+        old = await reserve(manager, lease_seconds=15)
+        old_generation = old.operation_generation
+        await manager.release(old.id, 'alice', CLIENT_ID)
+
+        replacement = await reserve(manager, lease_seconds=120)
+        assert replacement.operation_generation > old_generation
+
+        assert await manager.fail_reservation(old.id, old_generation) is None
+        with pytest.raises(SessionStateConflict):
+            await manager.activate(old.id, old_generation)
+        with pytest.raises(SessionNotFound):
+            await manager.release(old.id, 'alice', CLIENT_ID)
+        assert await manager.active_for_robot('robot-1') is replacement
+
+        # Simulate stale mutation from an obsolete callback. Authority expiry
+        # scans only the live robot map, so obsolete history is ignored and can
+        # neither consume watchdog time nor unbind the replacement.
+        old.state = 'active'
+        old.operation_state = 'succeeded'
+        clock.monotonic += 16
+        expired = await manager.expire_due()
+        assert expired == []
+        assert await manager.active_for_robot('robot-1') is replacement
+
+    asyncio.run(scenario())
+
+
+def test_activate_rejects_expired_released_and_nonpreparing_sessions():
+    async def scenario():
+        clock = MutableClock()
+        manager = make_manager(clock)
+
+        active = await reserve(manager, robot_id='active')
+        await manager.activate(active.id, active.operation_generation)
+        with pytest.raises(SessionStateConflict):
+            await manager.activate(active.id, active.operation_generation)
+
+        released = await reserve(manager, robot_id='released')
+        await manager.release(released.id, 'alice', CLIENT_ID)
+        with pytest.raises(SessionStateConflict):
+            await manager.activate(released.id, released.operation_generation)
+
+        expiring = await reserve(manager, robot_id='expired', lease_seconds=15)
+        clock.monotonic += 16
+        with pytest.raises(SessionStateConflict):
+            await manager.activate(expiring.id, expiring.operation_generation)
+
+    asyncio.run(scenario())
+
+
+def test_heartbeat_renews_only_live_owned_session_using_monotonic_time():
+    async def scenario():
+        clock = MutableClock()
+        manager = make_manager(clock)
+        session = await reserve(manager, lease_seconds=15)
+        with pytest.raises(SessionStateConflict):
+            await manager.heartbeat(session.id, 'alice', CLIENT_ID)
+
+        await manager.activate(session.id, session.operation_generation)
+        clock.monotonic += 14
+        clock.wall -= 100_000
+        await manager.heartbeat(session.id, 'alice', CLIENT_ID)
+        assert session.deadline_monotonic == 129
+
+        clock.monotonic = 128.9
+        assert await manager.active_for_robot(session.robot_id) is session
+        clock.monotonic = 129.1
+        assert await manager.active_for_robot(session.robot_id) is None
+
+    asyncio.run(scenario())
+
+
+def test_soft_stop_exposes_idempotent_hold_that_can_heartbeat_and_pause():
+    async def scenario():
+        clock = MutableClock()
+        manager = make_manager(clock)
+        session = await reserve(manager, lease_seconds=15)
+        await manager.activate(session.id, session.operation_generation)
+
+        assert await manager.soft_stop(session.id, 'alice', CLIENT_ID) is session
+        assert session.state == 'hold'
+        assert manager.public_dict(session)['state'] == 'hold'
+        assert await manager.soft_stop(session.id, 'alice', CLIENT_ID) is session
+
+        clock.monotonic += 4
+        await manager.heartbeat(session.id, 'alice', CLIENT_ID)
+        assert session.deadline_monotonic == 119
+        assert await manager.pause(session.id, 'alice', CLIENT_ID) is session
+        assert session.state == 'paused'
+
+    asyncio.run(scenario())
+
+
+def test_expiry_detected_by_read_is_drained_exactly_once_for_notifications():
+    async def scenario():
+        clock = MutableClock()
+        manager = make_manager(clock)
+        session = await reserve(manager, lease_seconds=5)
+        await manager.activate(session.id, session.operation_generation)
+
+        clock.monotonic += 16
+        # A status/read path notices expiry before the periodic worker.
+        assert await manager.get_current(session.id) is None
+        assert session.state == 'expired'
+
+        # The worker still receives it once for Driver cleanup and audit.
+        assert await manager.expire_due() == [session]
+        assert await manager.expire_due() == []
+        assert await manager.get(session.id) is session
+        assert await manager.expire_due() == []
+
+    asyncio.run(scenario())

--- a/agent-core/tests/teleop/test_static_page.py
+++ b/agent-core/tests/teleop/test_static_page.py
@@ -1,0 +1,606 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+WEB = Path(__file__).resolve().parents[2] / 'web'
+
+
+def _function_source(javascript: str, name: str) -> str:
+    match = re.search(
+        rf'^(?:async )?function {re.escape(name)}\([^)]*\) \{{.*?^\}}',
+        javascript,
+        flags=re.MULTILINE | re.DOTALL,
+    )
+    assert match, f'missing JavaScript function: {name}'
+    return match.group(0)
+
+
+def test_teleop_page_is_a_visible_adapter_neutral_session_console():
+    html = (WEB / 'teleop.html').read_text(encoding='utf-8')
+    javascript = (WEB / 'js' / 'teleop' / 'app.js').read_text(encoding='utf-8')
+    webxr = (WEB / 'js' / 'teleop' / 'webxr-frame.js').read_text(encoding='utf-8')
+    css = (WEB / 'css' / 'teleop.css').read_text(encoding='utf-8')
+
+    assert "api('/api/teleop/me')" in javascript
+    assert "api('/api/teleop/robots')" in javascript
+    assert "api('/api/teleop/sessions'," in javascript
+    assert '/heartbeat`' in javascript
+    assert '/events?limit=12`' in javascript
+    assert '/driver-status' not in javascript
+    assert "method: 'POST'" in javascript
+    assert "method: 'DELETE'" in javascript
+    assert 'keepalive: true' in javascript
+    assert 'WebSocket' not in javascript
+    assert '/call' not in javascript
+    assert '/api/mcp' not in javascript
+
+    button_ids = set(re.findall(r'<button[^>]+id="([^"]+)"', html))
+    assert button_ids == {
+        'capture-attach-button',
+        'capture-pair-button',
+        'capture-refresh-button',
+        'capture-revoke-button',
+        'logout-button',
+        'refresh-button',
+    }
+    assert '<form id="login-form">' in html
+    assert '通用遥操作控制台' in html
+    assert 'Shadow 只记录；Live 必须二次明确确认硬件输出' in html
+    assert '第一次 Acquire 只创建短期内存 reservation' in html
+    assert '不会调用 Driver、续租或开放 RTC' in html
+    assert '必须再次点击醒目的 Live 确认按钮' in html
+    assert '等待 Live 确认时不会写这把锁' in html
+    assert 'Pause 仍占用机器人' in html
+    assert '恢复必须先 Release，再重新 Acquire' in html
+    assert 'Core state=hold / Driver reason=soft_stop' in javascript
+    for reason in (
+            'deadman_released',
+            'command_timeout',
+            'intent_expired',
+        'pose_timeout',
+        'rtc_closed',
+        'rtc_disconnected',
+        'rtc_failed',
+        'rtc_not_ready',
+        'tracking_lost',
+    ):
+        assert f"'{reason}'" in javascript
+    assert 'RECOVERABLE_DRIVER_HOLD_REASONS.has(driverReason)' in javascript
+    assert '先松开再双握以产生更大的 clutch_sequence' in javascript
+    assert '每次页面加载都会生成独立 Client ID' in html
+    assert '避免复制标签页继承控制权' in html
+    assert '<code>local-floor</code>' in html
+    assert '能力声明的运动轴全部归入各自 deadzone' in html
+    assert '再空挡重握' in html
+    assert '不能预装首帧运动' in html
+    assert '未启用的 base 或 hands 不会出现在 frame 中' in html
+    assert '最终限幅和硬件适配仍由 Driver 负责' in html
+    assert '头显只显示诊断黑场' in html
+    assert '没有机器人视频，也没有头显内 HUD' in html
+    assert '2D 镜像页' in html
+    assert '绝不会自动确认 Live、自动恢复、自动重进 VR、自动重连或自动获取会话' in html
+    assert '重启后的普通执行器命令仍会被拒绝' in html
+    assert '旧会话始终不会恢复' in html
+    assert '验证安全并解除重启锁' in javascript
+    assert "action === 'reconcile-guard'" in javascript
+    assert (
+        '/api/teleop/authority-guards/${encodeURIComponent(robot.robot_id)}'
+        '/reconcile'
+    ) in javascript
+    assert '只有 owner 能验证安全停机并解除恢复锁' in javascript
+    assert 'id="webxr-support"' in html
+    assert 'id="teleop-client-id"' in html
+    for reason in (
+        'driver_transport_invalid',
+        'driver_runtime_not_trusted',
+        'driver_runtime_target_mismatch',
+    ):
+        assert reason in javascript
+    assert "driver_epoch_exhausted: 'Driver 防重放 epoch 已耗尽；Core 已拒绝创建新会话。'" in javascript
+    assert '.device-card.live-mode' in css
+    assert '.live-confirmation' in css
+    for vendor_term in ('unitree_go1_high_level', 'Go1', 'unitree'):
+        assert vendor_term not in html
+        assert vendor_term not in javascript
+        assert vendor_term not in webxr
+    assert 'dry-run' not in html.lower()
+    assert 'dry-run' not in javascript.lower()
+
+
+def test_teleop_console_locks_browser_lease_and_role_safety_contracts():
+    javascript = (WEB / 'js' / 'teleop' / 'app.js').read_text(encoding='utf-8')
+
+    assert 'const STATUS_POLL_MS = 1000;' in javascript
+    assert 'const CORE_HEARTBEAT_MS = 5000;' in javascript
+    assert 'window.setInterval(pollSessions, STATUS_POLL_MS)' in javascript
+    assert 'window.setInterval(renewOwnedSessions, CORE_HEARTBEAT_MS)' in javascript
+    assert 'robot.session.owned_by_client' in javascript
+    assert "principal.role === 'operator' || principal.role === 'owner'" in javascript
+    assert "if (!canControl()) return null;" in javascript
+    assert "makeActionButton('Pause'" in javascript
+    assert "makeActionButton('HOLD'" in javascript
+    assert "makeActionButton('Release'" in javascript
+    assert '`Acquire ${descriptorMode(robot).toUpperCase()}`' in javascript
+    assert javascript.count("api('/api/teleop/sessions',") == 1
+    assert "dataset.action = 'resume'" not in javascript.lower()
+    assert '此控制台没有 Resume' in javascript
+    assert '不会自动获取新会话' in javascript
+
+    renewal = _function_source(javascript, 'renewOwnedSessions')
+    release_targets = _function_source(javascript, 'ownedClientReleaseTargets')
+    assert 'owned_by_client' in renewal
+    assert 'owned_by_me' not in renewal
+    assert 'owned_by_client' in release_targets
+    assert 'owned_by_me' not in release_targets
+    assert 'RELEASABLE_SESSION_STATES.has(session.state)' in release_targets
+    assert "'awaiting_confirmation', 'preparing', 'active', 'paused', 'hold'" in javascript
+
+    action = _function_source(javascript, 'performAction')
+    assert 'body: JSON.stringify({ driver_id: robot.driver_id, mode })' in action
+    assert "action === 'confirm-live'" in action
+    assert '/confirm-live`' in action
+    assert 'confirm_live_actuation: true' in action
+    assert 'profile_id: session.profile_id' in action
+    assert "session.state !== 'awaiting_confirmation'" in action
+    assert 'robot.session?.owned_by_client' in action
+    assert action.index("action === 'confirm-live'") < action.index('closeRtcConnection(')
+
+
+def test_teleop_console_uses_per_tab_identity_and_bounded_single_flight_reads():
+    javascript = (WEB / 'js' / 'teleop' / 'app.js').read_text(encoding='utf-8')
+
+    assert 'sessionStorage.getItem' not in javascript
+    assert 'sessionStorage.setItem(CLIENT_ID_KEY, generated)' in javascript
+    assert 'crypto.randomUUID()' in javascript
+    assert 'CANONICAL_UUID.test(generated)' in javascript
+    assert 'return stored' not in javascript
+    assert "headers.set('X-Motus-Teleop-Client', TELEOP_CLIENT_ID)" in javascript
+    assert "headers: { 'X-Motus-Teleop-Client': TELEOP_CLIENT_ID }" in javascript
+
+    assert 'const REQUEST_TIMEOUT_MS = 4000;' in javascript
+    assert 'new AbortController()' in javascript
+    assert 'controller.abort()' in javascript
+    assert 'activeControllers.forEach((controller) => controller.abort())' in javascript
+    assert 'requestGeneration += 1' in javascript
+    assert 'generation !== requestGeneration' in javascript
+    assert 'directoryInFlight' in javascript
+    assert 'statusInFlight' in javascript
+    assert 'eventsInFlight' in javascript
+    assert 'heartbeatInFlight' in javascript
+
+    assert 'if (directoryInFlight ||' in _function_source(javascript, 'loadDevices')
+    assert 'statusInFlight ||' in _function_source(javascript, 'pollSessions')
+    assert 'heartbeatInFlight' in _function_source(javascript, 'renewOwnedSessions')
+
+    status_read = _function_source(javascript, 'pollOneSession')
+    assert status_read.count('await api(') == 1
+    assert '/heartbeat' not in status_read
+    assert '/events' not in status_read
+    assert '/driver-status' not in status_read
+
+    action = _function_source(javascript, 'performAction')
+    assert action.index('invalidateApiRequests()') < action.index('await api(')
+    assert 'actionInFlight' in action
+
+    timeout_ms = int(re.search(r'REQUEST_TIMEOUT_MS = (\d+);', javascript).group(1))
+    heartbeat_ms = int(re.search(r'CORE_HEARTBEAT_MS = (\d+);', javascript).group(1))
+    assert timeout_ms < heartbeat_ms
+    assert (2 * heartbeat_ms) + timeout_ms < 15_000
+
+
+def test_teleop_console_negotiates_visible_peer_bound_webrtc_without_secrets():
+    javascript = (WEB / 'js' / 'teleop' / 'app.js').read_text(encoding='utf-8')
+    connect = _function_source(javascript, 'connectRtc')
+
+    assert '`Direct WebXR fallback：连接 RTC ${descriptorMode(robot)}`' in javascript
+    assert '断开 Direct RTC（进入 HOLD）' in javascript
+    assert '进入 Quest VR' in javascript
+    assert "new RTCPeerConnection()" in connect
+    assert "createDataChannel('teleop-control', { ordered: true })" in connect
+    assert "createDataChannel('teleop-pose', {" in connect
+    assert 'ordered: false' in connect
+    assert 'maxRetransmits: 0' in connect
+    assert connect.index("createDataChannel('teleop-control'") < connect.index('createOffer()')
+    assert connect.index("createDataChannel('teleop-pose'") < connect.index('createOffer()')
+    assert 'waitForIceGatheringComplete(peer)' in connect
+    assert '/signaling/offer`' in connect
+    assert "JSON.stringify({ type: 'offer', sdp: local.sdp })" in connect
+    assert 'timeoutMs: RTC_SIGNAL_TIMEOUT_MS' in connect
+    assert 'peer.setRemoteDescription(answer)' in connect
+    ping = _function_source(javascript, 'sendPeerPing')
+    pong = _function_source(javascript, 'recordPeerPong')
+    assert "type: 'peer_ping'" in ping
+    assert 'performance.now()' in ping
+    assert 'performance.now() - startedAt' in pong
+    assert 'Date.now()' not in ping
+    assert 'Date.now()' not in pong
+    assert 'startPeerPings(sessionId, peer, control' in connect
+    assert 'lease_renewed' not in ping
+    assert 'lease_renewed' not in pong
+    assert 'poseChannel.send(payload)' in javascript
+    assert "robot.session?.owned_by_client" in connect
+    active_owner = _function_source(javascript, 'ownedActiveRobotSession')
+    assert "session?.state === 'active'" in active_owner
+    assert "session.mode !== 'live' || session.live_confirmed === true" in active_owner
+    assert "sessionState !== 'active'" in javascript
+    assert 'ticket' not in connect
+    assert 'fence' not in connect
+    assert 'driver_id' not in connect
+    assert 'WebSocket' not in javascript
+    assert 'ownedActiveRobotSession(robotId, sessionId)' in connect
+    assert 'captureAssignmentForSession(captures, sessionId) !== null' in connect
+
+
+def test_capture_panel_is_manual_pc_owned_and_keeps_direct_webxr_as_fallback():
+    html = (WEB / 'teleop.html').read_text(encoding='utf-8')
+    javascript = (WEB / 'js' / 'teleop' / 'app.js').read_text(encoding='utf-8')
+    capture_module = (
+        WEB / 'js' / 'teleop' / 'capture-console.js'
+    ).read_text(encoding='utf-8')
+
+    for element_id in (
+        'capture-panel',
+        'capture-pair-button',
+        'capture-refresh-button',
+        'capture-device-select',
+        'capture-session-select',
+        'capture-attach-button',
+        'capture-revoke-button',
+        'capture-wss-url',
+        'capture-pairing-id',
+        'capture-pairing-code',
+        'capture-ca-base64',
+    ):
+        assert f'id="{element_id}"' in html
+
+    assert 'PC 标签页始终持有会话与硬件确认权' in html
+    assert 'OPENXR CAPTURE' in html
+    assert '独立 OpenXR 头显姿态采集设备' in html
+    assert 'OpenXR 头显 Capture 只接收当前会话的安全投影' in html
+    assert 'value="OpenXR Headset Capture"' in html
+    assert 'Pairing code 是短期一次性秘密' in html
+    assert '交给 OpenXR 头显 Capture' in html
+    assert '不要放入 URL、HTTP header、浏览器 console、日志或 shell 历史' in html
+    assert 'Direct WebXR fallback（显式同页模式）仍保留' in html
+    assert '再手动进入 Quest VR' in html
+    assert '页面不会静默切换' in html
+    for quest_only_capture_copy in (
+        'QUEST CAPTURE',
+        '独立 Quest 姿态采集设备',
+        'Quest 只接收当前会话的安全投影',
+        'value="Quest 3 Capture"',
+        '交给 Quest；',
+        '可安全提供给 Quest 的当前 TLS',
+        'Quest 尚未连接并进入 xr_standby',
+        'Quest Capture 或 RTC frame',
+        'Quest 信令失败',
+        '已配对的 Quest Capture',
+        '自动连接 Quest',
+        '等待 Quest 一次 SDP offer',
+    ):
+        assert quest_only_capture_copy not in html
+        assert quest_only_capture_copy not in javascript
+    for openxr_capture_copy in (
+        '可安全提供给 OpenXR 头显 Capture 的当前 TLS',
+        'OpenXR 头显 Capture 尚未连接并进入 xr_standby',
+        'OpenXR 头显 Capture 或 RTC frame',
+        'OpenXR 头显 Capture 信令失败',
+        '已配对的 OpenXR 头显 Capture',
+        '不会自动连接 OpenXR 头显 Capture',
+        '等待 OpenXR 头显 Capture 的一次 SDP offer',
+    ):
+        assert openxr_capture_copy in javascript
+    assert "api('/api/teleop/capture-pairings'" in javascript
+    assert "api('/api/teleop/captures')" in javascript
+    assert '/capture-attachment`' in javascript
+    assert "method: 'DELETE'" in _function_source(javascript, 'revokeSelectedCapture')
+    attach = _function_source(javascript, 'attachSelectedCapture')
+    assert 'captureAttachEligibility(session, capture)' in attach
+    assert 'capture_id: capture.id' in attach
+    assert 'mode: session.mode' in attach
+    assert 'profile_id: session.profile_id' in attach
+    assert 'capability_digest: session.capability_digest' in attach
+    assert 'rtcInFlight.has(session.id)' in attach
+    assert 'capturePairing = captureBootstrapFields(pairing, window.location)' in javascript
+    assert 'localStorage' not in _function_source(javascript, 'createCapturePairing')
+    assert 'sessionStorage' not in _function_source(javascript, 'createCapturePairing')
+    assert 'console.' not in _function_source(javascript, 'copyCaptureBootstrapField')
+    assert 'wss://${host}/ws/teleop-capture' not in capture_module
+    assert 'wss://${host}${path}' in capture_module
+
+    # Read-only listing may refresh; authority-changing operations remain bound
+    # only to their explicit click handlers.
+    for automatic_source in (
+        _function_source(javascript, 'enterApp'),
+        _function_source(javascript, 'refreshSlowState'),
+    ):
+        assert 'createCapturePairing' not in automatic_source
+        assert 'attachSelectedCapture' not in automatic_source
+        assert 'confirm-live' not in automatic_source
+        assert 'connectRtc' not in automatic_source
+        assert 'requestImmersiveVr' not in automatic_source
+
+
+def test_quest_webxr_entry_sampling_and_fail_safe_contracts_are_visible():
+    html = (WEB / 'teleop.html').read_text(encoding='utf-8')
+    javascript = (WEB / 'js' / 'teleop' / 'app.js').read_text(encoding='utf-8')
+    request_vr = _function_source(javascript, 'requestImmersiveVr')
+    initialize = _function_source(javascript, 'initializeXrSession')
+    on_frame = _function_source(javascript, 'onXrFrame')
+    close_rtc = _function_source(javascript, 'closeRtcConnection')
+    connect = _function_source(javascript, 'connectRtc')
+
+    assert 'window.isSecureContext === true' in javascript
+    assert 'window.location.origin' in javascript
+    assert 'Boolean(navigator.xr)' in javascript
+    assert "navigator.xr.isSessionSupported('immersive-vr')" in javascript
+    assert 'Browser WebXR capability' in javascript
+    assert 'WebXR 能力' in html
+
+    # requestSession must remain in the direct click stack: no await can consume
+    # transient user activation before the immersive request.
+    assert request_vr.startswith('function requestImmersiveVr')
+    assert 'await ' not in request_vr
+    assert "navigator.xr.requestSession(" in request_vr
+    assert "'immersive-vr'" in request_vr
+    assert "{ requiredFeatures: ['local-floor'] }" in request_vr
+    assert request_vr.index('navigator.xr.requestSession(') < request_vr.index(
+        'xrSessions.set(sessionId, record)'
+    )
+    assert javascript.count('navigator.xr.requestSession(') == 1
+    entry_ready = _function_source(javascript, 'xrEntryReady')
+    assert 'ownedActiveRobotSession(robotId, sessionId)' in entry_ready
+    assert 'rtcReadyForXr(sessionId)' in entry_ready
+
+    assert 'gl.makeXRCompatible()' in initialize
+    assert "xrSession.requestReferenceSpace('local-floor')" in initialize
+    assert 'new XRWebGLLayer(xrSession, gl)' in initialize
+    assert "referenceSpace.addEventListener('reset'" in initialize
+    assert 'webxr_reference_space_reset' in initialize
+    assert "xrSession.addEventListener('end'" in initialize
+    assert "xrSession.addEventListener('visibilitychange'" in initialize
+
+    assert 'frame.getViewerPose(record.referenceSpace)' in on_frame
+    assert 'uniqueTrackedPointerGripSources(record.session)' in on_frame
+    assert 'frame.getPose(sources.left.gripSpace, record.referenceSpace)' in on_frame
+    assert 'frame.getPose(sources.right.gripSpace, record.referenceSpace)' in on_frame
+    assert 'poseIsActuallyTracked(viewerPose)' in on_frame
+    assert 'pose.emulatedPosition === true ? null : pose' in javascript
+    assert 'isDualSqueezeDeadmanRequested(sources.left, sources.right)' in on_frame
+    assert 'joystick' not in javascript.lower()
+
+    assert 'const XR_NORMAL_SEND_HZ = 60;' in javascript
+    assert 'const POSE_MESSAGE_LIMIT_BYTES = 64 * 1024;' in javascript
+    assert 'const POSE_BUFFER_HIGH_WATER_BYTES = 16 * 1024;' in javascript
+    assert 'new TextEncoder().encode(payload).byteLength' in on_frame
+    assert 'poseChannel?.bufferedAmount' in on_frame
+    assert 'poseChannel.bufferedAmount' in on_frame
+    assert 'bufferedAmount + payloadBytes > POSE_BUFFER_HIGH_WATER_BYTES' in on_frame
+    assert 'poseChannel.send(payload)' in on_frame
+    assert 'bufferedamountlow' not in javascript.lower()
+    assert '&& !safetyTransition' in on_frame
+    assert on_frame.index('isTrackingOrDeadmanSafetyTransition') < on_frame.index(
+        'frameTimeMs < record.nextPoseAtMs'
+    )
+
+    assert 'markSessionFrameReleased(sessionId)' in close_rtc
+    assert 'stopXrSession(sessionId, reason)' in close_rtc
+    assert 'rtcFrameStates.delete' not in close_rtc
+    assert 'markRtcFrameDeadmanReleased' in javascript
+    assert '需松开后重握' in javascript
+    assert 'frameStateForSession(sessionId)' in on_frame
+    assert 'rtcFrameStates.set(sessionId, built.state)' in on_frame
+    assert 'record.frameConfiguration' in on_frame
+    assert 'session.mode === record.mode' in _function_source(
+        javascript, 'xrSessionContractMatches'
+    )
+    released = _function_source(javascript, 'markSessionFrameReleased')
+    assert "stats.baseTwist = '本地已归零；RTC/XR 不再发送'" in released
+
+    assert "['closed', 'disconnected', 'failed'].includes(peer.connectionState)" in connect
+    assert "control.addEventListener('close'" in connect
+    assert "pose.addEventListener('close'" in connect
+    assert "control.addEventListener('error'" in connect
+    assert "pose.addEventListener('error'" in connect
+    assert "document.visibilityState !== 'visible'" in on_frame
+    assert "record.session.visibilityState !== 'visible'" in on_frame
+    assert 'closeRtcConnection(' in _function_source(javascript, 'handleXrSessionEnded')
+
+    assert 'frameTimeMs >= record.nextCoreHeartbeatAtMs && !heartbeatInFlight' in on_frame
+    assert 'void renewOwnedSessions(true)' in on_frame
+    assert '/heartbeat' not in _function_source(javascript, 'connectRtc')
+
+    for label in (
+        'Driver pose.latest_sequence',
+        'Driver dispatch.last_decision',
+        'Driver hardware published sequence',
+        'Driver would-apply sequence',
+        'Safe-stop ACK',
+        'Driver fault code',
+        'Latency receive→admit',
+        'Latency mailbox',
+        'Latency IK',
+        'Latency adapter publish',
+        'Latency adapter projection',
+        'Latency next LowState feedback arrival',
+        'Output evidence profile',
+        'Output evidence hardware path',
+        'Output evidence state',
+        'Configured hardware output',
+        'Browser peer RTT（同钟）',
+        'WebXR tracking',
+        'Quest left input',
+        'Quest right input',
+        'WebXR deadman',
+        'WebXR optional base_twist',
+        'Pose frames',
+        'Pose transport',
+    ):
+        assert label in javascript
+    assert 'profiles ${profiles.length' in javascript
+    assert 'buttons ${buttonsLength}' in javascript
+
+
+def test_control_and_lifecycle_transitions_quiesce_locally_before_rest():
+    javascript = (WEB / 'js' / 'teleop' / 'app.js').read_text(encoding='utf-8')
+    action = _function_source(javascript, 'performAction')
+    action_rest = 'result = await api(`/api/teleop/sessions/${encodeURIComponent(sessionId)}${endpoint}`'
+    assert action.index('closeRtcConnection(') < action.index(action_rest)
+    assert 'REST 前已本地解除 deadman 并关闭 XR/RTC' in action
+
+    remember = _function_source(javascript, 'rememberSession')
+    assert "snapshot.state !== 'active'" in remember
+    assert 'closeRtcConnection(' in remember
+    enforce = _function_source(javascript, 'enforceInteractiveSessionSafety')
+    assert 'owned_by_client' in enforce
+    assert "session?.state !== 'active'" in enforce
+
+    visibility = re.search(
+        r"document\.addEventListener\('visibilitychange'.*?^\}\);",
+        javascript,
+        flags=re.MULTILINE | re.DOTALL,
+    )
+    assert visibility
+    assert "document.visibilityState !== 'visible'" in visibility.group(0)
+    assert 'closeAllRtcConnections(' in visibility.group(0)
+
+    # Capability probing and BFCache restoration never enter VR, reconnect RTC,
+    # or Acquire a new session.
+    probe = _function_source(javascript, 'probeWebxrSupport')
+    assert 'requestSession' not in probe
+    assert 'confirm-live' not in probe
+    assert "api('/api/teleop/sessions'," not in probe
+    pageshow = re.search(
+        r"window\.addEventListener\('pageshow'.*?^\}\);",
+        javascript,
+        flags=re.MULTILINE | re.DOTALL,
+    )
+    assert pageshow
+    assert 'requestImmersiveVr' not in pageshow.group(0)
+    assert 'connectRtc' not in pageshow.group(0)
+    assert 'confirm-live' not in pageshow.group(0)
+    assert "api('/api/teleop/sessions'," not in pageshow.group(0)
+    assert javascript.count('/confirm-live`') == 1
+
+    load = _function_source(javascript, 'loadDevices')
+    assert 'confirm-live' not in load
+    assert "api('/api/teleop/sessions'," not in load
+
+
+def test_logout_and_pagehide_release_only_this_tabs_sessions_before_reset():
+    javascript = (WEB / 'js' / 'teleop' / 'app.js').read_text(encoding='utf-8')
+
+    logout = re.search(
+        r"logoutButton\.addEventListener\('click', async \(\) => \{.*?^\}\);",
+        javascript,
+        flags=re.MULTILINE | re.DOTALL,
+    )
+    assert logout
+    logout_source = logout.group(0)
+    assert logout_source.index('closeAllRtcConnections(') < logout_source.index(
+        'releaseOwnedClientSessions()'
+    )
+    assert logout_source.index('releaseOwnedClientSessions()') < logout_source.index('clearToken()')
+    assert logout_source.index('clearToken()') < logout_source.index('resetConsoleData()')
+    assert 'waitForBestEffortRelease(releaseRequests)' in logout_source
+
+    pagehide = re.search(
+        r"window\.addEventListener\('pagehide'.*?^\}\);",
+        javascript,
+        flags=re.MULTILINE | re.DOTALL,
+    )
+    assert pagehide
+    pagehide_source = pagehide.group(0)
+    assert 'releaseOwnedClientSessions()' in pagehide_source
+    assert pagehide_source.index('closeAllRtcConnections(') < pagehide_source.index(
+        'releaseOwnedClientSessions()'
+    )
+    assert 'keepalive: true' in javascript
+
+
+def test_teleop_console_retains_last_terminal_snapshot_and_events_in_this_page():
+    javascript = (WEB / 'js' / 'teleop' / 'app.js').read_text(encoding='utf-8')
+
+    assert 'const lastSessionByRobot = new Map();' in javascript
+    assert 'lastSessionByRobot.set(snapshot.robot_id, snapshot.id)' in javascript
+    assert 'lastSessionByRobot.get(robot.robot_id)' in javascript
+    assert 'JSON.stringify({ driver_id: robot.driver_id, mode })' in javascript
+    assert '`Driver: ${robot.driver_id} · Robot: ${robot.robot_id}`' in javascript
+    assert "fact('本页最后终态'" in javascript
+    assert 'const sessionEvents = new Map();' in javascript
+    assert 'sessionEvents.set(sessionId' in javascript
+
+
+def test_teleop_console_renders_remote_values_without_html_injection_sinks():
+    javascript = (WEB / 'js' / 'teleop' / 'app.js').read_text(encoding='utf-8')
+
+    assert '.textContent =' in javascript
+    assert '.innerHTML' not in javascript
+    assert '.outerHTML' not in javascript
+    assert 'insertAdjacentHTML' not in javascript
+    assert 'document.write' not in javascript
+    assert 'eval(' not in javascript
+
+
+def test_main_dashboard_links_to_the_teleop_directory():
+    index = (WEB / 'index.html').read_text(encoding='utf-8')
+    assert 'href="/teleop.html"' in index
+
+
+def test_authenticated_websocket_url_is_never_written_to_console():
+    dashboard = (WEB / 'js' / 'dashboard.js').read_text(encoding='utf-8')
+    console_calls = re.findall(r'console\.[a-z]+\([^\n;]*', dashboard)
+    assert all('_wsUrl' not in call and 'wsUrl' not in call for call in console_calls)
+    assert "console.log('[preview ws] open')" in dashboard
+    assert "console.log('[preview ws] closed', e.code)" in dashboard
+
+
+def test_dashboard_control_normalizes_tool_descriptors_and_has_no_hidden_replay():
+    dashboard = (WEB / 'js' / 'dashboard.js').read_text(encoding='utf-8')
+
+    assert "typeof tool === 'string' ? tool : tool?.name" in dashboard
+    assert 'completedTools' in dashboard
+    assert "_callNamedTool(skill, startedTool, 'stop')" in dashboard
+    assert "if (_globalRunning && skill.online)" not in dashboard
+    assert "localStorage.removeItem('motus_global_running')" in dashboard
+
+
+def test_canvas_project_ui_models_degraded_and_cleans_failed_microphone_start():
+    canvas = (WEB / 'js' / 'canvas.js').read_text(encoding='utf-8')
+
+    assert "let _projectState = 'stopped';" in canvas
+    assert "_projectState !== 'running'" in canvas
+    assert "'停止残留控制'" in canvas
+    assert "'状态未知—尝试停止'" in canvas
+    assert '_cleanupMicAfterFailedStart' in canvas
+    assert "btn.disabled = _projectTransitioning || (!_projectRunning && !_isEditor)" in canvas
+    assert "if (!_isEditor) throw new Error('请先获取画布编辑权');" in canvas
+    save_call = "await _saveLayout({ strict: true });"
+    assert save_call in canvas
+    assert canvas.index(save_call) < canvas.index("fetch('/api/config/start-project'")
+    assert canvas.index(save_call) < canvas.index("authenticatedWsUrl('/ws/mic')")
+    assert 'layout_revision: _layoutRevision' in canvas
+    assert 'session_id: _sessionId' in canvas
+    assert "sessionStorage.getItem(_CANVAS_SESSION_KEY)" not in canvas
+    assert "sessionStorage.setItem(_CANVAS_SESSION_KEY, _sessionId)" in canvas
+    assert "globalThis.crypto?.randomUUID?.()" in canvas
+    assert "|| ('sess-' + Date.now().toString(36)" in canvas
+    assert "localStorage.getItem('canvas_session_id')" not in canvas
+    assert "{ type: 'application/json' }" in canvas
+    assert 'if (!await _reloadLayout())' in canvas
+    assert '_reconcileAmbiguousProjectStart' in canvas
+    assert "_applyProjectState(true, 'unknown')" in canvas
+    assert "if (detail?.project_state === 'degraded')" in canvas
+    assert "typeof snapshot?.transitioning !== 'boolean'" in canvas
+    assert "if (!resp.ok || result?.code !== 200)" in canvas
+    assert 'result?.data?.revision' in canvas
+    assert 'if (strict) throw error;' in canvas
+
+
+def test_sidebar_keeps_saved_config_visible_when_driver_apply_fails():
+    sidebar = (WEB / 'js' / 'sidebar.js').read_text(encoding='utf-8')
+
+    assert 'if (saveResult?.data?.saved)' in sidebar
+    assert "statusEl.textContent = '⚠'" in sidebar
+    assert '配置已保存到 Core，但 Driver 应用失败' in sidebar

--- a/agent-core/tests/teleop/test_teleop_audit.py
+++ b/agent-core/tests/teleop/test_teleop_audit.py
@@ -1,0 +1,207 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import math
+import threading
+
+import config
+from api import motus_stream
+from teleop import audit
+
+
+def _assert_no_secret_keys(value):
+    if isinstance(value, dict):
+        for key, item in value.items():
+            normalized = ''.join(character for character in key.lower() if character.isalnum())
+            assert not any(
+                secret in normalized
+                for secret in (
+                    'credential',
+                    'fence',
+                    'password',
+                    'privatekey',
+                    'secret',
+                    'token',
+                )
+            )
+            _assert_no_secret_keys(item)
+    elif isinstance(value, list):
+        for item in value:
+            _assert_no_secret_keys(item)
+
+
+def test_audit_recursively_redacts_nested_secrets_and_bounds_payloads():
+    async def scenario():
+        cyclic: dict = {'safe': 'cycle-survives'}
+        cyclic['self'] = cyclic
+        details = {
+            'state': 'active',
+            'fence': 'top-level-fence',
+            'nested': {
+                'access_token': 'nested-token',
+                'private-key': 'nested-private-key',
+                'safe': [
+                    {'password': 'nested-password', 'value': math.nan},
+                    {'credentialId': 'credential', 'value': math.inf},
+                ],
+            },
+            'long': 'x' * 2_000,
+            'many': list(range(100)),
+            'cycle': cyclic,
+        }
+        event = await audit.emit(
+            'session.activated',
+            robot_id='robot-1',
+            details=details,
+        )
+        return event
+
+    event = asyncio.run(scenario())
+    _assert_no_secret_keys(event['details'])
+    assert event['details']['nested']['safe'] == [
+        {'value': None},
+        {'value': None},
+    ]
+    assert len(event['details']['long']) == audit.MAX_STRING_LENGTH
+    assert len(event['details']['many']) == audit.MAX_COLLECTION_ITEMS
+    assert event['details']['cycle']['self'] is None
+    assert json.dumps(event['details'], allow_nan=False)
+
+    persisted = audit.list_events()
+    assert len(persisted) == 1
+    assert persisted[0]['details'] == event['details']
+    _assert_no_secret_keys(persisted[0]['details'])
+
+
+def test_audit_read_resanitizes_legacy_rows_and_tolerates_malformed_json():
+    with config._get_conn() as conn:
+        audit._ensure_table(conn)
+        base = (
+            1.0,
+            'legacy',
+            '',
+            'robot-1',
+            '',
+            '',
+            '',
+            '',
+            '',
+            '',
+        )
+        conn.execute(
+            '''INSERT INTO teleop_audit
+               (id, created_at, event_type, session_id, robot_id, principal_id,
+                source, decision, reason, tool, action, details)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)''',
+            ('legacy-safe', *base, '{"nested":{"fence":"old","ok":1}}'),
+        )
+        conn.execute(
+            '''INSERT INTO teleop_audit
+               (id, created_at, event_type, session_id, robot_id, principal_id,
+                source, decision, reason, tool, action, details)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)''',
+            ('legacy-broken', *base, '{not-json'),
+        )
+        conn.commit()
+
+    events = {event['id']: event for event in audit.list_events()}
+    assert events['legacy-safe']['details'] == {'nested': {'ok': 1}}
+    assert events['legacy-broken']['details'] == {}
+
+
+def test_audit_write_and_broadcast_failures_never_break_control_flow(monkeypatch):
+    def fail_connection():
+        raise OSError('disk unavailable')
+
+    async def fail_broadcast(_event):
+        raise RuntimeError('no activity clients')
+
+    monkeypatch.setattr(config, '_get_conn', fail_connection)
+    monkeypatch.setattr(motus_stream, 'push_event', fail_broadcast)
+
+    event = asyncio.run(audit.emit(
+        'session.released',
+        robot_id='robot-1',
+        details={'safe': True, 'fence_token': 'must-not-leak'},
+    ))
+    assert event['details'] == {'safe': True}
+    assert audit.list_events() == []
+
+
+def test_audit_broadcast_receives_only_the_sanitized_event(monkeypatch):
+    delivered = []
+
+    async def capture(event):
+        delivered.append(event)
+
+    monkeypatch.setattr(motus_stream, 'push_event', capture)
+    event = asyncio.run(audit.emit(
+        'session.prepared',
+        robot_id='robot-1',
+        details={
+            'nested': {
+                'fence': 'fence-value',
+                'api_secret': 'secret-value',
+                'safe': 'visible',
+            },
+        },
+    ))
+
+    assert delivered == [{
+        'type': 'teleop_activity',
+        'mcp_id': 'robot-1',
+        'payload': event,
+    }]
+    assert delivered[0]['payload']['details'] == {
+        'nested': {'safe': 'visible'},
+    }
+
+
+def test_slow_audit_storage_never_blocks_the_control_fast_path(monkeypatch):
+    entered = threading.Event()
+    allow_persist = threading.Event()
+
+    def slow_persist(_event):
+        entered.set()
+        allow_persist.wait(timeout=1.0)
+
+    monkeypatch.setattr(audit, '_persist_event', slow_persist)
+
+    async def scenario():
+        loop = asyncio.get_running_loop()
+        started = loop.time()
+        event = await audit.emit('session.nonblocking', robot_id='robot-1')
+        elapsed = loop.time() - started
+        worker_started = await asyncio.to_thread(entered.wait, 0.2)
+        allow_persist.set()
+        await audit.flush()
+        return event, elapsed, worker_started
+
+    try:
+        event, elapsed, worker_started = asyncio.run(scenario())
+    finally:
+        allow_persist.set()
+
+    assert event['event_type'] == 'session.nonblocking'
+    assert worker_started is True
+    assert elapsed < 0.1
+
+
+def test_audit_storage_retention_is_bounded(monkeypatch):
+    monkeypatch.setattr(audit, 'MAX_STORED_EVENTS', 3)
+
+    async def scenario():
+        for index in range(5):
+            await audit.emit(f'session.event.{index}', robot_id='robot-1')
+        await audit.flush()
+
+    asyncio.run(scenario())
+
+    events = audit.list_events(limit=10)
+    assert len(events) == 3
+    assert {event['event_type'] for event in events} == {
+        'session.event.2',
+        'session.event.3',
+        'session.event.4',
+    }

--- a/agent-core/tests/teleop/test_teleop_service.py
+++ b/agent-core/tests/teleop/test_teleop_service.py
@@ -1,0 +1,4145 @@
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import threading
+import uuid
+from collections import defaultdict, deque
+from copy import deepcopy
+from typing import Any
+
+import aiohttp
+import pytest
+
+import auth
+import config
+import mcp_client
+from api import mcp_manage, motus_stream, teleop
+from teleop import audit, authority_guard
+from teleop.command_broker import CommandBroker, TeleopCommandBlocked
+from teleop.service import (
+    TeleopCoordinator,
+    TeleopServiceError,
+    _project_driver_snapshot,
+)
+from teleop.session_manager import (
+    MAX_DRIVER_EPOCH,
+    SessionConflict,
+    SessionNotFound,
+    ShadowSessionManager,
+)
+
+DRIVER_ID = 'teleop-shadow-driver'
+ROBOT_ID = 'robot-fixture'
+DIGEST = '0123456789abcdef' * 4
+BOOT_ID = 'f77787b9-c5d2-465a-b4b4-e74f61f35e30'
+DRIVER_TOKEN = 'driver-token-must-never-leak'
+CLIENT_ID = '7dbabfca-15c1-43ca-b600-75e7682c21d0'
+_REAL_AUDIT_EMIT = audit.emit
+LIVE_PROFILE_ID = 'dual_arm_profile_v1'
+LIVE_CAPABILITIES = {
+    'profile_id': LIVE_PROFILE_ID,
+    'input_bindings': {
+        'head': {'required': True, 'role': 'reference'},
+        'left_controller': {'required': True, 'role': 'left_end_effector'},
+        'right_controller': {'required': True, 'role': 'right_end_effector'},
+    },
+    'outputs': {
+        'dual_arm': {'enabled': True, 'joint_count': 10},
+        'base': {'enabled': False},
+        'hands': {'enabled': False},
+    },
+    'effectors': ['dual_arm'],
+}
+G1_PROFILE_ID = 'unitree_g1_23_dual_arm_controller_v1'
+G1_CAPABILITIES = deepcopy(LIVE_CAPABILITIES)
+G1_CAPABILITIES['profile_id'] = G1_PROFILE_ID
+G1_DRIVER_ID = 'unitree-g1'
+G1_SHADOW_DIGEST = (
+    '3a333966ddb1c146c3852e02e90b59825'
+    'e6844d6fbd9937502741af3b96a0757'
+)
+G1_SIGNALING_AUDIENCE = 'motus-teleop-rtc'
+
+
+def _latency_sample(value: float = 1.0, count: int = 1) -> dict[str, Any]:
+    if count == 0:
+        return {'last': None, 'p50': None, 'p95': None, 'p99': None, 'count': 0}
+    return {
+        'last': value,
+        'p50': value,
+        'p95': value + 1.0,
+        'p99': value + 2.0,
+        'count': count,
+    }
+
+
+class MutableClock:
+    def __init__(self) -> None:
+        self.monotonic = 100.0
+        self.wall = 1_000.0
+
+    def monotonic_now(self) -> float:
+        return self.monotonic
+
+    def wall_now(self) -> float:
+        return self.wall
+
+    def advance(self, seconds: float, *, wall_seconds: float | None = None) -> None:
+        self.monotonic += seconds
+        self.wall += seconds if wall_seconds is None else wall_seconds
+
+
+class FakeD1Caller:
+    """Stateful Shadow producer double with the recording-v1 snapshot shape."""
+
+    def __init__(self, *, lease_seconds: float = 1.0, epoch: int = 7) -> None:
+        self.driver_id = DRIVER_ID
+        self.boot_id = BOOT_ID
+        self.robot_id = ROBOT_ID
+        self.capability_digest = DIGEST
+        self.lease_seconds = lease_seconds
+        self.epoch = epoch
+        self.session_id: str | None = None
+        self.fence: str | None = None
+        self.state = 'idle'
+        self.reason: str | None = None
+        self.authority_valid = False
+        self.dispatch_generation = 0
+        self.dispatch_last_admitted: int | None = None
+        self.prepare_timeout_after_apply = False
+        self.calls: list[dict[str, Any]] = []
+        self.script: dict[str, deque[Any]] = defaultdict(deque)
+        self._aiohttp_session: aiohttp.ClientSession | None = None
+
+    def queue(self, action: str, *outcomes: Any) -> None:
+        self.script[action].extend(outcomes)
+
+    def count(self, action: str) -> int:
+        return sum(call['action'] == action for call in self.calls)
+
+    def _assert_identity(self, arguments: dict[str, Any] | None) -> None:
+        assert arguments == {
+            'boot_id': self.boot_id,
+            'session_id': self.session_id,
+            'epoch': self.epoch,
+            'fence': self.fence,
+        }
+
+    def snapshot(self, **overrides: Any) -> dict[str, Any]:
+        effective_state = overrides.get('state', self.state)
+        effective_reason = overrides.get('reason', self.reason)
+        dispatch_state = {
+            'idle': 'safe_unarmed',
+            'prepared_shadow': 'safe_waiting_frame',
+            'active_shadow': 'motion_eligible',
+            'paused': 'safe_latched',
+            'released': 'safe_revoked',
+        }.get(effective_state) if isinstance(effective_state, str) else 'safe_unarmed'
+        if effective_state == 'hold':
+            if effective_reason == 'soft_stop':
+                dispatch_state = 'safe_latched'
+            elif effective_reason == 'lease_timeout':
+                dispatch_state = 'safe_revoked'
+            else:
+                dispatch_state = 'safe_reclutch_required'
+        if effective_state == 'idle':
+            dispatch_decision = 'startup_safe_ack'
+        elif effective_state == 'prepared_shadow':
+            dispatch_decision = 'prepared_after_stop_ack'
+        elif effective_state == 'active_shadow':
+            dispatch_decision = 'admitted'
+        else:
+            dispatch_decision = f'would_stop:{effective_reason}'
+        if effective_state == 'active_shadow' and self.dispatch_last_admitted is None:
+            self.dispatch_last_admitted = 1
+        active_sequence = (
+            None
+            if isinstance(effective_state, str)
+            and effective_state in {'idle', 'prepared_shadow'}
+            else self.dispatch_last_admitted
+        )
+        snapshot = {
+            'driver': self.driver_id,
+            'driver_id': self.driver_id,
+            'driver_name': 'Generic Teleop Shadow Diagnostics',
+            'driver_type': 'teleop-shadow',
+            'robot_id': self.robot_id,
+            'mode': 'shadow',
+            'actuation_enabled': False,
+            'boot_id': self.boot_id,
+            'session_id': self.session_id,
+            'epoch': self.epoch,
+            'state': self.state,
+            'reason': self.reason,
+            'authority_valid': self.authority_valid,
+            'capability_digest': self.capability_digest,
+            'capabilities': {
+                'pose_transport': ['webrtc-datachannel'],
+                'control_transport': ['mcp'],
+            },
+            'lease': {
+                'source': 'agent-core-mcp-heartbeat-only',
+                'timeout_ms': round(self.lease_seconds * 1_000),
+                'age_ms': 0.0 if self.authority_valid else None,
+                'fresh': self.authority_valid,
+                'authority_valid': self.authority_valid,
+                'expired_latched': False,
+            },
+            'pose': {
+                'timeout_ms': 250.0,
+                'age_ms': None,
+                'fresh': False,
+                'latest_sequence': None,
+                'latest': None,
+            },
+            'rtc': {
+                'connected': False,
+                'channels': {
+                    'teleop-control': False,
+                    'teleop-pose': False,
+                },
+                'renews_lease': False,
+            },
+            'dispatch': {
+                'kind': 'recording',
+                'state': dispatch_state,
+                'ready': True,
+                'generation': self.dispatch_generation,
+                'mailbox_depth': 0,
+                'stop_queue_depth': 0,
+                'last_admitted_sequence': active_sequence,
+                'last_would_apply_sequence': None,
+                'last_decision': dispatch_decision,
+                'stop_acknowledged': True,
+                'fault_code': None,
+                'io_inflight': None,
+                'counters': {
+                    'startup_safe_acks': 1,
+                    'stop_acks': self.dispatch_generation + 1,
+                },
+                'adapter': {
+                    'kind': 'recording',
+                    'closed': False,
+                    'current': {'kind': 'safe', 'reason': 'not_started'},
+                    'records': [{'private': 'must-not-be-projected'}],
+                },
+            },
+            'counters': {'lease_heartbeats': self.count('heartbeat')},
+        }
+        snapshot.update(overrides)
+        return snapshot
+
+    async def __call__(
+        self,
+        driver_id: str,
+        action: str,
+        arguments: dict[str, Any] | None,
+        *,
+        timeout_seconds: float,
+        session: aiohttp.ClientSession,
+    ) -> dict[str, Any]:
+        assert driver_id == self.driver_id
+        assert isinstance(session, aiohttp.ClientSession)
+        assert not session.closed
+        if self._aiohttp_session is None:
+            self._aiohttp_session = session
+        else:
+            assert session is self._aiohttp_session
+        self.calls.append({
+            'action': action,
+            'arguments': deepcopy(arguments),
+            'timeout_seconds': timeout_seconds,
+        })
+
+        if self.script[action]:
+            outcome = self.script[action].popleft()
+            if isinstance(outcome, BaseException):
+                raise outcome
+            if callable(outcome):
+                outcome = outcome(self, arguments)
+                if asyncio.iscoroutine(outcome):
+                    outcome = await outcome
+                if isinstance(outcome, BaseException):
+                    raise outcome
+            return deepcopy(outcome)
+
+        if action == 'status':
+            return self.snapshot()
+        if action == 'prepare_shadow':
+            assert arguments is not None
+            assert set(arguments) == {'session_id', 'epoch', 'fence'}
+            assert str(uuid.UUID(arguments['session_id'])) == arguments['session_id']
+            assert arguments['epoch'] > self.epoch
+            self.session_id = arguments['session_id']
+            self.epoch = arguments['epoch']
+            self.fence = arguments['fence']
+            self.state = 'prepared_shadow'
+            self.reason = None
+            self.authority_valid = True
+            self.dispatch_generation += 1
+            self.dispatch_last_admitted = None
+            if self.prepare_timeout_after_apply:
+                self.prepare_timeout_after_apply = False
+                raise mcp_client.TrustedShadowTransportError('timeout')
+            return self.snapshot()
+        if action == 'heartbeat':
+            self._assert_identity(arguments)
+            return self.snapshot()
+        if action == 'pause':
+            self._assert_identity(arguments)
+            self.state = 'paused'
+            self.reason = 'operator_pause'
+            self.dispatch_generation += 1
+            return self.snapshot()
+        if action == 'soft_stop':
+            self._assert_identity(arguments)
+            self.state = 'hold'
+            self.reason = 'soft_stop'
+            self.dispatch_generation += 1
+            return self.snapshot()
+        if action == 'release':
+            self._assert_identity(arguments)
+            self.session_id = None
+            self.fence = None
+            self.state = 'released'
+            self.reason = 'operator_release'
+            self.authority_valid = False
+            self.dispatch_generation += 1
+            return self.snapshot()
+        if action == 'stop':
+            assert arguments in (None, {})
+            self.session_id = None
+            self.fence = None
+            self.state = 'released'
+            self.reason = 'lifecycle_stop'
+            self.authority_valid = False
+            self.dispatch_generation += 1
+            return self.snapshot()
+        raise AssertionError(f'unexpected action: {action}')
+
+
+class FakeG1ShadowCaller(FakeD1Caller):
+    """Stateful double using the adapter-neutral G1 Shadow wire contract."""
+
+    def __init__(self, *, lease_seconds: float = 10.0, epoch: int = 7) -> None:
+        super().__init__(lease_seconds=lease_seconds, epoch=epoch)
+        self.driver_id = G1_DRIVER_ID
+        self.robot_id = G1_DRIVER_ID
+        self.capability_digest = G1_SHADOW_DIGEST
+        self.rtc_connected = False
+        self.frames_received = 0
+        self.latest_sequence: int | None = None
+
+    def receive_direct_rtc_frames(self, sequence: int = 3) -> None:
+        """Model Browser -> Driver frames without creating a Core RPC action."""
+
+        self.rtc_connected = True
+        self.frames_received = sequence
+        self.latest_sequence = sequence
+        self.dispatch_last_admitted = sequence
+        self.state = 'active_shadow'
+
+    def latch_projection_fault(self) -> None:
+        self.rtc_connected = False
+        self.session_id = None
+        self.fence = None
+        self.state = 'fault'
+        self.reason = 'dispatch_fault'
+        self.authority_valid = False
+        self.dispatch_generation += 1
+
+    def snapshot(self, **overrides: Any) -> dict[str, Any]:
+        raw = super().snapshot(**overrides)
+        state = raw['state']
+        rtc_open = self.rtc_connected and state == 'active_shadow'
+        latency_count = 1 if self.frames_received else 0
+        raw.update({
+            'driver': self.driver_id,
+            'driver_id': self.driver_id,
+            'driver_name': 'Unitree G1 Bundle',
+            'driver_type': 'teleop',
+            'robot_id': self.robot_id,
+            'profile_id': G1_PROFILE_ID,
+            'capability_digest': self.capability_digest,
+            'capabilities': deepcopy(G1_CAPABILITIES),
+            'diagnostics': {
+                'transport': {
+                    'rtc_rtt_ms': None,
+                    'pose_age_ms': 4.0 if rtc_open else None,
+                    'frame_rate_hz': 60.0 if rtc_open else 0.0,
+                    'frames_received': self.frames_received,
+                    'frames_rejected': 0,
+                    'sequence_gaps': 0,
+                    'mailbox_replacements': 0,
+                },
+                'latency_ms': {
+                    'receive_to_admit': _latency_sample(1.0, latency_count),
+                    'mailbox_wait': _latency_sample(2.0, latency_count),
+                    'ik': _latency_sample(3.0, latency_count),
+                    'adapter_apply': _latency_sample(4.0, latency_count),
+                    'robot_follow': _latency_sample(count=0),
+                },
+            },
+            'output': {
+                'profile_id': G1_PROFILE_ID,
+                'hardware_output': False,
+                'state': 'tracking' if state == 'active_shadow' else state,
+                'target_joint_positions_rad': [0.1] * 10,
+                'measured_joint_positions_rad': [0.09] * 10,
+                'max_abs_error_rad': 0.01 if self.frames_received else 0.0,
+                'arm_sdk_weight': None,
+                'command_age_ms': 4.0 if rtc_open else None,
+                'fault_reason': None,
+            },
+        })
+        raw['rtc'].update({
+            'connected': rtc_open,
+            'channels': {
+                'teleop-control': rtc_open,
+                'teleop-pose': rtc_open,
+            },
+        })
+        raw['pose'].update({
+            'age_ms': 4.0 if rtc_open else None,
+            'fresh': rtc_open,
+            'latest_sequence': self.latest_sequence if rtc_open else None,
+        })
+        adapter = raw['dispatch']['adapter']
+        adapter.update({
+            'hardware_output': False,
+            'actuation_enabled': False,
+        })
+        if state == 'active_shadow':
+            raw['dispatch'].update({
+                'last_would_apply_sequence': self.latest_sequence,
+                'last_decision': 'would_apply',
+            })
+            adapter['current'] = {'kind': 'would_apply'}
+        elif state in {'hold', 'paused', 'released'}:
+            raw['dispatch']['last_would_apply_sequence'] = self.latest_sequence
+            adapter['current'] = {'kind': 'would_stop'}
+        else:
+            adapter['current'] = {'kind': 'safe'}
+        if state == 'fault':
+            raw['lease'].update({
+                'age_ms': None,
+                'fresh': False,
+                'authority_valid': False,
+                'expired_latched': False,
+            })
+            raw['dispatch'].update({
+                'state': 'fault_latched',
+                'ready': False,
+                'mailbox_depth': 0,
+                'stop_queue_depth': 0,
+                'last_would_apply_sequence': self.latest_sequence,
+                'last_decision': 'async_fault:projection_or_ik_failed',
+                'stop_acknowledged': False,
+                'fault_code': 'projection_or_ik_failed',
+                'io_inflight': None,
+            })
+            adapter['current'] = {'kind': 'would_stop'}
+            raw['output'].update({
+                'state': 'fault',
+                'fault_reason': 'projection_or_ik_failed',
+            })
+        return raw
+
+
+def _live_active_snapshot(
+    fake: FakeD1Caller,
+    *,
+    published_sequence: int | None = 9,
+) -> dict[str, Any]:
+    fake.state = 'active_shadow'
+    fake.authority_valid = True
+    fake.session_id = str(uuid.uuid4())
+    fake.dispatch_generation = 3
+    fake.dispatch_last_admitted = 9
+    raw = fake.snapshot()
+    raw.update({
+        'driver_type': 'teleop',
+        'mode': 'live',
+        'actuation_enabled': True,
+        'state': 'active_live',
+        'diagnostics': {
+            'transport': {
+                'rtc_rtt_ms': 8.0,
+                'pose_age_ms': 4.0,
+                'frame_rate_hz': 60.0,
+                'frames_received': 100,
+                'frames_rejected': 2,
+                'sequence_gaps': 1,
+                'mailbox_replacements': 3,
+            },
+            'latency_ms': {
+                'receive_to_admit': _latency_sample(1.0),
+                'mailbox_wait': _latency_sample(2.0),
+                'ik': _latency_sample(3.0),
+                'adapter_apply': _latency_sample(4.0),
+                'robot_follow': _latency_sample(5.0),
+            },
+        },
+        'output': {
+            'profile_id': LIVE_PROFILE_ID,
+            'hardware_output': True,
+            'state': 'tracking',
+            'target_joint_positions_rad': [0.1] * 10,
+            'measured_joint_positions_rad': [0.09] * 10,
+            'max_abs_error_rad': 0.01,
+            'arm_sdk_weight': 1.0,
+            'command_age_ms': 5.0,
+            'fault_reason': None,
+        },
+    })
+    raw['dispatch'].update({
+        'kind': 'hardware',
+        'last_published_sequence': published_sequence,
+        'last_decision': 'published',
+    })
+    raw['dispatch'].pop('last_would_apply_sequence')
+    raw['dispatch'].pop('adapter')
+    return raw
+
+
+def _live_fault_snapshot(fake: FakeD1Caller) -> dict[str, Any]:
+    """Mirror the bounded terminal status emitted by the G1 live runtime."""
+
+    raw = _live_active_snapshot(fake, published_sequence=7)
+    raw.update({
+        'session_id': None,
+        'state': 'fault',
+        'reason': 'dispatch_fault',
+        'authority_valid': False,
+    })
+    raw['lease'].update({
+        'age_ms': None,
+        'fresh': False,
+        'authority_valid': False,
+        'expired_latched': False,
+    })
+    raw['pose'].update({'age_ms': None, 'fresh': False, 'latest_sequence': None})
+    raw['rtc'].update({
+        'connected': False,
+        'channels': {'teleop-control': False, 'teleop-pose': False},
+    })
+    raw['dispatch'].update({
+        'state': 'fault_latched',
+        'ready': False,
+        'generation': 4,
+        'mailbox_depth': 0,
+        'stop_queue_depth': 0,
+        'last_admitted_sequence': 9,
+        'last_published_sequence': 7,
+        'last_decision': 'async_fault:arm_sdk_async_fault',
+        'stop_acknowledged': False,
+        'fault_code': 'arm_sdk_async_fault',
+        'io_inflight': None,
+    })
+    raw['output'].update({
+        'state': 'fault',
+        'arm_sdk_weight': 0.0,
+        'fault_reason': 'arm_sdk_async_fault',
+    })
+    return raw
+
+
+def _g1_shadow_snapshot(state: str, reason: str | None) -> dict[str, Any]:
+    """Adapter-neutral shape of the G1 Shadow runtime across lifecycle states."""
+
+    raw = _live_active_snapshot(FakeD1Caller(), published_sequence=7)
+    authority = state in {'prepared_shadow', 'active_shadow', 'hold', 'paused'}
+    terminal = state in {'idle', 'released', 'fault'}
+    raw.update({
+        'mode': 'shadow',
+        'actuation_enabled': False,
+        'session_id': None if terminal else raw['session_id'],
+        'state': state,
+        'reason': reason,
+        'authority_valid': authority,
+    })
+    raw['lease'].update({
+        'age_ms': 0.0 if authority else None,
+        'fresh': authority,
+        'authority_valid': authority,
+        'expired_latched': False,
+    })
+    if terminal:
+        raw['pose'].update({'age_ms': None, 'fresh': False, 'latest_sequence': None})
+        raw['rtc'].update({
+            'connected': False,
+            'channels': {'teleop-control': False, 'teleop-pose': False},
+        })
+    dispatch_state = {
+        'idle': 'safe_unarmed',
+        'prepared_shadow': 'safe_waiting_frame',
+        'active_shadow': 'motion_eligible',
+        'hold': 'safe_reclutch_required',
+        'paused': 'safe_latched',
+        'released': 'safe_revoked',
+        'fault': 'fault_latched',
+    }[state]
+    decision = {
+        'idle': 'startup_safe_ack',
+        'prepared_shadow': 'prepared_after_stop_ack',
+        'active_shadow': 'would_apply',
+        'hold': f'would_stop:{reason}',
+        'paused': 'would_stop:operator_pause',
+        'released': 'would_stop:operator_release',
+        'fault': 'async_fault:projection_or_ik_failed',
+    }[state]
+    has_sequence = state in {'active_shadow', 'hold', 'paused', 'released', 'fault'}
+    raw['dispatch'].update({
+        'kind': 'recording',
+        'state': dispatch_state,
+        'ready': state != 'fault',
+        'last_admitted_sequence': 9 if has_sequence else None,
+        'last_would_apply_sequence': 7 if has_sequence else None,
+        'last_decision': decision,
+        'stop_acknowledged': state != 'fault',
+        'fault_code': 'projection_or_ik_failed' if state == 'fault' else None,
+        'io_inflight': None,
+        'mailbox_depth': 0,
+        'stop_queue_depth': 0,
+        'adapter': {
+            'kind': 'recording',
+            'closed': False,
+            'hardware_output': False,
+            'actuation_enabled': False,
+            'current': {
+                'kind': (
+                    'would_apply'
+                    if state == 'active_shadow'
+                    else ('would_stop' if state in {'hold', 'paused', 'released', 'fault'} else 'safe')
+                ),
+            },
+            'records': [],
+        },
+    })
+    raw['dispatch'].pop('last_published_sequence')
+    raw['output'].update({
+        'profile_id': G1_PROFILE_ID,
+        'hardware_output': False,
+        'state': 'fault' if state == 'fault' else state,
+        'arm_sdk_weight': None,
+        'fault_reason': 'projection_or_ik_failed' if state == 'fault' else None,
+    })
+    return raw
+
+
+def _project_live(raw: dict[str, Any]) -> dict[str, Any]:
+    projected, _ = _project_driver_snapshot(
+        raw,
+        driver_id=DRIVER_ID,
+        robot_id=ROBOT_ID,
+        capability_digest=DIGEST,
+        action='status',
+        expected_mode='live',
+        expected_profile_id=LIVE_PROFILE_ID,
+        expected_capabilities=LIVE_CAPABILITIES,
+    )
+    return projected
+
+
+def _project_g1_shadow(raw: dict[str, Any]) -> dict[str, Any]:
+    projected, _ = _project_driver_snapshot(
+        raw,
+        driver_id=DRIVER_ID,
+        robot_id=ROBOT_ID,
+        capability_digest=DIGEST,
+        action='status',
+        expected_mode='shadow',
+        expected_profile_id=G1_PROFILE_ID,
+        expected_capabilities=G1_CAPABILITIES,
+    )
+    return projected
+
+
+@pytest.fixture(autouse=True)
+def quiet_audit(monkeypatch: pytest.MonkeyPatch):
+    async def emit(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+        return {}
+
+    monkeypatch.setattr(audit, 'emit', emit)
+
+
+def _install_descriptor(shadow_session_tool: dict[str, Any]) -> None:
+    tool = deepcopy(shadow_session_tool)
+    tool['x-teleop'].update({
+        'driver_id': DRIVER_ID,
+        'capability_digest': DIGEST,
+    })
+    config.main['services'] = {'mcp': [{
+        'id': DRIVER_ID,
+        'name': 'Generic Teleop Shadow Diagnostics',
+        'url': 'http://teleop-shadow.invalid/mcp',
+        'transport': 'http',
+        'category': 'driver',
+        'trust_state': 'trusted',
+        'reported_robot_id': ROBOT_ID,
+        'authority_domain': ROBOT_ID,
+        'tools': [tool],
+    }, {
+        'id': ROBOT_ID,
+        'name': 'Robot Fixture Actuator',
+        'url': 'http://robot-fixture.invalid/mcp',
+        'transport': 'http',
+        'category': 'driver',
+        'trust_state': 'trusted',
+        'tools': [{
+            'name': 'locomotion',
+            'type': 'actuator',
+            'inputSchema': {'type': 'object'},
+        }],
+    }]}
+
+
+def _install_g1_shadow_descriptor() -> tuple[dict[str, Any], dict[str, Any]]:
+    """Install the authority-relevant fields emitted by the G1 Driver."""
+
+    identity = {
+        'boot_id': {'type': 'string', 'format': 'uuid'},
+        'session_id': {'type': 'string', 'format': 'uuid'},
+        'epoch': {'type': 'integer', 'minimum': 1},
+        'fence': {'type': 'string', 'minLength': 24},
+    }
+    identity_params = list(identity)
+    actions = {
+        'stop': {'params': []},
+        'prepare_shadow': {'params': ['session_id', 'epoch', 'fence']},
+        'heartbeat': {'params': identity_params},
+        'pause': {'params': identity_params},
+        'release': {'params': identity_params},
+        'soft_stop': {'params': identity_params},
+        'status': {'params': []},
+    }
+    descriptor = {
+        'protocol': 'motus.teleop.shadow.v1',
+        'mode': 'shadow',
+        'profile_id': G1_PROFILE_ID,
+        'capabilities': deepcopy(G1_CAPABILITIES),
+        'dispatch_contract': 'motus.teleop.dispatch.recording.v1',
+        'signaling': {
+            'protocol': 'motus.teleop.webrtc-offer-answer.v1',
+            'path': '/offer',
+            'access': 'authenticated-core-proxy-only',
+            'audience': G1_SIGNALING_AUDIENCE,
+        },
+        'driver_id': G1_DRIVER_ID,
+        'driver_name': 'Unitree G1 Bundle',
+        'robot_id': G1_DRIVER_ID,
+        'actuation_enabled': False,
+        'capability_digest': G1_SHADOW_DIGEST,
+    }
+    session_tool = {
+        'name': 'teleop_session',
+        'type': 'actuator',
+        'multiInstance': False,
+        'description': 'Unitree G1_23 dual-arm controller teleoperation.',
+        'annotations': {'destructiveHint': False, 'idempotentHint': False},
+        'inputSchema': {
+            'type': 'object',
+            'additionalProperties': False,
+            'properties': {
+                'action': {'type': 'string', 'enum': list(actions)},
+                **identity,
+            },
+            'required': ['action'],
+            'x-action-params': actions,
+        },
+        'x-teleop': deepcopy(descriptor),
+    }
+    state_tool = {
+        'name': 'teleop_state',
+        'type': 'resource',
+        'multiInstance': False,
+        'readOnly': True,
+        'description': 'Read-only G1 teleoperation state and diagnostics.',
+        'annotations': {
+            'readOnlyHint': True,
+            'destructiveHint': False,
+            'idempotentHint': True,
+        },
+        'inputSchema': {
+            'type': 'object',
+            'properties': {},
+            'additionalProperties': False,
+        },
+        'x-teleop': deepcopy(descriptor),
+    }
+    record = {
+        'id': G1_DRIVER_ID,
+        'name': 'Unitree G1 Bundle',
+        'server_name': 'unitree-g1',
+        'url': 'https://unitree-g1.invalid/mcp',
+        'transport': 'http',
+        'category': 'driver',
+        'trust_state': 'trusted',
+        'reported_robot_id': G1_DRIVER_ID,
+        'authority_domain': G1_DRIVER_ID,
+        'tools': [session_tool, state_tool],
+    }
+    config.main['services'] = {'mcp': [record]}
+    mcp_client.registry[G1_DRIVER_ID] = {
+        'online': True,
+        'trusted': True,
+        'url': record['url'],
+        'teleop_fingerprint': mcp_client.teleop_tool_fingerprint(session_tool),
+    }
+    return record, session_tool
+
+
+def _coordinator(
+    fake: FakeD1Caller,
+    clock: MutableClock,
+    *,
+    command_broker: CommandBroker | None = None,
+) -> TeleopCoordinator:
+    manager = ShadowSessionManager(
+        monotonic=clock.monotonic_now,
+        wall_clock=clock.wall_now,
+    )
+    return TeleopCoordinator(
+        session_manager=manager,
+        caller=fake,
+        monotonic=clock.monotonic_now,
+        wall_clock=clock.wall_now,
+        command_broker=command_broker or CommandBroker(),
+    )
+
+
+async def _finish(coordinator: TeleopCoordinator) -> None:
+    """Release live fixtures before stop so cleanup does not add test calls."""
+
+    sessions = await coordinator.manager.list_visible('', owner=True)
+    for session in sessions:
+        if session.state in {'preparing', 'active', 'paused', 'hold'}:
+            try:
+                await coordinator.release(
+                    session.id,
+                    session.principal_id,
+                    CLIENT_ID,
+                    owner=False,
+                )
+            except Exception:  # noqa: BLE001, S110 -- teardown must close aiohttp
+                pass
+    await coordinator.stop()
+
+
+async def _crash_without_authority_cleanup(
+    coordinator: TeleopCoordinator,
+    fake: FakeD1Caller,
+) -> None:
+    """Drop process-owned tasks/transports without release or guard deletion."""
+
+    tasks = [
+        *coordinator._heartbeat_tasks.values(),
+        *coordinator._supervisor_tasks,
+        *coordinator._safety_tasks,
+    ]
+    if coordinator._reaper_task is not None:
+        tasks.append(coordinator._reaper_task)
+    for task in tasks:
+        task.cancel()
+    if tasks:
+        await asyncio.gather(*tasks, return_exceptions=True)
+    coordinator._heartbeat_tasks.clear()
+    coordinator._supervisor_tasks.clear()
+    coordinator._safety_tasks.clear()
+    coordinator._reaper_task = None
+    if coordinator._http_session is not None:
+        await coordinator._http_session.close()
+        coordinator._http_session = None
+    fake._aiohttp_session = None
+
+
+async def _wait_until(predicate, *, timeout: float = 0.8) -> None:
+    deadline = asyncio.get_running_loop().time() + timeout
+    while not predicate():
+        if asyncio.get_running_loop().time() >= deadline:
+            raise AssertionError('condition was not reached before the test deadline')
+        await asyncio.sleep(0.01)
+
+
+def test_acquire_uses_driver_epoch_floor_immediate_heartbeat_and_safe_status(
+    shadow_session_tool,
+):
+    async def scenario() -> None:
+        _install_descriptor(shadow_session_tool)
+        clock = MutableClock()
+        fake = FakeD1Caller(epoch=41, lease_seconds=10.0)
+        coordinator = _coordinator(fake, clock)
+        try:
+            result = await coordinator.acquire(DRIVER_ID, 'alice', CLIENT_ID)
+            public = coordinator.public_session(result.session)
+
+            assert result.disposition == 'created'
+            assert result.session.driver_id == DRIVER_ID
+            assert result.session.robot_id == ROBOT_ID
+            assert result.session.epoch >= 42
+            assert public['configured_dry_run_profile'] == 'recording'
+            assert [call['action'] for call in fake.calls[:3]] == [
+                'status', 'prepare_shadow', 'heartbeat',
+            ]
+            assert fake.calls[1]['arguments']['epoch'] == result.session.epoch
+            assert fake.calls[2]['arguments']['session_id'] == result.session.id
+            assert public['driver']['lease']['source'] == (
+                'agent-core-mcp-heartbeat-only'
+            )
+            assert public['driver']['rtc']['renews_lease'] is False
+            assert public['driver']['dispatch'] == {
+                'contract': 'motus.teleop.dispatch.recording.v1',
+                'kind': 'recording',
+                'state': 'safe_waiting_frame',
+                'ready': True,
+                'generation': 1,
+                'mailbox_depth': 0,
+                'stop_queue_depth': 0,
+                'last_admitted_sequence': None,
+                'last_would_apply_sequence': None,
+                'last_decision': 'prepared_after_stop_ack',
+                'stop_acknowledged': True,
+                'fault_code': None,
+                'io_inflight': None,
+                'counters': {
+                    'startup_safe_acks': 1,
+                    'stop_acks': 2,
+                },
+                'dry_run': {
+                    'profile': 'recording',
+                    'hardware_output': False,
+                    'actuation_enabled': False,
+                    'operation': 'recording',
+                    'sequence': None,
+                    'requested': None,
+                    'effective': None,
+                    'clamped_axes': [],
+                    'stop_reason': None,
+                    'gait_policy': None,
+                },
+            }
+            assert 'adapter' not in public['driver']['dispatch']
+            assert 'must-not-be-projected' not in repr(public)
+            assert public['driver_heartbeat']['state'] == 'healthy'
+            assert result.session.fence not in repr(public)
+            assert 'fence' not in repr(public).lower()
+        finally:
+            await _finish(coordinator)
+
+    asyncio.run(scenario())
+
+
+def test_trusted_g1_shadow_directory_to_rtc_hold_and_fault_stays_generic():
+    async def scenario() -> None:
+        record, session_tool = _install_g1_shadow_descriptor()
+        directory_entry = teleop._robot_view(record, [record])
+        declared_actions = session_tool['inputSchema']['properties']['action']['enum']
+
+        assert directory_entry['teleop_ready'] is True
+        assert directory_entry['robot_id'] == G1_DRIVER_ID
+        assert directory_entry['tools'] == ['teleop_session', 'teleop_state']
+        assert directory_entry['teleop']['mode'] == 'shadow'
+        assert directory_entry['teleop']['profile_id'] == G1_PROFILE_ID
+        assert directory_entry['teleop']['capabilities']['effectors'] == ['dual_arm']
+        assert directory_entry['teleop']['capabilities']['outputs']['base']['enabled'] is False
+        assert directory_entry['teleop']['capabilities']['outputs']['hands']['enabled'] is False
+        assert directory_entry['teleop']['signaling']['audience'] == G1_SIGNALING_AUDIENCE
+        assert 'submit_shadow_frame' not in declared_actions
+
+        clock = MutableClock()
+        fake = FakeG1ShadowCaller()
+        observed_offer: dict[str, Any] = {}
+
+        async def signaler(
+            driver_id: str,
+            offer: dict[str, Any],
+            ticket: str,
+            **kwargs: Any,
+        ) -> dict[str, Any]:
+            observed_offer.update({
+                'driver_id': driver_id,
+                'offer': deepcopy(offer),
+                'ticket': ticket,
+                'kwargs': kwargs,
+            })
+            fake.receive_direct_rtc_frames()
+            return {
+                'sdp': 'v=0\r\na=g1-shadow-answer',
+                'type': 'answer',
+                'boot_id': fake.boot_id,
+                'session_id': fake.session_id,
+                'epoch': fake.epoch,
+                'capability_digest': fake.capability_digest,
+                'mode': 'shadow',
+                'actuation_enabled': False,
+            }
+
+        coordinator = TeleopCoordinator(
+            session_manager=ShadowSessionManager(
+                monotonic=clock.monotonic_now,
+                wall_clock=clock.wall_now,
+            ),
+            caller=fake,
+            signaler=signaler,
+            monotonic=clock.monotonic_now,
+            wall_clock=clock.wall_now,
+            command_broker=CommandBroker(),
+        )
+        try:
+            acquired = await coordinator.acquire(
+                G1_DRIVER_ID,
+                'alice',
+                CLIENT_ID,
+                mode=directory_entry['teleop']['mode'],
+            )
+            session = acquired.session
+            public = coordinator.public_session(session)
+
+            assert acquired.disposition == 'created'
+            assert [call['action'] for call in fake.calls[:3]] == [
+                'status',
+                'prepare_shadow',
+                'heartbeat',
+            ]
+            assert public['mode'] == 'shadow'
+            assert public['profile_id'] == G1_PROFILE_ID
+            assert public['effectors'] == ['dual_arm']
+            assert public['driver']['profile_id'] == G1_PROFILE_ID
+            assert public['driver']['output']['hardware_output'] is False
+            assert len(public['driver']['output']['target_joint_positions_rad']) == 10
+
+            fingerprint = mcp_client.teleop_tool_fingerprint(session_tool)
+            assert fingerprint is not None
+            target = mcp_client.TrustedShadowTarget(
+                mcp_id=G1_DRIVER_ID,
+                url=record['url'],
+                capability_digest=G1_SHADOW_DIGEST,
+                descriptor_fingerprint=fingerprint,
+                actions=frozenset(declared_actions),
+            )
+            coordinator._pinned_targets[session.id] = target
+            offer = {'type': 'offer', 'sdp': 'v=0\r\no=quest-3-g1-shadow'}
+            answer = await coordinator.signaling_offer(
+                session.id,
+                'alice',
+                CLIENT_ID,
+                offer,
+            )
+
+            assert answer == {'sdp': 'v=0\r\na=g1-shadow-answer', 'type': 'answer'}
+            assert observed_offer['driver_id'] == G1_DRIVER_ID
+            assert observed_offer['offer'] == offer
+            assert observed_offer['kwargs']['target'] == target
+            ticket_payload = observed_offer['ticket'].split('.', 1)[0]
+            ticket_claims = json.loads(base64.urlsafe_b64decode(
+                ticket_payload + '=' * (-len(ticket_payload) % 4),
+            ))
+            assert ticket_claims['aud'] == G1_SIGNALING_AUDIENCE
+            assert ticket_claims['capability_digest'] == G1_SHADOW_DIGEST
+
+            rtc_status = await coordinator.status(session.id, 'alice', owner=False)
+            driver = rtc_status['driver']
+            assert driver['state'] == 'active_shadow'
+            assert driver['rtc'] == {
+                'connected': True,
+                'channels': {
+                    'teleop-control': True,
+                    'teleop-pose': True,
+                },
+                'renews_lease': False,
+            }
+            assert driver['diagnostics']['transport']['frames_received'] == 3
+            assert driver['diagnostics']['latency_ms']['ik']['p95'] == 4.0
+            assert driver['dispatch']['last_would_apply_sequence'] == 3
+            assert driver['output']['hardware_output'] is False
+            assert all(call['action'] != 'submit_shadow_frame' for call in fake.calls)
+            assert all(
+                'frame' not in (call['arguments'] or {})
+                for call in fake.calls
+            )
+
+            held = await coordinator.soft_stop(
+                session.id,
+                'alice',
+                CLIENT_ID,
+                owner=False,
+            )
+            held_public = coordinator.public_session(held)
+            assert held_public['state'] == 'hold'
+            assert held_public['driver']['state'] == 'hold'
+            assert held_public['driver']['reason'] == 'soft_stop'
+            assert held_public['driver']['rtc']['connected'] is False
+            assert held_public['driver']['dispatch']['state'] == 'safe_latched'
+            assert held_public['driver']['output']['hardware_output'] is False
+
+            fake.latch_projection_fault()
+            faulted = await coordinator.status(session.id, 'alice', owner=False)
+            assert faulted['state'] == 'faulted'
+            assert faulted['driver_heartbeat']['state'] == 'faulted'
+            assert faulted['driver']['state'] == 'fault'
+            assert faulted['driver']['reason'] == 'dispatch_fault'
+            assert faulted['driver']['dispatch']['state'] == 'fault_latched'
+            assert faulted['driver']['dispatch']['fault_code'] == (
+                'projection_or_ik_failed'
+            )
+            assert faulted['driver']['output']['fault_reason'] == (
+                'projection_or_ik_failed'
+            )
+            public_surface = repr({
+                'directory': directory_entry,
+                'answer': answer,
+                'status': faulted,
+            })
+            assert observed_offer['ticket'] not in public_surface
+            assert session.fence not in public_surface
+        finally:
+            await _finish(coordinator)
+
+    asyncio.run(scenario())
+
+
+def test_acquire_rejects_descriptor_without_lifecycle_stop_contract(
+    shadow_session_tool,
+):
+    async def scenario() -> None:
+        incomplete = deepcopy(shadow_session_tool)
+        incomplete['inputSchema']['properties']['action']['enum'].remove('stop')
+        incomplete['inputSchema']['x-action-params'].pop('stop')
+        _install_descriptor(incomplete)
+        fake = FakeD1Caller()
+        coordinator = _coordinator(fake, MutableClock())
+        try:
+            with pytest.raises(TeleopServiceError) as raised:
+                await coordinator.acquire(DRIVER_ID, 'alice', CLIENT_ID)
+            assert raised.value.code == 'driver_not_ready'
+            assert fake.calls == []
+        finally:
+            await coordinator.stop()
+
+    asyncio.run(scenario())
+
+
+def test_acquire_rejects_legacy_vendor_profile_before_driver_contact(
+    shadow_session_tool,
+):
+    async def scenario() -> None:
+        descriptor = deepcopy(shadow_session_tool)
+        descriptor['x-teleop']['dry_run_profile'] = 'vendor_specific_profile'
+        _install_descriptor(descriptor)
+        fake = FakeD1Caller()
+        coordinator = _coordinator(fake, MutableClock())
+        try:
+            with pytest.raises(TeleopServiceError) as raised:
+                await coordinator.acquire(DRIVER_ID, 'alice', CLIENT_ID)
+            assert raised.value.code == 'driver_not_ready'
+            assert fake.calls == []
+            assert await coordinator.manager.active_for_robot(ROBOT_ID) is None
+        finally:
+            await coordinator.stop()
+
+    asyncio.run(scenario())
+
+
+def test_live_output_and_latency_are_projected_without_adapter_internals():
+    fake = FakeD1Caller()
+    raw = _live_active_snapshot(fake)
+    raw['private_adapter_state'] = {
+        'sdk_call': 'must-not-be-projected',
+        'joint_mapping': 'must-not-be-projected',
+    }
+
+    projected = _project_live(raw)
+
+    assert projected['mode'] == 'live'
+    assert projected['actuation_enabled'] is True
+    assert projected['dispatch']['contract'] == 'motus.teleop.dispatch.hardware.v1'
+    assert projected['dispatch']['kind'] == 'hardware'
+    assert projected['dispatch']['last_admitted_sequence'] == 9
+    assert projected['dispatch']['last_published_sequence'] == 9
+    assert projected['output']['profile_id'] == LIVE_PROFILE_ID
+    assert projected['output']['hardware_output'] is True
+    assert len(projected['output']['target_joint_positions_rad']) == 10
+    assert projected['diagnostics']['latency_ms']['ik'] == _latency_sample(3.0)
+    serialized = repr(projected)
+    for private_value in (
+        'must-not-be-projected',
+        'sdk_call',
+        'joint_mapping',
+    ):
+        assert private_value not in serialized
+
+
+@pytest.mark.parametrize(
+    ('path', 'value'),
+    [
+        (('output', 'hardware_output'), False),
+        (('output', 'profile_id'), 'different_profile'),
+        (('output', 'state'), '<script>unsafe</script>'),
+        (('output', 'target_joint_positions_rad', 0), float('nan')),
+        (('output', 'measured_joint_positions_rad'), [0.1] * 9),
+        (('output', 'max_abs_error_rad'), 2_000.0),
+        (('output', 'arm_sdk_weight'), None),
+        (('diagnostics', 'transport', 'pose_age_ms'), -1.0),
+        (('diagnostics', 'latency_ms', 'ik', 'p50'), 10.0),
+        (('diagnostics', 'latency_ms', 'ik', 'count'), 0),
+    ],
+    ids=[
+        'hardware-output',
+        'profile',
+        'unsafe-state',
+        'joint-nan',
+        'joint-count-mismatch',
+        'error-out-of-range',
+        'missing-live-arm-weight',
+        'negative-pose-age',
+        'percentiles-out-of-order',
+        'zero-count-with-samples',
+    ],
+)
+def test_live_output_and_diagnostics_fail_closed(path, value):
+    fake = FakeD1Caller()
+    raw = _live_active_snapshot(fake)
+    target: Any = raw
+    for key in path[:-1]:
+        target = target[key]
+    target[path[-1]] = value
+
+    with pytest.raises(TeleopServiceError) as raised:
+        _project_live(raw)
+
+    assert raised.value.code == 'driver_response_invalid'
+
+
+@pytest.mark.parametrize('joint_count', [0, 9, 11])
+def test_live_authority_output_requires_exact_capability_joint_count(joint_count):
+    fake = FakeD1Caller()
+    raw = _live_active_snapshot(fake)
+    raw['output']['target_joint_positions_rad'] = [0.1] * joint_count
+    raw['output']['measured_joint_positions_rad'] = [0.09] * joint_count
+
+    with pytest.raises(TeleopServiceError) as raised:
+        _project_live(raw)
+
+    assert raised.value.code == 'driver_response_invalid'
+
+
+@pytest.mark.parametrize('joint_count', [0, 10])
+def test_live_idle_output_allows_empty_or_declared_joint_vector(joint_count):
+    fake = FakeD1Caller()
+    raw = _live_active_snapshot(fake)
+    raw.update({
+        'session_id': None,
+        'state': 'idle',
+        'reason': None,
+        'authority_valid': False,
+    })
+    raw['lease'].update({'age_ms': None, 'fresh': False, 'authority_valid': False})
+    raw['dispatch'].update({
+        'state': 'safe_unarmed',
+        'last_admitted_sequence': None,
+        'last_published_sequence': None,
+        'last_decision': 'startup_safe_ack',
+    })
+    raw['output'].update({
+        'state': 'idle',
+        'target_joint_positions_rad': [0.1] * joint_count,
+        'measured_joint_positions_rad': [0.09] * joint_count,
+        'max_abs_error_rad': None,
+        'arm_sdk_weight': 0.0,
+        'command_age_ms': None,
+    })
+
+    projected = _project_live(raw)
+
+    assert len(projected['output']['target_joint_positions_rad']) == joint_count
+
+
+@pytest.mark.parametrize(
+    ('state', 'reason', 'dispatch_state', 'decision'),
+    [
+        ('prepared_live', None, 'safe_waiting_frame', 'prepared_after_stop_ack'),
+        ('paused', 'operator_pause', 'safe_latched', 'would_stop:operator_pause'),
+        ('hold', 'deadman_released', 'safe_reclutch_required', 'would_stop:deadman_released'),
+        ('hold', 'command_timeout', 'safe_reclutch_required', 'would_stop:command_timeout'),
+    ],
+)
+def test_every_live_authority_state_requires_declared_joint_vector(
+    state,
+    reason,
+    dispatch_state,
+    decision,
+):
+    fake = FakeD1Caller()
+    raw = _live_active_snapshot(fake)
+    raw.update({'state': state, 'reason': reason})
+    raw['dispatch'].update({
+        'state': dispatch_state,
+        'last_decision': decision,
+        'last_admitted_sequence': None if state == 'prepared_live' else 9,
+        'last_published_sequence': None if state == 'prepared_live' else 9,
+    })
+    raw['output'].update({
+        'state': state,
+        'target_joint_positions_rad': [],
+        'measured_joint_positions_rad': [],
+    })
+
+    with pytest.raises(TeleopServiceError) as raised:
+        _project_live(raw)
+    assert raised.value.code == 'driver_response_invalid'
+
+    raw['output']['target_joint_positions_rad'] = [0.1] * 10
+    raw['output']['measured_joint_positions_rad'] = [0.09] * 10
+    projected = _project_live(raw)
+    assert len(projected['output']['target_joint_positions_rad']) == 10
+
+
+def test_live_hold_is_visible_without_joint_semantics():
+    fake = FakeD1Caller()
+    raw = _live_active_snapshot(fake)
+    raw.update({'state': 'hold', 'reason': 'deadman_released'})
+    raw['dispatch'].update({
+        'state': 'safe_reclutch_required',
+        'last_decision': 'would_stop:deadman_released',
+    })
+    raw['output'].update({
+        'state': 'hold',
+        'fault_reason': 'deadman_released',
+        'command_age_ms': None,
+    })
+
+    projected = _project_live(raw)
+
+    assert projected['state'] == 'hold'
+    assert projected['dispatch']['state'] == 'safe_reclutch_required'
+    assert projected['output']['state'] == 'hold'
+    assert projected['output']['fault_reason'] == 'deadman_released'
+    assert projected['output']['hardware_output'] is True
+
+
+def test_g1_live_terminal_dispatch_fault_fixture_is_projected_exactly():
+    raw = _live_fault_snapshot(FakeD1Caller())
+
+    projected = _project_live(raw)
+
+    assert projected['state'] == 'fault'
+    assert projected['reason'] == 'dispatch_fault'
+    assert projected['authority_valid'] is False
+    assert projected['session_id'] is None
+    assert projected['lease']['fresh'] is False
+    assert projected['dispatch']['state'] == 'fault_latched'
+    assert projected['dispatch']['ready'] is False
+    assert projected['dispatch']['stop_acknowledged'] is False
+    assert projected['dispatch']['fault_code'] == 'arm_sdk_async_fault'
+    assert projected['dispatch']['last_published_sequence'] == 7
+    assert projected['output']['state'] == 'fault'
+    assert projected['output']['arm_sdk_weight'] == 0.0
+    assert projected['output']['fault_reason'] == 'arm_sdk_async_fault'
+
+
+def test_g1_live_terminal_fault_accepts_confirmed_safe_stop_variant():
+    raw = _live_fault_snapshot(FakeD1Caller())
+    raw['dispatch'].update({
+        'stop_acknowledged': True,
+        'last_decision': 'would_stop:adapter_fault',
+    })
+
+    projected = _project_live(raw)
+
+    assert projected['dispatch']['stop_acknowledged'] is True
+    assert projected['dispatch']['fault_code'] == 'arm_sdk_async_fault'
+
+
+@pytest.mark.parametrize(
+    ('path', 'value'),
+    [
+        (('reason',), 'lease_timeout'),
+        (('session_id',), str(uuid.uuid4())),
+        (('authority_valid',), True),
+        (('lease', 'age_ms'), 1.0),
+        (('dispatch', 'state'), 'safe_revoked'),
+        (('dispatch', 'ready'), True),
+        (('dispatch', 'stop_acknowledged'), True),
+        (('dispatch', 'fault_code'), None),
+        (('output', 'state'), 'stopped'),
+        (('output', 'arm_sdk_weight'), 0.1),
+        (('output', 'fault_reason'), None),
+        (('output', 'target_joint_positions_rad'), []),
+        (('pose', 'latest_sequence'), 9),
+        (('rtc', 'connected'), True),
+    ],
+)
+def test_g1_live_terminal_dispatch_fault_rejects_contradictory_shapes(path, value):
+    raw = _live_fault_snapshot(FakeD1Caller())
+    target: Any = raw
+    for key in path[:-1]:
+        target = target[key]
+    target[path[-1]] = value
+    if path == ('authority_valid',):
+        raw['lease']['authority_valid'] = value
+    if path == ('rtc', 'connected'):
+        raw['rtc']['channels'] = {'teleop-control': True, 'teleop-pose': True}
+
+    with pytest.raises(TeleopServiceError) as raised:
+        _project_live(raw)
+    assert raised.value.code == 'driver_response_invalid'
+
+
+@pytest.mark.parametrize(
+    ('state', 'reason'),
+    [
+        ('idle', None),
+        ('prepared_shadow', None),
+        ('active_shadow', None),
+        ('hold', 'deadman_released'),
+        ('hold', 'command_timeout'),
+        ('hold', 'intent_expired'),
+        ('paused', 'operator_pause'),
+        ('released', 'operator_release'),
+        ('fault', 'dispatch_fault'),
+    ],
+)
+def test_g1_shadow_profile_is_orthogonal_to_standard_recording_envelope(
+    state,
+    reason,
+):
+    projected = _project_g1_shadow(_g1_shadow_snapshot(state, reason))
+
+    assert projected['profile_id'] == G1_PROFILE_ID
+    assert projected['dispatch']['kind'] == 'recording'
+    assert projected['dispatch']['dry_run']['profile'] == 'recording'
+    assert projected['output']['profile_id'] == G1_PROFILE_ID
+    assert projected['output']['hardware_output'] is False
+    if state == 'fault':
+        assert projected['dispatch']['state'] == 'fault_latched'
+        assert projected['dispatch']['ready'] is False
+        assert projected['dispatch']['fault_code'] == 'projection_or_ik_failed'
+        assert projected['output']['state'] == 'fault'
+        assert projected['output']['arm_sdk_weight'] is None
+        assert projected['output']['fault_reason'] == 'projection_or_ik_failed'
+
+
+def test_g1_shadow_terminal_fault_accepts_confirmed_recording_stop_variant():
+    raw = _g1_shadow_snapshot('fault', 'dispatch_fault')
+    raw['dispatch'].update({
+        'stop_acknowledged': True,
+        'last_decision': 'would_stop:adapter_fault',
+    })
+
+    projected = _project_g1_shadow(raw)
+
+    assert projected['dispatch']['stop_acknowledged'] is True
+    assert projected['dispatch']['fault_code'] == 'projection_or_ik_failed'
+
+
+def test_g1_shadow_rejects_hardware_arm_weight_in_non_fault_state():
+    raw = _g1_shadow_snapshot('active_shadow', None)
+    raw['output']['arm_sdk_weight'] = 0.5
+
+    with pytest.raises(TeleopServiceError) as raised:
+        _project_g1_shadow(raw)
+    assert raised.value.code == 'driver_response_invalid'
+
+
+@pytest.mark.parametrize(
+    ('path', 'value'),
+    [
+        (('dispatch', 'state'), 'safe_revoked'),
+        (('dispatch', 'ready'), True),
+        (('dispatch', 'fault_code'), None),
+        (('dispatch', 'last_decision'), 'would_stop:adapter_fault'),
+        (('output', 'state'), 'released'),
+        (('output', 'arm_sdk_weight'), 0.0),
+        (('output', 'fault_reason'), 'different_fault'),
+    ],
+)
+def test_g1_shadow_terminal_fault_rejects_contradictory_shapes(path, value):
+    raw = _g1_shadow_snapshot('fault', 'dispatch_fault')
+    target: Any = raw
+    for key in path[:-1]:
+        target = target[key]
+    target[path[-1]] = value
+
+    with pytest.raises(TeleopServiceError) as raised:
+        _project_g1_shadow(raw)
+    assert raised.value.code == 'driver_response_invalid'
+
+
+def test_adapter_snapshot_failure_is_visible_without_forwarding_raw_details():
+    fake = FakeD1Caller()
+    raw = fake.snapshot()
+    raw['dispatch']['adapter'] = {
+        'kind': 'unavailable',
+        'reason': 'adapter_snapshot_exception',
+        'exception': '<script>private</script>',
+    }
+    projected, _ = _project_driver_snapshot(
+        raw,
+        driver_id=DRIVER_ID,
+        robot_id=ROBOT_ID,
+        capability_digest=DIGEST,
+        action='status',
+    )
+    dry_run = projected['dispatch']['dry_run']
+    assert dry_run['profile'] == 'unavailable'
+    assert dry_run['operation'] == 'unavailable'
+    assert dry_run['stop_reason'] == 'adapter_snapshot_exception'
+    assert dry_run['hardware_output'] is None
+    assert dry_run['actuation_enabled'] is None
+    assert '<script>' not in repr(projected)
+
+    raw['dispatch']['adapter']['reason'] = 'arbitrary_exception_text'
+    with pytest.raises(TeleopServiceError) as raised:
+        _project_driver_snapshot(
+            raw,
+            driver_id=DRIVER_ID,
+            robot_id=ROBOT_ID,
+            capability_digest=DIGEST,
+            action='status',
+        )
+    assert raised.value.code == 'driver_response_invalid'
+
+
+@pytest.mark.parametrize(
+    'adapter',
+    [
+        {'kind': 'recording'},
+        {
+            'kind': 'recording',
+            'closed': True,
+            'current': {'kind': 'safe'},
+            'records': [],
+        },
+        {
+            'kind': 'recording',
+            'closed': False,
+            'current': {'kind': 'live_apply'},
+            'records': [],
+        },
+        {
+            'kind': 'recording',
+            'closed': False,
+            'current': {'kind': {}},
+            'records': [],
+        },
+        {
+            'kind': 'recording',
+            'closed': False,
+            'current': {'kind': 'safe'},
+            'records': [{}] * 65,
+        },
+        {
+            'kind': 'recording',
+            'closed': False,
+            'hardware_output': True,
+            'current': {'kind': 'safe'},
+            'records': [],
+        },
+        {
+            'kind': 'recording',
+            'closed': False,
+            'actuation_enabled': True,
+            'current': {'kind': 'safe'},
+            'records': [],
+        },
+    ],
+    ids=[
+        'incomplete',
+        'closed',
+        'unknown-current',
+        'unhashable-current',
+        'unbounded-history',
+        'contradictory-hardware-output',
+        'contradictory-actuation',
+    ],
+)
+def test_recording_adapter_projection_requires_bounded_zero_output_shape(adapter):
+    fake = FakeD1Caller()
+    raw = fake.snapshot()
+    raw['dispatch']['adapter'] = adapter
+    with pytest.raises(TeleopServiceError) as raised:
+        _project_driver_snapshot(
+            raw,
+            driver_id=DRIVER_ID,
+            robot_id=ROBOT_ID,
+            capability_digest=DIGEST,
+            action='status',
+        )
+    assert raised.value.code == 'driver_response_invalid'
+
+
+@pytest.mark.parametrize(
+    ('field', 'value'),
+    [
+        ('last_published_sequence', 10),
+        ('last_admitted_sequence', None),
+        ('last_published_sequence', -1),
+    ],
+    ids=['applied-after-admitted', 'applied-without-admission', 'negative-applied'],
+)
+def test_hardware_dispatch_sequence_evidence_fails_closed(field, value):
+    fake = FakeD1Caller()
+    raw = _live_active_snapshot(fake, published_sequence=8)
+    raw['dispatch'][field] = value
+
+    with pytest.raises(TeleopServiceError) as raised:
+        _project_live(raw)
+    assert raised.value.code == 'driver_response_invalid'
+
+
+@pytest.mark.parametrize('published_sequence', [None, 7, 9])
+def test_hardware_dispatch_accepts_bounded_publish_lag(
+    published_sequence,
+):
+    fake = FakeD1Caller()
+    raw = _live_active_snapshot(fake, published_sequence=published_sequence)
+
+    projected = _project_live(raw)
+
+    assert projected['dispatch']['last_admitted_sequence'] == 9
+    assert projected['dispatch']['last_published_sequence'] == published_sequence
+
+
+@pytest.mark.parametrize('spoofed_key', ['last_applied_sequence', 'last_would_apply_sequence'])
+def test_hardware_dispatch_rejects_non_publisher_sequence_aliases(spoofed_key):
+    fake = FakeD1Caller()
+    raw = _live_active_snapshot(fake, published_sequence=7)
+    raw['dispatch'][spoofed_key] = 7
+
+    with pytest.raises(TeleopServiceError) as raised:
+        _project_live(raw)
+    assert raised.value.code == 'driver_response_invalid'
+
+
+def test_guard_write_failure_never_reaches_prepare_shadow(
+    shadow_session_tool,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    async def scenario() -> None:
+        _install_descriptor(shadow_session_tool)
+        fake = FakeD1Caller()
+        broker = CommandBroker()
+        coordinator = _coordinator(fake, MutableClock(), command_broker=broker)
+
+        def fail_guard_write(_guard):
+            raise OSError('simulated guard database failure')
+
+        monkeypatch.setattr(authority_guard, 'create_guard', fail_guard_write)
+        try:
+            with pytest.raises(TeleopServiceError) as raised:
+                await coordinator.acquire(DRIVER_ID, 'alice', CLIENT_ID)
+            assert raised.value.code == 'authority_guard_persistence_error'
+            assert [call['action'] for call in fake.calls] == ['status']
+            assert await broker.authority_for(ROBOT_ID) is None
+        finally:
+            await coordinator.stop()
+
+    asyncio.run(scenario())
+
+
+def test_cancelled_guard_commit_is_removed_before_command_gate_reopens(
+    shadow_session_tool,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    async def scenario() -> None:
+        _install_descriptor(shadow_session_tool)
+        fake = FakeD1Caller(lease_seconds=10.0)
+        broker = CommandBroker()
+        coordinator = _coordinator(
+            fake,
+            MutableClock(),
+            command_broker=broker,
+        )
+        committed = threading.Event()
+        allow_return = threading.Event()
+        real_create = authority_guard.create_guard
+
+        def commit_then_wait(guard):
+            result = real_create(guard)
+            committed.set()
+            if not allow_return.wait(timeout=1.0):
+                raise AssertionError('test did not release committed guard write')
+            return result
+
+        monkeypatch.setattr(authority_guard, 'create_guard', commit_then_wait)
+        acquire_task = asyncio.create_task(
+            coordinator.acquire(DRIVER_ID, 'alice', CLIENT_ID),
+        )
+        try:
+            await _wait_until(committed.is_set)
+            acquire_task.cancel()
+            await asyncio.sleep(0)
+            assert not acquire_task.done()
+            allow_return.set()
+            with pytest.raises(asyncio.CancelledError):
+                await acquire_task
+
+            assert [call['action'] for call in fake.calls] == ['status']
+            assert authority_guard.get_guard(ROBOT_ID) is None
+            assert coordinator.authority_guard_for_robot(ROBOT_ID) is None
+            assert await broker.authority_for(ROBOT_ID) is None
+            async with broker.ordinary_command(
+                ROBOT_ID,
+                read_only=False,
+                source='test',
+                tool='locomotion',
+                action='move',
+                tool_verified=True,
+                action_verified=True,
+            ):
+                pass
+        finally:
+            allow_return.set()
+            await asyncio.gather(acquire_task, return_exceptions=True)
+            await coordinator.stop()
+
+    asyncio.run(scenario())
+
+
+def test_guard_commit_wins_race_with_target_delete_and_delete_is_rejected(
+    shadow_session_tool,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    async def scenario() -> None:
+        _install_descriptor(shadow_session_tool)
+        fake = FakeD1Caller(lease_seconds=10.0)
+        coordinator = _coordinator(fake, MutableClock())
+        create_entered = threading.Event()
+        allow_create = threading.Event()
+        real_create = authority_guard.create_guard
+
+        def delayed_create(guard):
+            create_entered.set()
+            if not allow_create.wait(timeout=1.0):
+                raise AssertionError('test did not release guard commit')
+            return real_create(guard)
+
+        monkeypatch.setattr(authority_guard, 'create_guard', delayed_create)
+        acquire_task = asyncio.create_task(
+            coordinator.acquire(DRIVER_ID, 'alice', CLIENT_ID),
+        )
+        try:
+            await _wait_until(create_entered.is_set)
+            delete_task = asyncio.create_task(mcp_manage.mcp_delete(DRIVER_ID))
+            await asyncio.sleep(0)
+            assert not delete_task.done()
+
+            allow_create.set()
+            acquired = await acquire_task
+            delete_response = await delete_task
+            assert delete_response.status_code == 409
+            assert json.loads(delete_response.body)['data'] == {
+                'code': 'authority_target_locked',
+                'reason': 'persistent_authority_guard_requires_stable_target',
+                'project_state': 'running',
+                'mcp_ids': [DRIVER_ID],
+            }
+            assert authority_guard.get_guard(ROBOT_ID).session_id == acquired.session.id
+            assert [call['action'] for call in fake.calls[:3]] == [
+                'status',
+                'prepare_shadow',
+                'heartbeat',
+            ]
+        finally:
+            allow_create.set()
+            await asyncio.gather(acquire_task, return_exceptions=True)
+            await _finish(coordinator)
+
+    asyncio.run(scenario())
+
+
+def test_target_change_before_guard_commit_rejects_without_prepare(
+    shadow_session_tool,
+):
+    async def scenario() -> None:
+        _install_descriptor(shadow_session_tool)
+        fake = FakeD1Caller(lease_seconds=10.0)
+        status_entered = asyncio.Event()
+        allow_status = asyncio.Event()
+
+        async def delayed_status(producer, _arguments):
+            status_entered.set()
+            await allow_status.wait()
+            return producer.snapshot()
+
+        fake.queue('status', delayed_status)
+        broker = CommandBroker()
+        coordinator = _coordinator(
+            fake,
+            MutableClock(),
+            command_broker=broker,
+        )
+        acquire_task = asyncio.create_task(
+            coordinator.acquire(DRIVER_ID, 'alice', CLIENT_ID),
+        )
+        try:
+            await asyncio.wait_for(status_entered.wait(), timeout=0.5)
+            changed_services = deepcopy(config.main['services'])
+            changed_services['mcp'][0]['tools'][0]['x-teleop'][
+                'capability_digest'
+            ] = 'f' * 64
+            config.main['services'] = changed_services
+            allow_status.set()
+
+            with pytest.raises(TeleopServiceError) as raised:
+                await acquire_task
+            assert raised.value.code == 'driver_not_ready'
+            assert [call['action'] for call in fake.calls] == ['status']
+            assert authority_guard.get_guard(ROBOT_ID) is None
+            assert await broker.authority_for(ROBOT_ID) is None
+        finally:
+            allow_status.set()
+            await asyncio.gather(acquire_task, return_exceptions=True)
+            await coordinator.stop()
+
+    asyncio.run(scenario())
+
+
+def test_core_crash_restores_robot_gate_and_owner_stop_clears_it(
+    shadow_session_tool,
+):
+    async def scenario() -> None:
+        _install_descriptor(shadow_session_tool)
+        clock = MutableClock()
+        fake = FakeD1Caller(lease_seconds=10.0)
+        crashed = _coordinator(fake, clock, command_broker=CommandBroker())
+        acquired = await crashed.acquire(DRIVER_ID, 'alice', CLIENT_ID)
+        stored = authority_guard.get_guard(ROBOT_ID)
+        assert stored is not None
+        assert stored.phase == 'active'
+        assert stored.session_id == acquired.session.id
+        await _crash_without_authority_cleanup(crashed, fake)
+
+        recovered_broker = CommandBroker()
+        recovered = _coordinator(fake, clock, command_broker=recovered_broker)
+        await recovered.start()
+        try:
+            assert await recovered.manager.list_visible('', owner=True) == []
+            recovered_guard = recovered.authority_guard_for_robot(ROBOT_ID)
+            assert recovered_guard == {
+                'state': 'recovery_required',
+                'phase': 'recovery_required',
+                'driver_id': DRIVER_ID,
+                'robot_id': ROBOT_ID,
+                'retryable': True,
+                'created_at': stored.created_at,
+                'updated_at': recovered_guard['updated_at'],
+            }
+            assert recovered_guard['updated_at'] >= stored.updated_at
+            with pytest.raises(TeleopCommandBlocked) as blocked:
+                async with recovered_broker.ordinary_command(
+                    ROBOT_ID,
+                    read_only=False,
+                    source='test',
+                    tool='locomotion',
+                    action='move',
+                    tool_verified=True,
+                    action_verified=True,
+                ):
+                    raise AssertionError('guarded robot write must not be admitted')
+            assert blocked.value.public_detail()['state'] == 'recovery_required'
+            async with recovered_broker.ordinary_command(
+                'robot-b',
+                read_only=False,
+                source='test',
+                tool='locomotion',
+                action='move',
+                tool_verified=True,
+                action_verified=True,
+            ):
+                pass
+            with pytest.raises(TeleopServiceError) as acquire_blocked:
+                await recovered.acquire(DRIVER_ID, 'bob', CLIENT_ID)
+            assert acquire_blocked.value.code == 'robot_recovery_required'
+
+            result = await recovered.reconcile_authority_guard(
+                ROBOT_ID,
+                principal_id='owner:legacy',
+            )
+            assert result == {
+                'state': 'clear',
+                'robot_id': ROBOT_ID,
+                'driver_id': DRIVER_ID,
+                'old_session_restored': False,
+                'reacquire_required': True,
+            }
+            assert fake.count('stop') == 1
+            assert authority_guard.get_guard(ROBOT_ID) is None
+            assert recovered.authority_guard_for_robot(ROBOT_ID) is None
+            assert await recovered.manager.get(acquired.session.id) is None
+            async with recovered_broker.ordinary_command(
+                ROBOT_ID,
+                read_only=False,
+                source='test',
+                tool='locomotion',
+                action='move',
+                tool_verified=True,
+                action_verified=True,
+            ):
+                pass
+        finally:
+            await recovered.stop()
+
+    asyncio.run(scenario())
+
+
+def test_new_driver_boot_safe_unarmed_clears_guard_without_lifecycle_stop(
+    shadow_session_tool,
+):
+    async def scenario() -> None:
+        _install_descriptor(shadow_session_tool)
+        clock = MutableClock()
+        fake = FakeD1Caller(lease_seconds=10.0)
+        crashed = _coordinator(fake, clock, command_broker=CommandBroker())
+        await crashed.acquire(DRIVER_ID, 'alice', CLIENT_ID)
+        await _crash_without_authority_cleanup(crashed, fake)
+
+        fake.boot_id = 'f2b909a5-119c-4328-9213-4c8da7293188'
+        fake.epoch = 1
+        fake.session_id = None
+        fake.fence = None
+        fake.state = 'idle'
+        fake.reason = None
+        fake.authority_valid = False
+        fake.dispatch_generation = 0
+        fake.dispatch_last_admitted = None
+
+        recovered = _coordinator(fake, clock, command_broker=CommandBroker())
+        await recovered.start()
+        try:
+            result = await recovered.reconcile_authority_guard(
+                ROBOT_ID,
+                principal_id='owner:legacy',
+            )
+            assert result['state'] == 'clear'
+            assert result['old_session_restored'] is False
+            assert result['reacquire_required'] is True
+            assert fake.count('stop') == 0
+            assert authority_guard.get_guard(ROBOT_ID) is None
+        finally:
+            await recovered.stop()
+
+    asyncio.run(scenario())
+
+
+def test_new_driver_boot_with_reset_generation_can_be_stopped_and_cleared(
+    shadow_session_tool,
+):
+    async def scenario() -> None:
+        _install_descriptor(shadow_session_tool)
+        clock = MutableClock()
+        fake = FakeD1Caller(lease_seconds=10.0)
+        crashed = _coordinator(fake, clock, command_broker=CommandBroker())
+        await crashed.acquire(DRIVER_ID, 'alice', CLIENT_ID)
+        stored = authority_guard.get_guard(ROBOT_ID)
+        assert stored is not None
+        assert stored.dispatch_generation > 0
+        await _crash_without_authority_cleanup(crashed, fake)
+
+        fake.boot_id = 'ad401205-82aa-4a55-8bff-3c59ef543ce5'
+        fake.epoch = 1
+        fake.session_id = None
+        fake.fence = None
+        fake.state = 'released'
+        fake.reason = 'lifecycle_stop'
+        fake.authority_valid = False
+        fake.dispatch_generation = 0
+        fake.dispatch_last_admitted = None
+
+        recovered = _coordinator(fake, clock, command_broker=CommandBroker())
+        await recovered.start()
+        try:
+            result = await recovered.reconcile_authority_guard(
+                ROBOT_ID,
+                principal_id='owner:legacy',
+            )
+            assert result['state'] == 'clear'
+            assert fake.count('stop') == 1
+            assert authority_guard.get_guard(ROBOT_ID) is None
+        finally:
+            await recovered.stop()
+
+    asyncio.run(scenario())
+
+
+def test_recovery_target_change_keeps_persistent_and_runtime_gates(
+    shadow_session_tool,
+):
+    async def scenario() -> None:
+        _install_descriptor(shadow_session_tool)
+        clock = MutableClock()
+        fake = FakeD1Caller(lease_seconds=10.0)
+        crashed = _coordinator(fake, clock, command_broker=CommandBroker())
+        acquired = await crashed.acquire(DRIVER_ID, 'alice', CLIENT_ID)
+        await _crash_without_authority_cleanup(crashed, fake)
+
+        changed_services = deepcopy(config.main['services'])
+        changed_services['mcp'][0]['tools'][0]['x-teleop'][
+            'capability_digest'
+        ] = 'f' * 64
+        config.main['services'] = changed_services
+        broker = CommandBroker()
+        recovered = _coordinator(fake, clock, command_broker=broker)
+        await recovered.start()
+        try:
+            with pytest.raises(TeleopServiceError) as raised:
+                await recovered.reconcile_authority_guard(
+                    ROBOT_ID,
+                    principal_id='owner:legacy',
+                )
+            assert raised.value.code == 'authority_guard_target_changed'
+            persisted = authority_guard.get_guard(ROBOT_ID)
+            assert persisted is not None
+            assert persisted.session_id == acquired.session.id
+            assert recovered.authority_guard_for_robot(ROBOT_ID) is not None
+            with pytest.raises(TeleopCommandBlocked):
+                async with broker.ordinary_command(
+                    ROBOT_ID,
+                    read_only=False,
+                    source='test',
+                    tool='locomotion',
+                    action='move',
+                    tool_verified=True,
+                    action_verified=True,
+                ):
+                    raise AssertionError('changed target must remain quarantined')
+            assert fake.count('stop') == 0
+        finally:
+            await recovered.stop()
+
+    asyncio.run(scenario())
+
+
+def test_recovery_authority_root_change_keeps_guard_without_stop(
+    shadow_session_tool,
+):
+    async def scenario() -> None:
+        _install_descriptor(shadow_session_tool)
+        clock = MutableClock()
+        fake = FakeD1Caller(lease_seconds=10.0)
+        crashed = _coordinator(fake, clock, command_broker=CommandBroker())
+        acquired = await crashed.acquire(DRIVER_ID, 'alice', CLIENT_ID)
+        await _crash_without_authority_cleanup(crashed, fake)
+
+        changed_services = deepcopy(config.main['services'])
+        changed_services['mcp'][1]['url'] = 'http://changed-root.invalid/mcp'
+        config.main['services'] = changed_services
+        recovered = _coordinator(fake, clock, command_broker=CommandBroker())
+        await recovered.start()
+        try:
+            with pytest.raises(TeleopServiceError) as raised:
+                await recovered.reconcile_authority_guard(
+                    ROBOT_ID,
+                    principal_id='owner:legacy',
+                )
+            assert raised.value.code == 'authority_guard_target_changed'
+            persisted = authority_guard.get_guard(ROBOT_ID)
+            assert persisted is not None
+            assert persisted.session_id == acquired.session.id
+            assert fake.count('stop') == 0
+        finally:
+            await recovered.stop()
+
+    asyncio.run(scenario())
+
+
+def test_guard_delete_failure_keeps_gate_and_is_retryable(
+    shadow_session_tool,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    async def scenario() -> None:
+        _install_descriptor(shadow_session_tool)
+        clock = MutableClock()
+        fake = FakeD1Caller(lease_seconds=10.0)
+        crashed = _coordinator(fake, clock, command_broker=CommandBroker())
+        await crashed.acquire(DRIVER_ID, 'alice', CLIENT_ID)
+        await _crash_without_authority_cleanup(crashed, fake)
+
+        broker = CommandBroker()
+        recovered = _coordinator(fake, clock, command_broker=broker)
+        await recovered.start()
+        real_delete = authority_guard.delete_guard
+
+        def fail_delete(_robot_id: str, _session_id: str) -> bool:
+            raise OSError('simulated guard delete failure')
+
+        monkeypatch.setattr(authority_guard, 'delete_guard', fail_delete)
+        try:
+            with pytest.raises(TeleopServiceError) as raised:
+                await recovered.reconcile_authority_guard(
+                    ROBOT_ID,
+                    principal_id='owner:legacy',
+                )
+            assert raised.value.code == 'authority_guard_persistence_error'
+            assert fake.count('stop') == 1
+            assert authority_guard.get_guard(ROBOT_ID) is not None
+            assert recovered.authority_guard_for_robot(ROBOT_ID) is not None
+            with pytest.raises(TeleopCommandBlocked):
+                async with broker.ordinary_command(
+                    ROBOT_ID,
+                    read_only=False,
+                    source='test',
+                    tool='locomotion',
+                    action='move',
+                    tool_verified=True,
+                    action_verified=True,
+                ):
+                    raise AssertionError('failed delete must keep admission closed')
+
+            monkeypatch.setattr(authority_guard, 'delete_guard', real_delete)
+            result = await recovered.reconcile_authority_guard(
+                ROBOT_ID,
+                principal_id='owner:legacy',
+            )
+            assert result['state'] == 'clear'
+            assert fake.count('stop') == 1
+            assert authority_guard.get_guard(ROBOT_ID) is None
+        finally:
+            await recovered.stop()
+
+    asyncio.run(scenario())
+
+
+def test_cancelled_reconcile_finishes_guard_delete_and_broker_release(
+    shadow_session_tool,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    async def scenario() -> None:
+        _install_descriptor(shadow_session_tool)
+        clock = MutableClock()
+        fake = FakeD1Caller(lease_seconds=10.0)
+        crashed = _coordinator(fake, clock, command_broker=CommandBroker())
+        await crashed.acquire(DRIVER_ID, 'alice', CLIENT_ID)
+        await _crash_without_authority_cleanup(crashed, fake)
+
+        broker = CommandBroker()
+        recovered = _coordinator(fake, clock, command_broker=broker)
+        await recovered.start()
+        deleted = threading.Event()
+        allow_return = threading.Event()
+        real_delete = authority_guard.delete_guard
+
+        def delete_then_wait(robot_id: str, session_id: str) -> bool:
+            result = real_delete(robot_id, session_id)
+            deleted.set()
+            if not allow_return.wait(timeout=1.0):
+                raise AssertionError('test did not release committed guard delete')
+            return result
+
+        monkeypatch.setattr(authority_guard, 'delete_guard', delete_then_wait)
+        reconcile_task = asyncio.create_task(recovered.reconcile_authority_guard(
+            ROBOT_ID,
+            principal_id='owner:legacy',
+        ))
+        try:
+            await _wait_until(deleted.is_set)
+            reconcile_task.cancel()
+            await asyncio.sleep(0)
+            assert not reconcile_task.done()
+            allow_return.set()
+            with pytest.raises(asyncio.CancelledError):
+                await reconcile_task
+
+            assert fake.count('stop') == 1
+            assert authority_guard.get_guard(ROBOT_ID) is None
+            assert recovered.authority_guard_for_robot(ROBOT_ID) is None
+            assert await broker.authority_for(ROBOT_ID) is None
+            repeated = await recovered.reconcile_authority_guard(
+                ROBOT_ID,
+                principal_id='owner:legacy',
+            )
+            assert repeated['already_clear'] is True
+        finally:
+            allow_return.set()
+            await asyncio.gather(reconcile_task, return_exceptions=True)
+            await recovered.stop()
+
+    asyncio.run(scenario())
+
+
+def test_acquire_is_idempotent_for_same_operator_and_conflicts_for_another(
+    shadow_session_tool,
+):
+    async def scenario() -> None:
+        _install_descriptor(shadow_session_tool)
+        coordinator = _coordinator(FakeD1Caller(), MutableClock())
+        try:
+            created = await coordinator.acquire(DRIVER_ID, 'alice', CLIENT_ID)
+            call_count = len(coordinator._caller.calls)
+            repeated = await coordinator.acquire(DRIVER_ID, 'alice', CLIENT_ID)
+            assert repeated.disposition == 'existing'
+            assert repeated.session is created.session
+            assert len(coordinator._caller.calls) == call_count
+
+            with pytest.raises(SessionConflict) as raised:
+                await coordinator.acquire(DRIVER_ID, 'bob', CLIENT_ID)
+            assert raised.value.session is created.session
+            assert len(coordinator._caller.calls) == call_count
+        finally:
+            await _finish(coordinator)
+
+    asyncio.run(scenario())
+
+
+def test_random_unknown_ids_cannot_grow_lock_storage(shadow_session_tool):
+    async def scenario() -> None:
+        _install_descriptor(shadow_session_tool)
+        coordinator = _coordinator(FakeD1Caller(), MutableClock())
+        operation_lock_ids = tuple(map(id, coordinator._operation_locks))
+        acquire_lock_ids = tuple(map(id, coordinator._acquire_locks))
+        try:
+            for _ in range(300):
+                with pytest.raises(SessionNotFound):
+                    await coordinator.status(str(uuid.uuid4()), 'alice', owner=False)
+            for index in range(50):
+                with pytest.raises(TeleopServiceError) as raised:
+                    await coordinator.acquire(
+                        f'unknown-driver-{index}',
+                        'alice',
+                        CLIENT_ID,
+                    )
+                assert raised.value.code == 'driver_not_found'
+
+            assert tuple(map(id, coordinator._operation_locks)) == operation_lock_ids
+            assert tuple(map(id, coordinator._acquire_locks)) == acquire_lock_ids
+            assert len(coordinator._operation_locks) == 256
+            assert len(coordinator._acquire_locks) == 256
+        finally:
+            await coordinator.stop()
+
+    asyncio.run(scenario())
+
+
+def test_prepare_timeout_reconciles_exact_same_session_and_epoch(
+    shadow_session_tool,
+):
+    async def scenario() -> None:
+        _install_descriptor(shadow_session_tool)
+        fake = FakeD1Caller()
+        fake.prepare_timeout_after_apply = True
+        coordinator = _coordinator(fake, MutableClock())
+        try:
+            result = await coordinator.acquire(DRIVER_ID, 'alice', CLIENT_ID)
+            assert result.disposition == 'created'
+            assert [call['action'] for call in fake.calls[:4]] == [
+                'status', 'prepare_shadow', 'status', 'heartbeat',
+            ]
+            reconciled_status = fake.calls[2]
+            assert reconciled_status['arguments'] is None
+            assert fake.session_id == result.session.id
+            assert fake.epoch == result.session.epoch
+        finally:
+            await _finish(coordinator)
+
+    asyncio.run(scenario())
+
+
+def test_owner_release_cannot_pass_an_inflight_prepare(shadow_session_tool):
+    async def scenario() -> None:
+        _install_descriptor(shadow_session_tool)
+        fake = FakeD1Caller()
+        coordinator = _coordinator(fake, MutableClock())
+        prepare_started = asyncio.Event()
+        allow_prepare = asyncio.Event()
+
+        async def delayed_prepare(
+            producer: FakeD1Caller,
+            arguments: dict[str, Any] | None,
+        ) -> dict[str, Any]:
+            assert arguments is not None
+            prepare_started.set()
+            await allow_prepare.wait()
+            producer.session_id = arguments['session_id']
+            producer.epoch = arguments['epoch']
+            producer.fence = arguments['fence']
+            producer.state = 'prepared_shadow'
+            producer.reason = None
+            producer.authority_valid = True
+            producer.dispatch_generation += 1
+            return producer.snapshot()
+
+        fake.queue('prepare_shadow', delayed_prepare)
+        acquire = asyncio.create_task(coordinator.acquire(
+            DRIVER_ID,
+            'alice',
+            CLIENT_ID,
+        ))
+        try:
+            await asyncio.wait_for(prepare_started.wait(), timeout=0.8)
+            visible = await coordinator.manager.list_visible('', owner=True)
+            assert len(visible) == 1
+            release = asyncio.create_task(coordinator.release(
+                visible[0].id,
+                'owner',
+                CLIENT_ID,
+                owner=True,
+            ))
+            await asyncio.sleep(0)
+            assert release.done() is False
+
+            allow_prepare.set()
+            acquired = await acquire
+            released, acknowledged = await release
+            actions = [call['action'] for call in fake.calls]
+
+            assert acquired.session is released
+            assert released.state == 'released'
+            assert acknowledged is True
+            assert actions.index('release') > actions.index('heartbeat')
+            assert fake.count('prepare_shadow') == 1
+            assert fake.count('release') == 1
+            assert fake.session_id is None
+        finally:
+            allow_prepare.set()
+            if not acquire.done():
+                acquire.cancel()
+                await asyncio.gather(acquire, return_exceptions=True)
+            await coordinator.stop()
+
+    asyncio.run(scenario())
+
+
+@pytest.mark.parametrize(
+    'malformation',
+    [
+        {'actuation_enabled': True},
+        {'capability_digest': 'f' * 64},
+        {'authority_valid': 'yes'},
+        {'lease': {'source': 'browser', 'timeout_ms': 1_000}},
+        {'rtc': {'connected': False, 'channels': {'teleop-pose': False}}},
+    ],
+    ids=['actuation', 'digest', 'authority-type', 'lease-source', 'rtc-channels'],
+)
+def test_acquire_fails_closed_on_nonconforming_driver_response(
+    shadow_session_tool,
+    malformation,
+):
+    async def scenario() -> None:
+        _install_descriptor(shadow_session_tool)
+        fake = FakeD1Caller()
+        fake.queue('status', fake.snapshot(**malformation))
+        coordinator = _coordinator(fake, MutableClock())
+        try:
+            with pytest.raises(TeleopServiceError) as raised:
+                await coordinator.acquire(DRIVER_ID, 'alice', CLIENT_ID)
+            assert raised.value.code == 'driver_response_invalid'
+            assert raised.value.status_code == 502
+            assert await coordinator.manager.active_for_robot(ROBOT_ID) is None
+        finally:
+            await coordinator.stop()
+
+    asyncio.run(scenario())
+
+
+@pytest.mark.parametrize(
+    ('path', 'value'),
+    [
+        (('dispatch',), None),
+        (('dispatch', 'kind'), 'direct'),
+        (('dispatch', 'ready'), False),
+        (('dispatch', 'generation'), True),
+        (('dispatch', 'generation'), 2**63),
+        (('dispatch', 'mailbox_depth'), 2),
+        (('dispatch', 'stop_queue_depth'), 1),
+        (('dispatch', 'stop_acknowledged'), False),
+        (('dispatch', 'fault_code'), 'adapter_fault'),
+        (('dispatch', 'last_decision'), 'unknown'),
+        (('dispatch', 'io_inflight'), 'safe_stop'),
+        (('dispatch', 'last_would_apply_sequence'), 1),
+    ],
+    ids=[
+        'missing',
+        'wrong-kind',
+        'not-ready',
+        'bool-generation',
+        'generation-overflow',
+        'mailbox-overflow',
+        'stop-pending',
+        'stop-unacknowledged',
+        'faulted',
+        'unknown-decision',
+        'stop-inflight',
+        'applied-without-admission',
+    ],
+)
+def test_acquire_requires_stable_recording_dispatch_status(
+    shadow_session_tool,
+    path,
+    value,
+):
+    async def scenario() -> None:
+        _install_descriptor(shadow_session_tool)
+        fake = FakeD1Caller()
+        raw = fake.snapshot()
+        if len(path) == 1:
+            raw.pop(path[0])
+        else:
+            raw[path[0]][path[1]] = value
+        fake.queue('status', raw)
+        broker = CommandBroker()
+        coordinator = _coordinator(fake, MutableClock(), command_broker=broker)
+        try:
+            with pytest.raises(TeleopServiceError) as raised:
+                await coordinator.acquire(DRIVER_ID, 'alice', CLIENT_ID)
+            assert raised.value.code == 'driver_response_invalid'
+            assert coordinator._command_claims == {}
+            assert await broker.authority_for(ROBOT_ID) is None
+        finally:
+            await coordinator.stop()
+
+    asyncio.run(scenario())
+
+
+def test_post_prepare_numeric_overflow_revokes_driver_authority(
+    shadow_session_tool,
+):
+    async def scenario() -> None:
+        _install_descriptor(shadow_session_tool)
+        fake = FakeD1Caller()
+
+        def overflowing_prepare(
+            producer: FakeD1Caller,
+            arguments: dict[str, Any] | None,
+        ) -> dict[str, Any]:
+            assert arguments is not None
+            producer.session_id = arguments['session_id']
+            producer.epoch = arguments['epoch']
+            producer.fence = arguments['fence']
+            producer.state = 'prepared_shadow'
+            producer.reason = None
+            producer.authority_valid = True
+            producer.dispatch_generation += 1
+            snapshot = producer.snapshot()
+            snapshot['lease']['timeout_ms'] = 10**400
+            return snapshot
+
+        fake.queue('prepare_shadow', overflowing_prepare)
+        coordinator = _coordinator(fake, MutableClock())
+        try:
+            with pytest.raises(TeleopServiceError) as raised:
+                await coordinator.acquire(DRIVER_ID, 'alice', CLIENT_ID)
+
+            assert raised.value.code == 'driver_response_invalid'
+            assert await coordinator.manager.active_for_robot(ROBOT_ID) is None
+            assert fake.count('release') == 1
+            assert fake.state == 'released'
+            assert fake.authority_valid is False
+        finally:
+            await coordinator.stop()
+
+    asyncio.run(scenario())
+
+
+@pytest.mark.parametrize(
+    ('reported_epoch', 'expected_code'),
+    [
+        (MAX_DRIVER_EPOCH, 'driver_epoch_exhausted'),
+        (MAX_DRIVER_EPOCH + 1, 'driver_response_invalid'),
+    ],
+)
+def test_acquire_rejects_driver_epoch_exhaustion_without_preparing(
+    shadow_session_tool,
+    reported_epoch,
+    expected_code,
+):
+    async def scenario() -> None:
+        _install_descriptor(shadow_session_tool)
+        fake = FakeD1Caller(epoch=reported_epoch)
+        coordinator = _coordinator(fake, MutableClock())
+        try:
+            with pytest.raises(TeleopServiceError) as raised:
+                await coordinator.acquire(DRIVER_ID, 'alice', CLIENT_ID)
+            assert raised.value.code == expected_code
+            assert fake.count('prepare_shadow') == 0
+            assert await coordinator.manager.active_for_robot(ROBOT_ID) is None
+        finally:
+            await coordinator.stop()
+
+    asyncio.run(scenario())
+
+
+def test_supervisor_runs_within_250ms_and_keeps_paused_and_hold_alive(
+    shadow_session_tool,
+):
+    async def scenario() -> None:
+        _install_descriptor(shadow_session_tool)
+        fake = FakeD1Caller(lease_seconds=10.0)
+        coordinator = _coordinator(fake, MutableClock())
+        try:
+            acquired = await coordinator.acquire(DRIVER_ID, 'alice', CLIENT_ID)
+            initial = fake.count('heartbeat')
+            started = asyncio.get_running_loop().time()
+            await _wait_until(lambda: fake.count('heartbeat') > initial, timeout=0.35)
+            assert asyncio.get_running_loop().time() - started < 0.33
+
+            paused = await coordinator.pause(
+                acquired.session.id,
+                'alice',
+                CLIENT_ID,
+                owner=False,
+            )
+            paused_count = fake.count('heartbeat')
+            await _wait_until(lambda: fake.count('heartbeat') > paused_count)
+            assert paused.state == 'paused'
+            assert fake.state == 'paused'
+
+            # Driver-side active_shadow is a valid heartbeat state.  Enter HOLD
+            # through the public operation from a newly active fake state.
+            paused.state = 'active'
+            fake.state = 'active_shadow'
+            fake.reason = None
+            held = await coordinator.soft_stop(
+                paused.id,
+                'alice',
+                CLIENT_ID,
+                owner=False,
+            )
+            held_count = fake.count('heartbeat')
+            await _wait_until(lambda: fake.count('heartbeat') > held_count)
+            assert held.state == 'hold'
+            assert fake.state == 'hold'
+        finally:
+            await _finish(coordinator)
+
+    asyncio.run(scenario())
+
+
+@pytest.mark.parametrize(
+    ('action', 'malformation', 'expected_code'),
+    [
+        ('pause', {'state': {}}, 'driver_pause_rejected'),
+        ('soft_stop', {'state': 'hold', 'reason': []}, 'driver_soft_stop_rejected'),
+    ],
+)
+def test_unhashable_control_projection_faults_and_revokes(
+    shadow_session_tool,
+    action,
+    malformation,
+    expected_code,
+):
+    async def scenario() -> None:
+        _install_descriptor(shadow_session_tool)
+        fake = FakeD1Caller()
+        coordinator = _coordinator(fake, MutableClock())
+        try:
+            acquired = await coordinator.acquire(DRIVER_ID, 'alice', CLIENT_ID)
+            fake.queue(action, fake.snapshot(**malformation))
+            operation = getattr(coordinator, action)
+            with pytest.raises(TeleopServiceError) as raised:
+                await operation(
+                    acquired.session.id,
+                    'alice',
+                    CLIENT_ID,
+                    owner=False,
+                )
+
+            assert raised.value.code == expected_code
+            assert acquired.session.state == 'faulted'
+            assert await coordinator.manager.active_for_robot(ROBOT_ID) is None
+            assert fake.count('release') == 1
+            assert fake.state == 'released'
+            assert fake.authority_valid is False
+        finally:
+            await coordinator.stop()
+
+    asyncio.run(scenario())
+
+
+@pytest.mark.parametrize('action', ['pause', 'soft_stop'])
+def test_cancelled_control_faults_and_revokes_ambiguous_driver_result(
+    shadow_session_tool,
+    action,
+):
+    async def scenario() -> None:
+        _install_descriptor(shadow_session_tool)
+        fake = FakeD1Caller()
+        coordinator = _coordinator(fake, MutableClock())
+        driver_applied = asyncio.Event()
+
+        async def ambiguous_control(
+            producer: FakeD1Caller,
+            arguments: dict[str, Any] | None,
+        ) -> dict[str, Any]:
+            producer._assert_identity(arguments)
+            if action == 'pause':
+                producer.state = 'paused'
+                producer.reason = 'operator_pause'
+            else:
+                producer.state = 'hold'
+                producer.reason = 'soft_stop'
+            producer.dispatch_generation += 1
+            driver_applied.set()
+            await asyncio.Future()
+            raise AssertionError('unreachable')
+
+        try:
+            acquired = await coordinator.acquire(DRIVER_ID, 'alice', CLIENT_ID)
+            fake.queue(action, ambiguous_control)
+            operation = asyncio.create_task(getattr(coordinator, action)(
+                acquired.session.id,
+                'alice',
+                CLIENT_ID,
+                owner=False,
+            ))
+            await asyncio.wait_for(driver_applied.wait(), timeout=0.8)
+            operation.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await operation
+
+            assert acquired.session.state == 'faulted'
+            assert await coordinator.manager.active_for_robot(ROBOT_ID) is None
+            assert fake.count('release') == 1
+            assert fake.state == 'released'
+            assert fake.authority_valid is False
+            assert coordinator._safety_tasks == set()
+        finally:
+            await coordinator.stop()
+
+    asyncio.run(scenario())
+
+
+@pytest.mark.parametrize('failure_mode', ['three_failures', 'lease_age'])
+def test_retryable_heartbeat_faults_after_three_failures_or_75_percent_lease(
+    shadow_session_tool,
+    failure_mode,
+):
+    async def scenario() -> None:
+        _install_descriptor(shadow_session_tool)
+        clock = MutableClock()
+        fake = FakeD1Caller(lease_seconds=0.8)
+        coordinator = _coordinator(fake, clock)
+        try:
+            acquired = await coordinator.acquire(DRIVER_ID, 'alice', CLIENT_ID)
+            timeout = mcp_client.TrustedShadowTransportError('timeout')
+            if failure_mode == 'three_failures':
+                fake.queue('heartbeat', timeout, timeout, timeout)
+                await _wait_until(
+                    lambda: acquired.session.state == 'faulted',
+                    timeout=1.2,
+                )
+                assert coordinator._heartbeat_health[acquired.session.id].consecutive_failures == 3
+            else:
+                clock.advance(0.61)
+                fake.queue('heartbeat', timeout)
+                await asyncio.sleep(0.25)
+
+            await _wait_until(lambda: fake.count('release') == 1, timeout=0.8)
+            assert acquired.session.state == 'faulted'
+            assert await coordinator.manager.active_for_robot(ROBOT_ID) is None
+            assert fake.count('soft_stop') == 1
+            assert fake.count('release') == 1
+        finally:
+            await coordinator.stop()
+
+    asyncio.run(scenario())
+
+
+def test_terminal_rpc_faults_on_first_failed_supervisor_call(shadow_session_tool):
+    async def scenario() -> None:
+        _install_descriptor(shadow_session_tool)
+        fake = FakeD1Caller(lease_seconds=0.8)
+        coordinator = _coordinator(fake, MutableClock())
+        try:
+            acquired = await coordinator.acquire(DRIVER_ID, 'alice', CLIENT_ID)
+            heartbeat_task = coordinator._heartbeat_tasks[acquired.session.id]
+            fake.queue(
+                'heartbeat',
+                mcp_client.TrustedShadowTransportError(
+                    'rpc_error',
+                    rpc_code=-32602,
+                    rpc_data_code='session_expired',
+                ),
+            )
+            before = fake.count('heartbeat')
+            # Local authority is revoked before remote soft-stop/release finish.
+            # The worker itself, rather than a wall-clock sleep, is the cleanup
+            # completion signal for this terminal heartbeat path.
+            await asyncio.wait_for(asyncio.shield(heartbeat_task), timeout=1.0)
+            assert fake.count('heartbeat') == before + 1
+            assert acquired.session.state == 'faulted'
+            assert fake.count('soft_stop') == 1
+            assert fake.count('release') == 1
+        finally:
+            await coordinator.stop()
+
+    asyncio.run(scenario())
+
+
+def test_obsolete_worker_cannot_fault_a_replacement_session(shadow_session_tool):
+    async def scenario() -> None:
+        _install_descriptor(shadow_session_tool)
+        fake = FakeD1Caller()
+        coordinator = _coordinator(fake, MutableClock())
+        try:
+            old = (await coordinator.acquire(DRIVER_ID, 'alice', CLIENT_ID)).session
+            await coordinator.release(old.id, 'alice', CLIENT_ID, owner=False)
+            replacement = (
+                await coordinator.acquire(DRIVER_ID, 'bob', CLIENT_ID)
+            ).session
+
+            await coordinator._fault_session(old, 'late_old_worker')
+
+            assert old.state == 'released'
+            assert replacement.state == 'active'
+            assert await coordinator.manager.active_for_robot(ROBOT_ID) is replacement
+            assert fake.session_id == replacement.id
+        finally:
+            await _finish(coordinator)
+
+    asyncio.run(scenario())
+
+
+def test_browser_lease_uses_monotonic_heartbeat_then_expires_and_drains(
+    shadow_session_tool,
+    monkeypatch,
+):
+    async def scenario() -> None:
+        monkeypatch.setenv('MOTUS_TELEOP_LEASE_SECONDS', '5')
+        _install_descriptor(shadow_session_tool)
+        clock = MutableClock()
+        fake = FakeD1Caller(lease_seconds=10.0)
+        coordinator = _coordinator(fake, clock)
+        try:
+            acquired = await coordinator.acquire(DRIVER_ID, 'alice', CLIENT_ID)
+            original_deadline = acquired.session.deadline_monotonic
+            clock.advance(14.5, wall_seconds=-50_000)
+            renewed = await coordinator.heartbeat(
+                acquired.session.id,
+                'alice',
+                CLIENT_ID,
+            )
+            assert renewed.deadline_monotonic > original_deadline
+
+            clock.advance(0.6, wall_seconds=-50_000)
+            assert await coordinator.manager.active_for_robot(ROBOT_ID) is renewed
+
+            clock.advance(14.5, wall_seconds=-50_000)
+            await _wait_until(lambda: fake.count('release') == 1)
+            assert renewed.state == 'expired'
+            assert await coordinator.manager.active_for_robot(ROBOT_ID) is None
+            assert fake.count('soft_stop') == 1
+            assert fake.count('release') == 1
+        finally:
+            await coordinator.stop()
+
+    asyncio.run(scenario())
+
+
+def test_release_is_idempotent_and_only_calls_driver_once(shadow_session_tool):
+    async def scenario() -> None:
+        _install_descriptor(shadow_session_tool)
+        fake = FakeD1Caller()
+        coordinator = _coordinator(fake, MutableClock())
+        try:
+            acquired = await coordinator.acquire(DRIVER_ID, 'alice', CLIENT_ID)
+            first, first_ack = await coordinator.release(
+                acquired.session.id,
+                'alice',
+                CLIENT_ID,
+                owner=False,
+            )
+            second, second_ack = await coordinator.release(
+                acquired.session.id,
+                'alice',
+                CLIENT_ID,
+                owner=False,
+            )
+            assert first is second
+            assert first.state == 'released'
+            assert first_ack is True
+            assert second_ack is True
+            assert fake.count('release') == 1
+        finally:
+            await coordinator.stop()
+
+    asyncio.run(scenario())
+
+
+def test_concurrent_release_waits_for_one_shared_driver_ack(shadow_session_tool):
+    async def scenario() -> None:
+        _install_descriptor(shadow_session_tool)
+        fake = FakeD1Caller()
+        coordinator = _coordinator(fake, MutableClock())
+        cancellation_seen = asyncio.Event()
+        allow_cancel = asyncio.Event()
+
+        async def heartbeat_cancel_barrier() -> None:
+            try:
+                await asyncio.Future()
+            except asyncio.CancelledError:
+                cancellation_seen.set()
+                await allow_cancel.wait()
+                raise
+
+        try:
+            acquired = await coordinator.acquire(DRIVER_ID, 'alice', CLIENT_ID)
+            original = coordinator._heartbeat_tasks.pop(acquired.session.id)
+            original.cancel()
+            await asyncio.gather(original, return_exceptions=True)
+            coordinator._heartbeat_tasks[acquired.session.id] = asyncio.create_task(
+                heartbeat_cancel_barrier()
+            )
+
+            first = asyncio.create_task(coordinator.release(
+                acquired.session.id,
+                'alice',
+                CLIENT_ID,
+                owner=False,
+            ))
+            await asyncio.wait_for(cancellation_seen.wait(), timeout=0.5)
+            second = asyncio.create_task(coordinator.release(
+                acquired.session.id,
+                'alice',
+                CLIENT_ID,
+                owner=False,
+            ))
+            await asyncio.sleep(0)
+            assert second.done() is False
+
+            allow_cancel.set()
+            (first_session, first_ack), (second_session, second_ack) = await asyncio.gather(
+                first,
+                second,
+            )
+
+            assert first_session is second_session
+            assert first_ack is True
+            assert second_ack is True
+            assert fake.count('release') == 1
+        finally:
+            allow_cancel.set()
+            await coordinator.stop()
+
+    asyncio.run(scenario())
+
+
+def test_terminal_cleanup_keeps_the_owned_operation_lock(
+    shadow_session_tool,
+    monkeypatch,
+):
+    async def scenario() -> None:
+        _install_descriptor(shadow_session_tool)
+        fake = FakeD1Caller()
+        coordinator = _coordinator(fake, MutableClock())
+        cleanup_reached = asyncio.Event()
+        allow_cleanup_return = asyncio.Event()
+        original_cleanup = coordinator._cleanup_terminal_runtime
+
+        async def delayed_cleanup(session_id: str) -> None:
+            await original_cleanup(session_id)
+            cleanup_reached.set()
+            await allow_cleanup_return.wait()
+
+        monkeypatch.setattr(coordinator, '_cleanup_terminal_runtime', delayed_cleanup)
+        try:
+            acquired = await coordinator.acquire(DRIVER_ID, 'alice', CLIENT_ID)
+            session_id = acquired.session.id
+            original_lock = coordinator._session_lock(session_id)
+            fake.queue('pause', fake.snapshot(state='invalid-state'))
+            pause = asyncio.create_task(coordinator.pause(
+                session_id,
+                'alice',
+                CLIENT_ID,
+                owner=False,
+            ))
+            await asyncio.wait_for(cleanup_reached.wait(), timeout=0.8)
+
+            assert coordinator._session_lock(session_id) is original_lock
+            assert original_lock.locked() is True
+            release = asyncio.create_task(coordinator.release(
+                session_id,
+                'alice',
+                CLIENT_ID,
+                owner=False,
+            ))
+            await asyncio.sleep(0)
+            assert release.done() is False
+
+            allow_cleanup_return.set()
+            with pytest.raises(TeleopServiceError) as raised:
+                await pause
+            released, acknowledged = await release
+            assert raised.value.code == 'driver_pause_rejected'
+            assert released.state == 'faulted'
+            assert acknowledged is False
+            assert fake.count('soft_stop') == 1
+            assert fake.count('release') == 1
+        finally:
+            allow_cleanup_return.set()
+            await coordinator.stop()
+
+    asyncio.run(scenario())
+
+
+def test_cancelled_release_finishes_revocation_and_preserves_result(
+    shadow_session_tool,
+):
+    async def scenario() -> None:
+        _install_descriptor(shadow_session_tool)
+        fake = FakeD1Caller()
+        coordinator = _coordinator(fake, MutableClock())
+        release_started = asyncio.Event()
+        allow_release = asyncio.Event()
+
+        async def delayed_release(
+            producer: FakeD1Caller,
+            arguments: dict[str, Any] | None,
+        ) -> dict[str, Any]:
+            producer._assert_identity(arguments)
+            release_started.set()
+            await allow_release.wait()
+            producer.session_id = None
+            producer.fence = None
+            producer.state = 'released'
+            producer.reason = 'operator_release'
+            producer.authority_valid = False
+            producer.dispatch_generation += 1
+            return producer.snapshot()
+
+        try:
+            acquired = await coordinator.acquire(DRIVER_ID, 'alice', CLIENT_ID)
+            fake.queue('release', delayed_release)
+            first = asyncio.create_task(coordinator.release(
+                acquired.session.id,
+                'alice',
+                CLIENT_ID,
+                owner=False,
+            ))
+            await asyncio.wait_for(release_started.wait(), timeout=0.8)
+            first.cancel()
+            await asyncio.sleep(0)
+            first.cancel()
+            await asyncio.sleep(0)
+            assert first.done() is False
+            allow_release.set()
+            with pytest.raises(asyncio.CancelledError):
+                await first
+
+            released, acknowledged = await coordinator.release(
+                acquired.session.id,
+                'alice',
+                CLIENT_ID,
+                owner=False,
+            )
+            assert released.state == 'released'
+            assert acknowledged is True
+            assert fake.count('release') == 1
+            assert coordinator._safety_tasks == set()
+        finally:
+            allow_release.set()
+            await coordinator.stop()
+
+    asyncio.run(scenario())
+
+
+def test_double_cancelled_acquire_still_revokes_ambiguous_prepare(
+    shadow_session_tool,
+):
+    async def scenario() -> None:
+        _install_descriptor(shadow_session_tool)
+        fake = FakeD1Caller()
+        coordinator = _coordinator(fake, MutableClock())
+        prepare_applied = asyncio.Event()
+        release_started = asyncio.Event()
+        allow_release = asyncio.Event()
+
+        async def ambiguous_prepare(
+            producer: FakeD1Caller,
+            arguments: dict[str, Any] | None,
+        ) -> dict[str, Any]:
+            assert arguments is not None
+            producer.session_id = arguments['session_id']
+            producer.epoch = arguments['epoch']
+            producer.fence = arguments['fence']
+            producer.state = 'prepared_shadow'
+            producer.reason = None
+            producer.authority_valid = True
+            producer.dispatch_generation += 1
+            prepare_applied.set()
+            await asyncio.Future()
+            raise AssertionError('unreachable')
+
+        async def delayed_release(
+            producer: FakeD1Caller,
+            arguments: dict[str, Any] | None,
+        ) -> dict[str, Any]:
+            producer._assert_identity(arguments)
+            release_started.set()
+            await allow_release.wait()
+            producer.session_id = None
+            producer.fence = None
+            producer.state = 'released'
+            producer.reason = 'operator_release'
+            producer.authority_valid = False
+            producer.dispatch_generation += 1
+            return producer.snapshot()
+
+        fake.queue('prepare_shadow', ambiguous_prepare)
+        fake.queue('release', delayed_release)
+        acquire = asyncio.create_task(coordinator.acquire(
+            DRIVER_ID,
+            'alice',
+            CLIENT_ID,
+        ))
+        try:
+            await asyncio.wait_for(prepare_applied.wait(), timeout=0.8)
+            acquire.cancel()
+            await asyncio.wait_for(release_started.wait(), timeout=0.8)
+            acquire.cancel()
+            await asyncio.sleep(0)
+            assert acquire.done() is False
+
+            allow_release.set()
+            with pytest.raises(asyncio.CancelledError):
+                await acquire
+
+            assert fake.state == 'released'
+            assert fake.authority_valid is False
+            assert fake.count('release') == 1
+            assert await coordinator.manager.active_for_robot(ROBOT_ID) is None
+            assert coordinator._safety_tasks == set()
+        finally:
+            allow_release.set()
+            await coordinator.stop()
+
+    asyncio.run(scenario())
+
+
+def test_shutdown_releases_driver_and_leaves_no_background_tasks(
+    shadow_session_tool,
+):
+    async def scenario() -> None:
+        _install_descriptor(shadow_session_tool)
+        fake = FakeD1Caller()
+        coordinator = _coordinator(fake, MutableClock())
+        acquired = await coordinator.acquire(DRIVER_ID, 'alice', CLIENT_ID)
+
+        await coordinator.stop()
+
+        assert acquired.session.state == 'released'
+        assert fake.count('release') == 1
+        assert coordinator._reaper_task is None
+        assert coordinator._heartbeat_tasks == {}
+        assert coordinator._http_session is None
+        assert coordinator._stopping is True
+        assert await coordinator.manager.list_visible('', owner=True) == []
+
+    asyncio.run(scenario())
+
+
+def test_shutdown_drains_an_acquire_that_has_not_reserved_yet(shadow_session_tool):
+    async def scenario() -> None:
+        _install_descriptor(shadow_session_tool)
+        fake = FakeD1Caller()
+        coordinator = _coordinator(fake, MutableClock())
+        status_started = asyncio.Event()
+        allow_status = asyncio.Event()
+
+        async def delayed_status(
+            producer: FakeD1Caller,
+            _arguments: dict[str, Any] | None,
+        ) -> dict[str, Any]:
+            status_started.set()
+            await allow_status.wait()
+            return producer.snapshot()
+
+        fake.queue('status', delayed_status)
+        acquire = asyncio.create_task(coordinator.acquire(
+            DRIVER_ID,
+            'alice',
+            CLIENT_ID,
+        ))
+        await asyncio.wait_for(status_started.wait(), timeout=0.8)
+        stop = asyncio.create_task(coordinator.stop())
+        await asyncio.sleep(0)
+        assert stop.done() is False
+
+        allow_status.set()
+        acquired = await acquire
+        await stop
+
+        assert acquired.session.state == 'released'
+        assert fake.state == 'released'
+        assert fake.authority_valid is False
+        assert fake.count('prepare_shadow') == 1
+        assert fake.count('release') == 1
+        assert coordinator._acquire_tasks == set()
+        assert coordinator._heartbeat_tasks == {}
+        assert await coordinator.manager.list_visible('', owner=True) == []
+
+        with pytest.raises(TeleopServiceError) as raised:
+            await coordinator.acquire(DRIVER_ID, 'alice', CLIENT_ID)
+        assert raised.value.code == 'coordinator_stopping'
+
+    asyncio.run(scenario())
+
+
+def test_real_fence_and_driver_token_never_reach_public_error_audit_or_activity(
+    shadow_session_tool,
+    monkeypatch,
+):
+    async def scenario() -> None:
+        monkeypatch.setattr(audit, 'emit', _REAL_AUDIT_EMIT)
+        auth.init({
+            'ACCESS_TOKEN': 'owner-token',
+                'MOTUS_OPERATOR_TOKENS': '{"alice":"operator-token"}',
+                'MOTUS_DRIVER_TOKEN': DRIVER_TOKEN,
+                'MOTUS_TELEOP_TICKET_SECRET': 'test-service-ticket-secret-000001',
+            })
+        events: list[dict[str, Any]] = []
+
+        async def capture_event(event: dict[str, Any]) -> None:
+            events.append(deepcopy(event))
+
+        monkeypatch.setattr(motus_stream, 'push_event', capture_event)
+        _install_descriptor(shadow_session_tool)
+        fake = FakeD1Caller()
+        coordinator = _coordinator(fake, MutableClock())
+        try:
+            acquired = await coordinator.acquire(DRIVER_ID, 'alice', CLIENT_ID)
+            fence = acquired.session.fence
+            public = coordinator.public_session(acquired.session)
+
+            reflected = fake.snapshot(driver_name=fence)
+            fake.queue('status', reflected)
+            safe_status = await coordinator.status(
+                acquired.session.id,
+                'alice',
+                owner=False,
+            )
+            assert safe_status['driver']['driver_name'] == DRIVER_ID
+
+            await coordinator.release(
+                acquired.session.id,
+                'alice',
+                CLIENT_ID,
+                owner=False,
+            )
+            await audit.flush()
+            with config._get_conn() as conn:
+                rows = conn.execute(
+                    'SELECT event_type, session_id, robot_id, principal_id, '
+                    'source, decision, reason, tool, action, details '
+                    'FROM teleop_audit ORDER BY created_at, id'
+                ).fetchall()
+
+            columns = (
+                'event_type', 'session_id', 'robot_id', 'principal_id',
+                'source', 'decision', 'reason', 'tool', 'action', 'details',
+            )
+            audit_payload = [dict(zip(columns, row, strict=True)) for row in rows]
+            scan = json.dumps(
+                    {
+                        'public': public,
+                        'status': safe_status,
+                        'audit': audit_payload,
+                    'activity': events,
+                },
+                sort_keys=True,
+            )
+            assert fence not in scan
+            assert DRIVER_TOKEN not in scan
+            assert 'fence' not in json.dumps(public).lower()
+            assert events
+            assert audit_payload
+        finally:
+            await coordinator.stop()
+
+    asyncio.run(scenario())
+
+
+def test_acquire_waits_for_an_admitted_write_and_blocks_following_writes(
+    shadow_session_tool,
+):
+    async def scenario() -> None:
+        _install_descriptor(shadow_session_tool)
+        broker = CommandBroker()
+        fake = FakeD1Caller()
+        clock = MutableClock()
+        coordinator = _coordinator(fake, clock, command_broker=broker)
+        write_entered = asyncio.Event()
+        finish_write = asyncio.Event()
+
+        async def admitted_write() -> None:
+            async with broker.ordinary_command(
+                ROBOT_ID,
+                read_only=False,
+                source='test',
+                tool='locomotion',
+                action='move',
+            ):
+                write_entered.set()
+                await finish_write.wait()
+
+        write_task = asyncio.create_task(admitted_write())
+        try:
+            await asyncio.wait_for(write_entered.wait(), timeout=0.5)
+            acquire_task = asyncio.create_task(
+                coordinator.acquire(DRIVER_ID, 'alice', CLIENT_ID),
+            )
+            for _ in range(100):
+                if await broker.authority_for(ROBOT_ID) is not None:
+                    break
+                await asyncio.sleep(0.005)
+            else:
+                raise AssertionError('Acquire did not publish its command claim')
+
+            assert fake.calls == []
+            with pytest.raises(TeleopCommandBlocked):
+                async with broker.ordinary_command(
+                    ROBOT_ID,
+                    read_only=False,
+                    source='test',
+                    tool='locomotion',
+                    action='move',
+                ):
+                    raise AssertionError('blocked command entered the transport')
+
+            # Admission is exact per Driver, not a global robot stop.
+            async with broker.ordinary_command(
+                'another-driver',
+                read_only=False,
+                source='test',
+                tool='locomotion',
+                action='move',
+            ):
+                pass
+
+            finish_write.set()
+            acquired = await asyncio.wait_for(acquire_task, timeout=0.8)
+            assert acquired.session.state == 'active'
+            assert [call['action'] for call in fake.calls[:3]] == [
+                'status', 'prepare_shadow', 'heartbeat',
+            ]
+        finally:
+            finish_write.set()
+            await asyncio.gather(write_task, return_exceptions=True)
+            await _finish(coordinator)
+
+    asyncio.run(scenario())
+
+
+def test_release_keeps_write_gate_closed_until_driver_cleanup_finishes(
+    shadow_session_tool,
+):
+    async def scenario() -> None:
+        _install_descriptor(shadow_session_tool)
+        broker = CommandBroker()
+        fake = FakeD1Caller()
+        clock = MutableClock()
+        coordinator = _coordinator(fake, clock, command_broker=broker)
+        release_started = asyncio.Event()
+        finish_release = asyncio.Event()
+
+        async def delayed_release(caller, arguments):
+            caller._assert_identity(arguments)
+            release_started.set()
+            await finish_release.wait()
+            caller.session_id = None
+            caller.fence = None
+            caller.state = 'released'
+            caller.reason = 'operator_release'
+            caller.authority_valid = False
+            caller.dispatch_generation += 1
+            return caller.snapshot()
+
+        try:
+            acquired = await coordinator.acquire(DRIVER_ID, 'alice', CLIENT_ID)
+            fake.queue('release', delayed_release)
+            release_task = asyncio.create_task(coordinator.release(
+                acquired.session.id,
+                'alice',
+                CLIENT_ID,
+                owner=False,
+            ))
+            await asyncio.wait_for(release_started.wait(), timeout=0.5)
+
+            assert await coordinator.manager.active_for_robot(ROBOT_ID) is None
+            claim = await broker.authority_for(ROBOT_ID)
+            assert claim is not None
+            assert claim.state == 'releasing'
+            with pytest.raises(TeleopCommandBlocked):
+                async with broker.ordinary_command(
+                    ROBOT_ID,
+                    read_only=False,
+                    source='test',
+                    tool='locomotion',
+                    action='move',
+                ):
+                    raise AssertionError('write escaped during Driver release')
+
+            finish_release.set()
+            released, acknowledged = await asyncio.wait_for(release_task, timeout=0.8)
+            assert released.state == 'released'
+            assert acknowledged is True
+            assert await broker.authority_for(ROBOT_ID) is None
+            async with broker.ordinary_command(
+                ROBOT_ID,
+                read_only=False,
+                source='test',
+                tool='locomotion',
+                action='move',
+            ):
+                pass
+        finally:
+            finish_release.set()
+            await _finish(coordinator)
+
+    asyncio.run(scenario())
+
+
+def test_unconfirmed_release_stays_quarantined_until_a_retry_is_acknowledged(
+    shadow_session_tool,
+):
+    async def scenario() -> None:
+        _install_descriptor(shadow_session_tool)
+        broker = CommandBroker()
+        fake = FakeD1Caller()
+        clock = MutableClock()
+        coordinator = _coordinator(fake, clock, command_broker=broker)
+        try:
+            acquired = await coordinator.acquire(DRIVER_ID, 'alice', CLIENT_ID)
+            fake.queue(
+                'release',
+                mcp_client.TrustedShadowTransportError('timeout'),
+            )
+            released, acknowledged = await coordinator.release(
+                acquired.session.id,
+                'alice',
+                CLIENT_ID,
+                owner=False,
+            )
+
+            assert released.state == 'released'
+            assert acknowledged is False
+            assert await broker.authority_for(ROBOT_ID) is not None
+            assert released.id in coordinator._release_reconcile_tasks
+            with pytest.raises(TeleopCommandBlocked):
+                async with broker.ordinary_command(
+                    ROBOT_ID,
+                    read_only=False,
+                    source='test',
+                    tool='locomotion',
+                    action='move',
+                ):
+                    raise AssertionError('unconfirmed release opened the gate')
+
+            retried, retry_acknowledged = await coordinator.release(
+                acquired.session.id,
+                'alice',
+                CLIENT_ID,
+                owner=False,
+            )
+            assert retried is released
+            assert retry_acknowledged is True
+            assert fake.count('release') == 2
+            assert await broker.authority_for(ROBOT_ID) is None
+            assert released.id not in coordinator._release_reconcile_tasks
+        finally:
+            await _finish(coordinator)
+
+    asyncio.run(scenario())
+
+
+def test_double_cancelled_pre_reservation_acquire_cannot_orphan_command_claim(
+    shadow_session_tool,
+):
+    class DelayedReleaseBroker(CommandBroker):
+        def __init__(self) -> None:
+            super().__init__()
+            self.release_started = asyncio.Event()
+            self.finish_release = asyncio.Event()
+
+        async def release_authority(self, robot_id: str, token: str) -> bool:
+            self.release_started.set()
+            await self.finish_release.wait()
+            return await super().release_authority(robot_id, token)
+
+    async def scenario() -> None:
+        _install_descriptor(shadow_session_tool)
+        broker = DelayedReleaseBroker()
+        fake = FakeD1Caller()
+        status_started = asyncio.Event()
+
+        async def delayed_status(_caller, _arguments):
+            status_started.set()
+            await asyncio.Event().wait()
+
+        fake.queue('status', delayed_status)
+        coordinator = _coordinator(fake, MutableClock(), command_broker=broker)
+        acquire = asyncio.create_task(
+            coordinator.acquire(DRIVER_ID, 'alice', CLIENT_ID),
+        )
+        await asyncio.wait_for(status_started.wait(), timeout=0.5)
+        acquire.cancel()
+        await asyncio.wait_for(broker.release_started.wait(), timeout=0.5)
+        acquire.cancel()
+        await asyncio.sleep(0)
+        assert acquire.done() is False
+        broker.finish_release.set()
+        with pytest.raises(asyncio.CancelledError):
+            await acquire
+        assert await broker.authority_for(ROBOT_ID) is None
+        assert coordinator._command_claims == {}
+        await coordinator.stop()
+
+    asyncio.run(scenario())
+
+
+def test_cancel_during_broker_begin_return_cannot_orphan_untracked_claim(
+    shadow_session_tool,
+):
+    class DelayedBeginBroker(CommandBroker):
+        def __init__(self) -> None:
+            super().__init__()
+            self.claim_created = asyncio.Event()
+            self.release_started = asyncio.Event()
+            self.finish_release = asyncio.Event()
+
+        async def begin_authority(self, robot_id: str, token: str, **kwargs):
+            claim = await super().begin_authority(robot_id, token, **kwargs)
+            self.claim_created.set()
+            await asyncio.Event().wait()
+            return claim
+
+        async def release_authority(self, robot_id: str, token: str) -> bool:
+            self.release_started.set()
+            await self.finish_release.wait()
+            return await super().release_authority(robot_id, token)
+
+    async def scenario() -> None:
+        _install_descriptor(shadow_session_tool)
+        broker = DelayedBeginBroker()
+        coordinator = _coordinator(
+            FakeD1Caller(),
+            MutableClock(),
+            command_broker=broker,
+        )
+        acquire = asyncio.create_task(
+            coordinator.acquire(DRIVER_ID, 'alice', CLIENT_ID),
+        )
+        await asyncio.wait_for(broker.claim_created.wait(), timeout=0.5)
+        assert await broker.authority_for(ROBOT_ID) is not None
+        assert coordinator._command_claims == {}
+
+        acquire.cancel()
+        await asyncio.wait_for(broker.release_started.wait(), timeout=0.5)
+        acquire.cancel()
+        await asyncio.sleep(0)
+        assert acquire.done() is False
+        broker.finish_release.set()
+        with pytest.raises(asyncio.CancelledError):
+            await acquire
+
+        assert await broker.authority_for(ROBOT_ID) is None
+        assert coordinator._command_claims == {}
+        await coordinator.stop()
+
+    asyncio.run(scenario())
+
+
+def test_cross_id_acquire_requires_descriptor_to_echo_authority_root(
+    shadow_session_tool,
+):
+    async def scenario() -> None:
+        tool = deepcopy(shadow_session_tool)
+        tool['x-teleop'].pop('robot_id')
+        _install_descriptor(tool)
+        coordinator = _coordinator(FakeD1Caller(), MutableClock())
+        try:
+            with pytest.raises(TeleopServiceError) as error:
+                await coordinator.acquire(DRIVER_ID, 'alice', CLIENT_ID)
+            assert error.value.code == 'driver_not_ready'
+            assert coordinator._command_claims == {}
+        finally:
+            await coordinator.stop()
+
+    asyncio.run(scenario())
+
+
+def test_cancel_after_driver_activation_revokes_authority_and_command_claim(
+    shadow_session_tool,
+):
+    class ActiveUpdateBroker(CommandBroker):
+        def __init__(self) -> None:
+            super().__init__()
+            self.active_update_started = asyncio.Event()
+
+        async def update_authority(self, robot_id: str, token: str, **kwargs):
+            if kwargs.get('state') == 'active':
+                self.active_update_started.set()
+                await asyncio.Event().wait()
+            return await super().update_authority(robot_id, token, **kwargs)
+
+    async def scenario() -> None:
+        _install_descriptor(shadow_session_tool)
+        broker = ActiveUpdateBroker()
+        fake = FakeD1Caller()
+        coordinator = _coordinator(fake, MutableClock(), command_broker=broker)
+        acquire = asyncio.create_task(
+            coordinator.acquire(DRIVER_ID, 'alice', CLIENT_ID),
+        )
+        await asyncio.wait_for(broker.active_update_started.wait(), timeout=0.8)
+        assert fake.authority_valid is True
+        acquire.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await acquire
+        assert fake.authority_valid is False
+        assert fake.state == 'released'
+        assert await broker.authority_for(ROBOT_ID) is None
+        visible = await coordinator.manager.list_visible('', owner=True)
+        assert visible and visible[0].state == 'released'
+        await coordinator.stop()
+
+    asyncio.run(scenario())
+
+
+@pytest.mark.parametrize('malformation', ['missing-ack', 'same-generation'])
+def test_prepare_requires_new_recording_stop_generation_before_activation(
+    shadow_session_tool,
+    malformation,
+):
+    async def scenario() -> None:
+        _install_descriptor(shadow_session_tool)
+        broker = CommandBroker()
+        fake = FakeD1Caller()
+
+        def unacknowledged_prepare(
+            producer: FakeD1Caller,
+            arguments: dict[str, Any] | None,
+        ) -> dict[str, Any]:
+            assert arguments is not None
+            producer.session_id = arguments['session_id']
+            producer.epoch = arguments['epoch']
+            producer.fence = arguments['fence']
+            producer.state = 'prepared_shadow'
+            producer.reason = None
+            producer.authority_valid = True
+            if malformation == 'missing-ack':
+                producer.dispatch_generation += 1
+            raw = producer.snapshot()
+            if malformation == 'missing-ack':
+                raw['dispatch']['stop_acknowledged'] = False
+            return raw
+
+        fake.queue('prepare_shadow', unacknowledged_prepare)
+        coordinator = _coordinator(
+            fake,
+            MutableClock(),
+            command_broker=broker,
+        )
+        try:
+            with pytest.raises(TeleopServiceError) as raised:
+                await coordinator.acquire(DRIVER_ID, 'alice', CLIENT_ID)
+            assert raised.value.code == 'driver_response_invalid'
+            assert fake.count('release') == 1
+            assert fake.authority_valid is False
+            assert coordinator._command_claims == {}
+            assert await broker.authority_for(ROBOT_ID) is None
+        finally:
+            await coordinator.stop()
+
+    asyncio.run(scenario())
+
+
+@pytest.mark.parametrize(
+    ('action', 'state', 'reason', 'malformation', 'expected_code'),
+    [
+        (
+            'pause', 'paused', 'operator_pause', 'missing-ack',
+            'driver_pause_rejected',
+        ),
+        (
+            'pause', 'paused', 'operator_pause', 'same-generation',
+            'driver_pause_rejected',
+        ),
+        (
+            'soft_stop', 'hold', 'soft_stop', 'missing-ack',
+            'driver_soft_stop_rejected',
+        ),
+        (
+            'soft_stop', 'hold', 'soft_stop', 'same-generation',
+            'driver_soft_stop_rejected',
+        ),
+    ],
+)
+def test_control_stop_requires_recording_ack_or_faults_and_revokes(
+    shadow_session_tool,
+    action,
+    state,
+    reason,
+    malformation,
+    expected_code,
+):
+    async def scenario() -> None:
+        _install_descriptor(shadow_session_tool)
+        broker = CommandBroker()
+        fake = FakeD1Caller()
+        coordinator = _coordinator(
+            fake,
+            MutableClock(),
+            command_broker=broker,
+        )
+        try:
+            acquired = await coordinator.acquire(DRIVER_ID, 'alice', CLIENT_ID)
+
+            def unacknowledged_stop(
+                producer: FakeD1Caller,
+                arguments: dict[str, Any] | None,
+            ) -> dict[str, Any]:
+                producer._assert_identity(arguments)
+                saved = (
+                    producer.state,
+                    producer.reason,
+                    producer.dispatch_generation,
+                )
+                producer.state = state
+                producer.reason = reason
+                if malformation == 'missing-ack':
+                    producer.dispatch_generation += 1
+                raw = producer.snapshot()
+                producer.state, producer.reason, producer.dispatch_generation = saved
+                if malformation == 'missing-ack':
+                    raw['dispatch']['stop_acknowledged'] = False
+                return raw
+
+            fake.queue(action, unacknowledged_stop)
+            method = getattr(coordinator, action)
+            with pytest.raises(TeleopServiceError) as raised:
+                await method(
+                    acquired.session.id,
+                    'alice',
+                    CLIENT_ID,
+                    owner=False,
+                )
+
+            assert raised.value.code == expected_code
+            assert acquired.session.state == 'faulted'
+            assert fake.count('release') == 1
+            assert fake.authority_valid is False
+            assert await broker.authority_for(ROBOT_ID) is None
+        finally:
+            await coordinator.stop()
+
+    asyncio.run(scenario())
+
+
+@pytest.mark.parametrize('malformation', ['missing-ack', 'same-generation'])
+def test_unproven_released_snapshot_keeps_broker_quarantined(
+    shadow_session_tool,
+    malformation,
+):
+    async def scenario() -> None:
+        _install_descriptor(shadow_session_tool)
+        broker = CommandBroker()
+        fake = FakeD1Caller()
+        coordinator = _coordinator(
+            fake,
+            MutableClock(),
+            command_broker=broker,
+        )
+        try:
+            acquired = await coordinator.acquire(DRIVER_ID, 'alice', CLIENT_ID)
+
+            def unacknowledged_release(
+                producer: FakeD1Caller,
+                arguments: dict[str, Any] | None,
+            ) -> dict[str, Any]:
+                producer._assert_identity(arguments)
+                saved = (
+                    producer.session_id,
+                    producer.fence,
+                    producer.state,
+                    producer.reason,
+                    producer.authority_valid,
+                    producer.dispatch_generation,
+                )
+                producer.session_id = None
+                producer.fence = None
+                producer.state = 'released'
+                producer.reason = 'operator_release'
+                producer.authority_valid = False
+                if malformation == 'missing-ack':
+                    producer.dispatch_generation += 1
+                raw = producer.snapshot()
+                (
+                    producer.session_id,
+                    producer.fence,
+                    producer.state,
+                    producer.reason,
+                    producer.authority_valid,
+                    producer.dispatch_generation,
+                ) = saved
+                if malformation == 'missing-ack':
+                    raw['dispatch']['stop_acknowledged'] = False
+                return raw
+
+            fake.queue('release', unacknowledged_release)
+            released, acknowledged = await coordinator.release(
+                acquired.session.id,
+                'alice',
+                CLIENT_ID,
+                owner=False,
+            )
+
+            assert released.state == 'released'
+            assert acknowledged is False
+            assert await broker.authority_for(ROBOT_ID) is not None
+            with pytest.raises(TeleopCommandBlocked):
+                async with broker.ordinary_command(
+                    ROBOT_ID,
+                    read_only=False,
+                    source='test',
+                    tool='locomotion',
+                    action='move',
+                ):
+                    raise AssertionError('unacknowledged release opened the gate')
+
+            _, retry_acknowledged = await coordinator.release(
+                acquired.session.id,
+                'alice',
+                CLIENT_ID,
+                owner=False,
+            )
+            assert retry_acknowledged is True
+            assert await broker.authority_for(ROBOT_ID) is None
+        finally:
+            await coordinator.stop()
+
+    asyncio.run(scenario())
+
+
+@pytest.mark.parametrize('malformation', ['missing-dispatch', 'sequence-rollback'])
+def test_status_protocol_downgrade_or_sequence_rollback_revokes_authority(
+    shadow_session_tool,
+    malformation,
+):
+    async def scenario() -> None:
+        _install_descriptor(shadow_session_tool)
+        broker = CommandBroker()
+        fake = FakeD1Caller()
+        coordinator = _coordinator(
+            fake,
+            MutableClock(),
+            command_broker=broker,
+        )
+        try:
+            acquired = await coordinator.acquire(DRIVER_ID, 'alice', CLIENT_ID)
+            await coordinator._cancel_heartbeat(acquired.session.id, origin_task=None)
+            if malformation == 'missing-dispatch':
+                raw = fake.snapshot()
+                raw.pop('dispatch')
+            else:
+                fake.state = 'active_shadow'
+                fake.dispatch_last_admitted = 8
+                await coordinator.status(
+                    acquired.session.id,
+                    'alice',
+                    owner=False,
+                )
+                raw = fake.snapshot()
+                raw['dispatch']['last_admitted_sequence'] = 7
+            fake.queue('status', raw)
+
+            with pytest.raises(TeleopServiceError) as raised:
+                await coordinator.status(
+                    acquired.session.id,
+                    'alice',
+                    owner=False,
+                )
+            assert raised.value.code == 'driver_session_lost'
+            assert acquired.session.state == 'faulted'
+            assert fake.authority_valid is False
+            assert await broker.authority_for(ROBOT_ID) is None
+        finally:
+            await coordinator.stop()
+
+    asyncio.run(scenario())
+
+
+def test_status_exposes_stop_pending_without_treating_it_as_stop_proof(
+    shadow_session_tool,
+):
+    async def scenario() -> None:
+        _install_descriptor(shadow_session_tool)
+        broker = CommandBroker()
+        fake = FakeD1Caller()
+        coordinator = _coordinator(
+            fake,
+            MutableClock(),
+            command_broker=broker,
+        )
+        try:
+            session = (
+                await coordinator.acquire(DRIVER_ID, 'alice', CLIENT_ID)
+            ).session
+            await coordinator._cancel_heartbeat(session.id, origin_task=None)
+            pending = fake.snapshot(
+                state='hold',
+                reason='deadman_released',
+            )
+            pending['dispatch'].update({
+                'state': 'safe_reclutch_required',
+                'generation': fake.dispatch_generation + 1,
+                'stop_queue_depth': 1,
+                'last_decision': 'stop_requested:deadman_released',
+                'stop_acknowledged': False,
+            })
+            fake.queue('status', pending)
+
+            public_pending = await coordinator.status(
+                session.id,
+                'alice',
+                owner=False,
+            )
+            assert session.state == 'active'
+            assert public_pending['driver']['state'] == 'hold'
+            assert public_pending['driver']['dispatch']['stop_acknowledged'] is False
+            assert public_pending['driver']['dispatch']['stop_queue_depth'] == 1
+            assert await broker.authority_for(ROBOT_ID) is not None
+
+            fake.state = 'hold'
+            fake.reason = 'deadman_released'
+            fake.dispatch_generation += 1
+            public_stable = await coordinator.status(
+                session.id,
+                'alice',
+                owner=False,
+            )
+            assert public_stable['driver']['dispatch']['stop_acknowledged'] is True
+            assert public_stable['driver']['dispatch']['stop_queue_depth'] == 0
+        finally:
+            await _finish(coordinator)
+
+    asyncio.run(scenario())
+
+
+def test_delayed_heartbeat_snapshot_cannot_overwrite_newer_pause_proof(
+    shadow_session_tool,
+):
+    async def scenario() -> None:
+        _install_descriptor(shadow_session_tool)
+        fake = FakeD1Caller(lease_seconds=0.8)
+        coordinator = _coordinator(fake, MutableClock())
+        heartbeat_started = asyncio.Event()
+        allow_heartbeat_return = asyncio.Event()
+        heartbeat_returned = asyncio.Event()
+
+        async def delayed_old_heartbeat(
+            producer: FakeD1Caller,
+            arguments: dict[str, Any] | None,
+        ) -> dict[str, Any]:
+            producer._assert_identity(arguments)
+            captured = producer.snapshot()
+            heartbeat_started.set()
+            await allow_heartbeat_return.wait()
+            heartbeat_returned.set()
+            return captured
+
+        try:
+            session = (
+                await coordinator.acquire(DRIVER_ID, 'alice', CLIENT_ID)
+            ).session
+            fake.queue('heartbeat', delayed_old_heartbeat)
+            await asyncio.wait_for(heartbeat_started.wait(), timeout=0.6)
+
+            paused = await coordinator.pause(
+                session.id,
+                'alice',
+                CLIENT_ID,
+                owner=False,
+            )
+            allow_heartbeat_return.set()
+            await asyncio.wait_for(heartbeat_returned.wait(), timeout=0.5)
+            await asyncio.sleep(0.02)
+
+            cached = coordinator._driver_snapshots[session.id]
+            assert paused.state == 'paused'
+            assert cached['state'] == 'paused'
+            assert cached['dispatch']['generation'] == 2
+            assert cached['dispatch']['stop_acknowledged'] is True
+            assert coordinator._heartbeat_health[session.id].state == 'healthy'
+        finally:
+            allow_heartbeat_return.set()
+            await _finish(coordinator)
+
+    asyncio.run(scenario())
+
+
+def test_delayed_pending_heartbeat_cannot_replace_stable_stop_or_mark_health(
+    shadow_session_tool,
+):
+    async def scenario() -> None:
+        _install_descriptor(shadow_session_tool)
+        clock = MutableClock()
+        fake = FakeD1Caller(lease_seconds=0.8)
+        coordinator = _coordinator(fake, clock)
+        heartbeat_started = asyncio.Event()
+        allow_heartbeat_return = asyncio.Event()
+
+        try:
+            session = (
+                await coordinator.acquire(DRIVER_ID, 'alice', CLIENT_ID)
+            ).session
+            initial_confirmation = coordinator._heartbeat_health[
+                session.id
+            ].last_confirmed_monotonic
+            pending = fake.snapshot(state='paused', reason='operator_pause')
+            pending['dispatch'].update({
+                'state': 'safe_latched',
+                'generation': fake.dispatch_generation + 1,
+                'stop_queue_depth': 1,
+                'last_decision': 'stop_requested:operator_pause',
+                'stop_acknowledged': False,
+            })
+
+            async def delayed_pending_heartbeat(
+                producer: FakeD1Caller,
+                arguments: dict[str, Any] | None,
+            ) -> dict[str, Any]:
+                producer._assert_identity(arguments)
+                heartbeat_started.set()
+                await allow_heartbeat_return.wait()
+                return pending
+
+            fake.queue('heartbeat', delayed_pending_heartbeat)
+            await asyncio.wait_for(heartbeat_started.wait(), timeout=0.6)
+
+            stable = deepcopy(pending)
+            stable['dispatch'].update({
+                'stop_queue_depth': 0,
+                'last_decision': 'would_stop:operator_pause',
+                'stop_acknowledged': True,
+            })
+            fake.queue('status', stable)
+            await coordinator.status(session.id, 'alice', owner=False)
+            clock.advance(0.1)
+            allow_heartbeat_return.set()
+            await asyncio.sleep(0.02)
+            await coordinator._cancel_heartbeat(session.id, origin_task=None)
+
+            cached = coordinator._driver_snapshots[session.id]
+            assert cached['dispatch']['stop_acknowledged'] is True
+            assert cached['dispatch']['stop_queue_depth'] == 0
+            assert coordinator._heartbeat_health[
+                session.id
+            ].last_confirmed_monotonic == initial_confirmation
+
+            fake.state = 'paused'
+            fake.reason = 'operator_pause'
+            fake.dispatch_generation += 1
+        finally:
+            allow_heartbeat_return.set()
+            await _finish(coordinator)
+
+    asyncio.run(scenario())
+
+
+def test_terminal_status_requires_same_epoch_revocation_or_restart_startup_ack(
+    shadow_session_tool,
+):
+    async def scenario() -> None:
+        _install_descriptor(shadow_session_tool)
+        fake = FakeD1Caller()
+        coordinator = _coordinator(fake, MutableClock())
+        try:
+            session = (
+                await coordinator.acquire(DRIVER_ID, 'alice', CLIENT_ID)
+            ).session
+
+            def projected_terminal(
+                *,
+                state: str,
+                reason: str | None,
+                boot_id: str,
+                epoch: int,
+                pending: bool = False,
+            ) -> dict[str, Any]:
+                raw = fake.snapshot()
+                raw.update({
+                    'boot_id': boot_id,
+                    'session_id': None,
+                    'epoch': epoch,
+                    'state': state,
+                    'reason': reason,
+                    'authority_valid': False,
+                })
+                raw['lease'].update({
+                    'age_ms': None,
+                    'fresh': False,
+                    'authority_valid': False,
+                    'expired_latched': reason == 'lease_timeout',
+                })
+                raw['dispatch'].update({
+                    'state': (
+                        'safe_unarmed' if state == 'idle' else 'safe_revoked'
+                    ),
+                    'generation': fake.dispatch_generation + 1,
+                    'mailbox_depth': 0,
+                    'stop_queue_depth': int(pending),
+                    'last_decision': (
+                        'startup_safe_ack'
+                        if state == 'idle'
+                        else f'stop_requested:{reason}'
+                        if pending
+                        else f'would_stop:{reason}'
+                    ),
+                    'stop_acknowledged': not pending,
+                    'fault_code': None,
+                    'io_inflight': None,
+                })
+                projected, _ = _project_driver_snapshot(
+                    raw,
+                    driver_id=DRIVER_ID,
+                    robot_id=ROBOT_ID,
+                    capability_digest=DIGEST,
+                    action='status',
+                    allow_stop_pending=pending,
+                )
+                return projected
+
+            same_boot_idle = projected_terminal(
+                state='idle',
+                reason=None,
+                boot_id=session.boot_id,
+                epoch=session.epoch,
+            )
+            same_boot_released = projected_terminal(
+                state='released',
+                reason='operator_release',
+                boot_id=session.boot_id,
+                epoch=session.epoch,
+            )
+            wrong_epoch_released = projected_terminal(
+                state='released',
+                reason='operator_release',
+                boot_id=session.boot_id,
+                epoch=session.epoch + 1,
+            )
+            restarted_idle = projected_terminal(
+                state='idle',
+                reason=None,
+                boot_id=str(uuid.uuid4()),
+                epoch=0,
+            )
+            same_boot_release_pending = projected_terminal(
+                state='released',
+                reason='operator_release',
+                boot_id=session.boot_id,
+                epoch=session.epoch,
+                pending=True,
+            )
+
+            assert coordinator._terminal_status_proves_safe(
+                session,
+                same_boot_idle,
+            ) is False
+            assert coordinator._terminal_status_proves_safe(
+                session,
+                same_boot_released,
+            ) is True
+            assert coordinator._terminal_status_proves_safe(
+                session,
+                wrong_epoch_released,
+            ) is False
+            assert coordinator._terminal_status_proves_safe(
+                session,
+                restarted_idle,
+            ) is True
+            assert coordinator._terminal_status_proves_safe(
+                session,
+                same_boot_release_pending,
+            ) is False
+        finally:
+            await _finish(coordinator)
+
+    asyncio.run(scenario())
+
+
+def test_terminal_cleanup_rejects_unproven_unlock(shadow_session_tool):
+    async def scenario() -> None:
+        _install_descriptor(shadow_session_tool)
+        broker = CommandBroker()
+        coordinator = _coordinator(
+            FakeD1Caller(),
+            MutableClock(),
+            command_broker=broker,
+        )
+        try:
+            session = (
+                await coordinator.acquire(DRIVER_ID, 'alice', CLIENT_ID)
+            ).session
+            with pytest.raises(RuntimeError, match='acknowledged safety proof'):
+                await coordinator._cleanup_terminal_runtime(session.id)
+            assert await broker.authority_for(ROBOT_ID) is not None
+        finally:
+            await _finish(coordinator)
+
+    asyncio.run(scenario())
+
+
+def test_terminal_cleanup_retains_quarantined_snapshot_baseline():
+    async def scenario() -> None:
+        coordinator = _coordinator(FakeD1Caller(), MutableClock())
+        coordinator._terminal_cleanup_done.add('completed-session')
+        coordinator._driver_snapshots.update({
+            'quarantined-session': {'dispatch': {'generation': 9}},
+            'unretained-session': {'dispatch': {'generation': 4}},
+        })
+        coordinator._driver_snapshot_revisions.update({
+            'quarantined-session': 3,
+            'unretained-session': 2,
+        })
+        coordinator._command_claims['quarantined-session'] = (
+            ROBOT_ID,
+            'quarantine-token',
+        )
+
+        await coordinator._cleanup_terminal_runtime('completed-session')
+
+        assert 'quarantined-session' in coordinator._driver_snapshots
+        assert 'quarantined-session' in coordinator._driver_snapshot_revisions
+        assert 'unretained-session' not in coordinator._driver_snapshots
+        assert 'unretained-session' not in coordinator._driver_snapshot_revisions
+
+    asyncio.run(scenario())
+
+
+def test_shutdown_keeps_unconfirmed_driver_release_quarantined(
+    shadow_session_tool,
+):
+    async def scenario() -> None:
+        _install_descriptor(shadow_session_tool)
+        broker = CommandBroker()
+        fake = FakeD1Caller()
+        coordinator = _coordinator(
+            fake,
+            MutableClock(),
+            command_broker=broker,
+        )
+        acquired = await coordinator.acquire(DRIVER_ID, 'alice', CLIENT_ID)
+        fake.queue(
+            'release',
+            mcp_client.TrustedShadowTransportError('timeout'),
+        )
+
+        await coordinator.stop()
+
+        claim = await broker.authority_for(ROBOT_ID)
+        assert claim is not None
+        assert claim.state == 'releasing'
+        assert acquired.session.id in coordinator._command_claims
+        assert coordinator._http_session is None
+        with pytest.raises(TeleopCommandBlocked):
+            async with broker.ordinary_command(
+                ROBOT_ID,
+                read_only=False,
+                source='test',
+                tool='locomotion',
+                action='move',
+            ):
+                raise AssertionError('shutdown opened an unconfirmed write gate')
+
+    asyncio.run(scenario())

--- a/agent-core/tests/teleop/test_teleop_session_api.py
+++ b/agent-core/tests/teleop/test_teleop_session_api.py
@@ -1,0 +1,1198 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from copy import deepcopy
+
+import pytest
+
+import auth
+import config
+import mcp_client
+from api import teleop
+from teleop import audit
+from teleop.models import ShadowSession
+from teleop.service import AcquireResult, TeleopServiceError
+from teleop.session_manager import (
+    SessionClientMismatch,
+    SessionConflict,
+    SessionForbidden,
+    SessionNotFound,
+    SessionStateConflict,
+)
+
+DRIVER_TOKEN = 'driver-token-that-must-never-cross-the-api-boundary'
+CLIENT_ID = '7dbabfca-15c1-43ca-b600-75e7682c21d0'
+OTHER_CLIENT_ID = '68991413-d37a-4603-9f07-3e25219d6d96'
+ALICE_SESSION_ID = 'd097eb8f-b386-455f-9e2b-23f1ad6a1ee3'
+BOB_SESSION_ID = 'b6f55f8c-0989-48ef-bf9a-55ed0bbb60df'
+ACQUIRED_SESSION_ID = '0ae6c709-36f8-4730-a388-62160ee742a8'
+FENCE_BY_SESSION = {
+    ALICE_SESSION_ID: 'alice-real-session-fence-0123456789abcdef',
+    BOB_SESSION_ID: 'bob-real-session-fence-0123456789abcdef',
+    ACQUIRED_SESSION_ID: 'acquired-real-session-fence-0123456789abcdef',
+}
+
+
+def _session(
+    session_id: str,
+    robot_id: str,
+    principal_id: str,
+    *,
+    state: str = 'active',
+) -> ShadowSession:
+    return ShadowSession(
+        id=session_id,
+        robot_id=robot_id,
+        driver_id=robot_id,
+        principal_id=principal_id,
+        boot_id='72559c63-e2a7-46ed-a50f-e8128ed8aa2b',
+        epoch=7,
+        capability_digest='0123456789abcdef' * 4,
+        client_id=CLIENT_ID if principal_id != 'operator:bob' else OTHER_CLIENT_ID,
+        fence=FENCE_BY_SESSION.get(
+            session_id,
+            f'generated-real-session-fence-{session_id}',
+        ),
+        state=state,
+        operation_generation=3,
+        operation_state='succeeded',
+        created_at=time.time() - 1.0,
+        lease_seconds=15.0,
+        deadline_monotonic=time.monotonic() + 15.0,
+    )
+
+
+class _FakeManager:
+    def __init__(self, sessions: list[ShadowSession]):
+        self.sessions = {session.id: session for session in sessions}
+        self.robot_sessions = {
+            session.robot_id: session.id
+            for session in sessions
+            if session.state not in {'released', 'expired', 'faulted'}
+        }
+        self.get_authorized_calls: list[tuple[str, str, bool, bool]] = []
+
+    async def active_for_robot(self, robot_id: str) -> ShadowSession | None:
+        session_id = self.robot_sessions.get(robot_id)
+        return self.sessions.get(session_id) if session_id else None
+
+    async def get(self, session_id: str) -> ShadowSession | None:
+        return self.sessions.get(session_id)
+
+    async def get_authorized(
+        self,
+        session_id: str,
+        principal_id: str,
+        owner: bool = False,
+        include_terminal: bool = False,
+    ) -> ShadowSession:
+        self.get_authorized_calls.append(
+            (session_id, principal_id, owner, include_terminal),
+        )
+        session = self.sessions.get(session_id)
+        if session is None:
+            raise SessionNotFound(session_id)
+        if session.state in {'released', 'expired', 'faulted'} and not include_terminal:
+            raise SessionNotFound(session_id)
+        if not owner and session.principal_id != principal_id:
+            raise SessionForbidden(session_id)
+        return session
+
+    def public_dict(self, session: ShadowSession) -> dict:
+        return session.public_dict()
+
+
+class _FakeCoordinator:
+    def __init__(self):
+        self.alice = _session(
+            ALICE_SESSION_ID,
+            'robot-a',
+            'operator:alice',
+        )
+        self.bob = _session(
+            BOB_SESSION_ID,
+            'robot-b',
+            'operator:bob',
+        )
+        self.manager = _FakeManager([self.alice, self.bob])
+        self.heartbeat_calls: list[tuple[str, str]] = []
+        self.signaling_calls: list[tuple[str, str, str, dict]] = []
+        self.confirm_calls: list[tuple[str, str, str, str]] = []
+        self.live_prepare_count = 0
+        self.authority_guards: dict[str, dict] = {}
+        self.reconcile_calls: list[tuple[str, str]] = []
+
+    def authority_guard_for_robot(self, robot_id: str) -> dict | None:
+        return self.authority_guards.get(robot_id)
+
+    def list_authority_guards(self) -> list[dict]:
+        return [self.authority_guards[key] for key in sorted(self.authority_guards)]
+
+    async def reconcile_authority_guard(
+        self,
+        robot_id: str,
+        *,
+        principal_id: str,
+    ) -> dict:
+        self.reconcile_calls.append((robot_id, principal_id))
+        guard = self.authority_guards.pop(robot_id, None)
+        return {
+            'state': 'clear',
+            'robot_id': robot_id,
+            'driver_id': guard['driver_id'] if guard else robot_id,
+            'old_session_restored': False,
+            'reacquire_required': True,
+            'already_clear': guard is None,
+        }
+
+    async def acquire(
+        self,
+        driver_id: str,
+        principal_id: str,
+        client_id: str,
+        mode: str = 'shadow',
+    ) -> AcquireResult:
+        assert client_id == CLIENT_ID
+        assert mode in {'shadow', 'live'}
+        if driver_id == 'robot-busy':
+            raise SessionConflict(self.bob)
+        service_errors = {
+            'robot-not-ready': ('driver_not_ready', 503),
+            'robot-timeout': ('driver_timeout', 504),
+            'robot-protocol-error': ('driver_protocol_error', 502),
+        }
+        if driver_id in service_errors:
+            code, status = service_errors[driver_id]
+            raise TeleopServiceError(code, status)
+
+        disposition = {
+            'robot-new': 'created',
+            'robot-existing': 'existing',
+            'robot-preparing': 'preparing',
+        }.get(driver_id, 'created')
+        if mode == 'live':
+            disposition = 'confirmation_required'
+        state = (
+            'awaiting_confirmation'
+            if mode == 'live'
+            else 'preparing'
+            if disposition == 'preparing'
+            else 'active'
+        )
+        session = _session(
+            ACQUIRED_SESSION_ID,
+            driver_id,
+            principal_id,
+            state=state,
+        )
+        if mode == 'live':
+            self._configure_live(session)
+        return AcquireResult(session=session, disposition=disposition)
+
+    @staticmethod
+    def _configure_live(session: ShadowSession) -> None:
+        session.mode = 'live'
+        session.profile_id = 'dual_arm_profile_v1'
+        session.capabilities = {
+            'profile_id': session.profile_id,
+            'input_bindings': {},
+            'outputs': {'dual_arm': {'enabled': True, 'joint_count': 10}},
+            'effectors': ['dual_arm'],
+        }
+        session.effectors = ['dual_arm']
+        session.signaling_audience = 'motus-teleop-rtc'
+        session.live_confirmed = False
+
+    async def confirm_live(
+        self,
+        session_id: str,
+        principal_id: str,
+        client_id: str,
+        *,
+        profile_id: str,
+    ) -> AcquireResult:
+        session = self.manager.sessions.get(session_id)
+        if session is None or session.state in {'released', 'expired', 'faulted'}:
+            raise SessionNotFound(session_id)
+        if session.principal_id != principal_id:
+            raise SessionForbidden(session_id)
+        if session.client_id != client_id:
+            raise SessionClientMismatch(session_id)
+        if session.mode != 'live' or session.profile_id != profile_id:
+            raise TeleopServiceError('live_confirmation_mismatch', 409)
+        self.confirm_calls.append((session_id, principal_id, client_id, profile_id))
+        if session.state == 'active' and session.live_confirmed:
+            return AcquireResult(session=session, disposition='existing')
+        if session.state != 'awaiting_confirmation' or session.live_confirmed:
+            raise SessionStateConflict(session_id)
+        self.live_prepare_count += 1
+        session.live_confirmed = True
+        session.state = 'active'
+        session.operation_state = 'succeeded'
+        session.epoch = 8
+        return AcquireResult(session=session, disposition='created')
+
+    def public_session(self, session: ShadowSession) -> dict:
+        result = self.manager.public_dict(session)
+        result['driver'] = {
+            'driver_id': session.driver_id,
+            'mode': session.mode,
+            'actuation_enabled': session.mode == 'live',
+            'profile_id': session.profile_id,
+            'state': {
+                'active': f'prepared_{session.mode}',
+                'paused': 'paused',
+                'hold': 'hold',
+                'released': 'released',
+            }.get(session.state, session.state),
+            'authority_valid': session.state != 'released',
+        }
+        result['driver_heartbeat'] = {
+            'state': 'healthy' if session.state != 'released' else 'stopped',
+            'last_confirmed_at': time.time(),
+            'consecutive_failures': 0,
+        }
+        return result
+
+    async def sessions_for(self, principal_id: str, *, owner: bool) -> list[dict]:
+        sessions = list(self.manager.sessions.values())
+        if not owner:
+            sessions = [session for session in sessions if session.principal_id == principal_id]
+        return [self.public_session(session) for session in sessions]
+
+    async def session_for(
+        self,
+        session_id: str,
+        principal_id: str,
+        *,
+        owner: bool,
+    ) -> dict:
+        session = await self.manager.get_authorized(
+            session_id,
+            principal_id,
+            owner=owner,
+            include_terminal=True,
+        )
+        return self.public_session(session)
+
+    async def status(
+        self,
+        session_id: str,
+        principal_id: str,
+        *,
+        owner: bool,
+    ) -> dict:
+        session = await self.manager.get_authorized(
+            session_id,
+            principal_id,
+            owner=owner,
+        )
+        return self.public_session(session)
+
+    async def heartbeat(
+        self,
+        session_id: str,
+        principal_id: str,
+        client_id: str,
+    ) -> ShadowSession:
+        assert client_id == CLIENT_ID
+        # This intentionally mirrors the real coordinator: owner status does not
+        # bypass heartbeat ownership.
+        session = await self.manager.get_authorized(
+            session_id,
+            principal_id,
+            owner=False,
+        )
+        self.heartbeat_calls.append((session_id, principal_id))
+        session.deadline_monotonic = time.monotonic() + session.lease_seconds
+        return session
+
+    async def signaling_offer(
+        self,
+        session_id: str,
+        principal_id: str,
+        client_id: str,
+        offer: dict,
+    ) -> dict:
+        session = self.manager.sessions.get(session_id)
+        if session is None:
+            raise SessionNotFound(session_id)
+        if session.principal_id != principal_id:
+            raise SessionForbidden(session_id)
+        if session.client_id != client_id:
+            raise SessionClientMismatch(session_id)
+        if session.state in {'released', 'expired', 'faulted'}:
+            raise SessionNotFound(session_id)
+        if session.state != 'active':
+            raise SessionStateConflict(session_id)
+        self.signaling_calls.append((session_id, principal_id, client_id, offer))
+        return {'type': 'answer', 'sdp': 'v=0\r\na=fake-driver-answer'}
+
+    async def pause(
+        self,
+        session_id: str,
+        principal_id: str,
+        client_id: str,
+        *,
+        owner: bool,
+    ) -> ShadowSession:
+        assert client_id == CLIENT_ID
+        session = await self.manager.get_authorized(session_id, principal_id, owner=owner)
+        if session.state not in {'active', 'paused', 'hold'}:
+            raise SessionStateConflict(session_id)
+        session.state = 'paused'
+        return session
+
+    async def soft_stop(
+        self,
+        session_id: str,
+        principal_id: str,
+        client_id: str,
+        *,
+        owner: bool,
+    ) -> ShadowSession:
+        assert client_id == CLIENT_ID
+        session = await self.manager.get_authorized(session_id, principal_id, owner=owner)
+        if session.state not in {'active', 'hold'}:
+            raise SessionStateConflict(session_id)
+        session.state = 'hold'
+        return session
+
+    async def release(
+        self,
+        session_id: str,
+        principal_id: str,
+        client_id: str,
+        *,
+        owner: bool,
+    ) -> tuple[ShadowSession, bool]:
+        assert client_id == CLIENT_ID
+        session = await self.manager.get_authorized(
+            session_id,
+            principal_id,
+            owner=owner,
+            include_terminal=True,
+        )
+        if session.state == 'released':
+            return session, True
+        if session.state in {'expired', 'faulted'}:
+            return session, False
+        session.state = 'released'
+        session.operation_state = 'cancelled'
+        self.manager.robot_sessions.pop(session.robot_id, None)
+        return session, True
+
+
+class _ApiHarness:
+    def __init__(self, client, auth_headers, coordinator: _FakeCoordinator):
+        self.client = client
+        self.headers = auth_headers
+        self.coordinator = coordinator
+
+    def request(self, method: str, path: str, *, role: str = 'operator', **kwargs):
+        response = self.client.request(
+            method,
+            path,
+            headers=self.headers[role],
+            **kwargs,
+        )
+        _assert_secret_free(response)
+        return response
+
+
+def _walk_json(value):
+    if isinstance(value, dict):
+        for key, item in value.items():
+            yield str(key)
+            yield from _walk_json(item)
+    elif isinstance(value, list):
+        for item in value:
+            yield from _walk_json(item)
+    elif value is not None:
+        yield str(value)
+
+
+def _assert_secret_free(response) -> None:
+    payload = response.json()
+    serialized = json.dumps(payload, ensure_ascii=False, sort_keys=True)
+    leaves = list(_walk_json(payload))
+    for secret in (*FENCE_BY_SESSION.values(), DRIVER_TOKEN):
+        assert secret not in serialized
+        assert all(secret not in leaf for leaf in leaves)
+
+
+def _robot_record(shadow_session_tool: dict, robot_id: str, name: str) -> dict:
+    tool = deepcopy(shadow_session_tool)
+    tool['x-teleop']['driver_id'] = robot_id
+    tool['x-teleop']['robot_id'] = robot_id
+    return {
+        'id': robot_id,
+        'name': name,
+        'server_name': f'{robot_id}-shadow',
+        'url': f'https://{robot_id}.invalid/mcp',
+        'transport': 'http',
+        'category': 'driver',
+        'trust_state': 'trusted',
+        'tools': [tool],
+    }
+
+
+@pytest.fixture
+def api_harness(
+    client,
+    auth_headers,
+    shadow_session_tool,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    auth.init({
+        'ACCESS_TOKEN': 'owner-token',
+        'MOTUS_OPERATOR_TOKENS': '{"alice":"operator-token"}',
+        'MOTUS_VIEWER_TOKENS': '{"auditor":"viewer-token"}',
+        'MOTUS_DRIVER_TOKEN': DRIVER_TOKEN,
+        'MOTUS_TELEOP_TICKET_SECRET': 'test-session-api-ticket-secret-0001',
+    })
+    coordinator = _FakeCoordinator()
+    monkeypatch.setattr(teleop, 'coordinator', coordinator)
+
+    records = [
+        _robot_record(shadow_session_tool, 'robot-a', 'A Owned Robot'),
+        _robot_record(shadow_session_tool, 'robot-b', 'B Other Robot'),
+        _robot_record(shadow_session_tool, 'robot-idle', 'C Idle Robot'),
+    ]
+    config.main['services'] = {'mcp': records}
+    for record in records:
+        mcp_client.registry[record['id']] = {
+            'online': True,
+            'trusted': True,
+            'url': record['url'],
+            'teleop_fingerprint': mcp_client.teleop_tool_fingerprint(record['tools'][0]),
+        }
+    return _ApiHarness(client, auth_headers, coordinator)
+
+
+def test_me_control_permission_matches_role(api_harness: _ApiHarness):
+    expectations = {'viewer': False, 'operator': True, 'owner': True}
+    for role, expected in expectations.items():
+        response = api_harness.request('GET', '/api/teleop/me', role=role)
+        assert response.status_code == 200
+        assert response.json()['code'] == 200
+        assert response.json()['data']['permissions'] == {
+            'view_devices': True,
+            'control': expected,
+        }
+
+
+def test_robot_busy_state_is_deidentified_except_for_owner_or_session_operator(
+    api_harness: _ApiHarness,
+):
+    viewer = api_harness.request('GET', '/api/teleop/robots', role='viewer')
+    operator = api_harness.request('GET', '/api/teleop/robots', role='operator')
+    owner = api_harness.request('GET', '/api/teleop/robots', role='owner')
+
+    def robots(response):
+        return {item['id']: item for item in response.json()['data']}
+
+    viewer_robots = robots(viewer)
+    operator_robots = robots(operator)
+    owner_robots = robots(owner)
+
+    assert viewer_robots['robot-idle']['session'] == {
+        'busy': False,
+        'owned_by_me': False,
+        'owned_by_client': False,
+    }
+    for robot_id in ('robot-a', 'robot-b'):
+        visible = viewer_robots[robot_id]['session']
+        assert visible['busy'] is True
+        assert visible['owned_by_me'] is False
+        assert 'id' not in visible
+        assert 'principal_id' not in visible
+
+    assert operator_robots['robot-a']['session']['owned_by_me'] is True
+    assert operator_robots['robot-a']['session']['owned_by_client'] is True
+    assert operator_robots['robot-a']['session']['id'] == ALICE_SESSION_ID
+    assert operator_robots['robot-a']['session']['principal_id'] == 'operator:alice'
+    assert 'id' not in operator_robots['robot-b']['session']
+    assert 'principal_id' not in operator_robots['robot-b']['session']
+    assert operator_robots['robot-b']['session']['owned_by_client'] is False
+    assert owner_robots['robot-a']['session']['id'] == ALICE_SESSION_ID
+    assert owner_robots['robot-b']['session']['id'] == BOB_SESSION_ID
+
+
+def test_directory_rejects_driver_without_lifecycle_stop_parameters(
+    api_harness: _ApiHarness,
+):
+    services = deepcopy(config.main['services'])
+    record = next(item for item in services['mcp'] if item['id'] == 'robot-idle')
+    record['tools'][0]['inputSchema']['x-action-params'].pop('stop')
+    config.main['services'] = services
+    mcp_client.registry['robot-idle']['teleop_fingerprint'] = (
+        mcp_client.teleop_tool_fingerprint(record['tools'][0])
+    )
+
+    directory = api_harness.request('GET', '/api/teleop/robots', role='viewer')
+    robot = next(
+        item for item in directory.json()['data'] if item['id'] == 'robot-idle'
+    )
+    assert robot['descriptor_valid'] is False
+    assert robot['teleop_ready'] is False
+    assert robot['reason'] == 'teleop_descriptor_invalid'
+
+
+def test_restart_guard_is_visible_but_only_owner_can_reconcile(
+    api_harness: _ApiHarness,
+):
+    api_harness.coordinator.authority_guards['robot-idle'] = {
+        'state': 'recovery_required',
+        'phase': 'recovery_required',
+        'driver_id': 'robot-idle',
+        'robot_id': 'robot-idle',
+        'retryable': True,
+        'created_at': 1.0,
+        'updated_at': 2.0,
+    }
+
+    directory = api_harness.request('GET', '/api/teleop/robots', role='viewer')
+    guarded = next(
+        item for item in directory.json()['data'] if item['id'] == 'robot-idle'
+    )
+    assert guarded['teleop_ready'] is False
+    assert guarded['reason'] == 'authority_recovery_required'
+    assert guarded['session'] == {
+        'busy': True,
+        'owned_by_me': False,
+        'owned_by_client': False,
+        'state': 'recovery_required',
+    }
+    assert guarded['authority_guard'] == {
+        'state': 'recovery_required',
+        'phase': 'recovery_required',
+        'driver_id': 'robot-idle',
+        'robot_id': 'robot-idle',
+        'retryable': True,
+        'created_at': 1.0,
+        'updated_at': 2.0,
+    }
+
+    path = '/api/teleop/authority-guards/robot-idle/reconcile'
+    for role in ('viewer', 'operator'):
+        denied = api_harness.request('POST', path, role=role)
+        assert denied.status_code == 403
+    cleared = api_harness.request('POST', path, role='owner')
+    assert cleared.status_code == 200
+    assert cleared.json()['data']['state'] == 'clear'
+    assert cleared.json()['data']['old_session_restored'] is False
+    assert api_harness.coordinator.reconcile_calls == [
+        ('robot-idle', 'owner:legacy'),
+    ]
+
+    after = api_harness.request('GET', '/api/teleop/robots', role='viewer')
+    idle = next(item for item in after.json()['data'] if item['id'] == 'robot-idle')
+    assert idle['teleop_ready'] is True
+    assert idle['session']['busy'] is False
+
+
+def test_orphan_restart_guard_stays_visible_when_driver_record_is_missing(
+    api_harness: _ApiHarness,
+):
+    api_harness.coordinator.authority_guards['robot-orphan'] = {
+        'state': 'recovery_required',
+        'phase': 'recovery_required',
+        'driver_id': 'missing-teleop-driver',
+        'robot_id': 'robot-orphan',
+        'retryable': True,
+        'created_at': 3.0,
+        'updated_at': 4.0,
+    }
+
+    directory = api_harness.request('GET', '/api/teleop/robots', role='viewer')
+    assert directory.status_code == 200
+    orphan = next(
+        item for item in directory.json()['data']
+        if item['id'] == 'recovery:robot-orphan'
+    )
+    assert orphan['driver_id'] == 'missing-teleop-driver'
+    assert orphan['robot_id'] == 'robot-orphan'
+    assert orphan['online'] is False
+    assert orphan['teleop_ready'] is False
+    assert orphan['reason'] == 'authority_recovery_required'
+    assert orphan['session'] == {
+        'busy': True,
+        'owned_by_me': False,
+        'owned_by_client': False,
+        'state': 'recovery_required',
+    }
+    assert set(orphan['authority_guard']) == {
+        'state',
+        'phase',
+        'driver_id',
+        'robot_id',
+        'retryable',
+        'created_at',
+        'updated_at',
+    }
+
+    reconcile = api_harness.request(
+        'POST',
+        '/api/teleop/authority-guards/robot-orphan/reconcile',
+        role='owner',
+    )
+    assert reconcile.status_code == 200
+    assert reconcile.json()['data']['old_session_restored'] is False
+
+
+@pytest.mark.parametrize(
+    'body',
+    [
+        {},
+        {'driver_id': ''},
+        {'driver_id': 'contains a space'},
+        {'driver_id': 'robot-a', 'extra': 'not-accepted'},
+    ],
+)
+def test_acquire_body_accepts_only_a_valid_driver_id(api_harness: _ApiHarness, body):
+    response = api_harness.request('POST', '/api/teleop/sessions', json=body)
+    assert response.status_code == 422
+
+
+def test_viewer_cannot_create_a_session(api_harness: _ApiHarness):
+    response = api_harness.request(
+        'POST',
+        '/api/teleop/sessions',
+        role='viewer',
+        json={'driver_id': 'robot-new'},
+    )
+    assert response.status_code == 403
+    assert response.json() == {'detail': 'operator role required'}
+
+
+@pytest.mark.parametrize(
+    ('driver_id', 'expected_status', 'disposition'),
+    [
+        ('robot-new', 201, 'created'),
+        ('robot-existing', 200, 'existing'),
+        ('robot-preparing', 202, 'preparing'),
+    ],
+)
+def test_acquire_uses_http_and_json_envelopes_for_each_disposition(
+    api_harness: _ApiHarness,
+    driver_id: str,
+    expected_status: int,
+    disposition: str,
+):
+    response = api_harness.request(
+        'POST',
+        '/api/teleop/sessions',
+        json={'driver_id': driver_id},
+    )
+    body = response.json()
+    assert response.status_code == expected_status
+    assert body['code'] == expected_status
+    assert body['data']['disposition'] == disposition
+    assert body['data']['session']['driver_id'] == driver_id
+    assert body['data']['session']['mode'] == 'shadow'
+
+
+def test_live_acquire_requires_confirmation_before_becoming_active(
+    api_harness: _ApiHarness,
+):
+    response = api_harness.request(
+        'POST',
+        '/api/teleop/sessions',
+        json={'driver_id': 'robot-new', 'mode': 'live'},
+    )
+
+    assert response.status_code == 202
+    assert response.json()['data']['disposition'] == 'confirmation_required'
+    session = response.json()['data']['session']
+    assert session['mode'] == 'live'
+    assert session['state'] == 'awaiting_confirmation'
+    assert session['live_confirmed'] is False
+    assert session['driver']['actuation_enabled'] is True
+
+
+def test_confirm_live_route_binds_profile_and_is_idempotent_for_same_tab(
+    api_harness: _ApiHarness,
+):
+    session = api_harness.coordinator.alice
+    api_harness.coordinator._configure_live(session)
+    session.state = 'awaiting_confirmation'
+    body = {
+        'confirm_live_actuation': True,
+        'profile_id': 'dual_arm_profile_v1',
+    }
+    path = f'/api/teleop/sessions/{session.id}/confirm-live'
+
+    confirmed = api_harness.request('POST', path, json=body)
+    retried = api_harness.request('POST', path, json=body)
+
+    assert confirmed.status_code == 200
+    assert confirmed.json()['data']['disposition'] == 'created'
+    assert confirmed.json()['data']['session']['mode'] == 'live'
+    assert confirmed.json()['data']['session']['live_confirmed'] is True
+    assert retried.status_code == 200
+    assert retried.json()['data']['disposition'] == 'existing'
+    assert api_harness.coordinator.live_prepare_count == 1
+    assert api_harness.coordinator.confirm_calls == [
+        (session.id, 'operator:alice', CLIENT_ID, 'dual_arm_profile_v1'),
+        (session.id, 'operator:alice', CLIENT_ID, 'dual_arm_profile_v1'),
+    ]
+
+
+@pytest.mark.parametrize(
+    'body',
+    [
+        {},
+        {'confirm_live_actuation': False, 'profile_id': 'dual_arm_profile_v1'},
+        {'confirm_live_actuation': 1, 'profile_id': 'dual_arm_profile_v1'},
+        {'confirm_live_actuation': True},
+        {'confirm_live_actuation': True, 'profile_id': 'contains a space'},
+        {
+            'confirm_live_actuation': True,
+            'profile_id': 'dual_arm_profile_v1',
+            'extra': 'rejected',
+        },
+    ],
+)
+def test_confirm_live_body_is_strict_and_never_reaches_coordinator(
+    api_harness: _ApiHarness,
+    body,
+):
+    session = api_harness.coordinator.alice
+    api_harness.coordinator._configure_live(session)
+    session.state = 'awaiting_confirmation'
+
+    response = api_harness.request(
+        'POST',
+        f'/api/teleop/sessions/{session.id}/confirm-live',
+        json=body,
+    )
+
+    assert response.status_code == 422
+    assert api_harness.coordinator.confirm_calls == []
+    assert api_harness.coordinator.live_prepare_count == 0
+
+
+def test_confirm_live_rejects_viewer_owner_other_tab_and_wrong_profile(
+    api_harness: _ApiHarness,
+):
+    session = api_harness.coordinator.alice
+    api_harness.coordinator._configure_live(session)
+    session.state = 'awaiting_confirmation'
+    path = f'/api/teleop/sessions/{session.id}/confirm-live'
+    body = {
+        'confirm_live_actuation': True,
+        'profile_id': 'dual_arm_profile_v1',
+    }
+
+    viewer = api_harness.request('POST', path, role='viewer', json=body)
+    owner = api_harness.request('POST', path, role='owner', json=body)
+    other_tab = api_harness.client.post(
+        path,
+        headers={
+            'Authorization': 'Bearer operator-token',
+            'X-Motus-Teleop-Client': OTHER_CLIENT_ID,
+        },
+        json=body,
+    )
+    _assert_secret_free(other_tab)
+    wrong_profile = api_harness.request(
+        'POST',
+        path,
+        json={**body, 'profile_id': 'different_profile'},
+    )
+
+    assert viewer.status_code == 403
+    assert owner.status_code == 403
+    assert owner.json() == {'detail': {'code': 'session_forbidden'}}
+    assert other_tab.status_code == 403
+    assert other_tab.json() == {'detail': {'code': 'session_client_mismatch'}}
+    assert wrong_profile.status_code == 409
+    assert wrong_profile.json() == {
+        'detail': {'code': 'live_confirmation_mismatch'},
+    }
+    assert api_harness.coordinator.live_prepare_count == 0
+
+
+@pytest.mark.parametrize(
+    ('driver_id', 'expected_status', 'expected_code'),
+    [
+        ('robot-busy', 409, 'robot_busy'),
+        ('robot-not-ready', 503, 'driver_not_ready'),
+        ('robot-timeout', 504, 'driver_timeout'),
+        ('robot-protocol-error', 502, 'driver_protocol_error'),
+    ],
+)
+def test_acquire_maps_conflicts_and_service_errors_to_stable_codes(
+    api_harness: _ApiHarness,
+    driver_id: str,
+    expected_status: int,
+    expected_code: str,
+):
+    response = api_harness.request(
+        'POST',
+        '/api/teleop/sessions',
+        json={'driver_id': driver_id},
+    )
+    assert response.status_code == expected_status
+    assert response.json() == {'detail': {'code': expected_code}}
+
+
+def test_operator_lists_only_own_sessions_while_owner_lists_all(
+    api_harness: _ApiHarness,
+):
+    operator = api_harness.request('GET', '/api/teleop/sessions')
+    owner = api_harness.request('GET', '/api/teleop/sessions', role='owner')
+
+    assert operator.status_code == 200
+    assert [item['id'] for item in operator.json()['data']] == [ALICE_SESSION_ID]
+    assert {item['id'] for item in owner.json()['data']} == {
+        ALICE_SESSION_ID,
+        BOB_SESSION_ID,
+    }
+
+    forbidden = api_harness.request(
+        'GET',
+        f'/api/teleop/sessions/{BOB_SESSION_ID}',
+    )
+    owner_read = api_harness.request(
+        'GET',
+        f'/api/teleop/sessions/{BOB_SESSION_ID}',
+        role='owner',
+    )
+    assert forbidden.status_code == 403
+    assert forbidden.json() == {'detail': {'code': 'session_forbidden'}}
+    assert owner_read.status_code == 200
+    assert owner_read.json()['data']['id'] == BOB_SESSION_ID
+
+
+def test_owner_cannot_renew_another_principals_browser_lease(
+    api_harness: _ApiHarness,
+):
+    original_deadline = api_harness.coordinator.bob.deadline_monotonic
+    response = api_harness.request(
+        'POST',
+        f'/api/teleop/sessions/{BOB_SESSION_ID}/heartbeat',
+        role='owner',
+    )
+    assert response.status_code == 403
+    assert response.json() == {'detail': {'code': 'session_forbidden'}}
+    assert api_harness.coordinator.bob.deadline_monotonic == original_deadline
+    assert api_harness.coordinator.heartbeat_calls == []
+
+    own = api_harness.request(
+        'POST',
+        f'/api/teleop/sessions/{ALICE_SESSION_ID}/heartbeat',
+    )
+    assert own.status_code == 200
+    assert own.json()['code'] == 200
+    assert api_harness.coordinator.heartbeat_calls == [
+        (ALICE_SESSION_ID, 'operator:alice'),
+    ]
+
+
+def test_signaling_offer_returns_only_sdp_answer_for_original_tab(
+    api_harness: _ApiHarness,
+):
+    deadline = api_harness.coordinator.alice.deadline_monotonic
+    offer = {'type': 'offer', 'sdp': 'v=0\r\no=quest-browser'}
+    response = api_harness.request(
+        'POST',
+        f'/api/teleop/sessions/{ALICE_SESSION_ID}/signaling/offer',
+        json=offer,
+    )
+    assert response.status_code == 200
+    assert response.json() == {
+        'code': 200,
+        'data': {'type': 'answer', 'sdp': 'v=0\r\na=fake-driver-answer'},
+    }
+    assert response.headers['cache-control'] == 'no-store'
+    assert api_harness.coordinator.signaling_calls == [(
+        ALICE_SESSION_ID,
+        'operator:alice',
+        CLIENT_ID,
+        offer,
+    )]
+    assert api_harness.coordinator.alice.deadline_monotonic == deadline
+
+
+def test_owner_and_other_browser_tab_cannot_take_over_signaling(
+    api_harness: _ApiHarness,
+):
+    path = f'/api/teleop/sessions/{ALICE_SESSION_ID}/signaling/offer'
+    offer = {'type': 'offer', 'sdp': 'v=0'}
+    viewer = api_harness.request('POST', path, role='viewer', json=offer)
+    assert viewer.status_code == 403
+    owner = api_harness.request('POST', path, role='owner', json=offer)
+    assert owner.status_code == 403
+    assert owner.json() == {'detail': {'code': 'session_forbidden'}}
+
+    other_tab_headers = {
+        'Authorization': 'Bearer operator-token',
+        'X-Motus-Teleop-Client': OTHER_CLIENT_ID,
+    }
+    other_tab = api_harness.client.post(path, headers=other_tab_headers, json=offer)
+    _assert_secret_free(other_tab)
+    assert other_tab.status_code == 403
+    assert other_tab.json() == {'detail': {'code': 'session_client_mismatch'}}
+    assert api_harness.coordinator.signaling_calls == []
+
+
+@pytest.mark.parametrize(
+    ('content', 'content_type', 'expected_status', 'expected_code'),
+    [
+        (
+            b'{"type":"offer","sdp":"v=0","extra":true}',
+            'application/json',
+            400,
+            'invalid_signaling_offer',
+        ),
+        (
+            b'{"type":"answer","sdp":"v=0"}',
+            'application/json',
+            400,
+            'invalid_signaling_offer',
+        ),
+        (
+            b'{"type":"offer","type":"offer","sdp":"v=0"}',
+            'application/json',
+            400,
+            'invalid_signaling_offer',
+        ),
+        (
+            b'{"type":"offer","sdp":NaN}',
+            'application/json',
+            400,
+            'invalid_signaling_offer',
+        ),
+        (
+            b'{"type":"offer","sdp":"v=0"}',
+            'text/plain',
+            415,
+            'signaling_content_type_required',
+        ),
+    ],
+)
+def test_signaling_offer_body_is_strict_and_stably_rejected(
+    api_harness: _ApiHarness,
+    content,
+    content_type,
+    expected_status,
+    expected_code,
+):
+    response = api_harness.client.request(
+        'POST',
+        f'/api/teleop/sessions/{ALICE_SESSION_ID}/signaling/offer',
+        content=content,
+        headers={**api_harness.headers['operator'], 'Content-Type': content_type},
+    )
+    _assert_secret_free(response)
+    assert response.status_code == expected_status
+    assert response.json() == {'detail': {'code': expected_code}}
+    assert api_harness.coordinator.signaling_calls == []
+
+
+def test_signaling_offer_raw_body_has_a_hard_byte_limit(api_harness: _ApiHarness):
+    response = api_harness.client.request(
+        'POST',
+        f'/api/teleop/sessions/{ALICE_SESSION_ID}/signaling/offer',
+        content=b'{"type":"offer","sdp":"' + b'x' * (129 * 1024) + b'"}',
+        headers={**api_harness.headers['operator'], 'Content-Type': 'application/json'},
+    )
+    _assert_secret_free(response)
+    assert response.status_code == 413
+    assert response.json() == {
+        'detail': {'code': 'signaling_offer_too_large'},
+    }
+    assert api_harness.coordinator.signaling_calls == []
+
+
+@pytest.mark.parametrize(
+    ('path_suffix', 'expected_state'),
+    [
+        ('pause', 'paused'),
+        ('soft-stop', 'hold'),
+    ],
+)
+def test_pause_and_soft_stop_return_visible_states(
+    api_harness: _ApiHarness,
+    path_suffix: str,
+    expected_state: str,
+):
+    response = api_harness.request(
+        'POST',
+        f'/api/teleop/sessions/{ALICE_SESSION_ID}/{path_suffix}',
+    )
+    assert response.status_code == 200
+    assert response.json()['code'] == 200
+    assert response.json()['data']['state'] == expected_state
+
+
+def test_release_is_idempotent_and_terminal_control_routes_return_410(
+    api_harness: _ApiHarness,
+):
+    path = f'/api/teleop/sessions/{ALICE_SESSION_ID}'
+    first = api_harness.request('DELETE', path)
+    repeated = api_harness.request('DELETE', path)
+
+    assert first.status_code == 200
+    assert first.json()['data']['session']['state'] == 'released'
+    assert first.json()['data']['driver_acknowledged'] is True
+    assert repeated.status_code == 200
+    assert repeated.json()['code'] == 200
+    assert repeated.json()['data']['session']['id'] == ALICE_SESSION_ID
+    assert repeated.json()['data']['session']['state'] == 'released'
+    assert repeated.json()['data']['driver_acknowledged'] is True
+
+    # The historical read remains available, while every route that requires
+    # live authority reports the stable 410 terminal code.
+    history = api_harness.request('GET', path)
+    assert history.status_code == 200
+    assert history.json()['data']['state'] == 'released'
+
+    terminal_requests = [
+        ('GET', f'{path}/driver-status'),
+        ('POST', f'{path}/heartbeat'),
+        ('POST', f'{path}/pause'),
+        ('POST', f'{path}/soft-stop'),
+    ]
+    for method, terminal_path in terminal_requests:
+        response = api_harness.request(method, terminal_path)
+        assert response.status_code == 410
+        assert response.json() == {'detail': {'code': 'session_released'}}
+    signaling = api_harness.request(
+        'POST',
+        f'{path}/signaling/offer',
+        json={'type': 'offer', 'sdp': 'v=0'},
+    )
+    assert signaling.status_code == 410
+    assert signaling.json() == {'detail': {'code': 'session_released'}}
+
+
+def test_unknown_and_invalid_state_errors_have_stable_envelopes(
+    api_harness: _ApiHarness,
+):
+    missing = api_harness.request(
+        'GET',
+        '/api/teleop/sessions/00000000-0000-0000-0000-000000000000',
+    )
+    assert missing.status_code == 404
+    assert missing.json() == {'detail': {'code': 'session_not_found'}}
+
+    api_harness.coordinator.alice.state = 'paused'
+    conflict = api_harness.request(
+        'POST',
+        f'/api/teleop/sessions/{ALICE_SESSION_ID}/soft-stop',
+    )
+    assert conflict.status_code == 409
+    assert conflict.json() == {'detail': {'code': 'session_state_conflict'}}
+
+
+def test_get_routes_never_renew_browser_lease(api_harness: _ApiHarness):
+    deadline = api_harness.coordinator.alice.deadline_monotonic
+    calls = list(api_harness.coordinator.heartbeat_calls)
+    paths = [
+        '/api/teleop/robots',
+        '/api/teleop/sessions',
+        f'/api/teleop/sessions/{ALICE_SESSION_ID}',
+        f'/api/teleop/sessions/{ALICE_SESSION_ID}/driver-status',
+        f'/api/teleop/sessions/{ALICE_SESSION_ID}/events',
+    ]
+    for path in paths:
+        response = api_harness.request('GET', path)
+        assert response.status_code == 200
+    assert api_harness.coordinator.alice.deadline_monotonic == deadline
+    assert api_harness.coordinator.heartbeat_calls == calls
+
+
+def test_session_events_are_authorized_and_isolated_by_exact_session(
+    api_harness: _ApiHarness,
+):
+    async def seed_events():
+        await audit.emit(
+            'teleop.session.alice',
+            session_id=ALICE_SESSION_ID,
+            robot_id='robot-a',
+            principal_id='operator:alice',
+            details={
+                'safe': 'alice-event',
+                'fence': FENCE_BY_SESSION[ALICE_SESSION_ID],
+                'driver_token': DRIVER_TOKEN,
+            },
+        )
+        await audit.emit(
+            'teleop.session.same-robot-other-session',
+            session_id='80f42326-4555-4481-92b1-dba426d2f4c4',
+            robot_id='robot-a',
+            principal_id='operator:alice',
+        )
+        await audit.emit(
+            'teleop.session.bob',
+            session_id=BOB_SESSION_ID,
+            robot_id='robot-b',
+            principal_id='operator:bob',
+        )
+
+    asyncio.run(seed_events())
+
+    alice = api_harness.request(
+        'GET',
+        f'/api/teleop/sessions/{ALICE_SESSION_ID}/events?limit=200',
+    )
+    assert alice.status_code == 200
+    assert [event['event_type'] for event in alice.json()['data']] == [
+        'teleop.session.alice',
+    ]
+    assert alice.json()['data'][0]['details'] == {'safe': 'alice-event'}
+
+    forbidden = api_harness.request(
+        'GET',
+        f'/api/teleop/sessions/{BOB_SESSION_ID}/events',
+    )
+    owner = api_harness.request(
+        'GET',
+        f'/api/teleop/sessions/{BOB_SESSION_ID}/events',
+        role='owner',
+    )
+    assert forbidden.status_code == 403
+    assert forbidden.json() == {'detail': {'code': 'session_forbidden'}}
+    assert [event['event_type'] for event in owner.json()['data']] == [
+        'teleop.session.bob',
+    ]
+
+
+def test_every_session_route_returns_json_without_private_authority(
+    api_harness: _ApiHarness,
+):
+    # This is an explicit response-surface inventory in addition to the scan
+    # automatically performed by every request made through the harness.
+    requests = [
+        ('GET', '/api/teleop/me', 'operator', None),
+        ('GET', '/api/teleop/robots', 'viewer', None),
+        ('GET', '/api/teleop/sessions', 'operator', None),
+        ('GET', f'/api/teleop/sessions/{ALICE_SESSION_ID}', 'operator', None),
+        (
+            'GET',
+            f'/api/teleop/sessions/{ALICE_SESSION_ID}/driver-status',
+            'operator',
+            None,
+        ),
+        ('GET', f'/api/teleop/sessions/{ALICE_SESSION_ID}/events', 'operator', None),
+        ('POST', f'/api/teleop/sessions/{ALICE_SESSION_ID}/heartbeat', 'operator', None),
+        ('POST', f'/api/teleop/sessions/{ALICE_SESSION_ID}/pause', 'operator', None),
+        (
+            'POST',
+            f'/api/teleop/sessions/{ALICE_SESSION_ID}/signaling/offer',
+            'operator',
+            {'type': 'offer', 'sdp': 'v=0'},
+        ),
+        ('DELETE', f'/api/teleop/sessions/{ALICE_SESSION_ID}', 'operator', None),
+        ('POST', '/api/teleop/sessions', 'operator', {'driver_id': 'robot-timeout'}),
+        ('POST', '/api/teleop/sessions', 'operator', {'driver_id': 'bad id'}),
+    ]
+    for method, path, role, body in requests:
+        kwargs = {'json': body} if body is not None else {}
+        response = api_harness.request(method, path, role=role, **kwargs)
+        assert response.headers['content-type'].startswith('application/json')

--- a/agent-core/tests/teleop/test_teleop_signaling_service.py
+++ b/agent-core/tests/teleop/test_teleop_signaling_service.py
@@ -1,0 +1,1359 @@
+from __future__ import annotations
+
+import asyncio
+import base64
+import hashlib
+import hmac
+import json
+import re
+from copy import deepcopy
+
+import pytest
+
+import auth
+import mcp_client
+from teleop import audit
+from teleop.capture_manager import CaptureError
+from teleop.models import ShadowSession
+from teleop.service import (
+    TeleopCoordinator,
+    TeleopServiceError,
+    _project_driver_snapshot,
+)
+from teleop.session_manager import (
+    SessionClientMismatch,
+    SessionForbidden,
+    SessionNotFound,
+    SessionStateConflict,
+    ShadowSessionManager,
+)
+
+SESSION_ID = 'd097eb8f-b386-455f-9e2b-23f1ad6a1ee3'
+BOOT_ID = '72559c63-e2a7-46ed-a50f-e8128ed8aa2b'
+CLIENT_ID = '7dbabfca-15c1-43ca-b600-75e7682c21d0'
+OTHER_CLIENT_ID = '68991413-d37a-4603-9f07-3e25219d6d96'
+PRINCIPAL_ID = 'operator:alice'
+FENCE = 'private-fence-token-0123456789abcdef'
+DIGEST = '0123456789abcdef' * 4
+TICKET_SECRET = 'ticket-secret-that-is-at-least-32-bytes-long'
+OFFER = {'type': 'offer', 'sdp': 'v=0\r\no=quest-3-offer'}
+CAPTURE_METADATA = {
+    'capture_protocol': 'motus.teleop.capture.v1',
+    'frame_protocol': 'motus.teleop.rtc-frame.v1',
+    'client_kind': 'browser_webxr',
+    'app_version': '1.0.0-test',
+}
+
+
+class _Clock:
+    def __init__(self):
+        self.monotonic = 100.0
+        self.wall = 1_800_000_000.75
+
+    def monotonic_now(self) -> float:
+        return self.monotonic
+
+    def wall_now(self) -> float:
+        return self.wall
+
+
+class _OpenSession:
+    closed = False
+
+
+def _answer(**changes) -> dict:
+    value = {
+        'sdp': 'v=0\r\na=driver-answer',
+        'type': 'answer',
+        'boot_id': BOOT_ID,
+        'session_id': SESSION_ID,
+        'epoch': 7,
+        'capability_digest': DIGEST,
+        'mode': 'shadow',
+        'actuation_enabled': False,
+    }
+    value.update(changes)
+    return value
+
+
+def _build(signaler, *, state: str = 'active', caller=None):
+    clock = _Clock()
+    manager = ShadowSessionManager(
+        monotonic=clock.monotonic_now,
+        wall_clock=clock.wall_now,
+    )
+    session = ShadowSession(
+        id=SESSION_ID,
+        robot_id='robot-a',
+        driver_id='teleop-driver-a',
+        principal_id=PRINCIPAL_ID,
+        boot_id=BOOT_ID,
+        epoch=7,
+        capability_digest=DIGEST,
+        client_id=CLIENT_ID,
+        fence=FENCE,
+        state=state,
+        operation_generation=3,
+        operation_state='succeeded',
+        created_at=clock.wall - 1,
+        lease_seconds=15.0,
+        deadline_monotonic=clock.monotonic + 15.0,
+    )
+    manager._sessions[session.id] = session
+    if state not in {'released', 'expired', 'faulted'}:
+        manager._robot_sessions[session.robot_id] = session.id
+    coordinator_kwargs = {
+        'session_manager': manager,
+        'signaler': signaler,
+        'monotonic': clock.monotonic_now,
+        'wall_clock': clock.wall_now,
+    }
+    if caller is not None:
+        coordinator_kwargs['caller'] = caller
+    coordinator = TeleopCoordinator(
+        **coordinator_kwargs,
+    )
+    coordinator._http_session = _OpenSession()  # type: ignore[assignment]
+    target = mcp_client.TrustedShadowTarget(
+        mcp_id=session.driver_id,
+        url='https://teleop-driver.invalid/mcp',
+        capability_digest=DIGEST,
+        descriptor_fingerprint='descriptor-fingerprint',
+        actions=frozenset({'status'}),
+    )
+    coordinator._pinned_targets[session.id] = target
+    return coordinator, manager, session, clock, target
+
+
+def _recording_snapshot(
+    *,
+    state: str,
+    reason: str | None,
+    generation: int,
+) -> dict:
+    authority_valid = state in {'active_shadow', 'hold', 'paused'}
+    terminal = state == 'released'
+    dispatch_state = {
+        'active_shadow': 'motion_eligible',
+        'hold': 'safe_latched',
+        'paused': 'safe_latched',
+        'released': 'safe_revoked',
+    }[state]
+    decision = {
+        'active_shadow': 'admitted',
+        'hold': 'would_stop:soft_stop',
+        'paused': 'would_stop:operator_pause',
+        'released': 'would_stop:operator_release',
+    }[state]
+    return {
+        'driver': 'teleop-driver-a',
+        'driver_id': 'teleop-driver-a',
+        'driver_name': 'Generic Teleop Shadow Diagnostics',
+        'driver_type': 'teleop-shadow',
+        'robot_id': 'robot-a',
+        'mode': 'shadow',
+        'actuation_enabled': False,
+        'boot_id': BOOT_ID,
+        'session_id': None if terminal else SESSION_ID,
+        'epoch': 7,
+        'state': state,
+        'reason': reason,
+        'authority_valid': authority_valid,
+        'capability_digest': DIGEST,
+        'capabilities': {
+            'pose_transport': ['webrtc-datachannel'],
+            'control_transport': ['mcp'],
+        },
+        'lease': {
+            'source': 'agent-core-mcp-heartbeat-only',
+            'timeout_ms': 10_000,
+            'age_ms': 0.0 if authority_valid else None,
+            'fresh': authority_valid,
+            'authority_valid': authority_valid,
+            'expired_latched': False,
+        },
+        'pose': {
+            'timeout_ms': 250.0,
+            'age_ms': None,
+            'fresh': False,
+            'latest_sequence': None,
+            'latest': None,
+        },
+        'rtc': {
+            'connected': False,
+            'channels': {'teleop-control': False, 'teleop-pose': False},
+            'renews_lease': False,
+        },
+        'dispatch': {
+            'kind': 'recording',
+            'state': dispatch_state,
+            'ready': True,
+            'generation': generation,
+            'mailbox_depth': 0,
+            'stop_queue_depth': 0,
+            'last_admitted_sequence': 1,
+            'last_would_apply_sequence': None,
+            'last_decision': decision,
+            'stop_acknowledged': True,
+            'fault_code': None,
+            'io_inflight': None,
+            'counters': {'startup_safe_acks': 1, 'stop_acks': generation + 1},
+            'adapter': {
+                'kind': 'recording',
+                'closed': False,
+                'current': {'kind': 'safe', 'reason': 'not_started'},
+                'records': [],
+            },
+        },
+        'counters': {'lease_heartbeats': 1},
+    }
+
+
+class _CaptureLossCaller:
+    def __init__(self, *, fail_soft_stop: bool = False):
+        self.actions: list[str] = []
+        self.generation = 1
+        self.fail_soft_stop = fail_soft_stop
+
+    async def __call__(
+        self,
+        _driver_id,
+        action,
+        _arguments,
+        **_kwargs,
+    ):
+        self.actions.append(action)
+        if action == 'soft_stop':
+            if self.fail_soft_stop:
+                raise mcp_client.TrustedShadowTransportError('network_error')
+            self.generation += 1
+            return _recording_snapshot(
+                state='hold',
+                reason='soft_stop',
+                generation=self.generation,
+            )
+        raise AssertionError(f'unexpected capture-loss action: {action}')
+
+
+def _seed_active_driver_snapshot(
+    coordinator: TeleopCoordinator,
+    session: ShadowSession,
+) -> None:
+    projected, _ = _project_driver_snapshot(
+        _recording_snapshot(
+            state='active_shadow',
+            reason=None,
+            generation=1,
+        ),
+        driver_id=session.driver_id,
+        robot_id=session.robot_id,
+        capability_digest=session.capability_digest,
+        action='status',
+        session=session,
+    )
+    coordinator._driver_snapshots[session.id] = projected
+    coordinator._driver_snapshot_revisions[session.id] = 1
+
+
+def _decode_ticket(ticket: str) -> tuple[dict, str, str]:
+    payload, signature = ticket.split('.', 1)
+    decoded = base64.urlsafe_b64decode(payload + '=' * (-len(payload) % 4))
+    return json.loads(decoded), payload, signature
+
+
+async def _ready_capture(coordinator: TeleopCoordinator, *, label: str = 'Quest 3'):
+    pairing = await coordinator.create_capture_pairing(
+        PRINCIPAL_ID,
+        CLIENT_ID,
+        label=label,
+    )
+    connection = await coordinator.connect_capture_with_pairing(
+        pairing.pairing_id,
+        pairing.pairing_code,
+        **CAPTURE_METADATA,
+    )
+    await coordinator.capture_presence(
+        connection.capture_id,
+        connection.connection_id,
+        state='xr_standby',
+        assignment_id=None,
+    )
+    return connection
+
+
+async def _attach_ready_capture(
+    coordinator: TeleopCoordinator,
+    *,
+    label: str = 'Quest 3',
+):
+    connection = await _ready_capture(coordinator, label=label)
+    assignment = await coordinator.attach_capture(
+        SESSION_ID,
+        PRINCIPAL_ID,
+        CLIENT_ID,
+        capture_id=connection.capture_id,
+        mode='shadow',
+        profile_id='recording',
+        capability_digest=DIGEST,
+    )
+    assert (await connection.events.get())['assignment']['id'] == assignment.id
+    return connection, assignment
+
+
+def test_offer_ticket_is_driver_compatible_private_and_does_not_renew_lease(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    observed = {}
+    events = []
+
+    async def signaler(driver_id, offer, ticket, **kwargs):
+        observed.update({
+            'driver_id': driver_id,
+            'offer': deepcopy(offer),
+            'ticket': ticket,
+            'kwargs': kwargs,
+        })
+        return _answer()
+
+    async def capture(event_type, **fields):
+        events.append({'event_type': event_type, **deepcopy(fields)})
+        return events[-1]
+
+    monkeypatch.setenv('MOTUS_TELEOP_TICKET_SECRET', TICKET_SECRET)
+    monkeypatch.setattr(audit, 'emit', capture)
+    coordinator, _manager, session, clock, target = _build(signaler)
+    deadline_before = session.deadline_monotonic
+
+    result = asyncio.run(coordinator.signaling_offer(
+        SESSION_ID,
+        PRINCIPAL_ID,
+        CLIENT_ID,
+        OFFER,
+    ))
+
+    assert result == {'sdp': 'v=0\r\na=driver-answer', 'type': 'answer'}
+    assert session.deadline_monotonic == deadline_before
+    assert observed['driver_id'] == session.driver_id
+    assert observed['offer'] == OFFER
+    assert observed['kwargs'] == {
+        'timeout_seconds': 2.0,
+        'session': coordinator._http_session,
+        'target': target,
+    }
+
+    claims, payload, signature = _decode_ticket(observed['ticket'])
+    expected_signature = base64.urlsafe_b64encode(
+        hmac.new(
+            TICKET_SECRET.encode(),
+            payload.encode('ascii'),
+            hashlib.sha256,
+        ).digest(),
+    ).rstrip(b'=').decode('ascii')
+    assert hmac.compare_digest(signature, expected_signature)
+    assert claims == {
+        'aud': 'teleop-shadow-rtc',
+        'boot_id': BOOT_ID,
+        'capability_digest': DIGEST,
+        'epoch': 7,
+        'exp': int(clock.wall) + 20,
+        'fence': FENCE,
+        'iat': int(clock.wall),
+        'jti': claims['jti'],
+        'sdp_sha256': hashlib.sha256(OFFER['sdp'].encode()).hexdigest(),
+        'session_id': SESSION_ID,
+        'v': 1,
+    }
+    assert re.fullmatch(r'[A-Za-z0-9_-]{16,128}', claims['jti'])
+    public_surface = json.dumps({'result': result, 'events': events}, sort_keys=True)
+    assert FENCE not in public_surface
+    assert observed['ticket'] not in public_surface
+    assert OFFER['sdp'] not in public_surface
+    assert events[-1]['event_type'] == 'teleop.signaling.offer.accepted'
+
+
+def test_offer_uses_ticket_secret_loaded_by_auth_when_process_env_is_absent(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    observed_ticket = ''
+
+    async def signaler(_driver_id, _offer, ticket, **_kwargs):
+        nonlocal observed_ticket
+        observed_ticket = ticket
+        return _answer()
+
+    async def quiet(*_args, **_kwargs):
+        return {}
+
+    monkeypatch.delenv('MOTUS_TELEOP_TICKET_SECRET', raising=False)
+    auth.init({'MOTUS_TELEOP_TICKET_SECRET': TICKET_SECRET})
+    monkeypatch.setattr(audit, 'emit', quiet)
+    coordinator, *_ = _build(signaler)
+
+    result = asyncio.run(coordinator.signaling_offer(
+        SESSION_ID,
+        PRINCIPAL_ID,
+        CLIENT_ID,
+        OFFER,
+    ))
+
+    assert result['type'] == 'answer'
+    claims, _payload, _signature = _decode_ticket(observed_ticket)
+    assert claims['fence'] == FENCE
+
+
+def test_offer_selects_dedicated_ticket_secret_by_exact_driver_id(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    observed_ticket = ''
+    dedicated = 'd' * 32
+    other = 'e' * 32
+
+    async def signaler(_driver_id, _offer, ticket, **_kwargs):
+        nonlocal observed_ticket
+        observed_ticket = ticket
+        return _answer()
+
+    async def quiet(*_args, **_kwargs):
+        return {}
+
+    auth.init({
+        'MOTUS_TELEOP_TICKET_SECRETS': json.dumps({
+            'teleop-driver-a': dedicated,
+            'teleop-driver-b': other,
+        }),
+    })
+    # A dedicated mapping must take precedence over the legacy process-wide
+    # fallback, including in focused deployments that still export it.
+    monkeypatch.setenv('MOTUS_TELEOP_TICKET_SECRET', TICKET_SECRET)
+    monkeypatch.setattr(audit, 'emit', quiet)
+    coordinator, *_ = _build(signaler)
+
+    result = asyncio.run(coordinator.signaling_offer(
+        SESSION_ID,
+        PRINCIPAL_ID,
+        CLIENT_ID,
+        OFFER,
+    ))
+
+    assert result['type'] == 'answer'
+    _claims, payload, signature = _decode_ticket(observed_ticket)
+    expected = base64.urlsafe_b64encode(
+        hmac.new(dedicated.encode(), payload.encode('ascii'), hashlib.sha256).digest(),
+    ).rstrip(b'=').decode('ascii')
+    wrong_driver = base64.urlsafe_b64encode(
+        hmac.new(other.encode(), payload.encode('ascii'), hashlib.sha256).digest(),
+    ).rstrip(b'=').decode('ascii')
+    assert hmac.compare_digest(signature, expected)
+    assert not hmac.compare_digest(signature, wrong_driver)
+
+
+@pytest.mark.parametrize(
+    ('principal_id', 'client_id', 'error_type'),
+    [
+        ('owner:root', CLIENT_ID, SessionForbidden),
+        (PRINCIPAL_ID, OTHER_CLIENT_ID, SessionClientMismatch),
+    ],
+)
+def test_original_principal_and_client_are_both_required(
+    monkeypatch: pytest.MonkeyPatch,
+    principal_id,
+    client_id,
+    error_type,
+):
+    called = False
+
+    async def signaler(*_args, **_kwargs):
+        nonlocal called
+        called = True
+        return _answer()
+
+    async def quiet(*_args, **_kwargs):
+        return {}
+
+    monkeypatch.setenv('MOTUS_TELEOP_TICKET_SECRET', TICKET_SECRET)
+    monkeypatch.setattr(audit, 'emit', quiet)
+    coordinator, *_ = _build(signaler)
+    with pytest.raises(error_type):
+        asyncio.run(coordinator.signaling_offer(
+            SESSION_ID,
+            principal_id,
+            client_id,
+            OFFER,
+        ))
+    assert called is False
+
+
+@pytest.mark.parametrize(
+    'state',
+    ['preparing', 'paused', 'hold', 'released', 'expired', 'faulted'],
+)
+def test_only_live_shadow_session_states_may_signal(
+    monkeypatch: pytest.MonkeyPatch,
+    state,
+):
+    async def signaler(*_args, **_kwargs):
+        raise AssertionError('signaler must not run')
+
+    async def quiet(*_args, **_kwargs):
+        return {}
+
+    monkeypatch.setenv('MOTUS_TELEOP_TICKET_SECRET', TICKET_SECRET)
+    monkeypatch.setattr(audit, 'emit', quiet)
+    coordinator, *_ = _build(signaler, state=state)
+    expected = (
+        SessionStateConflict
+        if state in {'preparing', 'paused', 'hold'}
+        else SessionNotFound
+    )
+    with pytest.raises(expected):
+        asyncio.run(coordinator.signaling_offer(
+            SESSION_ID,
+            PRINCIPAL_ID,
+            CLIENT_ID,
+            OFFER,
+        ))
+
+
+@pytest.mark.parametrize('secret', [None, 'short-secret'])
+def test_missing_or_short_ticket_secret_fails_closed(
+    monkeypatch: pytest.MonkeyPatch,
+    secret,
+):
+    async def signaler(*_args, **_kwargs):
+        raise AssertionError('signaler must not run')
+
+    async def quiet(*_args, **_kwargs):
+        return {}
+
+    auth.init({})
+    if secret is None:
+        monkeypatch.delenv('MOTUS_TELEOP_TICKET_SECRET', raising=False)
+    else:
+        monkeypatch.setenv('MOTUS_TELEOP_TICKET_SECRET', secret)
+    monkeypatch.setattr(audit, 'emit', quiet)
+    coordinator, *_ = _build(signaler)
+    with pytest.raises(TeleopServiceError) as captured:
+        asyncio.run(coordinator.signaling_offer(
+            SESSION_ID,
+            PRINCIPAL_ID,
+            CLIENT_ID,
+            OFFER,
+        ))
+    assert (captured.value.code, captured.value.status_code) == (
+        'teleop_signaling_unavailable',
+        503,
+    )
+    assert secret is None or secret not in str(captured.value)
+
+
+@pytest.mark.parametrize('pin_change', ['missing', 'driver', 'digest'])
+def test_signaling_requires_the_exact_session_pinned_target(
+    monkeypatch: pytest.MonkeyPatch,
+    pin_change,
+):
+    async def signaler(*_args, **_kwargs):
+        raise AssertionError('signaler must not run')
+
+    async def quiet(*_args, **_kwargs):
+        return {}
+
+    monkeypatch.setenv('MOTUS_TELEOP_TICKET_SECRET', TICKET_SECRET)
+    monkeypatch.setattr(audit, 'emit', quiet)
+    coordinator, _manager, session, _clock, target = _build(signaler)
+    if pin_change == 'missing':
+        coordinator._pinned_targets.pop(session.id)
+    elif pin_change == 'driver':
+        coordinator._pinned_targets[session.id] = mcp_client.TrustedShadowTarget(
+            'other-driver', target.url, DIGEST, target.descriptor_fingerprint, target.actions,
+        )
+    else:
+        coordinator._pinned_targets[session.id] = mcp_client.TrustedShadowTarget(
+            session.driver_id,
+            target.url,
+            'f' * 64,
+            target.descriptor_fingerprint,
+            target.actions,
+        )
+    with pytest.raises(TeleopServiceError) as captured:
+        asyncio.run(coordinator.signaling_offer(
+            SESSION_ID,
+            PRINCIPAL_ID,
+            CLIENT_ID,
+            OFFER,
+        ))
+    assert captured.value.code == 'driver_not_ready'
+
+
+@pytest.mark.parametrize(
+    'change',
+    [
+        {'type': 'offer'},
+        {'boot_id': 'e4314745-5d67-4745-9c9f-fe4615778a4c'},
+        {'session_id': '09259f38-bd2f-42e6-80f8-bc5bd931c8b7'},
+        {'epoch': True},
+        {'epoch': 8},
+        {'capability_digest': 'f' * 64},
+        {'mode': 'active'},
+        {'actuation_enabled': True},
+        {'sdp': FENCE},
+        {'unexpected': 'field'},
+    ],
+)
+def test_driver_answer_identity_and_shadow_mode_are_exact(
+    monkeypatch: pytest.MonkeyPatch,
+    change,
+):
+    async def signaler(*_args, **_kwargs):
+        return _answer(**change)
+
+    async def quiet(*_args, **_kwargs):
+        return {}
+
+    monkeypatch.setenv('MOTUS_TELEOP_TICKET_SECRET', TICKET_SECRET)
+    monkeypatch.setattr(audit, 'emit', quiet)
+    coordinator, *_ = _build(signaler)
+    with pytest.raises(TeleopServiceError) as captured:
+        asyncio.run(coordinator.signaling_offer(
+            SESSION_ID,
+            PRINCIPAL_ID,
+            CLIENT_ID,
+            OFFER,
+        ))
+    assert (captured.value.code, captured.value.status_code) == (
+        'driver_protocol_error',
+        502,
+    )
+    assert FENCE not in str(captured.value)
+
+
+def test_driver_cannot_reflect_the_private_offer_ticket_to_the_browser(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    reflected_ticket = ''
+    events = []
+
+    async def signaler(_driver_id, _offer, ticket, **_kwargs):
+        nonlocal reflected_ticket
+        reflected_ticket = ticket
+        return _answer(sdp=ticket)
+
+    async def capture(event_type, **fields):
+        events.append({'event_type': event_type, **deepcopy(fields)})
+        return events[-1]
+
+    monkeypatch.setenv('MOTUS_TELEOP_TICKET_SECRET', TICKET_SECRET)
+    monkeypatch.setattr(audit, 'emit', capture)
+    coordinator, *_ = _build(signaler)
+    with pytest.raises(TeleopServiceError) as captured:
+        asyncio.run(coordinator.signaling_offer(
+            SESSION_ID,
+            PRINCIPAL_ID,
+            CLIENT_ID,
+            OFFER,
+        ))
+    assert captured.value.code == 'driver_protocol_error'
+    assert reflected_ticket
+    serialized = json.dumps(events, sort_keys=True)
+    assert reflected_ticket not in serialized
+    assert FENCE not in serialized
+
+
+@pytest.mark.parametrize(
+    ('transport_error', 'expected'),
+    [
+        (mcp_client.TrustedShadowTransportError('timeout'), ('driver_timeout', 504)),
+        (
+            mcp_client.TrustedShadowTransportError('pinned_target_changed'),
+            ('driver_session_lost', 409),
+        ),
+        (
+            mcp_client.TrustedShadowTransportError('http_error', http_status=401),
+            ('driver_auth_rejected', 502),
+        ),
+        (
+            mcp_client.TrustedShadowTransportError('network_error'),
+            ('driver_unreachable', 503),
+        ),
+        (
+            mcp_client.TrustedShadowTransportError('response_too_large'),
+            ('driver_protocol_error', 502),
+        ),
+        (
+            mcp_client.TrustedShadowTransportError('redirect_rejected', http_status=307),
+            ('driver_protocol_error', 502),
+        ),
+    ],
+)
+def test_transport_errors_are_stably_mapped_and_audited_without_secrets(
+    monkeypatch: pytest.MonkeyPatch,
+    transport_error,
+    expected,
+):
+    issued_ticket = ''
+    events = []
+
+    async def signaler(_driver_id, _offer, ticket, **_kwargs):
+        nonlocal issued_ticket
+        issued_ticket = ticket
+        raise transport_error
+
+    async def capture(event_type, **fields):
+        events.append({'event_type': event_type, **deepcopy(fields)})
+        return events[-1]
+
+    monkeypatch.setenv('MOTUS_TELEOP_TICKET_SECRET', TICKET_SECRET)
+    monkeypatch.setattr(audit, 'emit', capture)
+    coordinator, *_ = _build(signaler)
+    with pytest.raises(TeleopServiceError) as captured:
+        asyncio.run(coordinator.signaling_offer(
+            SESSION_ID,
+            PRINCIPAL_ID,
+            CLIENT_ID,
+            OFFER,
+        ))
+    assert (captured.value.code, captured.value.status_code) == expected
+    assert events[-1]['reason'] == expected[0]
+    serialized = json.dumps(events, sort_keys=True)
+    assert issued_ticket not in serialized
+    assert FENCE not in serialized
+    assert OFFER['sdp'] not in serialized
+
+
+def test_release_preempts_offer_network_wait_and_stale_answer_is_rejected(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    entered = asyncio.Event()
+    finish_offer = asyncio.Event()
+
+    async def signaler(*_args, **_kwargs):
+        entered.set()
+        await finish_offer.wait()
+        return _answer()
+
+    async def quiet(*_args, **_kwargs):
+        return {}
+
+    async def scenario():
+        coordinator, _manager, session, _clock, _target = _build(signaler)
+
+        async def complete_release(_released, _principal_id, *, origin_task):
+            assert origin_task is not None
+            return True
+
+        coordinator._complete_release_cleanup = complete_release  # type: ignore[method-assign]
+        offer_task = asyncio.create_task(coordinator.signaling_offer(
+            SESSION_ID,
+            PRINCIPAL_ID,
+            CLIENT_ID,
+            OFFER,
+        ))
+        await entered.wait()
+        release_task = asyncio.create_task(coordinator.release(
+            SESSION_ID,
+            PRINCIPAL_ID,
+            CLIENT_ID,
+            owner=False,
+        ))
+        for _ in range(20):
+            if release_task.done():
+                break
+            await asyncio.sleep(0)
+        assert release_task.done() is True
+        assert offer_task.done() is False
+        released, acknowledged = await release_task
+        assert session.state == 'released'
+        finish_offer.set()
+        with pytest.raises(SessionNotFound):
+            await offer_task
+        return released.state, acknowledged
+
+    monkeypatch.setenv('MOTUS_TELEOP_TICKET_SECRET', TICKET_SECRET)
+    monkeypatch.setattr(audit, 'emit', quiet)
+    assert asyncio.run(scenario()) == ('released', True)
+
+
+def test_expiry_during_offer_is_rejected_without_lease_renewal(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    async def quiet(*_args, **_kwargs):
+        return {}
+
+    coordinator = None
+
+    async def signaler(*_args, **_kwargs):
+        assert coordinator is not None
+        clock.monotonic += 16.0
+        return _answer()
+
+    monkeypatch.setenv('MOTUS_TELEOP_TICKET_SECRET', TICKET_SECRET)
+    monkeypatch.setattr(audit, 'emit', quiet)
+    coordinator, _manager, session, clock, _target = _build(signaler)
+    deadline = session.deadline_monotonic
+    with pytest.raises(SessionNotFound):
+        asyncio.run(coordinator.signaling_offer(
+            SESSION_ID,
+            PRINCIPAL_ID,
+            CLIENT_ID,
+            OFFER,
+        ))
+    assert deadline == 115.0
+    assert session.deadline_monotonic == deadline
+    assert session.state == 'expired'
+
+
+def test_capture_source_blocks_direct_offer_and_consumes_one_capture_offer(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    calls = []
+
+    async def signaler(driver_id, offer, ticket, **kwargs):
+        calls.append((driver_id, deepcopy(offer), ticket, kwargs))
+        return _answer()
+
+    async def quiet(*_args, **_kwargs):
+        return {}
+
+    async def scenario():
+        coordinator, *_ = _build(signaler)
+        connection, assignment = await _attach_ready_capture(coordinator)
+
+        with pytest.raises(TeleopServiceError, match='signaling_source_conflict'):
+            await coordinator.signaling_offer(
+                SESSION_ID,
+                PRINCIPAL_ID,
+                CLIENT_ID,
+                OFFER,
+            )
+        answer = await coordinator.capture_signaling_offer(
+            connection.capture_id,
+            connection.connection_id,
+            assignment.id,
+            OFFER,
+        )
+        with pytest.raises(CaptureError, match='capture_offer_already_consumed'):
+            await coordinator.capture_signaling_offer(
+                connection.capture_id,
+                connection.connection_id,
+                assignment.id,
+                OFFER,
+            )
+        return coordinator, connection, answer
+
+    monkeypatch.setenv('MOTUS_TELEOP_TICKET_SECRET', TICKET_SECRET)
+    monkeypatch.setattr(audit, 'emit', quiet)
+    coordinator, connection, answer = asyncio.run(scenario())
+
+    assert answer == {'sdp': 'v=0\r\na=driver-answer', 'type': 'answer'}
+    assert len(calls) == 1
+    assert coordinator._signaling_sources[SESSION_ID] == (
+        'capture',
+        connection.capture_id,
+    )
+    claims, _payload, _signature = _decode_ticket(calls[0][2])
+    assert claims['fence'] == FENCE
+    assert FENCE not in json.dumps(answer, sort_keys=True)
+
+
+def test_completed_direct_offer_blocks_capture_attachment(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    calls = 0
+
+    async def signaler(*_args, **_kwargs):
+        nonlocal calls
+        calls += 1
+        return _answer()
+
+    async def quiet(*_args, **_kwargs):
+        return {}
+
+    async def scenario():
+        coordinator, *_ = _build(signaler)
+        connection = await _ready_capture(coordinator)
+        await coordinator.signaling_offer(
+            SESSION_ID,
+            PRINCIPAL_ID,
+            CLIENT_ID,
+            OFFER,
+        )
+        with pytest.raises(TeleopServiceError, match='signaling_source_conflict'):
+            await coordinator.attach_capture(
+                SESSION_ID,
+                PRINCIPAL_ID,
+                CLIENT_ID,
+                capture_id=connection.capture_id,
+                mode='shadow',
+                profile_id='recording',
+                capability_digest=DIGEST,
+            )
+        return coordinator, connection
+
+    monkeypatch.setenv('MOTUS_TELEOP_TICKET_SECRET', TICKET_SECRET)
+    monkeypatch.setattr(audit, 'emit', quiet)
+    coordinator, connection = asyncio.run(scenario())
+
+    assert calls == 1
+    assert coordinator._signaling_sources[SESSION_ID] == ('direct', CLIENT_ID)
+    captures = asyncio.run(coordinator.list_captures(PRINCIPAL_ID))
+    assert captures[0]['id'] == connection.capture_id
+    assert captures[0]['assignment'] is None
+
+
+def test_inflight_direct_offer_claims_source_before_capture_can_attach(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    entered = asyncio.Event()
+    finish = asyncio.Event()
+
+    async def signaler(*_args, **_kwargs):
+        entered.set()
+        await finish.wait()
+        return _answer()
+
+    async def quiet(*_args, **_kwargs):
+        return {}
+
+    async def scenario():
+        coordinator, *_ = _build(signaler)
+        connection = await _ready_capture(coordinator)
+        direct = asyncio.create_task(coordinator.signaling_offer(
+            SESSION_ID,
+            PRINCIPAL_ID,
+            CLIENT_ID,
+            OFFER,
+        ))
+        await entered.wait()
+        with pytest.raises(TeleopServiceError, match='signaling_source_conflict'):
+            await coordinator.attach_capture(
+                SESSION_ID,
+                PRINCIPAL_ID,
+                CLIENT_ID,
+                capture_id=connection.capture_id,
+                mode='shadow',
+                profile_id='recording',
+                capability_digest=DIGEST,
+            )
+        finish.set()
+        return coordinator, await direct
+
+    monkeypatch.setenv('MOTUS_TELEOP_TICKET_SECRET', TICKET_SECRET)
+    monkeypatch.setattr(audit, 'emit', quiet)
+    coordinator, answer = asyncio.run(scenario())
+
+    assert answer == {'sdp': 'v=0\r\na=driver-answer', 'type': 'answer'}
+    assert coordinator._signaling_sources[SESSION_ID] == ('direct', CLIENT_ID)
+
+
+def test_failed_capture_offer_holds_session_and_requires_new_pc_session(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    calls = 0
+    caller = _CaptureLossCaller()
+
+    async def signaler(*_args, **_kwargs):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise mcp_client.TrustedShadowTransportError('network_error')
+        return _answer()
+
+    async def quiet(*_args, **_kwargs):
+        return {}
+
+    async def scenario():
+        coordinator, _manager, session, *_ = _build(signaler, caller=caller)
+        _seed_active_driver_snapshot(coordinator, session)
+        connection, assignment = await _attach_ready_capture(coordinator)
+        with pytest.raises(TeleopServiceError, match='driver_unreachable'):
+            await coordinator.capture_signaling_offer(
+                connection.capture_id,
+                connection.connection_id,
+                assignment.id,
+                OFFER,
+            )
+        assert session.state == 'hold'
+        assert caller.actions == ['soft_stop']
+        assert await connection.events.get() == {
+            'type': 'assignment_revoked',
+            'assignment_id': assignment.id,
+            'reason': 'capture_signaling_failed',
+        }
+        with pytest.raises(SessionStateConflict):
+            await coordinator.attach_capture(
+                SESSION_ID,
+                PRINCIPAL_ID,
+                CLIENT_ID,
+                capture_id=connection.capture_id,
+                mode='shadow',
+                profile_id='recording',
+                capability_digest=DIGEST,
+            )
+        # WSS finally disconnects after returning the stable offer error. The
+        # already revoked assignment must not issue a second Driver stop.
+        await coordinator.disconnect_capture(
+            connection.capture_id,
+            connection.connection_id,
+        )
+        return coordinator, session, connection
+
+    monkeypatch.setenv('MOTUS_TELEOP_TICKET_SECRET', TICKET_SECRET)
+    monkeypatch.setattr(audit, 'emit', quiet)
+    coordinator, session, connection = asyncio.run(scenario())
+
+    assert calls == 1
+    assert session.state == 'hold'
+    assert caller.actions == ['soft_stop']
+    assert coordinator._signaling_sources[SESSION_ID] == (
+        'capture',
+        connection.capture_id,
+    )
+
+
+def test_unconfirmed_live_session_cannot_attach_capture(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    async def signaler(*_args, **_kwargs):
+        raise AssertionError('signaler must not run')
+
+    async def quiet(*_args, **_kwargs):
+        return {}
+
+    async def scenario():
+        coordinator, _manager, session, *_ = _build(signaler)
+        session.mode = 'live'
+        session.profile_id = 'dual_arm_profile_v1'
+        session.signaling_audience = 'motus-teleop-rtc'
+        session.live_confirmed = False
+        connection = await _ready_capture(coordinator)
+        with pytest.raises(SessionStateConflict):
+            await coordinator.attach_capture(
+                SESSION_ID,
+                PRINCIPAL_ID,
+                CLIENT_ID,
+                capture_id=connection.capture_id,
+                mode='live',
+                profile_id=session.profile_id,
+                capability_digest=DIGEST,
+            )
+        return coordinator
+
+    monkeypatch.setattr(audit, 'emit', quiet)
+    coordinator = asyncio.run(scenario())
+    assert coordinator._signaling_sources == {}
+
+
+@pytest.mark.parametrize(
+    ('terminal_method', 'terminal_state', 'reason'),
+    [
+        ('pause', 'paused', 'operator_pause'),
+        ('soft_stop', 'hold', 'operator_soft_stop'),
+        ('release', 'released', 'operator_release'),
+    ],
+)
+def test_operator_lifecycle_revokes_capture_assignment_before_return(
+    monkeypatch: pytest.MonkeyPatch,
+    terminal_method,
+    terminal_state,
+    reason,
+):
+    async def signaler(*_args, **_kwargs):
+        raise AssertionError('signaler must not run')
+
+    async def quiet(*_args, **_kwargs):
+        return {}
+
+    async def scenario():
+        coordinator, _manager, session, *_ = _build(signaler)
+        connection, assignment = await _attach_ready_capture(coordinator)
+        session.state = terminal_state
+        if terminal_method == 'release':
+            coordinator._release_results[session.id] = True
+        method = getattr(coordinator, terminal_method)
+        await method(
+            SESSION_ID,
+            PRINCIPAL_ID,
+            CLIENT_ID,
+            owner=False,
+        )
+        return coordinator, connection, assignment
+
+    monkeypatch.setattr(audit, 'emit', quiet)
+    coordinator, connection, assignment = asyncio.run(scenario())
+    assert asyncio.run(connection.events.get()) == {
+        'type': 'assignment_revoked',
+        'assignment_id': assignment.id,
+        'reason': reason,
+    }
+    assert asyncio.run(coordinator.list_captures(PRINCIPAL_ID))[0]['assignment'] is None
+
+
+def test_fault_and_expiry_cleanup_revoke_capture_assignment(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    async def signaler(*_args, **_kwargs):
+        raise AssertionError('signaler must not run')
+
+    async def quiet(*_args, **_kwargs):
+        return {}
+
+    async def fault_scenario():
+        coordinator, _manager, session, *_ = _build(signaler)
+        connection, assignment = await _attach_ready_capture(coordinator)
+
+        async def cleanup(*_args, **_kwargs):
+            return None
+
+        coordinator._complete_fault_cleanup = cleanup  # type: ignore[method-assign]
+        await coordinator._fault_session(session, 'test_fault')
+        return coordinator, connection, assignment
+
+    async def expiry_scenario():
+        coordinator, manager, _session, clock, *_ = _build(signaler)
+        connection, assignment = await _attach_ready_capture(coordinator)
+        clock.monotonic += 16.0
+        expired = (await manager.expire_due())[0]
+
+        async def cleanup(*_args, **_kwargs):
+            return None
+
+        async def acknowledged(*_args, **_kwargs):
+            return True
+
+        coordinator._cancel_heartbeat = cleanup  # type: ignore[method-assign]
+        coordinator._update_command_claim = cleanup  # type: ignore[method-assign]
+        coordinator._best_effort_soft_stop_and_release = acknowledged  # type: ignore[method-assign]
+        coordinator._finalize_or_quarantine_release = cleanup  # type: ignore[method-assign]
+        await coordinator._complete_expiry_cleanup(expired, origin_task=None)
+        return coordinator, connection, assignment
+
+    monkeypatch.setattr(audit, 'emit', quiet)
+    faulted = asyncio.run(fault_scenario())
+    expired = asyncio.run(expiry_scenario())
+    for coordinator, connection, assignment in (faulted, expired):
+        event = asyncio.run(connection.events.get())
+        assert event['type'] == 'assignment_revoked'
+        assert event['assignment_id'] == assignment.id
+        assert asyncio.run(
+            coordinator.list_captures(PRINCIPAL_ID),
+        )[0]['assignment'] is None
+    assert faulted[0]._signaling_sources[SESSION_ID][0] == 'capture'
+
+
+@pytest.mark.parametrize(
+    ('loss_kind', 'presence_state'),
+    [
+        ('disconnect', None),
+        ('timeout', None),
+        ('presence', 'xr_ended'),
+        ('presence', 'error'),
+        ('presence', 'browser_ready'),
+        ('presence', 'xr_standby'),
+    ],
+)
+def test_selective_capture_control_loss_forces_driver_hold(
+    monkeypatch: pytest.MonkeyPatch,
+    loss_kind,
+    presence_state,
+):
+    caller = _CaptureLossCaller()
+
+    async def signaler(*_args, **_kwargs):
+        raise AssertionError('signaling is already peer-to-peer')
+
+    async def quiet(*_args, **_kwargs):
+        return {}
+
+    async def scenario():
+        coordinator, manager, session, clock, *_ = _build(
+            signaler,
+            caller=caller,
+        )
+        _seed_active_driver_snapshot(coordinator, session)
+        connection, assignment = await _attach_ready_capture(coordinator)
+
+        # The PC ownership heartbeat remains healthy while only the capture
+        # control WSS is lost. This must not leave the Driver RTC pose path live.
+        clock.monotonic += 1.0
+        await coordinator.heartbeat(
+            SESSION_ID,
+            PRINCIPAL_ID,
+            CLIENT_ID,
+        )
+        assert session.state == 'active'
+
+        if loss_kind == 'disconnect':
+            await coordinator.disconnect_capture(
+                connection.capture_id,
+                connection.connection_id,
+            )
+        elif loss_kind == 'timeout':
+            clock.monotonic += 5.0
+            assert await coordinator.expire_capture_connection(
+                connection.capture_id,
+                connection.connection_id,
+            ) is True
+        else:
+            await coordinator.capture_presence(
+                connection.capture_id,
+                connection.connection_id,
+                state=presence_state,
+                assignment_id=assignment.id if presence_state == 'error' else None,
+            )
+        return coordinator, manager, session, connection
+
+    monkeypatch.setattr(audit, 'emit', quiet)
+    coordinator, _manager, session, connection = asyncio.run(scenario())
+
+    assert session.state == 'hold'
+    assert caller.actions == ['soft_stop']
+    assert coordinator._driver_snapshots[SESSION_ID]['state'] == 'hold'
+    capture = asyncio.run(coordinator.list_captures(PRINCIPAL_ID))[0]
+    assert capture['id'] == connection.capture_id
+    assert capture['assignment'] is None
+
+
+def test_capture_loss_pending_blocks_racing_reconnect_assignment_until_hold(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    caller = _CaptureLossCaller()
+
+    async def signaler(*_args, **_kwargs):
+        raise AssertionError('signaling must not run')
+
+    async def quiet(*_args, **_kwargs):
+        return {}
+
+    async def scenario():
+        coordinator, _manager, session, *_ = _build(
+            signaler,
+            caller=caller,
+        )
+        _seed_active_driver_snapshot(coordinator, session)
+        old_connection, _old_assignment = await _attach_ready_capture(coordinator)
+        credential = old_connection.capture_credential
+        assert credential is not None
+
+        # Block the fail-close task before it can take the session lock. The
+        # Manager must fence a racing reconnect/attach as soon as disconnect
+        # commits, independent of which waiter gets the session lock next.
+        session_lock = coordinator._session_lock(SESSION_ID)
+        await session_lock.acquire()
+        lost = await coordinator.capture_manager.disconnect(
+            old_connection.capture_id,
+            old_connection.connection_id,
+        )
+        assert lost is not None
+
+        new_connection = await coordinator.connect_capture_with_credential(
+            old_connection.capture_id,
+            credential,
+            **CAPTURE_METADATA,
+        )
+        await coordinator.capture_presence(
+            new_connection.capture_id,
+            new_connection.connection_id,
+            state='xr_standby',
+            assignment_id=None,
+        )
+        attach_task = asyncio.create_task(coordinator.attach_capture(
+            SESSION_ID,
+            PRINCIPAL_ID,
+            CLIENT_ID,
+            capture_id=new_connection.capture_id,
+            mode='shadow',
+            profile_id='recording',
+            capability_digest=DIGEST,
+        ))
+        await asyncio.sleep(0)
+        loss_task = asyncio.create_task(
+            coordinator._fail_close_capture_assignment_loss(lost),
+        )
+        session_lock.release()
+        with pytest.raises(CaptureError, match='capture_loss_pending'):
+            await attach_task
+        await loss_task
+        return coordinator, session, new_connection
+
+    monkeypatch.setattr(audit, 'emit', quiet)
+    coordinator, session, new_connection = asyncio.run(scenario())
+
+    assert session.state == 'hold'
+    assert caller.actions == ['soft_stop']
+    assert coordinator._driver_snapshots[SESSION_ID]['state'] == 'hold'
+    assert asyncio.run(coordinator.list_captures(PRINCIPAL_ID))[0]['assignment'] is None
+    assert new_connection.events.empty()
+
+
+def test_capture_loss_soft_stop_failure_uses_existing_fault_cleanup(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    caller = _CaptureLossCaller(fail_soft_stop=True)
+    cleanup_calls = []
+
+    async def signaler(*_args, **_kwargs):
+        raise AssertionError('signaling must not run')
+
+    async def quiet(*_args, **_kwargs):
+        return {}
+
+    async def scenario():
+        coordinator, _manager, session, *_ = _build(
+            signaler,
+            caller=caller,
+        )
+        _seed_active_driver_snapshot(coordinator, session)
+        connection, _assignment = await _attach_ready_capture(coordinator)
+
+        async def cleanup(faulted, reason, *, origin_task):
+            cleanup_calls.append((faulted.id, reason, origin_task is not None))
+
+        coordinator._complete_fault_cleanup = cleanup  # type: ignore[method-assign]
+        await coordinator.disconnect_capture(
+            connection.capture_id,
+            connection.connection_id,
+        )
+        return session
+
+    monkeypatch.setattr(audit, 'emit', quiet)
+    session = asyncio.run(scenario())
+
+    assert session.state == 'faulted'
+    assert caller.actions == ['soft_stop']
+    assert cleanup_calls == [(SESSION_ID, 'driver_soft_stop_unconfirmed', True)]
+
+
+def test_operator_soft_stop_then_wss_disconnect_does_not_stop_twice(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    caller = _CaptureLossCaller()
+
+    async def signaler(*_args, **_kwargs):
+        raise AssertionError('signaling must not run')
+
+    async def quiet(*_args, **_kwargs):
+        return {}
+
+    async def scenario():
+        coordinator, _manager, session, *_ = _build(
+            signaler,
+            caller=caller,
+        )
+        _seed_active_driver_snapshot(coordinator, session)
+        connection, _assignment = await _attach_ready_capture(coordinator)
+        held = await coordinator.soft_stop(
+            SESSION_ID,
+            PRINCIPAL_ID,
+            CLIENT_ID,
+            owner=False,
+        )
+        await coordinator.disconnect_capture(
+            connection.capture_id,
+            connection.connection_id,
+        )
+        return held
+
+    monkeypatch.setattr(audit, 'emit', quiet)
+    held = asyncio.run(scenario())
+
+    assert held.state == 'hold'
+    assert caller.actions == ['soft_stop']

--- a/agent-core/tests/teleop/test_teleop_signaling_transport.py
+++ b/agent-core/tests/teleop/test_teleop_signaling_transport.py
@@ -1,0 +1,236 @@
+from __future__ import annotations
+
+import asyncio
+import json
+
+import auth
+import mcp_client
+import pytest
+from aiohttp import web
+
+DRIVER_TOKEN = 'driver-bearer-must-stay-server-side'
+OTHER_DRIVER_TOKEN = 'other-driver-bearer-must-stay-private'
+DIGEST = '0123456789abcdef' * 4
+
+
+async def _serve(handler):
+    app = web.Application()
+    app.router.add_post('/offer', handler)
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, '127.0.0.1', 0)
+    await site.start()
+    sockets = site._server.sockets  # type: ignore[union-attr]
+    origin = f'http://127.0.0.1:{sockets[0].getsockname()[1]}'
+    target = mcp_client.TrustedShadowTarget(
+        mcp_id='teleop-driver',
+        url=f'{origin}/mcp',
+        capability_digest=DIGEST,
+        descriptor_fingerprint='descriptor-fingerprint',
+        actions=frozenset({'status'}),
+    )
+    mcp_client.registry['teleop-driver'] = {
+        'trusted': True,
+        'url': target.url,
+        'teleop_fingerprint': target.descriptor_fingerprint,
+    }
+    return runner, target, origin
+
+
+def _call(target: mcp_client.TrustedShadowTarget, **kwargs):
+    return mcp_client.call_trusted_shadow_offer(
+        'teleop-driver',
+        {'type': 'offer', 'sdp': 'v=0\r\no=quest-offer'},
+        'private.ticket.signature',
+        target=target,
+        **kwargs,
+    )
+
+
+def test_offer_uses_same_origin_bearer_and_strict_server_payload():
+    observed = {}
+
+    async def scenario():
+        async def handler(request: web.Request):
+            observed['path'] = request.path
+            observed['authorization'] = request.headers.get('Authorization')
+            observed['payload'] = await request.json()
+            return web.json_response({'type': 'answer', 'sdp': 'v=0\r\na=answer'})
+
+        runner, target, _origin = await _serve(handler)
+        auth.init({
+            'MOTUS_DRIVER_TOKENS': (
+                f'{{"other-driver":"{OTHER_DRIVER_TOKEN}",'
+                f'"teleop-driver":"{DRIVER_TOKEN}"}}'
+            ),
+        })
+        try:
+            return await _call(target, timeout_seconds=1.0)
+        finally:
+            await runner.cleanup()
+
+    result = asyncio.run(scenario())
+    assert result == {'type': 'answer', 'sdp': 'v=0\r\na=answer'}
+    assert observed == {
+        'path': '/offer',
+        'authorization': f'Bearer {DRIVER_TOKEN}',
+        'payload': {
+            'sdp': 'v=0\r\no=quest-offer',
+            'type': 'offer',
+            'ticket': 'private.ticket.signature',
+        },
+    }
+    assert OTHER_DRIVER_TOKEN not in json.dumps(observed)
+
+
+@pytest.mark.parametrize(
+    ('target_url', 'expected_code'),
+    [
+        ('http://127.0.0.1:9/not-mcp', 'invalid_url'),
+        ('http://127.0.0.1:9/mcp/', 'invalid_url'),
+        ('http://127.0.0.1:9/mcp?next=/offer', 'invalid_url'),
+        ('http://user@127.0.0.1:9/mcp', 'invalid_url'),
+    ],
+)
+def test_offer_url_derivation_rejects_noncanonical_mcp_targets(target_url, expected_code):
+    target = mcp_client.TrustedShadowTarget(
+        mcp_id='teleop-driver',
+        url=target_url,
+        capability_digest=DIGEST,
+        descriptor_fingerprint='descriptor-fingerprint',
+        actions=frozenset({'status'}),
+    )
+    mcp_client.registry['teleop-driver'] = {
+        'trusted': True,
+        'url': target.url,
+        'teleop_fingerprint': target.descriptor_fingerprint,
+    }
+    auth.init({'MOTUS_DRIVER_TOKEN': DRIVER_TOKEN})
+    with pytest.raises(mcp_client.TrustedShadowTransportError) as captured:
+        asyncio.run(_call(target, timeout_seconds=0.25))
+    assert captured.value.code == expected_code
+    assert DRIVER_TOKEN not in str(captured.value)
+
+
+def test_redirect_is_rejected_and_never_followed():
+    followed = False
+
+    async def scenario():
+        nonlocal followed
+        app = web.Application()
+
+        async def offer(_request: web.Request):
+            raise web.HTTPTemporaryRedirect('/sink')
+
+        async def sink(_request: web.Request):
+            nonlocal followed
+            followed = True
+            return web.json_response({'type': 'answer', 'sdp': 'wrong'})
+
+        app.router.add_post('/offer', offer)
+        app.router.add_post('/sink', sink)
+        runner = web.AppRunner(app)
+        await runner.setup()
+        site = web.TCPSite(runner, '127.0.0.1', 0)
+        await site.start()
+        sockets = site._server.sockets  # type: ignore[union-attr]
+        url = f'http://127.0.0.1:{sockets[0].getsockname()[1]}/mcp'
+        target = mcp_client.TrustedShadowTarget(
+            'teleop-driver', url, DIGEST, 'descriptor-fingerprint', frozenset({'status'}),
+        )
+        mcp_client.registry['teleop-driver'] = {
+            'trusted': True,
+            'url': url,
+            'teleop_fingerprint': target.descriptor_fingerprint,
+        }
+        auth.init({'MOTUS_DRIVER_TOKEN': DRIVER_TOKEN})
+        try:
+            with pytest.raises(mcp_client.TrustedShadowTransportError) as captured:
+                await _call(target, timeout_seconds=1.0)
+            return captured.value
+        finally:
+            await runner.cleanup()
+
+    error = asyncio.run(scenario())
+    assert error.code == 'redirect_rejected'
+    assert error.http_status == 307
+    assert followed is False
+
+
+@pytest.mark.parametrize(
+    ('kind', 'expected_code'),
+    [
+        ('timeout', 'timeout'),
+        ('large', 'response_too_large'),
+        ('invalid_json', 'invalid_response'),
+        ('duplicate_json', 'invalid_response'),
+    ],
+)
+def test_offer_bounds_time_size_and_json(kind, expected_code):
+    async def scenario():
+        async def handler(_request: web.Request):
+            if kind == 'timeout':
+                await asyncio.sleep(0.5)
+                return web.json_response({'type': 'answer', 'sdp': 'late'})
+            if kind == 'large':
+                return web.Response(
+                    body=json.dumps({'sdp': 'x' * (300 * 1024)}).encode(),
+                    content_type='application/json',
+                )
+            if kind == 'duplicate_json':
+                return web.Response(
+                    body=b'{"type":"answer","type":"answer","sdp":"v=0"}',
+                    content_type='application/json',
+                )
+            return web.Response(body=b'{"sdp":NaN}', content_type='application/json')
+
+        runner, target, _origin = await _serve(handler)
+        auth.init({'MOTUS_DRIVER_TOKEN': DRIVER_TOKEN})
+        try:
+            with pytest.raises(mcp_client.TrustedShadowTransportError) as captured:
+                await _call(target, timeout_seconds=0.25 if kind == 'timeout' else 1.0)
+            return captured.value
+        finally:
+            await runner.cleanup()
+
+    error = asyncio.run(scenario())
+    assert error.code == expected_code
+    assert DRIVER_TOKEN not in str(error)
+    assert 'quest-offer' not in str(error)
+
+
+def test_offer_rechecks_pinned_registry_identity_after_network_await():
+    async def scenario():
+        async def handler(_request: web.Request):
+            mcp_client.registry['teleop-driver']['url'] = 'http://127.0.0.1:9/mcp'
+            return web.json_response({'type': 'answer', 'sdp': 'v=0'})
+
+        runner, target, _origin = await _serve(handler)
+        auth.init({'MOTUS_DRIVER_TOKEN': DRIVER_TOKEN})
+        try:
+            with pytest.raises(mcp_client.TrustedShadowTransportError) as captured:
+                await _call(target, timeout_seconds=1.0)
+            return captured.value
+        finally:
+            await runner.cleanup()
+
+    error = asyncio.run(scenario())
+    assert error.code == 'pinned_target_changed'
+
+
+def test_offer_fails_closed_without_driver_bearer():
+    async def scenario():
+        async def handler(_request: web.Request):
+            raise AssertionError('request must not be sent')
+
+        runner, target, _origin = await _serve(handler)
+        auth.init({})
+        try:
+            with pytest.raises(mcp_client.TrustedShadowTransportError) as captured:
+                await _call(target, timeout_seconds=1.0)
+            return captured.value
+        finally:
+            await runner.cleanup()
+
+    error = asyncio.run(scenario())
+    assert error.code == 'driver_auth_unavailable'

--- a/agent-core/tests/teleop/test_teleop_transport.py
+++ b/agent-core/tests/teleop/test_teleop_transport.py
@@ -1,0 +1,784 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from copy import deepcopy
+
+import aiohttp
+import auth
+import config
+import mcp_client
+import pytest
+from aiohttp import web
+
+DRIVER_SECRET = 'driver-token-must-not-leak'
+OTHER_DRIVER_SECRET = 'other-driver-token-must-not-leak'
+FENCE_SECRET = 'fence-value-must-not-leak-123456'
+
+
+def _install_target(
+    tool: dict,
+    url: str,
+    *,
+    trust_state: str = 'trusted',
+    online: bool = True,
+    runtime_trusted: bool = True,
+) -> None:
+    auth.init({
+        'MOTUS_DRIVER_TOKENS': (
+            f'{{"other-robot":"{OTHER_DRIVER_SECRET}",'
+            f'"teleop-robot":"{DRIVER_SECRET}"}}'
+        ),
+    })
+    configured_tool = deepcopy(tool)
+    configured_tool['x-teleop']['driver_id'] = 'teleop-robot'
+    config.main['services'] = {'mcp': [{
+        'id': 'teleop-robot',
+        'name': 'Teleop Robot',
+        'url': url,
+        'transport': 'http',
+        'trust_state': trust_state,
+        'credential_binding': auth.driver_credential_binding('teleop-robot'),
+        'tools': [configured_tool],
+    }]}
+    mcp_client.registry['teleop-robot'] = {
+        'online': online,
+        'trusted': runtime_trusted,
+        'url': url,
+        'teleop_fingerprint': mcp_client.teleop_tool_fingerprint(configured_tool),
+    }
+
+
+async def _call_through_server(
+    shadow_session_tool: dict,
+    handler,
+    *,
+    action: str = 'status',
+    arguments: dict | None = None,
+) -> dict:
+    app = web.Application()
+    app.router.add_post('/mcp', handler)
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, '127.0.0.1', 0)
+    await site.start()
+    sockets = site._server.sockets  # type: ignore[union-attr]
+    url = f'http://127.0.0.1:{sockets[0].getsockname()[1]}/mcp'
+    _install_target(shadow_session_tool, url)
+    try:
+        return await mcp_client.call_trusted_shadow_session(
+            'teleop-robot',
+            action,
+            arguments,
+            timeout_seconds=1.0,
+        )
+    finally:
+        await runner.cleanup()
+
+
+def _rpc_success(request_id: str, value: dict) -> web.Response:
+    return web.json_response({
+        'jsonrpc': '2.0',
+        'id': request_id,
+        'result': {
+            'content': [{
+                'type': 'text',
+                'text': json.dumps(value, allow_nan=False),
+            }],
+        },
+    })
+
+
+def test_success_sends_bearer_and_returns_strict_json_object(shadow_session_tool):
+    observed = {}
+    arguments = {
+        'session_id': '9a9d7841-b587-434c-bda2-bf0baeb6381d',
+        'epoch': 3,
+        'fence': FENCE_SECRET,
+    }
+
+    async def handler(request: web.Request):
+        observed['authorization'] = request.headers.get('Authorization')
+        observed['content_type'] = request.headers.get('Content-Type')
+        observed['payload'] = await request.json()
+        return _rpc_success(
+            observed['payload']['id'],
+            {'state': 'shadow', 'boot_id': 'driver-boot'},
+        )
+
+    result = asyncio.run(_call_through_server(
+        shadow_session_tool,
+        handler,
+        action='prepare_shadow',
+        arguments=arguments,
+    ))
+
+    assert result == {'state': 'shadow', 'boot_id': 'driver-boot'}
+    assert observed['authorization'] == f'Bearer {DRIVER_SECRET}'
+    assert OTHER_DRIVER_SECRET not in json.dumps(observed)
+    assert observed['content_type'] == 'application/json'
+    assert observed['payload']['method'] == 'tools/call'
+    assert observed['payload']['params'] == {
+        'name': 'teleop_session',
+        'arguments': {'action': 'prepare_shadow', **arguments},
+    }
+    assert 'action' not in arguments
+
+
+@pytest.mark.parametrize('status', [401, 500])
+def test_http_failures_are_sanitized(shadow_session_tool, status):
+    async def handler(request: web.Request):
+        request_payload = await request.json()
+        leaked_fence = request_payload['params']['arguments']['fence']
+        return web.json_response(
+            {'error': f'{DRIVER_SECRET}:{leaked_fence}'},
+            status=status,
+        )
+
+    with pytest.raises(mcp_client.TrustedShadowTransportError) as raised:
+        asyncio.run(_call_through_server(
+            shadow_session_tool,
+            handler,
+            action='prepare_shadow',
+            arguments={
+                'session_id': '9a9d7841-b587-434c-bda2-bf0baeb6381d',
+                'epoch': 1,
+                'fence': FENCE_SECRET,
+            },
+        ))
+
+    assert raised.value.code == 'http_error'
+    assert raised.value.http_status == status
+    assert DRIVER_SECRET not in str(raised.value)
+    assert FENCE_SECRET not in str(raised.value)
+    assert DRIVER_SECRET not in repr(raised.value)
+    assert FENCE_SECRET not in repr(raised.value)
+
+
+@pytest.mark.parametrize('driver_code', ['session_mismatch', 'session_expired'])
+def test_json_rpc_error_on_http_200_preserves_only_safe_codes(
+    shadow_session_tool,
+    driver_code,
+):
+    async def handler(request: web.Request):
+        payload = await request.json()
+        return web.json_response({
+            'jsonrpc': '2.0',
+            'id': payload['id'],
+            'error': {
+                'code': -32602,
+                'message': f'echo {DRIVER_SECRET} {FENCE_SECRET}',
+                'data': {
+                    'code': driver_code,
+                    'debug': FENCE_SECRET,
+                },
+            },
+        })
+
+    with pytest.raises(mcp_client.TrustedShadowTransportError) as raised:
+        asyncio.run(_call_through_server(shadow_session_tool, handler))
+
+    assert raised.value.code == 'rpc_error'
+    assert raised.value.rpc_code == -32602
+    assert raised.value.rpc_data_code == driver_code
+    assert DRIVER_SECRET not in str(raised.value)
+    assert FENCE_SECRET not in str(raised.value)
+
+
+def test_unknown_rpc_subcode_cannot_echo_a_secret(shadow_session_tool):
+    async def handler(request: web.Request):
+        payload = await request.json()
+        return web.json_response({
+            'jsonrpc': '2.0',
+            'id': payload['id'],
+            'error': {
+                'code': -32603,
+                'message': 'internal error',
+                'data': {'code': DRIVER_SECRET},
+            },
+        })
+
+    with pytest.raises(mcp_client.TrustedShadowTransportError) as raised:
+        asyncio.run(_call_through_server(shadow_session_tool, handler))
+
+    assert raised.value.rpc_data_code is None
+    assert DRIVER_SECRET not in str(raised.value)
+
+
+@pytest.mark.parametrize('unsafe_code', [{}, []], ids=['object', 'list'])
+def test_unhashable_rpc_subcode_is_safely_discarded(
+    shadow_session_tool,
+    unsafe_code,
+):
+    async def handler(request: web.Request):
+        payload = await request.json()
+        return web.json_response({
+            'jsonrpc': '2.0',
+            'id': payload['id'],
+            'error': {
+                'code': -32603,
+                'message': 'internal error',
+                'data': {'code': unsafe_code},
+            },
+        })
+
+    with pytest.raises(mcp_client.TrustedShadowTransportError) as raised:
+        asyncio.run(_call_through_server(shadow_session_tool, handler))
+
+    assert raised.value.code == 'rpc_error'
+    assert raised.value.rpc_data_code is None
+
+
+@pytest.mark.parametrize(
+    ('body_factory', 'expected_code'),
+    [
+        (lambda _request_id: b'not-json', 'invalid_response'),
+        (lambda _request_id: b'[]', 'invalid_response'),
+        (
+            lambda request_id: json.dumps({
+                'jsonrpc': '2.0',
+                'id': f'wrong-{request_id}',
+                'result': {'content': []},
+            }).encode(),
+            'invalid_response',
+        ),
+        (
+            lambda request_id: json.dumps({
+                'jsonrpc': '2.0',
+                'id': request_id,
+                'result': {'content': [
+                    {'type': 'text', 'text': '{}'},
+                    {'type': 'text', 'text': '{}'},
+                ]},
+            }).encode(),
+            'invalid_result',
+        ),
+        (
+            lambda request_id: json.dumps({
+                'jsonrpc': '2.0',
+                'id': request_id,
+                'result': {'content': [{'type': 'text', 'text': '[]'}]},
+            }).encode(),
+            'invalid_result',
+        ),
+        (
+            lambda request_id: (
+                '{"jsonrpc":"2.0","id":"'
+                + request_id
+                + '","result":{"content":[{"type":"text",'
+                '"text":"{\\"value\\":NaN}"}]}}'
+            ).encode(),
+            'invalid_result',
+        ),
+    ],
+    ids=[
+        'non-json',
+        'top-level-list',
+        'wrong-request-id',
+        'multiple-content-items',
+        'json-text-not-object',
+        'non-finite-result',
+    ],
+)
+def test_malformed_responses_fail_closed(
+    shadow_session_tool,
+    body_factory,
+    expected_code,
+):
+    async def handler(request: web.Request):
+        payload = await request.json()
+        return web.Response(
+            body=body_factory(payload['id']),
+            content_type='application/json',
+        )
+
+    with pytest.raises(mcp_client.TrustedShadowTransportError) as raised:
+        asyncio.run(_call_through_server(shadow_session_tool, handler))
+
+    assert raised.value.code == expected_code
+
+
+def test_fragmented_response_is_read_to_eof_before_strict_decode(shadow_session_tool):
+    async def handler(request: web.Request):
+        payload = await request.json()
+        response = web.StreamResponse(headers={'Content-Type': 'application/json'})
+        await response.prepare(request)
+        encoded = json.dumps({
+            'jsonrpc': '2.0',
+            'id': payload['id'],
+            'result': {
+                'content': [{'type': 'text', 'text': '{"fragmented":true}'}],
+            },
+        }).encode()
+        for boundary in (1, 7, 19, len(encoded)):
+            chunk, encoded = encoded[:boundary], encoded[boundary:]
+            if chunk:
+                await response.write(chunk)
+        if encoded:
+            await response.write(encoded)
+        await response.write_eof()
+        return response
+
+    result = asyncio.run(_call_through_server(shadow_session_tool, handler))
+    assert result == {'fragmented': True}
+
+
+def test_excessively_nested_json_is_a_sanitized_protocol_error(shadow_session_tool):
+    nested = (b'{"x":' * 2_000) + b'0' + (b'}' * 2_000)
+
+    async def handler(_request: web.Request):
+        return web.Response(body=nested, content_type='application/json')
+
+    with pytest.raises(mcp_client.TrustedShadowTransportError) as raised:
+        asyncio.run(_call_through_server(shadow_session_tool, handler))
+
+    assert raised.value.code == 'invalid_response'
+
+
+@pytest.mark.parametrize(
+    ('trust_state', 'online', 'runtime_trusted', 'expected_code'),
+    [
+        ('untrusted', True, True, 'target_not_trusted'),
+        ('quarantined', True, True, 'target_not_trusted'),
+        ('trusted', False, True, 'registry_offline'),
+        ('trusted', True, False, 'registry_not_trusted'),
+    ],
+)
+def test_target_requires_trust_and_online_runtime(
+    shadow_session_tool,
+    trust_state,
+    online,
+    runtime_trusted,
+    expected_code,
+):
+    url = 'http://127.0.0.1:9/mcp'
+    _install_target(
+        shadow_session_tool,
+        url,
+        trust_state=trust_state,
+        online=online,
+        runtime_trusted=runtime_trusted,
+    )
+
+    with pytest.raises(mcp_client.TrustedShadowTransportError) as raised:
+        asyncio.run(mcp_client.call_trusted_shadow_session(
+            'teleop-robot',
+            'status',
+        ))
+
+    assert raised.value.code == expected_code
+
+
+def test_target_id_must_be_unique(shadow_session_tool):
+    url = 'http://127.0.0.1:9/mcp'
+    _install_target(shadow_session_tool, url)
+    duplicate = deepcopy(config.main['services']['mcp'][0])
+    duplicate['url'] = 'http://127.0.0.1:10/mcp'
+    config.main['services'] = {
+        'mcp': [*config.main['services']['mcp'], duplicate],
+    }
+
+    with pytest.raises(mcp_client.TrustedShadowTransportError) as raised:
+        asyncio.run(mcp_client.call_trusted_shadow_session(
+            'teleop-robot',
+            'status',
+        ))
+
+    assert raised.value.code == 'target_ambiguous'
+
+
+@pytest.mark.parametrize(
+    ('url', 'transport', 'runtime_url', 'expected_code'),
+    [
+        ('ftp://robot.local/mcp', 'http', None, 'invalid_url'),
+        ('http://user:password@robot.local/mcp', 'http', None, 'invalid_url'),
+        ('http://robot.local/mcp?fence=private', 'http', None, 'invalid_url'),
+        ('http://robot.local/mcp#fragment', 'http', None, 'invalid_url'),
+        ('http://robot.local/mcp', 'internal', None, 'invalid_transport'),
+        (
+            'http://127.0.0.1:15711/mcp',
+            'http',
+            'http://127.0.0.1:15712/mcp',
+            'registry_target_mismatch',
+        ),
+    ],
+)
+def test_target_transport_url_and_registry_identity_are_exact(
+    shadow_session_tool,
+    url,
+    transport,
+    runtime_url,
+    expected_code,
+):
+    _install_target(shadow_session_tool, url)
+    target = config.main['services']['mcp'][0]
+    target['transport'] = transport
+    config.main['services'] = {'mcp': [target]}
+    if runtime_url is not None:
+        mcp_client.registry['teleop-robot']['url'] = runtime_url
+
+    with pytest.raises(mcp_client.TrustedShadowTransportError) as raised:
+        asyncio.run(mcp_client.call_trusted_shadow_session(
+            'teleop-robot',
+            'status',
+        ))
+
+    assert raised.value.code == expected_code
+    assert 'private' not in str(raised.value)
+    assert 'password' not in str(raised.value)
+
+
+@pytest.mark.parametrize(
+    ('mutate', 'action', 'expected_code'),
+    [
+        (
+            lambda tool: tool['x-teleop'].__setitem__('mode', 'live'),
+            'status',
+            'descriptor_invalid',
+        ),
+        (
+            lambda tool: tool['x-teleop'].__setitem__('actuation_enabled', 0),
+            'status',
+            'descriptor_invalid',
+        ),
+        (
+            lambda tool: tool['x-teleop'].__setitem__('capability_digest', 'A' * 64),
+            'status',
+            'descriptor_invalid',
+        ),
+        pytest.param(
+            lambda tool: tool['x-teleop'].pop('dispatch_contract'),
+            'status',
+            'descriptor_invalid',
+            id='missing-dispatch-contract',
+        ),
+        pytest.param(
+            lambda tool: tool['x-teleop'].__setitem__(
+                'dispatch_contract',
+                'motus.teleop.dispatch.live.v1',
+            ),
+            'status',
+            'descriptor_invalid',
+            id='wrong-dispatch-contract',
+        ),
+        pytest.param(
+            lambda tool: tool['x-teleop'].pop('signaling'),
+            'status',
+            'descriptor_invalid',
+            id='missing-signaling-contract',
+        ),
+        pytest.param(
+            lambda tool: tool['x-teleop']['signaling'].__setitem__(
+                'access',
+                'browser-direct',
+            ),
+            'status',
+            'descriptor_invalid',
+            id='unsafe-signaling-access',
+        ),
+        (lambda _tool: None, 'not_declared', 'action_not_declared'),
+    ],
+)
+def test_descriptor_and_action_are_revalidated_before_every_call(
+    shadow_session_tool,
+    mutate,
+    action,
+    expected_code,
+):
+    tool = deepcopy(shadow_session_tool)
+    mutate(tool)
+    url = 'http://127.0.0.1:9/mcp'
+    _install_target(tool, url)
+
+    with pytest.raises(mcp_client.TrustedShadowTransportError) as raised:
+        asyncio.run(mcp_client.call_trusted_shadow_session(
+            'teleop-robot',
+            action,
+        ))
+
+    assert raised.value.code == expected_code
+
+
+@pytest.mark.parametrize('missing_action', ['heartbeat', 'release', 'stop'])
+def test_full_revocation_contract_is_required_before_prepare(
+    shadow_session_tool,
+    missing_action,
+):
+    requests_received = 0
+
+    async def handler(request: web.Request):
+        nonlocal requests_received
+        requests_received += 1
+        payload = await request.json()
+        return _rpc_success(payload['id'], {'unexpected': True})
+
+    async def scenario() -> None:
+        tool = deepcopy(shadow_session_tool)
+        action_enum = tool['inputSchema']['properties']['action']['enum']
+        action_enum.remove(missing_action)
+        tool['inputSchema']['x-action-params'].pop(missing_action)
+        app = web.Application()
+        app.router.add_post('/mcp', handler)
+        runner = web.AppRunner(app)
+        await runner.setup()
+        site = web.TCPSite(runner, '127.0.0.1', 0)
+        await site.start()
+        sockets = site._server.sockets  # type: ignore[union-attr]
+        url = f'http://127.0.0.1:{sockets[0].getsockname()[1]}/mcp'
+        _install_target(tool, url)
+        try:
+            await mcp_client.call_trusted_shadow_session(
+                'teleop-robot',
+                'prepare_shadow',
+                {
+                    'session_id': '9a9d7841-b587-434c-bda2-bf0baeb6381d',
+                    'epoch': 1,
+                    'fence': FENCE_SECRET,
+                },
+                timeout_seconds=1.0,
+            )
+        finally:
+            await runner.cleanup()
+
+    with pytest.raises(mcp_client.TrustedShadowTransportError) as raised:
+        asyncio.run(scenario())
+
+    assert raised.value.code == 'descriptor_invalid'
+    assert requests_received == 0
+
+
+def test_descriptor_driver_id_must_match_config_target(shadow_session_tool):
+    url = 'http://127.0.0.1:9/mcp'
+    _install_target(shadow_session_tool, url)
+    target = config.main['services']['mcp'][0]
+    target['tools'][0]['x-teleop']['driver_id'] = 'different-driver'
+    config.main['services'] = {'mcp': [target]}
+
+    with pytest.raises(mcp_client.TrustedShadowTransportError) as raised:
+        asyncio.run(mcp_client.call_trusted_shadow_session(
+            'teleop-robot',
+            'status',
+        ))
+
+    assert raised.value.code == 'descriptor_invalid'
+
+
+def test_reuses_supplied_session_connector_without_closing_it(shadow_session_tool):
+    observed_transports = set()
+    observed_calls = 0
+
+    async def handler(request: web.Request):
+        nonlocal observed_calls
+        observed_calls += 1
+        observed_transports.add(id(request.transport))
+        payload = await request.json()
+        return _rpc_success(payload['id'], {'sequence': observed_calls})
+
+    async def scenario():
+        app = web.Application()
+        app.router.add_post('/mcp', handler)
+        runner = web.AppRunner(app)
+        await runner.setup()
+        site = web.TCPSite(runner, '127.0.0.1', 0)
+        await site.start()
+        sockets = site._server.sockets  # type: ignore[union-attr]
+        url = f'http://127.0.0.1:{sockets[0].getsockname()[1]}/mcp'
+        _install_target(shadow_session_tool, url)
+        connector = aiohttp.TCPConnector(limit=1)
+        try:
+            async with aiohttp.ClientSession(connector=connector) as shared:
+                first = await mcp_client.call_trusted_shadow_session(
+                    'teleop-robot',
+                    'status',
+                    session=shared,
+                    timeout_seconds=1.0,
+                )
+                second = await mcp_client.call_trusted_shadow_session(
+                    'teleop-robot',
+                    'status',
+                    session=shared,
+                    timeout_seconds=1.0,
+                )
+                assert shared.closed is False
+                assert shared.connector is connector
+            assert connector.closed is True
+            return first, second
+        finally:
+            await runner.cleanup()
+
+    first, second = asyncio.run(scenario())
+
+    assert first == {'sequence': 1}
+    assert second == {'sequence': 2}
+    assert observed_calls == 2
+    assert len(observed_transports) == 1
+
+
+def test_pinned_live_call_uses_only_runtime_identity_and_survives_offline_hint(
+    shadow_session_tool,
+    monkeypatch,
+):
+    observed_calls = 0
+
+    async def handler(request: web.Request):
+        nonlocal observed_calls
+        observed_calls += 1
+        payload = await request.json()
+        return _rpc_success(payload['id'], {'heartbeat': 'accepted'})
+
+    async def scenario() -> dict:
+        app = web.Application()
+        app.router.add_post('/mcp', handler)
+        runner = web.AppRunner(app)
+        await runner.setup()
+        site = web.TCPSite(runner, '127.0.0.1', 0)
+        await site.start()
+        sockets = site._server.sockets  # type: ignore[union-attr]
+        url = f'http://127.0.0.1:{sockets[0].getsockname()[1]}/mcp'
+        _install_target(shadow_session_tool, url)
+        target = await mcp_client.resolve_trusted_shadow_target('teleop-robot')
+
+        def unexpected_config_resolution(*_args, **_kwargs):
+            raise AssertionError('pinned authority call touched config/SQLite')
+
+        monkeypatch.setattr(
+            mcp_client,
+            '_trusted_shadow_target',
+            unexpected_config_resolution,
+        )
+        mcp_client.registry['teleop-robot']['online'] = False
+        try:
+            return await mcp_client.call_trusted_shadow_session(
+                'teleop-robot',
+                'heartbeat',
+                {
+                    'boot_id': '8ced194d-1677-465b-bd96-8fd17b97582d',
+                    'session_id': '9a9d7841-b587-434c-bda2-bf0baeb6381d',
+                    'epoch': 3,
+                    'fence': FENCE_SECRET,
+                },
+                target=target,
+                timeout_seconds=1.0,
+            )
+        finally:
+            await runner.cleanup()
+
+    result = asyncio.run(scenario())
+    assert result == {'heartbeat': 'accepted'}
+    assert observed_calls == 1
+
+
+@pytest.mark.parametrize('mutation', ['url', 'fingerprint'])
+def test_pinned_identity_change_rejects_before_sending_fence(
+    shadow_session_tool,
+    mutation,
+):
+    old_endpoint_calls = 0
+    new_endpoint_calls = 0
+
+    async def old_handler(request: web.Request):
+        nonlocal old_endpoint_calls
+        old_endpoint_calls += 1
+        payload = await request.json()
+        return _rpc_success(payload['id'], {'unexpected': 'old'})
+
+    async def new_handler(request: web.Request):
+        nonlocal new_endpoint_calls
+        new_endpoint_calls += 1
+        payload = await request.json()
+        assert FENCE_SECRET not in repr(payload)
+        return _rpc_success(payload['id'], {'unexpected': 'new'})
+
+    async def start_server(handler):
+        app = web.Application()
+        app.router.add_post('/mcp', handler)
+        runner = web.AppRunner(app)
+        await runner.setup()
+        site = web.TCPSite(runner, '127.0.0.1', 0)
+        await site.start()
+        sockets = site._server.sockets  # type: ignore[union-attr]
+        return runner, f'http://127.0.0.1:{sockets[0].getsockname()[1]}/mcp'
+
+    async def scenario() -> None:
+        old_runner, old_url = await start_server(old_handler)
+        new_runner, new_url = await start_server(new_handler)
+        _install_target(shadow_session_tool, old_url)
+        target = await mcp_client.resolve_trusted_shadow_target('teleop-robot')
+        if mutation == 'url':
+            mcp_client.registry['teleop-robot']['url'] = new_url
+        else:
+            mcp_client.registry['teleop-robot']['teleop_fingerprint'] = 'f' * 64
+        try:
+            await mcp_client.call_trusted_shadow_session(
+                'teleop-robot',
+                'heartbeat',
+                {
+                    'boot_id': '8ced194d-1677-465b-bd96-8fd17b97582d',
+                    'session_id': '9a9d7841-b587-434c-bda2-bf0baeb6381d',
+                    'epoch': 3,
+                    'fence': FENCE_SECRET,
+                },
+                target=target,
+                timeout_seconds=1.0,
+            )
+        finally:
+            await old_runner.cleanup()
+            await new_runner.cleanup()
+
+    with pytest.raises(mcp_client.TrustedShadowTransportError) as raised:
+        asyncio.run(scenario())
+
+    assert raised.value.code == 'pinned_target_changed'
+    assert old_endpoint_calls == 0
+    assert new_endpoint_calls == 0
+
+
+def test_redirect_is_not_followed_with_driver_authorization(shadow_session_tool):
+    redirect_target_hit = False
+
+    async def source(_request: web.Request):
+        raise web.HTTPFound('/credential-sink')
+
+    async def sink(_request: web.Request):
+        nonlocal redirect_target_hit
+        redirect_target_hit = True
+        return web.Response(text='unexpected')
+
+    async def scenario():
+        app = web.Application()
+        app.router.add_post('/mcp', source)
+        app.router.add_get('/credential-sink', sink)
+        runner = web.AppRunner(app)
+        await runner.setup()
+        site = web.TCPSite(runner, '127.0.0.1', 0)
+        await site.start()
+        sockets = site._server.sockets  # type: ignore[union-attr]
+        url = f'http://127.0.0.1:{sockets[0].getsockname()[1]}/mcp'
+        _install_target(shadow_session_tool, url)
+        try:
+            await mcp_client.call_trusted_shadow_session(
+                'teleop-robot',
+                'status',
+                timeout_seconds=1.0,
+            )
+        finally:
+            await runner.cleanup()
+
+    with pytest.raises(mcp_client.TrustedShadowTransportError) as raised:
+        asyncio.run(scenario())
+
+    assert raised.value.code == 'http_error'
+    assert raised.value.http_status == 302
+    assert redirect_target_hit is False
+
+
+def test_generic_call_still_refuses_reserved_teleop_tool(shadow_session_tool):
+    url = 'http://127.0.0.1:9/mcp'
+    _install_target(shadow_session_tool, url)
+
+    result = asyncio.run(mcp_client.call_tool(
+        'mcp__teleop-robot__teleop_session',
+        {'action': 'status'},
+    ))
+
+    assert result == 'Teleop tools are reserved for the dedicated teleop API'

--- a/agent-core/tests/teleop/test_tls_config.py
+++ b/agent-core/tests/teleop/test_tls_config.py
@@ -1,0 +1,445 @@
+from __future__ import annotations
+
+import base64
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+import tls_config
+
+_REAL_VALIDATE_CERTIFICATE_PAIR = tls_config._validate_certificate_pair
+
+
+@pytest.fixture(autouse=True)
+def _stub_certificate_pair_validation(monkeypatch: pytest.MonkeyPatch):
+    """Keep path-policy tests small; dedicated tests exercise real OpenSSL."""
+
+    monkeypatch.setattr(
+        tls_config,
+        '_validate_certificate_pair',
+        lambda _cert_path, _key_path: None,
+    )
+
+
+def _write_pair(directory: Path) -> tuple[Path, Path]:
+    directory.mkdir(parents=True, exist_ok=True)
+    cert = directory / 'cert.pem'
+    key = directory / 'key.pem'
+    cert.write_text('certificate', encoding='utf-8')
+    key.write_text('private-key', encoding='utf-8')
+    key.chmod(0o600)
+    return cert, key
+
+
+def _unexpected_openssl(*args, **kwargs):
+    raise AssertionError('openssl must not run for this TLS configuration')
+
+
+def _minimal_public_certificate_pem() -> str:
+    der = b'\x30\x03\x02\x01\x01'
+    body = base64.b64encode(der).decode('ascii')
+    return f'-----BEGIN CERTIFICATE-----\n{body}\n-----END CERTIFICATE-----\n'
+
+
+def test_public_certificate_projection_rebuilds_certificate_blocks_only():
+    projected = tls_config.project_public_certificate_chain(
+        '\n' + _minimal_public_certificate_pem() + '\n'
+    )
+
+    assert projected == _minimal_public_certificate_pem()
+    assert 'PRIVATE KEY' not in projected
+
+
+@pytest.mark.parametrize('invalid_suffix', [
+    'deployment comment',
+    '-----BEGIN PRIVATE KEY-----\nsecret\n-----END PRIVATE KEY-----',
+])
+def test_public_certificate_projection_rejects_non_certificate_material(
+    invalid_suffix: str,
+):
+    with pytest.raises(tls_config.TLSConfigurationError):
+        tls_config.project_public_certificate_chain(
+            _minimal_public_certificate_pem() + invalid_suffix
+        )
+
+
+def test_public_certificate_loader_is_bounded(tmp_path: Path):
+    oversized = tmp_path / 'oversized.pem'
+    oversized.write_bytes(
+        b'-' * (tls_config.MAX_PUBLIC_CERTIFICATE_CHAIN_BYTES + 1)
+    )
+
+    with pytest.raises(tls_config.TLSConfigurationError, match='exceeds'):
+        tls_config.load_public_certificate_chain(oversized)
+
+
+def test_existing_compatibility_pair_is_reused_without_generation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    cert, key = _write_pair(tmp_path / 'compatibility')
+    monkeypatch.setattr(tls_config.subprocess, 'run', _unexpected_openssl)
+
+    resolved = tls_config.resolve_tls_certificates(
+        environ={},
+        cert_dir=cert.parent,
+    )
+
+    assert resolved == (str(cert), str(key))
+    assert cert.read_text(encoding='utf-8') == 'certificate'
+    assert key.read_text(encoding='utf-8') == 'private-key'
+
+
+def test_missing_compatibility_pair_generates_both_files_once(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+):
+    calls: list[list[str]] = []
+
+    def fake_openssl(command, *, check, capture_output):
+        calls.append(command)
+        assert check is True
+        assert capture_output is True
+        cert = Path(command[command.index('-out') + 1])
+        key = Path(command[command.index('-keyout') + 1])
+        cert.write_text('generated-certificate', encoding='utf-8')
+        key.write_text('generated-private-key', encoding='utf-8')
+        return subprocess.CompletedProcess(command, 0)
+
+    monkeypatch.setattr(tls_config.subprocess, 'run', fake_openssl)
+    cert_dir = tmp_path / 'generated'
+
+    resolved = tls_config.resolve_tls_certificates(
+        environ={},
+        cert_dir=cert_dir,
+    )
+
+    assert resolved == (str(cert_dir / 'cert.pem'), str(cert_dir / 'key.pem'))
+    assert (cert_dir / 'key.pem').stat().st_mode & 0o777 == 0o600
+    assert len(calls) == 1
+    assert calls[0][0:2] == ['openssl', 'req']
+    output = capsys.readouterr().out
+    assert 'self-signed compatibility fallback' in output
+    assert 'does not establish browser trust or Quest WebXR readiness' in output
+
+
+def test_generated_pair_is_rejected_if_both_paths_resolve_to_one_file(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    def fake_openssl(command, *, check, capture_output):
+        assert check is True
+        assert capture_output is True
+        cert = Path(command[command.index('-out') + 1])
+        key = Path(command[command.index('-keyout') + 1])
+        cert.write_text('combined', encoding='utf-8')
+        key.unlink()
+        key.symlink_to(cert)
+        return subprocess.CompletedProcess(command, 0)
+
+    monkeypatch.setattr(tls_config.subprocess, 'run', fake_openssl)
+
+    with pytest.raises(tls_config.TLSConfigurationError, match='different files'):
+        tls_config.resolve_tls_certificates(
+            environ={},
+            cert_dir=tmp_path / 'generated',
+        )
+
+
+@pytest.mark.skipif(shutil.which('openssl') is None, reason='openssl is unavailable')
+def test_real_generated_pair_is_parseable_matching_and_private(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(
+        tls_config,
+        '_validate_certificate_pair',
+        _REAL_VALIDATE_CERTIFICATE_PAIR,
+    )
+
+    cert_file, key_file = tls_config.resolve_tls_certificates(
+        environ={},
+        cert_dir=tmp_path / 'real-pair',
+    )
+
+    assert Path(cert_file).is_file()
+    assert Path(key_file).stat().st_mode & 0o777 == 0o600
+
+
+@pytest.mark.skipif(shutil.which('openssl') is None, reason='openssl is unavailable')
+def test_real_mismatched_explicit_pair_fails_before_server_start(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(
+        tls_config,
+        '_validate_certificate_pair',
+        _REAL_VALIDATE_CERTIFICATE_PAIR,
+    )
+    cert_a, _key_a = tls_config.resolve_tls_certificates(
+        environ={},
+        cert_dir=tmp_path / 'pair-a',
+    )
+    _cert_b, key_b = tls_config.resolve_tls_certificates(
+        environ={},
+        cert_dir=tmp_path / 'pair-b',
+    )
+
+    with pytest.raises(tls_config.TLSConfigurationError, match='parseable matching'):
+        tls_config.resolve_tls_certificates(
+            environ={
+                tls_config.TLS_CERT_FILE_ENV: cert_a,
+                tls_config.TLS_KEY_FILE_ENV: key_b,
+            },
+            cert_dir=tmp_path / 'must-not-exist',
+        )
+
+
+def test_existing_compatibility_key_permissions_are_tightened(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    cert, key = _write_pair(tmp_path / 'compatibility')
+    key.chmod(0o644)
+    monkeypatch.setattr(tls_config.subprocess, 'run', _unexpected_openssl)
+
+    resolved = tls_config.resolve_tls_certificates(environ={}, cert_dir=cert.parent)
+
+    assert resolved == (str(cert), str(key))
+    assert key.stat().st_mode & 0o777 == 0o600
+
+
+def test_broad_managed_compatibility_symlink_fails_without_chmod_target(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    managed = tmp_path / 'managed'
+    cert, key = _write_pair(managed)
+    key.chmod(0o640)
+    compatibility = tmp_path / 'compatibility'
+    compatibility.mkdir()
+    (compatibility / 'cert.pem').symlink_to(cert)
+    (compatibility / 'key.pem').symlink_to(key)
+    monkeypatch.setattr(tls_config.subprocess, 'run', _unexpected_openssl)
+
+    with pytest.raises(tls_config.TLSConfigurationError, match='linked compatibility'):
+        tls_config.resolve_tls_certificates(environ={}, cert_dir=compatibility)
+
+    assert key.stat().st_mode & 0o777 == 0o640
+
+
+def test_broad_hard_linked_compatibility_key_fails_without_chmod_target(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    compatibility = tmp_path / 'compatibility'
+    _cert, key = _write_pair(compatibility)
+    key.chmod(0o640)
+    other_link = tmp_path / 'shared-key.pem'
+    os.link(key, other_link)
+    monkeypatch.setattr(tls_config.subprocess, 'run', _unexpected_openssl)
+
+    with pytest.raises(tls_config.TLSConfigurationError, match='multiply-linked'):
+        tls_config.resolve_tls_certificates(environ={}, cert_dir=compatibility)
+
+    assert key.stat().st_mode & 0o777 == 0o640
+    assert other_link.stat().st_mode & 0o777 == 0o640
+
+
+def test_explicit_pair_is_reused_without_touching_files_or_fallback(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    cert, key = _write_pair(tmp_path / 'deployment')
+    monkeypatch.setattr(tls_config.subprocess, 'run', _unexpected_openssl)
+
+    resolved = tls_config.resolve_tls_certificates(
+        environ={
+            tls_config.TLS_CERT_FILE_ENV: str(cert),
+            tls_config.TLS_KEY_FILE_ENV: str(key),
+        },
+        cert_dir=tmp_path / 'must-not-exist',
+    )
+
+    assert resolved == (str(cert), str(key))
+    assert cert.read_text(encoding='utf-8') == 'certificate'
+    assert key.read_text(encoding='utf-8') == 'private-key'
+    assert not (tmp_path / 'must-not-exist').exists()
+
+
+def test_explicit_private_key_with_group_or_world_access_fails_closed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    cert, key = _write_pair(tmp_path / 'deployment')
+    key.chmod(0o640)
+    monkeypatch.setattr(tls_config.subprocess, 'run', _unexpected_openssl)
+
+    with pytest.raises(tls_config.TLSConfigurationError, match='mode to 0600 or 0400'):
+        tls_config.resolve_tls_certificates(
+            environ={
+                tls_config.TLS_CERT_FILE_ENV: str(cert),
+                tls_config.TLS_KEY_FILE_ENV: str(key),
+            },
+            cert_dir=tmp_path / 'must-not-exist',
+        )
+
+    assert key.stat().st_mode & 0o777 == 0o640
+
+
+@pytest.mark.parametrize('configured_name', [
+    tls_config.TLS_CERT_FILE_ENV,
+    tls_config.TLS_KEY_FILE_ENV,
+])
+def test_partial_explicit_pair_fails_closed(
+    configured_name: str,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    configured_file = tmp_path / 'configured.pem'
+    configured_file.write_text('configured', encoding='utf-8')
+    monkeypatch.setattr(tls_config.subprocess, 'run', _unexpected_openssl)
+
+    with pytest.raises(tls_config.TLSConfigurationError, match='configured together'):
+        tls_config.resolve_tls_certificates(
+            environ={configured_name: str(configured_file)},
+            cert_dir=tmp_path / 'must-not-exist',
+        )
+
+    assert not (tmp_path / 'must-not-exist').exists()
+
+
+@pytest.mark.parametrize('bad_kind', ['missing', 'directory'])
+@pytest.mark.parametrize('bad_name', [
+    tls_config.TLS_CERT_FILE_ENV,
+    tls_config.TLS_KEY_FILE_ENV,
+])
+def test_non_file_explicit_path_fails_closed(
+    bad_kind: str,
+    bad_name: str,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    cert, key = _write_pair(tmp_path / 'deployment')
+    bad_path = tmp_path / 'bad-path'
+    if bad_kind == 'directory':
+        bad_path.mkdir()
+    environ = {
+        tls_config.TLS_CERT_FILE_ENV: str(cert),
+        tls_config.TLS_KEY_FILE_ENV: str(key),
+    }
+    environ[bad_name] = str(bad_path)
+    monkeypatch.setattr(tls_config.subprocess, 'run', _unexpected_openssl)
+
+    with pytest.raises(tls_config.TLSConfigurationError, match='regular file'):
+        tls_config.resolve_tls_certificates(
+            environ=environ,
+            cert_dir=tmp_path / 'must-not-exist',
+        )
+
+    assert not (tmp_path / 'must-not-exist').exists()
+
+
+@pytest.mark.parametrize('present_name', ['cert.pem', 'key.pem'])
+def test_partial_compatibility_pair_fails_without_overwriting(
+    present_name: str,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    cert_dir = tmp_path / 'partial'
+    cert_dir.mkdir()
+    present = cert_dir / present_name
+    present.write_text('must-survive', encoding='utf-8')
+    monkeypatch.setattr(tls_config.subprocess, 'run', _unexpected_openssl)
+
+    with pytest.raises(tls_config.TLSConfigurationError, match='incomplete'):
+        tls_config.resolve_tls_certificates(environ={}, cert_dir=cert_dir)
+
+    assert present.read_text(encoding='utf-8') == 'must-survive'
+    assert len(list(cert_dir.iterdir())) == 1
+
+
+def test_broken_default_symlinks_fail_without_running_openssl(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    cert_dir = tmp_path / 'broken-links'
+    cert_dir.mkdir()
+    cert_link = cert_dir / 'cert.pem'
+    key_link = cert_dir / 'key.pem'
+    cert_link.symlink_to(tmp_path / 'missing-cert.pem')
+    key_link.symlink_to(tmp_path / 'missing-key.pem')
+    monkeypatch.setattr(tls_config.subprocess, 'run', _unexpected_openssl)
+
+    with pytest.raises(tls_config.TLSConfigurationError, match='incomplete'):
+        tls_config.resolve_tls_certificates(environ={}, cert_dir=cert_dir)
+
+    assert cert_link.is_symlink()
+    assert key_link.is_symlink()
+
+
+def test_explicit_certificate_and_key_must_not_be_the_same_file(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    combined = tmp_path / 'combined.pem'
+    combined.write_text('combined', encoding='utf-8')
+    monkeypatch.setattr(tls_config.subprocess, 'run', _unexpected_openssl)
+
+    with pytest.raises(tls_config.TLSConfigurationError, match='different files'):
+        tls_config.resolve_tls_certificates(
+            environ={
+                tls_config.TLS_CERT_FILE_ENV: str(combined),
+                tls_config.TLS_KEY_FILE_ENV: str(combined),
+            },
+            cert_dir=tmp_path / 'must-not-exist',
+        )
+
+
+@pytest.mark.skipif(not hasattr(os, 'symlink'), reason='symlinks are unavailable')
+def test_explicit_symlinks_to_distinct_regular_files_are_supported(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    cert, key = _write_pair(tmp_path / 'managed')
+    cert_link = tmp_path / 'fullchain.pem'
+    key_link = tmp_path / 'privkey.pem'
+    cert_link.symlink_to(cert)
+    key_link.symlink_to(key)
+    monkeypatch.setattr(tls_config.subprocess, 'run', _unexpected_openssl)
+
+    resolved = tls_config.resolve_tls_certificates(
+        environ={
+            tls_config.TLS_CERT_FILE_ENV: str(cert_link),
+            tls_config.TLS_KEY_FILE_ENV: str(key_link),
+        },
+        cert_dir=tmp_path / 'must-not-exist',
+    )
+
+    assert resolved == (str(cert_link), str(key_link))
+
+
+def test_distinct_symlinks_to_the_same_file_are_rejected(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    combined = tmp_path / 'combined.pem'
+    combined.write_text('combined', encoding='utf-8')
+    cert_link = tmp_path / 'cert-link.pem'
+    key_link = tmp_path / 'key-link.pem'
+    cert_link.symlink_to(combined)
+    key_link.symlink_to(combined)
+    monkeypatch.setattr(tls_config.subprocess, 'run', _unexpected_openssl)
+
+    with pytest.raises(tls_config.TLSConfigurationError, match='different files'):
+        tls_config.resolve_tls_certificates(
+            environ={
+                tls_config.TLS_CERT_FILE_ENV: str(cert_link),
+                tls_config.TLS_KEY_FILE_ENV: str(key_link),
+            },
+            cert_dir=tmp_path / 'must-not-exist',
+        )

--- a/agent-core/tests/teleop/test_tls_deployment_contract.py
+++ b/agent-core/tests/teleop/test_tls_deployment_contract.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+CORE = Path(__file__).resolve().parents[2]
+REPOSITORY = CORE.parent
+
+
+def test_core_compose_passes_mounted_tls_paths_as_an_optional_pair():
+    compose = yaml.safe_load(
+        (CORE / 'deploy' / 'docker-compose.yml').read_text(encoding='utf-8')
+    )
+    core_service = compose['services']['agent-core']
+    environment = {
+        entry.split('=', 1)[0]: entry.split('=', 1)[1]
+        for entry in core_service['environment']
+    }
+
+    assert '/opt/phanthy-motus:/opt/phanthy-motus' in core_service['volumes']
+    assert environment['MOTUS_TLS_CERT_FILE'] == '${MOTUS_TLS_CERT_FILE:-}'
+    assert environment['MOTUS_TLS_KEY_FILE'] == '${MOTUS_TLS_KEY_FILE:-}'
+
+    # The self-update path parses and dumps this Compose document with PyYAML.
+    # Keep the interpolation expressions intact across that real round trip.
+    round_trip = yaml.safe_load(yaml.safe_dump(compose, sort_keys=False))
+    round_trip_environment = {
+        entry.split('=', 1)[0]: entry.split('=', 1)[1]
+        for entry in round_trip['services']['agent-core']['environment']
+    }
+    assert round_trip_environment['MOTUS_TLS_CERT_FILE'] == '${MOTUS_TLS_CERT_FILE:-}'
+    assert round_trip_environment['MOTUS_TLS_KEY_FILE'] == '${MOTUS_TLS_KEY_FILE:-}'
+
+
+def test_deployment_env_example_uses_container_visible_tls_paths():
+    example = (REPOSITORY / 'deploy' / '.env.example').read_text(encoding='utf-8')
+
+    assert (
+        'MOTUS_TLS_CERT_FILE=/opt/phanthy-motus/tls/fullchain.pem'
+        in example
+    )
+    assert (
+        'MOTUS_TLS_KEY_FILE=/opt/phanthy-motus/tls/privkey.pem'
+        in example
+    )
+    assert 'Configure both paths or neither.' in example
+    assert 'exact Quest Browser hostname in its SAN' in example
+    assert 'chmod 600, or 400' in example
+
+
+def test_start_uses_the_fail_closed_tls_resolver():
+    source = (CORE / 'src' / 'start.py').read_text(encoding='utf-8')
+
+    assert 'load_public_certificate_chain, resolve_tls_certificates' in source
+    assert 'cert_file, key_file = resolve_tls_certificates()' in source
+    assert 'app_api.state.teleop_capture_ca_certificate_pem' in source
+    assert 'load_public_certificate_chain(cert_file)' in source
+    assert 'ssl_certfile=cert_file, ssl_keyfile=key_file' in source
+    assert '_ensure_ssl_certs' not in source
+
+
+def test_readmes_require_browser_accepted_exact_host_certificates_for_quest():
+    english = (REPOSITORY / 'README.md').read_text(encoding='utf-8')
+    chinese = (REPOSITORY / 'README_zh.md').read_text(encoding='utf-8')
+
+    assert 'http://<device-ip>:15678' not in english
+    assert 'http://<\u8bbe\u5907IP>:15678' not in chinese
+    assert 'Subject Alternative Name (SAN)' in english
+    assert '完整证书链也必须被 Quest Browser 接受' in chinese
+    assert 'does **not** guarantee browser trust' in english
+    assert '**不保证**浏览器信任' in chinese
+    assert 'window.isSecureContext=true' in english
+    assert 'window.isSecureContext=true' in chinese
+    assert 'Merely seeing an `https://` URL' in english
+    assert '仅看到 `https://` URL' in chinese
+    assert 'private key must be owner-only (`0600` or `0400`)' in english
+    assert '私钥必须为 owner-only（`0600` 或 `0400`）' in chinese
+    assert 'parseable' in english
+    assert 'matching server pair' in english
+    assert '可解析且相互匹配的服务端 pair' in chinese

--- a/agent-core/tests/teleop/test_webxr_frame.mjs
+++ b/agent-core/tests/teleop/test_webxr_frame.mjs
@@ -1,0 +1,691 @@
+import {
+  MAX_SAFE_WIRE_INTEGER,
+  RTC_FRAME_PROTOCOL,
+  buildRtcFrameV1 as buildConfiguredRtcFrameV1,
+  createRtcFrameGenerator,
+  createRtcFrameState,
+  isDualSqueezeDeadmanRequested,
+  markRtcFrameDeadmanReleased,
+  performanceMillisecondsToNanoseconds,
+  xrPoseToWirePose,
+  xrStandardInputToWireController,
+} from '../../web/js/teleop/webxr-frame.js';
+
+const BASE_CAPABILITIES = {
+  profile_id: 'fixture_base_profile_v1',
+  input_bindings: {
+    base_twist: {
+      linear_x: {
+        hand: 'left', axis: 3, scale: 0.5, deadzone: 0.2, direction: -1,
+      },
+      linear_y: {
+        hand: 'left', axis: 2, scale: 0.3, deadzone: 0.2, direction: -1,
+      },
+      angular_z: {
+        hand: 'right', axis: 2, scale: 0.6, deadzone: 0.2, direction: -1,
+      },
+    },
+  },
+  outputs: {
+    base: { enabled: true },
+    hands: { enabled: false },
+  },
+  effectors: ['base'],
+};
+
+const BASE_FRAME_CONFIGURATION = {
+  mode: 'shadow',
+  capabilities: BASE_CAPABILITIES,
+};
+
+const ARM_ONLY_FRAME_CONFIGURATION = {
+  mode: 'live',
+  capabilities: {
+    profile_id: 'dual_arm_fixture_v1',
+    input_bindings: {
+      head: { required: true, role: 'reference' },
+      left_controller: { required: true, role: 'left_end_effector' },
+      right_controller: { required: true, role: 'right_end_effector' },
+    },
+    outputs: {
+      dual_arm: { enabled: true, joint_count: 10 },
+      base: { enabled: false },
+      hands: { enabled: false },
+    },
+    effectors: ['dual_arm'],
+  },
+};
+
+function buildRtcFrameV1(state, sample = {}, configuration = BASE_FRAME_CONFIGURATION) {
+  return buildConfiguredRtcFrameV1(state, sample, configuration);
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+function assertEqual(actual, expected, message) {
+  const left = JSON.stringify(actual);
+  const right = JSON.stringify(expected);
+  assert(left === right, `${message}: expected ${right}, got ${left}`);
+}
+
+function assertNear(actual, expected, message, tolerance = 1e-12) {
+  assert(Math.abs(actual - expected) <= tolerance,
+    `${message}: expected ${expected}, got ${actual}`);
+}
+
+function assertThrows(callback, message) {
+  let threw = false;
+  try {
+    callback();
+  } catch {
+    threw = true;
+  }
+  assert(threw, message);
+}
+
+function pose({
+  position = [0.1, 1.2, -0.3],
+  orientation = [0, 0, 0, 0.999],
+} = {}) {
+  return {
+    transform: {
+      position: { x: position[0], y: position[1], z: position[2] },
+      orientation: {
+        x: orientation[0],
+        y: orientation[1],
+        z: orientation[2],
+        w: orientation[3],
+      },
+    },
+  };
+}
+
+function button(value, pressed = value >= 0.75) {
+  return { value, pressed, touched: pressed };
+}
+
+function inputSource({
+  handedness = 'left',
+  targetRayMode = 'tracked-pointer',
+  gripSpace = {},
+  mapping = 'xr-standard',
+  axes = [0, 0, 0, 0],
+  buttons = [button(0, false), button(0.9, true)],
+} = {}) {
+  return {
+    handedness,
+    targetRayMode,
+    gripSpace,
+    gamepad: { mapping, axes, buttons },
+  };
+}
+
+function validSample(overrides = {}) {
+  return {
+    monotonicTimeMs: 12.345678,
+    headPose: pose(),
+    leftGripPose: pose({ position: [-0.2, 1.1, -0.4] }),
+    rightGripPose: pose({ position: [0.2, 1.1, -0.4] }),
+    leftInputSource: inputSource(),
+    rightInputSource: inputSource({ handedness: 'right' }),
+    deadman: false,
+    ...overrides,
+  };
+}
+
+function assertNoPrivateAuthority(value) {
+  const forbidden = new Set(['boot_id', 'session_id', 'epoch', 'fence']);
+  if (Array.isArray(value)) {
+    value.forEach(assertNoPrivateAuthority);
+    return;
+  }
+  if (!value || typeof value !== 'object') return;
+  for (const [key, nested] of Object.entries(value)) {
+    assert(!forbidden.has(key), `public RTC frame disclosed ${key}`);
+    assertNoPrivateAuthority(nested);
+  }
+}
+
+assert(RTC_FRAME_PROTOCOL === 'motus.teleop.rtc-frame.v1', 'protocol name must match Driver');
+
+// Exact public frame schema, normalized poses, default-off deadman, and no private identity.
+let result = buildRtcFrameV1(createRtcFrameState(), validSample());
+assertEqual(Object.keys(result.frame).sort(), [
+  'schema_version',
+  'sequence',
+  'client_monotonic_ns',
+  'mode',
+  'deadman',
+  'clutch_sequence',
+  'tracking',
+  'head',
+  'left_controller',
+  'right_controller',
+  'controllers',
+  'base_twist',
+].sort(), 'frame must contain exactly the Driver public RTC fields');
+assertNoPrivateAuthority(result.frame);
+assert(result.frame.schema_version === 1, 'schema_version must be 1');
+assert(result.frame.mode === 'shadow', 'mode must be shadow');
+assert(result.frame.sequence === 0, 'first sequence must be zero');
+assert(result.frame.deadman === false, 'deadman must default false');
+assert(result.frame.clutch_sequence === 0, 'default-off deadman must not advance clutch');
+assertEqual(result.frame.base_twist, {
+  linear: [0, 0, 0],
+  angular: [0, 0, 0],
+}, 'default-off deadman must emit an explicit six-dimensional zero base_twist');
+assertEqual(result.frame.tracking, {
+  head: true,
+  left_controller: true,
+  right_controller: true,
+}, 'valid poses must have matching tracking flags');
+assert(Math.abs(Math.hypot(...result.frame.head.orientation) - 1) < 1e-12,
+  'wire quaternion must be strictly normalized');
+
+const armOnlyLive = buildRtcFrameV1(
+  createRtcFrameState({ rearmRequired: false }),
+  validSample({ deadman: true }),
+  ARM_ONLY_FRAME_CONFIGURATION,
+);
+assert(armOnlyLive.frame.mode === 'live', 'frame mode must come from the live session contract');
+assert(!Object.hasOwn(armOnlyLive.frame, 'base_twist'),
+  'base-disabled capabilities must omit base_twist instead of sending a fixed zero output');
+assert(!Object.hasOwn(armOnlyLive.frame, 'hands'),
+  'hands-disabled capabilities must not invent a hands output field');
+assertThrows(
+  () => buildConfiguredRtcFrameV1(
+    createRtcFrameState(),
+    validSample(),
+    { ...BASE_FRAME_CONFIGURATION, mode: 'invalid' },
+  ),
+  'an RTC frame without an exact session mode must fail closed',
+);
+assertThrows(
+  () => buildConfiguredRtcFrameV1(
+    createRtcFrameState(),
+    validSample(),
+    {
+      mode: 'live',
+      capabilities: {
+        ...ARM_ONLY_FRAME_CONFIGURATION.capabilities,
+        input_bindings: BASE_CAPABILITIES.input_bindings,
+      },
+    },
+  ),
+  'a base binding cannot bypass capabilities.outputs.base.enabled=false',
+);
+
+// Explicit dual-squeeze policy is centralized and fails closed.
+const left = inputSource();
+const right = inputSource({ handedness: 'right' });
+const releasedLeft = inputSource({ buttons: [button(0, false), button(0, false)] });
+const releasedRight = inputSource({
+  handedness: 'right',
+  buttons: [button(0, false), button(0, false)],
+});
+assert(isDualSqueezeDeadmanRequested(left, right), 'both valid squeezes must request deadman');
+assert(!isDualSqueezeDeadmanRequested(
+  left,
+  inputSource({
+    handedness: 'right',
+    buttons: [button(0, false), button(0.9, false)],
+  }),
+), 'pressed=false must reject squeeze even at a high value');
+assert(!isDualSqueezeDeadmanRequested(
+  left,
+  inputSource({
+    handedness: 'right',
+    buttons: [button(0, false), button(Number.NaN, true)],
+  }),
+), 'non-finite squeeze must fail closed');
+assert(!isDualSqueezeDeadmanRequested(left, inputSource({ handedness: 'right', mapping: '' })),
+  'non-xr-standard mapping must fail closed');
+assert(!isDualSqueezeDeadmanRequested(left, inputSource()),
+  'duplicate left-handed sources must fail closed');
+assert(!isDualSqueezeDeadmanRequested(left, inputSource({
+  handedness: 'right',
+  targetRayMode: 'gaze',
+})), 'non tracked-pointer sources must fail closed');
+assert(!isDualSqueezeDeadmanRequested(left, new Proxy({}, {
+  get() { throw new Error('malformed input source'); },
+})), 'throwing input source must fail closed');
+const rejectedDeadman = buildRtcFrameV1(result.state, validSample({
+  leftInputSource: inputSource({ buttons: [button(0, false), button(0.5, true)] }),
+  deadman: true,
+}));
+assert(rejectedDeadman.frame.deadman === false,
+  'frame reducer must independently reject deadman without both squeeze thresholds');
+assert(rejectedDeadman.state.rearmRequired === true,
+  'pressed/value disagreement must not masquerade as a physical release');
+const partialSqueeze = buildRtcFrameV1(
+  createRtcFrameState({ rearmRequired: false }),
+  validSample({
+    leftInputSource: inputSource({ buttons: [button(0, false), button(0.5, true)] }),
+    rightInputSource: inputSource({
+      handedness: 'right',
+      buttons: [button(0, false), button(0.5, true)],
+    }),
+    deadman: false,
+  }),
+);
+assert(partialSqueeze.frame.deadman === false && partialSqueeze.state.rearmRequired === false,
+  'a gradual squeeze below threshold must not engage or erase a prior valid rearm');
+
+// Sequence is strictly increasing; clutch advances only on safe false -> true edges.
+const requested = isDualSqueezeDeadmanRequested(left, right);
+const armed = buildRtcFrameV1(result.state, validSample({
+  leftInputSource: releasedLeft,
+  rightInputSource: releasedRight,
+  deadman: false,
+}));
+assert(armed.frame.deadman === false && armed.state.rearmRequired === false,
+  'a valid observed squeeze release must arm the next deliberate engagement');
+result = buildRtcFrameV1(armed.state, validSample({ deadman: requested }));
+assert(result.frame.sequence === 2, 'sequence must advance on every frame');
+assert(result.frame.deadman === true, 'explicit valid request must engage deadman');
+assert(result.frame.clutch_sequence === 1, 'first engagement must advance clutch');
+const held = buildRtcFrameV1(result.state, validSample({
+  monotonicTimeMs: 12.345678,
+  deadman: requested,
+}));
+assert(held.frame.sequence === 3, 'held frame sequence must advance');
+assert(held.frame.clutch_sequence === 1, 'held deadman must not advance clutch twice');
+assert(held.frame.client_monotonic_ns > result.frame.client_monotonic_ns,
+  'equal performance timestamps must still produce increasing integer nanoseconds');
+const open = buildRtcFrameV1(held.state, validSample({
+  leftInputSource: releasedLeft,
+  rightInputSource: releasedRight,
+  deadman: false,
+}));
+const reengaged = buildRtcFrameV1(open.state, validSample({ deadman: true }));
+assert(open.frame.clutch_sequence === 1 && reengaged.frame.clutch_sequence === 2,
+  'release then engagement must advance clutch exactly once');
+
+// RTC/XR reconnect persists the stream counters and explicitly clears the edge detector.
+const persisted = markRtcFrameDeadmanReleased(reengaged.state);
+assert(persisted.nextSequence === reengaged.state.nextSequence,
+  'reconnect must preserve next sequence');
+assert(persisted.clutchSequence === reengaged.state.clutchSequence,
+  'reconnect must preserve clutch generation');
+assert(persisted.lastMonotonicNs === reengaged.state.lastMonotonicNs,
+  'reconnect must preserve monotonic watermark');
+assert(persisted.deadmanActive === false, 'stream end must explicitly release deadman edge state');
+assert(persisted.rearmRequired === true, 'stream end must require an observed physical release');
+const heldAcrossReconnect = buildRtcFrameV1(persisted, validSample({
+  leftInputSource: inputSource({ axes: [0, 0, -1, -1] }),
+  rightInputSource: inputSource({ handedness: 'right', axes: [0, 0, -1, 0] }),
+  deadman: true,
+}));
+assert(heldAcrossReconnect.frame.sequence === reengaged.state.nextSequence,
+  'reconnected RTC stream must continue rather than reset sequence');
+assert(heldAcrossReconnect.frame.deadman === false
+  && heldAcrossReconnect.frame.clutch_sequence === reengaged.state.clutchSequence,
+  'held squeezes across reconnect must not automatically recover motion');
+assertEqual(heldAcrossReconnect.frame.base_twist, {
+  linear: [0, 0, 0],
+  angular: [0, 0, 0],
+}, 'rearm latch must keep base_twist strictly zero');
+const reconnectReleasedWithHeldSticks = buildRtcFrameV1(
+  heldAcrossReconnect.state,
+  validSample({
+    leftInputSource: inputSource({
+      axes: [0, 0, -1, -1],
+      buttons: [button(0, false), button(0, false)],
+    }),
+    rightInputSource: inputSource({
+      handedness: 'right',
+      axes: [0, 0, -1, 0],
+      buttons: [button(0, false), button(0, false)],
+    }),
+    deadman: false,
+  }),
+);
+assert(reconnectReleasedWithHeldSticks.state.rearmRequired === true,
+  'squeeze release with locomotion sticks held must remain re-arm latched');
+const reconnectNeutralBeforePreload = buildRtcFrameV1(
+  reconnectReleasedWithHeldSticks.state,
+  validSample({
+    leftInputSource: inputSource({
+      axes: [0, 0, 0, 0],
+      buttons: [button(0, false), button(0, false)],
+    }),
+    rightInputSource: inputSource({
+      handedness: 'right',
+      axes: [0, 0, 0, 0],
+      buttons: [button(0, false), button(0, false)],
+    }),
+    deadman: false,
+  }),
+);
+assert(reconnectNeutralBeforePreload.state.rearmRequired === false,
+  'neutral squeeze release must clear the re-arm latch before the preload test');
+const reconnectAttemptedAtFullScale = buildRtcFrameV1(
+  reconnectNeutralBeforePreload.state,
+  validSample({
+    leftInputSource: inputSource({ axes: [0, 0, -1, -1] }),
+    rightInputSource: inputSource({ handedness: 'right', axes: [0, 0, -1, 0] }),
+    deadman: true,
+  }),
+);
+assert(reconnectAttemptedAtFullScale.frame.deadman === false
+  && reconnectAttemptedAtFullScale.state.rearmRequired === true,
+  'first re-squeeze with non-neutral sticks must not preload a motion command');
+assertEqual(reconnectAttemptedAtFullScale.frame.base_twist, {
+  linear: [0, 0, 0],
+  angular: [0, 0, 0],
+}, 'non-neutral engagement attempt must remain six-dimensional zero');
+const reconnectReleased = buildRtcFrameV1(reconnectAttemptedAtFullScale.state, validSample({
+  leftInputSource: inputSource({
+    axes: [0, 0, 0, 0],
+    buttons: [button(0, false), button(0, false)],
+  }),
+  rightInputSource: inputSource({
+    handedness: 'right',
+    axes: [0, 0, 0, 0],
+    buttons: [button(0, false), button(0, false)],
+  }),
+  deadman: false,
+}));
+const reconnected = buildRtcFrameV1(reconnectReleased.state, validSample({
+  leftInputSource: inputSource({ axes: [0, 0, 0, 0] }),
+  rightInputSource: inputSource({ handedness: 'right', axes: [0, 0, 0, 0] }),
+  deadman: true,
+}));
+assert(reconnected.frame.clutch_sequence === reengaged.state.clutchSequence + 1,
+  'neutral release then neutral re-squeeze after reconnect must start a new clutch generation');
+assertEqual(reconnected.frame.base_twist, {
+  linear: [0, 0, 0],
+  angular: [0, 0, 0],
+}, 'neutral engagement must start from zero twist');
+const reconnectedMotion = buildRtcFrameV1(reconnected.state, validSample({
+  leftInputSource: inputSource({ axes: [0, 0, -1, -1] }),
+  rightInputSource: inputSource({ handedness: 'right', axes: [0, 0, -1, 0] }),
+  deadman: true,
+}));
+assertEqual(reconnectedMotion.frame.base_twist, {
+  linear: [0.5, 0.3, 0],
+  angular: [0, 0, 0.6],
+}, 'stick motion after neutral engagement must re-enable the mapped twist');
+
+// Public base_twist uses only descriptor-declared xr-standard axes/scales.
+// Per-axis deadzone remapping is deterministic and gated by final deadman.
+const fullPositiveTwist = buildRtcFrameV1(
+  createRtcFrameState({ deadmanActive: true, rearmRequired: false }),
+  validSample({
+    leftInputSource: inputSource({ axes: [0, 0, -1, -1] }),
+    rightInputSource: inputSource({ handedness: 'right', axes: [0, 0, -1, 0] }),
+    deadman: true,
+  }),
+);
+assert(fullPositiveTwist.frame.deadman === true,
+  'valid dual squeeze and tracked inputs must admit the twist sample');
+assertEqual(fullPositiveTwist.frame.base_twist, {
+  linear: [0.5, 0.3, 0],
+  angular: [0, 0, 0.6],
+}, 'negative xr-standard axes must map to full-scale +forward/+left/+CCW');
+
+const reboundConfiguration = {
+  mode: 'live',
+  capabilities: {
+    ...BASE_CAPABILITIES,
+    input_bindings: {
+      base_twist: {
+        linear_x: {
+          hand: 'right', axis: 0, scale: 2, deadzone: 0, direction: 1,
+        },
+        linear_y: {
+          hand: 'left', axis: 1, scale: 1, deadzone: 0, direction: -1,
+        },
+        angular_z: {
+          hand: 'right', axis: 1, scale: 3, deadzone: 0, direction: -1,
+        },
+      },
+    },
+  },
+};
+const rebound = buildRtcFrameV1(
+  createRtcFrameState({ deadmanActive: true, rearmRequired: false }),
+  validSample({
+    leftInputSource: inputSource({ axes: [0, -0.25, -1, -1] }),
+    rightInputSource: inputSource({ handedness: 'right', axes: [0.5, -0.5, -1, 0] }),
+    deadman: true,
+  }),
+  reboundConfiguration,
+);
+assertEqual(rebound.frame.base_twist, {
+  linear: [1, 0.25, 0],
+  angular: [0, 0, 1.5],
+}, 'base mapping must consume the capability binding rather than fixed browser axes/speeds');
+
+const fullNegativeTwist = buildRtcFrameV1(
+  createRtcFrameState({ deadmanActive: true, rearmRequired: false }),
+  validSample({
+    leftInputSource: inputSource({ axes: [0, 0, 1, 1] }),
+    rightInputSource: inputSource({ handedness: 'right', axes: [0, 0, 1, 0] }),
+    deadman: true,
+  }),
+);
+assertEqual(fullNegativeTwist.frame.base_twist, {
+  linear: [-0.5, -0.3, 0],
+  angular: [0, 0, -0.6],
+}, 'positive xr-standard axes must map to full-scale -forward/-left/-CCW');
+
+const remappedDeadzone = buildRtcFrameV1(
+  createRtcFrameState({ deadmanActive: true, rearmRequired: false }),
+  validSample({
+    leftInputSource: inputSource({ axes: [0, 0, -0.6, -0.2] }),
+    rightInputSource: inputSource({ handedness: 'right', axes: [0, 0, 0.19, 0] }),
+    deadman: true,
+  }),
+);
+assert(remappedDeadzone.frame.base_twist.linear[0] === 0,
+  'axis at the inclusive 0.2 deadzone boundary must be zero');
+assertNear(remappedDeadzone.frame.base_twist.linear[1], 0.15,
+  'axis travel after the deadzone must be remapped to the remaining full range');
+assert(remappedDeadzone.frame.base_twist.angular[2] === 0,
+  'axis inside the deadzone must be zero');
+
+const ignoredSecondarySlots = buildRtcFrameV1(
+  createRtcFrameState({ deadmanActive: true, rearmRequired: false }),
+  validSample({
+    leftInputSource: inputSource({ axes: [1, -1, 0, 0] }),
+    rightInputSource: inputSource({ handedness: 'right', axes: [-1, 1, 0, 0] }),
+    deadman: true,
+  }),
+);
+assertEqual(ignoredSecondarySlots.frame.base_twist, {
+  linear: [0, 0, 0],
+  angular: [0, 0, 0],
+}, 'axes[0]/axes[1] must never drive generic base_twist');
+
+const missingPrimaryAxes = buildRtcFrameV1(
+  createRtcFrameState({ rearmRequired: false }),
+  validSample({
+    leftInputSource: inputSource({ axes: [0, 0] }),
+    rightInputSource: inputSource({ handedness: 'right', axes: [0, 0] }),
+    deadman: true,
+  }),
+);
+assert(missingPrimaryAxes.frame.deadman === false,
+  'a descriptor-bound axis must exist before deadman can become true');
+assert(missingPrimaryAxes.state.rearmRequired === true,
+  'a missing descriptor-bound axis must latch re-arm');
+assertEqual(missingPrimaryAxes.frame.base_twist, {
+  linear: [0, 0, 0],
+  angular: [0, 0, 0],
+}, 'missing primary thumbstick slots must fail closed to zero base_twist');
+
+const malformedPrimaryAxes = buildRtcFrameV1(
+  createRtcFrameState({ deadmanActive: true, rearmRequired: false }),
+  validSample({
+    leftInputSource: inputSource({ axes: [0, 0, Number.NaN, -1] }),
+    rightInputSource: inputSource({
+      handedness: 'right',
+      axes: [0, 0, Number.POSITIVE_INFINITY, 0],
+    }),
+    deadman: true,
+  }),
+);
+assert(malformedPrimaryAxes.frame.deadman === false,
+  'non-finite primary locomotion axes must fail closed before mapping');
+assertEqual(malformedPrimaryAxes.frame.base_twist, {
+  linear: [0, 0, 0],
+  angular: [0, 0, 0],
+}, 'non-finite selected axes must emit only finite zeros');
+
+const canonicalNegativeZero = buildRtcFrameV1(
+  createRtcFrameState({ deadmanActive: true, rearmRequired: false }),
+  validSample({
+    leftInputSource: inputSource({ axes: [0, 0, -0, -0] }),
+    rightInputSource: inputSource({ handedness: 'right', axes: [0, 0, -0, 0] }),
+    deadman: true,
+  }),
+);
+assert(
+  [...canonicalNegativeZero.frame.base_twist.linear,
+    ...canonicalNegativeZero.frame.base_twist.angular]
+    .every((value) => value === 0 && !Object.is(value, -0)),
+  'negative-zero stick samples must serialize as canonical positive zeros',
+);
+
+const releasedWithFullAxes = buildRtcFrameV1(
+  createRtcFrameState({ deadmanActive: true, rearmRequired: false }),
+  validSample({
+    leftInputSource: inputSource({
+      axes: [0, 0, -1, -1],
+      buttons: [button(0, false), button(0, false)],
+    }),
+    rightInputSource: inputSource({
+      handedness: 'right',
+      axes: [0, 0, -1, 0],
+      buttons: [button(0, false), button(0, false)],
+    }),
+    deadman: false,
+  }),
+);
+assert(releasedWithFullAxes.frame.deadman === false,
+  'physical squeeze release must clear the final deadman');
+assertEqual(releasedWithFullAxes.frame.base_twist, {
+  linear: [0, 0, 0],
+  angular: [0, 0, 0],
+}, 'released deadman must zero all six twist components despite full stick travel');
+
+// Invalid pose data becomes null and tracking=false; it can never retain deadman.
+const badPose = pose({ position: [Number.NaN, 1, 0] });
+const untracked = buildRtcFrameV1(reconnected.state, validSample({
+  headPose: badPose,
+  leftGripPose: null,
+  deadman: true,
+}));
+assert(untracked.frame.head === null && untracked.frame.tracking.head === false,
+  'NaN head pose must become consistently untracked');
+assert(untracked.frame.left_controller === null
+  && untracked.frame.tracking.left_controller === false,
+  'missing grip pose must become consistently untracked');
+assert(untracked.frame.right_controller !== null
+  && untracked.frame.tracking.right_controller === true,
+  'independent valid grip tracking must remain visible');
+assert(untracked.frame.deadman === false, 'tracking loss must force deadman false');
+assert(xrPoseToWirePose(pose({ orientation: [0, 0, 0, 0] })) === null,
+  'zero quaternion must be rejected');
+assert(xrPoseToWirePose(pose({ orientation: [0, 0, 0, 2] })) === null,
+  'malformed quaternion magnitude must be rejected');
+assert(xrPoseToWirePose(pose({ position: [101, 0, 0] })) === null,
+  'out-of-workspace pose must be rejected');
+assert(xrPoseToWirePose({ ...pose(), emulatedPosition: true }) === null,
+  'emulated poses must be rejected as untracked');
+
+// Controller arrays are bounded and clamped, while malformed values disable deadman.
+const malformedController = inputSource({
+  axes: [-2, Number.NaN, 2, 0, 0, 0, 0, 0, 0],
+  buttons: Array.from({ length: 17 }, (_, index) => button(index === 0 ? -1 : 2, true)),
+});
+const normalizedController = xrStandardInputToWireController(malformedController);
+assert(normalizedController.axes.length === 8, 'axes must be capped at 8');
+assert(normalizedController.buttons.length === 16, 'buttons must be capped at 16');
+assertEqual(normalizedController.axes.slice(0, 3), [-1, 0, 1],
+  'axes must clamp and replace NaN with a safe zero');
+assertEqual(normalizedController.buttons.slice(0, 2), [0, 1],
+  'buttons must clamp to [0,1]');
+const malformedFrame = buildRtcFrameV1(untracked.state, validSample({
+  leftInputSource: malformedController,
+  deadman: true,
+}));
+assert(malformedFrame.frame.deadman === false,
+  'truncated, clamped, or non-finite controller data must force deadman false');
+assertEqual(malformedFrame.frame.base_twist, {
+  linear: [0, 0, 0],
+  angular: [0, 0, 0],
+}, 'malformed controller input must fail closed to zero base_twist');
+assertNoPrivateAuthority(malformedFrame.frame);
+const missingSqueeze = buildRtcFrameV1(malformedFrame.state, validSample({
+  leftInputSource: inputSource({ buttons: [button(0, false)] }),
+  deadman: true,
+}));
+assert(missingSqueeze.frame.deadman === false && missingSqueeze.state.rearmRequired === true,
+  'a controller without the xr-standard squeeze slot must remain unarmed');
+
+// A sample Proxy that throws is data loss, not a control-path exception.
+const throwingSample = new Proxy({}, {
+  get() { throw new Error('bad WebXR sample getter'); },
+});
+const failSafe = buildRtcFrameV1(malformedFrame.state, throwingSample);
+assertEqual(failSafe.frame.tracking, {
+  head: false,
+  left_controller: false,
+  right_controller: false,
+}, 'throwing sample must become fully untracked');
+assert(failSafe.frame.deadman === false, 'throwing sample must force deadman false');
+assert(failSafe.frame.head === null
+  && failSafe.frame.left_controller === null
+  && failSafe.frame.right_controller === null,
+  'throwing sample must emit null poses');
+
+// JS-safe bounds are explicit; internal counter exhaustion fails before a frame is emitted.
+assert(performanceMillisecondsToNanoseconds(1.25) === 1_250_000,
+  'performance milliseconds must convert to integer nanoseconds');
+assert(performanceMillisecondsToNanoseconds(Number.NaN) === null,
+  'NaN performance time must be rejected');
+assert(performanceMillisecondsToNanoseconds(-1) === null,
+  'negative performance time must be rejected');
+assert(performanceMillisecondsToNanoseconds((MAX_SAFE_WIRE_INTEGER / 1_000_000) + 1) === null,
+  'unsafe performance nanoseconds must be rejected');
+assertThrows(
+  () => createRtcFrameState({ nextSequence: MAX_SAFE_WIRE_INTEGER + 1 }),
+  'unsafe sequence state must be rejected',
+);
+assertThrows(
+  () => buildRtcFrameV1(
+    createRtcFrameState({ nextSequence: MAX_SAFE_WIRE_INTEGER }),
+    validSample(),
+  ),
+  'exhausted sequence must fail before emitting a repeated/unsafe next state',
+);
+assertThrows(
+  () => buildRtcFrameV1(
+    createRtcFrameState({
+      clutchSequence: MAX_SAFE_WIRE_INTEGER,
+      rearmRequired: false,
+    }),
+    validSample({ deadman: true }),
+  ),
+  'exhausted clutch counter must fail before engagement',
+);
+
+// The convenience generator has instance-local state and preserves the same reducer rules.
+const generator = createRtcFrameGenerator({
+  nextSequence: 10,
+  clutchSequence: 4,
+  rearmRequired: false,
+}, BASE_FRAME_CONFIGURATION);
+const generatedA = generator.next(validSample({ deadman: true }));
+const generatedB = generator.next(validSample({ deadman: true }));
+assert(generatedA.sequence === 10 && generatedB.sequence === 11,
+  'generator sequence must be monotonic');
+assert(generatedA.clutch_sequence === 5 && generatedB.clutch_sequence === 5,
+  'generator clutch edge must be monotonic and stable while held');
+assert(generator.snapshot().nextSequence === 12, 'generator snapshot must expose resumable state');
+
+console.log('webxr-frame: all tests passed');

--- a/agent-core/web/css/style.css
+++ b/agent-core/web/css/style.css
@@ -268,6 +268,7 @@ html, body {
 /* Mode toggle icons */
 .mode-toggle-btn { display: flex; align-items: center; gap: 4px; }
 .mode-toggle-btn svg { opacity: 0.7; flex-shrink: 0; }
+.topbar-teleop-link { text-decoration: none; }
 
 #btn-monitor.monitor-active {
   background: var(--green-bg);
@@ -6790,4 +6791,3 @@ html, body {
   color: var(--text-secondary);
   white-space: nowrap;
 }
-

--- a/agent-core/web/css/teleop.css
+++ b/agent-core/web/css/teleop.css
@@ -1,0 +1,219 @@
+:root {
+  color-scheme: dark;
+  --bg: #080b11;
+  --surface: #111722;
+  --surface-2: #171f2c;
+  --line: #293448;
+  --text: #f4f7fb;
+  --muted: #95a2b6;
+  --accent: #7c9cff;
+  --good: #43d19e;
+  --warn: #f5b942;
+  --bad: #ff6b7a;
+}
+
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  min-height: 100vh;
+  background:
+    radial-gradient(circle at 85% 0%, rgba(80, 111, 255, .14), transparent 34rem),
+    var(--bg);
+  color: var(--text);
+  font: 14px/1.5 Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+button, input, select, textarea { font: inherit; }
+.hidden { display: none !important; }
+.teleop-shell { width: min(1120px, calc(100% - 32px)); margin: 0 auto; padding: 36px 0 64px; }
+.teleop-header, .section-heading, .identity-card, .login-row, .header-actions {
+  display: flex;
+  align-items: center;
+}
+.teleop-header, .section-heading, .identity-card { justify-content: space-between; gap: 20px; }
+.header-actions, .login-row { gap: 10px; }
+.eyebrow, .section-label {
+  margin: 0 0 6px;
+  color: var(--accent);
+  font-size: 11px;
+  font-weight: 750;
+  letter-spacing: .14em;
+}
+h1, h2, p { margin-top: 0; }
+h1 { margin-bottom: 5px; font-size: clamp(28px, 5vw, 42px); line-height: 1.1; }
+h2 { margin-bottom: 0; font-size: 21px; }
+.subtitle, .login-panel p, .empty { color: var(--muted); }
+.notice, .login-panel, .identity-card, .safety-card, .capture-section, .devices-section {
+  border: 1px solid var(--line);
+  border-radius: 16px;
+  background: rgba(17, 23, 34, .93);
+}
+.notice { margin: 28px 0 16px; padding: 12px 16px; color: var(--muted); }
+.notice.error { border-color: rgba(255, 107, 122, .55); color: var(--bad); }
+.notice.success { border-color: rgba(67, 209, 158, .4); color: var(--good); }
+.login-panel { max-width: 620px; padding: 24px; }
+.login-panel label { display: block; margin-bottom: 8px; color: var(--muted); }
+.login-row input {
+  min-width: 0;
+  flex: 1;
+  padding: 11px 13px;
+  border: 1px solid var(--line);
+  border-radius: 9px;
+  outline: none;
+  background: #090d14;
+  color: var(--text);
+}
+.login-row input:focus { border-color: var(--accent); }
+.form-error { min-height: 21px; margin: 10px 0 0; color: var(--bad) !important; }
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 38px;
+  padding: 8px 14px;
+  border: 1px solid var(--line);
+  border-radius: 9px;
+  cursor: pointer;
+  text-decoration: none;
+  white-space: nowrap;
+}
+.button.primary { border-color: transparent; background: var(--accent); color: #071020; font-weight: 700; }
+.button.secondary { background: var(--surface-2); color: var(--text); }
+.button:hover { filter: brightness(1.09); }
+.button:disabled { cursor: not-allowed; filter: none; opacity: .45; }
+.button.danger { border-color: rgba(255, 107, 122, .65); background: rgba(255, 107, 122, .13); color: #ff9aa5; }
+.button.warning { border-color: rgba(245, 185, 66, .6); background: rgba(245, 185, 66, .12); color: var(--warn); }
+.content { display: grid; gap: 18px; }
+.identity-card { padding: 18px 20px; }
+.identity-card strong { font-size: 18px; }
+.identity-permission { margin: 4px 0 0; color: var(--muted); font-size: 12px; }
+.client-identity { margin: 5px 0 0; color: var(--muted); font-size: 11px; }
+.client-identity code { color: #b9c9ff; overflow-wrap: anywhere; }
+.role-badge, .status-badge {
+  display: inline-flex;
+  align-items: center;
+  width: fit-content;
+  padding: 4px 9px;
+  border-radius: 999px;
+  background: rgba(124, 156, 255, .14);
+  color: #b9c9ff;
+  font-size: 12px;
+  font-weight: 700;
+}
+.devices-section { padding: 20px; }
+.capture-section { padding: 20px; }
+.capture-heading-actions, .capture-actions, .capture-copy-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.capture-explanation, .capture-fallback, .capture-status, .capture-expiry {
+  margin: 12px 0 0;
+  color: var(--muted);
+}
+.capture-pair-row { display: grid; grid-template-columns: auto minmax(220px, 1fr); align-items: center; gap: 10px; margin-top: 16px; }
+.capture-pair-row label, .capture-selection-grid label, .capture-bootstrap-grid label { color: var(--muted); }
+.capture-pair-row input, .capture-selection-grid select, .capture-copy-row input, .capture-copy-row textarea {
+  width: 100%;
+  min-width: 0;
+  padding: 9px 11px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  outline: none;
+  background: #090d14;
+  color: var(--text);
+}
+.capture-bootstrap {
+  margin-top: 16px;
+  padding: 15px;
+  border: 1px solid rgba(245, 185, 66, .55);
+  border-radius: 11px;
+  background: rgba(245, 185, 66, .08);
+}
+.capture-bootstrap h3 { margin: 0; font-size: 16px; }
+.capture-secret-warning { margin: 7px 0 13px; color: var(--warn); }
+.capture-bootstrap-grid, .capture-selection-grid {
+  display: grid;
+  grid-template-columns: minmax(150px, auto) minmax(0, 1fr);
+  align-items: center;
+  gap: 9px 12px;
+}
+.capture-copy-row textarea { resize: vertical; overflow-wrap: anywhere; }
+.capture-copy-row .button { flex: 0 0 auto; }
+.capture-selection-grid { margin-top: 16px; }
+.capture-facts { display: grid; grid-template-columns: auto 1fr; gap: 6px 14px; margin: 15px 0 0; }
+.capture-facts dt { color: var(--muted); }
+.capture-facts dd { margin: 0; text-align: right; overflow-wrap: anywhere; }
+.capture-actions { flex-wrap: wrap; margin-top: 15px; }
+.capture-status.error { color: var(--bad); }
+.capture-status.success { color: var(--good); }
+.capture-fallback { padding-top: 12px; border-top: 1px solid var(--line); }
+.safety-card { display: flex; align-items: flex-start; gap: 16px; padding: 20px; border-color: rgba(67, 209, 158, .35); }
+.safety-card h2 { margin-bottom: 5px; }
+.safety-card p:last-child { margin: 0; color: var(--muted); }
+.safety-icon { display: grid; flex: 0 0 38px; height: 38px; place-items: center; border-radius: 10px; background: rgba(67, 209, 158, .15); color: var(--good); font-weight: 800; }
+.device-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(340px, 1fr)); gap: 12px; margin-top: 18px; }
+.device-card { display: grid; gap: 13px; padding: 17px; border: 1px solid var(--line); border-radius: 12px; background: var(--surface-2); }
+.device-card.ready { border-color: rgba(67, 209, 158, .45); }
+.device-card.blocked { border-color: rgba(255, 107, 122, .34); }
+.device-card.busy { border-color: rgba(245, 185, 66, .52); }
+.device-card.live-mode {
+  border-color: rgba(255, 107, 122, .78);
+  box-shadow: inset 0 0 0 1px rgba(255, 107, 122, .16);
+}
+.device-card.live-mode .status-badge {
+  background: rgba(255, 107, 122, .17);
+  color: #ffabb4;
+}
+.device-card header { display: flex; align-items: flex-start; justify-content: space-between; gap: 12px; }
+.device-name { margin: 0; font-size: 17px; }
+.device-id { color: var(--muted); font: 12px ui-monospace, SFMono-Regular, Menlo, monospace; word-break: break-all; }
+.status-badge.ready { background: rgba(67, 209, 158, .13); color: var(--good); }
+.status-badge.blocked { background: rgba(255, 107, 122, .13); color: var(--bad); }
+.status-badge.busy { background: rgba(245, 185, 66, .13); color: var(--warn); }
+.device-facts { display: grid; grid-template-columns: auto 1fr; gap: 6px 14px; margin: 0; }
+.device-facts dt { color: var(--muted); }
+.device-facts dd { margin: 0; text-align: right; overflow-wrap: anywhere; }
+.capability-list { display: flex; flex-wrap: wrap; gap: 6px; }
+.capability-list span { padding: 3px 7px; border-radius: 6px; background: #0c111a; color: var(--muted); font-size: 11px; }
+.session-controls { display: flex; flex-wrap: wrap; gap: 8px; padding-top: 12px; border-top: 1px solid var(--line); }
+.control-hint, .paused-warning, .owner-warning { flex-basis: 100%; margin: 2px 0 0; color: var(--muted); font-size: 12px; }
+.control-hint.busy { color: var(--warn); }
+.paused-warning { color: var(--warn); }
+.owner-warning { color: var(--bad); }
+.live-confirmation {
+  flex-basis: 100%;
+  padding: 14px;
+  border: 1px solid rgba(255, 107, 122, .72);
+  border-radius: 10px;
+  background: rgba(255, 107, 122, .11);
+}
+.live-confirmation h4 { margin: 0 0 7px; color: #ffabb4; font-size: 15px; }
+.live-confirmation p { margin: 0 0 12px; color: var(--text); }
+.live-confirmation .button { width: 100%; white-space: normal; }
+.events-panel { padding-top: 12px; border-top: 1px solid var(--line); }
+.events-panel h4 { margin: 0 0 8px; font-size: 13px; }
+.events-empty { margin: 0; color: var(--muted); font-size: 12px; }
+.event-list { display: grid; gap: 6px; max-height: 180px; margin: 0; padding: 0; overflow: auto; list-style: none; }
+.event-list li { display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: 10px; padding: 7px 9px; border-radius: 7px; background: #0c111a; font-size: 11px; }
+.event-main { overflow-wrap: anywhere; color: var(--text); }
+.event-detail { color: var(--muted); text-align: right; }
+.empty { margin: 18px 0 0; }
+
+@media (max-width: 640px) {
+  .teleop-shell { width: min(100% - 20px, 1120px); padding-top: 20px; }
+  .teleop-header { align-items: flex-start; flex-direction: column; }
+  .header-actions { width: 100%; }
+  .header-actions .button { flex: 1; }
+  .login-row { align-items: stretch; flex-direction: column; }
+  .identity-card { align-items: flex-start; }
+  .safety-card { flex-direction: column; }
+  .capture-heading-actions, .capture-copy-row { width: 100%; align-items: stretch; flex-direction: column; }
+  .capture-heading-actions .button, .capture-copy-row .button { width: 100%; }
+  .capture-pair-row, .capture-bootstrap-grid, .capture-selection-grid, .capture-facts { grid-template-columns: 1fr; }
+  .capture-facts dd { margin-bottom: 7px; text-align: left; }
+  .device-grid { grid-template-columns: 1fr; }
+  .device-facts { grid-template-columns: 1fr; gap: 1px; }
+  .device-facts dd { margin-bottom: 7px; text-align: left; }
+  .event-list li { grid-template-columns: 1fr; gap: 2px; }
+  .event-detail { text-align: left; }
+}

--- a/agent-core/web/index.html
+++ b/agent-core/web/index.html
@@ -39,6 +39,7 @@
     </div>
     <button class="mobile-sidebar-toggle" id="mobile-sidebar-toggle" aria-label="工具列表">☰</button>
     <div class="topbar-actions">
+      <a class="btn-ghost topbar-btn topbar-teleop-link" href="/teleop.html">遥操设备</a>
       <div id="update-banner" class="update-banner hidden">
         <span id="update-banner-text"></span>
         <button class="btn-update" id="btn-update">更新</button>

--- a/agent-core/web/js/auth.js
+++ b/agent-core/web/js/auth.js
@@ -21,13 +21,25 @@ export function clearToken() {
 }
 
 export async function verifyToken(token) {
+  const status = await getAuthStatus(token);
+  return status.valid;
+}
+
+/** Return auth status and the authenticated Principal, when present. */
+export async function getAuthStatus(token = getToken()) {
   try {
     const res = await _origFetch('/api/auth/verify', {
       headers: { 'Authorization': `Bearer ${token}` }
     });
-    return res.ok;
+    const data = await res.json().catch(() => ({}));
+    return {
+      valid: res.ok && data.valid !== false,
+      authRequired: Boolean(data.auth_required),
+      principal: data.principal || null,
+      status: res.status,
+    };
   } catch {
-    return false;
+    return { valid: false, authRequired: true, principal: null, status: 0 };
   }
 }
 

--- a/agent-core/web/js/canvas.js
+++ b/agent-core/web/js/canvas.js
@@ -14,6 +14,7 @@
 import { showTopicDetail } from './detail-panel.js';
 import { showToolDetail, isToolConfigured, isInstanceConfigured, openInstanceConfigModal, hasSharedRequired } from './sidebar.js';
 import { toggleMicStream, isMicActive } from './mic-stream.js';
+import { wsUrl as authenticatedWsUrl } from './auth.js';
 
 let _canvasEl   = null;
 let _viewport   = null;
@@ -24,11 +25,14 @@ let _cards      = [];   // [{ id, mcpId, toolName, driverName, x, y, el }]
 let _allMcps    = [];
 
 // ── Editor Lock ──────────────────────────────────────────────────────────────
-let _sessionId = localStorage.getItem('canvas_session_id');
-if (!_sessionId) {
-  _sessionId = 'sess-' + Date.now().toString(36) + Math.random().toString(36).slice(2, 6);
-  localStorage.setItem('canvas_session_id', _sessionId);
-}
+const _CANVAS_SESSION_KEY = 'canvas_session_id';
+// Never reuse a sessionStorage value: duplicated tabs inherit it and would
+// otherwise share editor authority. The stored value is diagnostic only.
+const _sessionId = globalThis.crypto?.randomUUID?.()
+  || ('sess-' + Date.now().toString(36) + Math.random().toString(36).slice(2));
+try {
+  sessionStorage.setItem(_CANVAS_SESSION_KEY, _sessionId);
+} catch { /* document-lifetime identity is sufficient */ }
 let _isEditor = false;
 let _currentEditor = null;  // session_id of current editor (null = no one)
 
@@ -60,6 +64,9 @@ let _draggingConn = null; // {fromCardId, fromPortEl, format, topic, tempPath, t
 
 // Project run state
 let _projectRunning = false;
+let _projectState = 'stopped';
+let _projectTransitioning = false;
+let _layoutRevision = 0;
 
 export function isProjectRunning() { return _projectRunning; }
 export function redrawCanvas() { _redrawConnections(); }
@@ -117,6 +124,9 @@ export async function initCanvas(initialMcps) {
   try {
     const layoutRes = await fetch('/api/canvas/layout');
     const layoutJson = await layoutRes.json();
+    _layoutRevision = Number.isInteger(layoutJson.data?.revision)
+      ? layoutJson.data.revision
+      : 0;
 
     const saved = layoutJson.data?.cards || [];
     for (const c of saved) {
@@ -168,12 +178,10 @@ export async function initCanvas(initialMcps) {
 
   // Restore project running state from backend
   try {
-    const runRes = await fetch('/api/config/project-running');
-    const runData = await runRes.json();
-    if (runData.running) {
-      _projectRunning = true;
-      _syncProjectBtn();
-      document.querySelectorAll('.canvas-exec-btn').forEach(btn => btn.classList.remove('locked'));
+    const runData = await _fetchProjectStateSnapshot();
+    _applyProjectState(runData.running, runData.state);
+    if (runData.state === 'degraded') {
+      _logActivity('error', '项目处于 degraded：部分组件可能仍在运行，请执行停止。');
     }
   } catch { /* ignore */ }
 
@@ -181,28 +189,18 @@ export async function initCanvas(initialMcps) {
   const { onMotusEvent } = await import('./motus-stream.js');
   onMotusEvent(null, (event) => {
     if (event.type === 'project_state') {
-      const running = event.payload?.running;
-      if (running !== _projectRunning) {
-        _projectRunning = running;
-        _syncProjectBtn();
-        document.querySelectorAll('.canvas-exec-btn').forEach(btn => {
-          btn.classList.toggle('locked', !_projectRunning);
-        });
-      }
+      _applyProjectState(event.payload?.running, event.payload?.state);
     }
   });
 
   // Re-sync state when tab becomes visible (fallback for WS disconnect)
   document.addEventListener('visibilitychange', () => {
     if (!document.hidden) {
-      fetch('/api/config/project-running').then(r => r.json()).then(d => {
-        if (d.running !== _projectRunning) {
-          _projectRunning = d.running;
-          _syncProjectBtn();
-          document.querySelectorAll('.canvas-exec-btn').forEach(btn => {
-            btn.classList.toggle('locked', !_projectRunning);
-          });
-        }
+      const refresh = _projectState === 'unknown'
+        ? _reconcileAmbiguousProjectStart()
+        : _fetchProjectStateSnapshot();
+      refresh.then(d => {
+        if (d && !d.transitioning) _applyProjectState(d.running, d.state);
       }).catch(() => {});
     }
   });
@@ -442,7 +440,13 @@ function _setupControlButtons() {
   });
 
   document.getElementById('canvas-project-toggle')?.addEventListener('click', () => {
-    _projectRunning ? _stopProject() : _startProject();
+    if (_projectRunning) {
+      _stopProject();
+    } else if (!_isEditor) {
+      _showToast('请先获取画布编辑权，再启动当前所见布局');
+    } else {
+      _startProject();
+    }
   });
   _syncProjectBtn();
 
@@ -1518,8 +1522,28 @@ function _autoStopOnDisconnect(cardId, portIdx, topic) {
 }
 
 async function _startProject() {
-  // Save canvas layout first (so backend reads latest topology)
-  await _saveLayout();
+  if (_projectTransitioning) return;
+  if (!_isEditor) {
+    _showToast('请先获取画布编辑权，再启动当前所见布局');
+    return;
+  }
+  _projectTransitioning = true;
+  _syncProjectBtn();
+  try {
+    await _startProjectOnce();
+  } catch (error) {
+    _logActivity('error', `启动失败: ${error.message}`);
+  } finally {
+    _projectTransitioning = false;
+    _syncProjectBtn();
+  }
+}
+
+async function _startProjectOnce() {
+  // An editor must receive an explicit save acknowledgement before any start
+  // side effect. Otherwise the backend could start an older, invisible layout.
+  if (!_isEditor) throw new Error('请先获取画布编辑权');
+  await _saveLayout({ strict: true });
 
   // Import motus for event subscription
   const { onMotusEvent, offMotusEvent } = await import('./motus-stream.js');
@@ -1553,46 +1577,111 @@ async function _startProject() {
 
   // 立即启动浏览器麦克风（与 API 调用并行，解决 self-check 时序问题）
   const remoteMicCard = _cards.find(c => c.toolName === 'remote_mic');
-  if (remoteMicCard && !isMicActive()) {
-    const wsProto = location.protocol === 'https:' ? 'wss' : 'ws';
-    const wsUrl = `${wsProto}://${location.host}/ws/mic`;
-    toggleMicStream(wsUrl, (active) => {
+  const micWasActive = isMicActive();
+  let micStartPromise = null;
+  if (remoteMicCard && !micWasActive) {
+    micStartPromise = toggleMicStream(authenticatedWsUrl('/ws/mic'), (active) => {
       const micBtn = remoteMicCard.el?.querySelector('.canvas-mic-btn');
       if (micBtn) {
         micBtn.textContent = active ? '\u23F9 停止录音' : '\uD83C\uDF99 开始录音';
         micBtn.classList.toggle('recording', active);
       }
-    }).catch(err => _logActivity('warn', `麦克风启动失败: ${err.message}`));
+    });
+    micStartPromise.catch(err => _logActivity('warn', `麦克风启动失败: ${err.message}`));
   }
 
   // Call unified backend start-project
   try {
-    const res = await fetch('/api/config/start-project', { method: 'POST' });
+    const res = await fetch('/api/config/start-project', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        session_id: _sessionId,
+        layout_revision: _layoutRevision,
+      }),
+    });
     if (res.ok) {
-      _projectRunning = true;
-      _syncProjectBtn();
-      document.querySelectorAll('.canvas-exec-btn').forEach(btn => btn.classList.remove('locked'));
+      _applyProjectState(true, 'running');
       _logActivity('project', '智能控制已开启');
     } else {
       const data = await res.json().catch(() => ({}));
-      _logActivity('error', `启动失败: ${data.detail || res.status}`);
+      const detail = data.detail;
+      const message = detail?.code === 'teleop_command_blocked'
+        ? '遥操会话正在占用该机器人，智能控制启动已被阻止'
+        : (typeof detail === 'string' ? detail : detail?.code || res.status);
+      if (detail?.project_state === 'degraded') {
+        _applyProjectState(true, 'degraded');
+      }
+      if (detail?.rollback_incomplete) {
+        _logActivity('error', `启动回滚不完整：${(detail.rollback_errors || []).join(', ') || '仍有组件可能运行'}`);
+      }
+      _logActivity('error', `启动失败: ${message}`);
+      await _cleanupMicAfterFailedStart(remoteMicCard, micWasActive, micStartPromise);
       offMotusEvent(_onEvent);
       if (modal) {
         _showStartupError(modal);
       }
     }
   } catch (e) {
-    _logActivity('error', `启动失败: ${e.message}`);
     offMotusEvent(_onEvent);
     if (modal) modal.close();
+
+    // The request may have reached Core even when the browser did not receive
+    // the HTTP response. Reconcile before deciding what the Start button means.
+    const snapshot = await _reconcileAmbiguousProjectStart();
+    if (snapshot) {
+      _applyProjectState(snapshot.running, snapshot.state);
+      if (!snapshot.running || snapshot.state === 'degraded') {
+        await _cleanupMicAfterFailedStart(remoteMicCard, micWasActive, micStartPromise);
+      }
+      if (snapshot.state === 'running') {
+        _logActivity('warn', '启动响应中断，但已从 Core 确认智能控制正在运行');
+      } else if (snapshot.state === 'degraded') {
+        _logActivity('error', '启动响应中断，Core 报告仍有残留控制，请执行停止');
+      } else {
+        _logActivity('error', `启动失败: ${e.message}（Core 已确认未运行）`);
+      }
+    } else {
+      // Unknown is deliberately represented as running=true: the next click
+      // can only issue Stop, never a second Start against uncertain hardware.
+      _applyProjectState(true, 'unknown');
+      await _cleanupMicAfterFailedStart(remoteMicCard, micWasActive, micStartPromise);
+      _logActivity('error', `启动响应中断且无法确认状态: ${e.message}；请尝试停止控制`);
+    }
   }
 }
 
-function _stopProject() {
-  _projectRunning = false;
+async function _stopProject() {
+  if (_projectTransitioning) return;
+  _projectTransitioning = true;
   _syncProjectBtn();
-  document.querySelectorAll('.canvas-exec-btn').forEach(btn => btn.classList.add('locked'));
-  // Auto-stop mic stream
+  try {
+    await _stopProjectOnce();
+  } finally {
+    _projectTransitioning = false;
+    _syncProjectBtn();
+  }
+}
+
+async function _stopProjectOnce() {
+  try {
+    const res = await fetch('/api/config/stop-project', { method: 'POST' });
+    if (!res.ok) {
+      const data = await res.json().catch(() => ({}));
+      const detail = data.detail;
+      const message = detail?.code === 'teleop_command_blocked'
+        ? '遥操会话正在占用该机器人，智能控制停止命令未执行'
+        : (typeof detail === 'string' ? detail : detail?.code || res.status);
+      _logActivity('error', `停止失败: ${message}`);
+      return;
+    }
+  } catch (error) {
+    _logActivity('error', `停止失败: ${error.message}`);
+    return;
+  }
+
+  _applyProjectState(false, 'stopped');
+  // Auto-stop mic stream only after the backend confirms project shutdown.
   for (const card of _cards) {
     if (card.toolName === 'remote_mic' && isMicActive()) {
       toggleMicStream('', () => {}).catch(() => {});
@@ -1603,16 +1692,88 @@ function _stopProject() {
       }
     }
   }
-  fetch('/api/config/stop-project', { method: 'POST' }).catch(() => {});
   _logActivity('project', '智能控制已停止');
+}
+
+async function _cleanupMicAfterFailedStart(remoteMicCard, micWasActive, micStartPromise) {
+  if (micStartPromise) await micStartPromise.catch(() => {});
+  if (!micWasActive && isMicActive()) {
+    await toggleMicStream('', () => {}).catch(() => {});
+  }
+  const micBtn = remoteMicCard?.el?.querySelector('.canvas-mic-btn');
+  if (micBtn && !isMicActive()) {
+    micBtn.textContent = '\uD83C\uDF99 开始录音';
+    micBtn.classList.remove('recording');
+  }
+}
+
+async function _fetchProjectStateSnapshot() {
+  const response = await fetch('/api/config/project-running', { cache: 'no-store' });
+  if (!response.ok) throw new Error(`HTTP ${response.status}`);
+  const snapshot = await response.json();
+  const validState = snapshot?.state === 'stopped'
+    || snapshot?.state === 'running'
+    || snapshot?.state === 'degraded';
+  const stateMatchesRunning = snapshot?.running === (snapshot?.state !== 'stopped');
+  if (
+    typeof snapshot?.running !== 'boolean'
+    || typeof snapshot?.transitioning !== 'boolean'
+    || !validState
+    || !stateMatchesRunning
+  ) {
+    throw new Error('Core returned an invalid project state');
+  }
+  return snapshot;
+}
+
+async function _reconcileAmbiguousProjectStart() {
+  const deadline = Date.now() + 8000;
+  let observedTransition = false;
+  while (Date.now() < deadline) {
+    try {
+      const snapshot = await _fetchProjectStateSnapshot();
+      observedTransition = observedTransition || snapshot.transitioning;
+      if (!snapshot.transitioning) {
+        // A running/degraded state proves that a start reached Core. A stopped
+        // state is authoritative only after this client observed the matching
+        // transition; otherwise a delayed POST could still arrive after GET.
+        if (snapshot.running || observedTransition) return snapshot;
+      }
+    } catch { /* retry until the safety deadline */ }
+    await new Promise(resolve => setTimeout(resolve, 250));
+  }
+  return null;
+}
+
+function _applyProjectState(running, state) {
+  _projectRunning = Boolean(running);
+  _projectState = state || (_projectRunning ? 'running' : 'stopped');
+  _syncProjectBtn();
+  document.querySelectorAll('.canvas-exec-btn').forEach(btn => {
+    btn.classList.toggle('locked', _projectState !== 'running');
+  });
 }
 
 function _syncProjectBtn() {
   const btn = document.getElementById('canvas-project-toggle');
   if (!btn) return;
-  btn.textContent = _projectRunning ? '停止智能控制' : '开启智能控制';
-  btn.title = _projectRunning ? '停止智能控制' : '开启智能控制';
+  btn.textContent = _projectTransitioning
+    ? '处理中…'
+    : (_projectState === 'unknown'
+      ? '状态未知—尝试停止'
+      : (_projectState === 'degraded'
+      ? '停止残留控制'
+      : (_projectRunning ? '停止智能控制' : '开启智能控制')));
+  btn.title = _projectTransitioning
+    ? '项目状态切换中'
+    : (_projectState === 'unknown'
+      ? 'Core 状态未知；只允许尝试停止'
+      : (_projectRunning
+        ? '停止智能控制'
+        : (_isEditor ? '开启当前所见布局' : '请先获取画布编辑权')));
+  btn.disabled = _projectTransitioning || (!_projectRunning && !_isEditor);
   btn.classList.toggle('running', _projectRunning);
+  btn.classList.toggle('degraded', _projectState === 'degraded' || _projectState === 'unknown');
 }
 
 function _initAutoStartToggle() {
@@ -1997,8 +2158,8 @@ function _debouncedSave() {
   _saveTimer = setTimeout(_saveLayout, 400);
 }
 
-async function _saveLayout() {
-  if (!_isEditor) return;  // Only editor can save
+async function _saveLayout({ strict = false } = {}) {
+  if (!_isEditor) return true;  // Only editor can save
   const cards = _cards.map(c => ({
     id:         c.id,
     mcpId:      c.mcpId,
@@ -2013,15 +2174,29 @@ async function _saveLayout() {
     const resp = await fetch('/api/canvas/layout', {
       method:  'POST',
       headers: { 'Content-Type': 'application/json' },
-      body:    JSON.stringify({ cards, connections: _connections, execConnections: _execConnections, transform: { zoom: _zoom, tx: _tx, ty: _ty }, session_id: _sessionId }),
+      body:    JSON.stringify({ cards, connections: _connections, execConnections: _execConnections, transform: { zoom: _zoom, tx: _tx, ty: _ty }, session_id: _sessionId, revision: _layoutRevision }),
     });
+    const result = await resp.json().catch(() => null);
     if (resp.status === 403) {
       // Lost edit permission — reload layout from server
       _isEditor = false;
       _updateEditorUI();
       await _reloadLayout();
     }
-  } catch { /* silent */ }
+    if (!resp.ok || result?.code !== 200) {
+      const reason = result?.detail?.code || result?.message || `HTTP ${resp.status}`;
+      throw new Error(`画布保存未确认：${reason}`);
+    }
+    const savedRevision = result?.data?.revision;
+    if (!Number.isInteger(savedRevision) || savedRevision <= _layoutRevision) {
+      throw new Error('画布保存未返回有效 revision');
+    }
+    _layoutRevision = savedRevision;
+    return true;
+  } catch (error) {
+    if (strict) throw error;
+    return false;
+  }
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -2064,6 +2239,7 @@ function _updateEditorUI() {
     bar.querySelector('#canvas-claim-btn').onclick = _claimEdit;
     _setCanvasReadonly(true);
   }
+  _syncProjectBtn();
 }
 
 function _setCanvasReadonly(readonly) {
@@ -2082,8 +2258,16 @@ async function _claimEdit() {
     });
     const data = await resp.json();
     if (resp.ok) {
-      _isEditor = true;
       _currentEditor = _sessionId;
+      _isEditor = false;
+      if (!await _reloadLayout()) {
+        await fetch('/api/canvas/release-edit', {
+          method: 'POST', headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ session_id: _sessionId }),
+        }).catch(() => {});
+        _currentEditor = null;
+        _showToast('无法刷新最新画布，编辑权已释放');
+      }
     } else {
       _currentEditor = data.editor || null;
     }
@@ -2124,6 +2308,10 @@ async function _reloadLayout() {
   try {
     const layoutRes = await fetch('/api/canvas/layout');
     const layoutJson = await layoutRes.json();
+    if (!layoutRes.ok || layoutJson?.code !== 200) return false;
+    _layoutRevision = Number.isInteger(layoutJson.data?.revision)
+      ? layoutJson.data.revision
+      : 0;
     // Clear current cards
     for (const c of _cards) c.el.remove();
     _cards = [];
@@ -2140,15 +2328,22 @@ async function _reloadLayout() {
     _syncEmptyState();
     // Update editor info
     _currentEditor = layoutJson.editor || null;
-    if (_currentEditor === _sessionId) _isEditor = true;
+    _isEditor = _currentEditor === _sessionId;
     _updateEditorUI();
-  } catch { /* silent */ }
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 // Release on page close
 window.addEventListener('beforeunload', () => {
   if (_isEditor) {
-    navigator.sendBeacon('/api/canvas/release-edit', JSON.stringify({ session_id: _sessionId }));
+    const payload = new Blob(
+      [JSON.stringify({ session_id: _sessionId })],
+      { type: 'application/json' },
+    );
+    navigator.sendBeacon('/api/canvas/release-edit', payload);
   }
 });
 

--- a/agent-core/web/js/dashboard.js
+++ b/agent-core/web/js/dashboard.js
@@ -10,6 +10,7 @@ import { VideoRenderer }    from './renderers/video.js';
 import { ImageRenderer }    from './renderers/image.js';
 import { AudioRenderer }    from './renderers/audio.js';
 import { LidarRenderer }    from './renderers/lidar.js';
+import { wsUrl as authenticatedWsUrl } from './auth.js';
 
 const RENDERERS = [VideoRenderer, ImageRenderer, AudioRenderer, LidarRenderer, TextRenderer, ActivityRenderer];
 
@@ -34,9 +35,11 @@ class SkillBuffer {
   _connect() {
     const ws = new WebSocket(this._wsUrl);
     ws.binaryType = 'arraybuffer';
-    ws.onopen  = () => console.log('[preview ws] open', this._wsUrl);
+    // Never log the full WebSocket URL: it carries the owner token in its
+    // query string until the WS authentication protocol is migrated.
+    ws.onopen  = () => console.log('[preview ws] open');
     ws.onclose = (e) => {
-      console.log('[preview ws] closed', e.code, this._wsUrl);
+      console.log('[preview ws] closed', e.code);
       if (this._ws === ws) {
         this._ws = null;
         // Reconnect after 3 s if not destroyed
@@ -155,8 +158,6 @@ async function loadSkills() {
       renderSkillList();
       // Spin up background preview buffers for this skill
       _startPreviewBuffers(skill);
-      // Auto-start if global state is running
-      if (_globalRunning && skill.online) _callToolForSkill(skill, 'start');
     } catch {
       skill.online = false;
       renderSkillList();
@@ -202,34 +203,111 @@ function selectSkill(id) {
 // ── Global Start / Stop ───────────────────────────────────────────────────────
 
 async function _callToolForSkill(skill, actionName) {
-  const tools = skill.tools || [];
-  for (const tool of tools) {
+  const tools = (skill.tools || []).map(tool => (
+    typeof tool === 'string' ? tool : tool?.name
+  )).filter(Boolean);
+  const completedTools = [];
+  for (const toolName of tools) {
     const args = { action: actionName };
     if (actionName === 'start' && skill.topic_in?.[0]?.topic) {
       const t = skill.topic_in[0].topic;
       args.input_topic = t;
       args.topic       = t;
     }
-    console.log(`[ctrl] ${tool} ${skill.id} action=${actionName} args=${JSON.stringify(args)}`);
+    console.log(`[ctrl] ${toolName} ${skill.id} action=${actionName} args=${JSON.stringify(args)}`);
     try {
       const resp = await fetch(`/api/mcp/${encodeURIComponent(skill.id)}/call`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ tool, arguments: args }),
+        body: JSON.stringify({ tool: toolName, arguments: args }),
       });
-      const j = await resp.json();
-      console.log(`[ctrl] ${tool} ${skill.id} →`, JSON.stringify(j).slice(0, 200));
+      const j = await resp.json().catch(() => ({}));
+      console.log(`[ctrl] ${toolName} ${skill.id} →`, JSON.stringify(j).slice(0, 200));
+      if (!resp.ok || j.code !== 200) {
+        const detail = j.detail;
+        const reason = detail?.code === 'teleop_command_blocked'
+          ? '遥操会话正在占用机器人'
+          : (typeof detail === 'string'
+            ? detail
+            : detail?.code || j.message || j.code || `HTTP ${resp.status}`);
+        const rollback = [];
+        if (actionName === 'start') {
+          for (const startedTool of [...completedTools].reverse()) {
+            rollback.push(await _callNamedTool(skill, startedTool, 'stop'));
+          }
+        }
+        return {
+          ok: false,
+          skill,
+          reason,
+          completedTools,
+          rollbackOk: rollback.every(result => result.ok),
+        };
+      }
+      completedTools.push(toolName);
     } catch (e) {
-      console.error(`[ctrl] ${tool} ${skill.id} failed:`, e);
+      console.error(`[ctrl] ${toolName} ${skill.id} failed:`, e);
+      const rollback = [];
+      if (actionName === 'start') {
+        for (const startedTool of [...completedTools].reverse()) {
+          rollback.push(await _callNamedTool(skill, startedTool, 'stop'));
+        }
+      }
+      return {
+        ok: false,
+        skill,
+        reason: e.message,
+        completedTools,
+        rollbackOk: rollback.every(result => result.ok),
+      };
     }
+  }
+  return { ok: true, skill, completedTools, rollbackOk: true };
+}
+
+async function _callNamedTool(skill, toolName, actionName) {
+  const args = { action: actionName };
+  if (actionName === 'start' && skill.topic_in?.[0]?.topic) {
+    const topic = skill.topic_in[0].topic;
+    args.input_topic = topic;
+    args.topic = topic;
+  }
+  try {
+    const resp = await fetch(`/api/mcp/${encodeURIComponent(skill.id)}/call`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ tool: toolName, arguments: args }),
+    });
+    const body = await resp.json().catch(() => ({}));
+    return { ok: resp.ok && body.code === 200, toolName };
+  } catch {
+    return { ok: false, toolName };
   }
 }
 
 async function globalStart() {
+  const results = await Promise.all(
+    _skills.filter(s => s.online).map(s => _callToolForSkill(s, 'start')),
+  );
+  const failed = results.find(result => !result.ok);
+  if (failed) {
+    const rollback = await Promise.all(results.filter(result => result.ok).map(async (result) => {
+      const stopped = [];
+      for (const toolName of [...result.completedTools].reverse()) {
+        stopped.push(await _callNamedTool(result.skill, toolName, 'stop'));
+      }
+      return stopped.every(item => item.ok);
+    }));
+    const rollbackOk = (
+      results.filter(result => !result.ok).every(result => result.rollbackOk !== false)
+      && rollback.every(Boolean)
+    );
+    window.alert(`启动失败：${failed.reason}${rollbackOk ? '' : '；部分工具回滚失败'}`);
+    return;
+  }
   _globalRunning = true;
   localStorage.setItem('motus_global_running', '1');
   updateGlobalCtrlUI();
-  await Promise.all(_skills.filter(s => s.online).map(s => _callToolForSkill(s, 'start')));
   // Re-select the active skill to re-attach the renderer after start.
   // Without this, Stop → Start All leaves the renderer detached (no waveform).
   const targetId = _activeSkillId || _skills.find(s => s.online)?.id;
@@ -237,12 +315,19 @@ async function globalStart() {
 }
 
 async function globalStop() {
+  const results = await Promise.all(
+    _skills.filter(s => s.online).map(s => _callToolForSkill(s, 'stop')),
+  );
+  const failed = results.find(result => !result.ok);
+  if (failed) {
+    window.alert(`停止失败：${failed.reason}`);
+    return;
+  }
   _globalRunning = false;
   localStorage.removeItem('motus_global_running');
   updateGlobalCtrlUI();
   _activeRenderer?.stopPlayback?.();
   _inRenderer?.stopPlayback?.();
-  await Promise.all(_skills.filter(s => s.online).map(s => _callToolForSkill(s, 'stop')));
 }
 
 function updateGlobalCtrlUI() {
@@ -253,9 +338,15 @@ function updateGlobalCtrlUI() {
 }
 
 function setupGlobalCtrl() {
-  _globalRunning = localStorage.getItem('motus_global_running') === '1';
   const startBtn = document.getElementById('btn-global-start');
   const stopBtn  = document.getElementById('btn-global-stop');
+  if (!startBtn && !stopBtn) {
+    _globalRunning = false;
+    localStorage.removeItem('motus_global_running');
+    return;
+  }
+  _globalRunning = false;
+  localStorage.removeItem('motus_global_running');
   if (startBtn) startBtn.onclick = globalStart;
   if (stopBtn)  stopBtn.onclick  = globalStop;
   updateGlobalCtrlUI();
@@ -265,8 +356,7 @@ function setupGlobalCtrl() {
 
 function _wsUrlFor(path) {
   if (!path) return null;
-  const proto = location.protocol === 'https:' ? 'wss' : 'ws';
-  return `${proto}://${location.host}${path}`;
+  return authenticatedWsUrl(path);
 }
 
 function _startPreviewBuffers(skill) {

--- a/agent-core/web/js/detail-panel.js
+++ b/agent-core/web/js/detail-panel.js
@@ -16,6 +16,7 @@ import { SkeletonRenderer } from './renderers/skeleton.js';
 import { CameraRenderer, DepthRenderer } from './renderers/camera.js';
 import { HTMSGRenderer }    from './renderers/htmsg.js';
 import { openDetailPanelMobile, closeDetailPanelMobile } from './mobile.js';
+import { wsUrl as authenticatedWsUrl } from './auth.js';
 
 const RENDERERS = [VideoRenderer, CameraRenderer, DepthRenderer, ImageRenderer, AudioRenderer, LidarRenderer, HTMSGRenderer, SkeletonRenderer, TextRenderer, ActivityRenderer];
 
@@ -46,10 +47,7 @@ export function showTopicDetail(topicPath, format) {
   _renderer.mount(body, 'detail');
 
   // Connect WebSocket — /ws/bus/* is proxied through agent-core
-  const proto = location.protocol === 'https:' ? 'wss' : 'ws';
-  const wsHost = location.host;
-  const wsUrl = `${proto}://${wsHost}/ws/bus${topicPath}`;
-  _ws = new WebSocket(wsUrl);
+  _ws = new WebSocket(authenticatedWsUrl(`/ws/bus${topicPath}`));
   _ws.binaryType = 'arraybuffer';
   _ws.onmessage = (ev) => {
     if (ev.data instanceof ArrayBuffer) {

--- a/agent-core/web/js/monitor-dashboard.js
+++ b/agent-core/web/js/monitor-dashboard.js
@@ -16,6 +16,7 @@ import { SkeletonRenderer } from './renderers/skeleton.js';
 import { KvLatestRenderer } from './renderers/kv-latest.js';
 import { CameraRenderer, DepthRenderer } from './renderers/camera.js';
 import { HTMSGRenderer }    from './renderers/htmsg.js';
+import { wsUrl as authenticatedWsUrl } from './auth.js';
 
 const RENDERERS = [VideoRenderer, CameraRenderer, DepthRenderer, ImageRenderer, AudioRenderer, PointCloudRenderer, MappingRenderer, LidarRenderer, HTMSGRenderer, SkeletonRenderer, TextRenderer, ActivityRenderer];
 const STORAGE_KEY = 'monitor-dashboard-layout-v2';
@@ -238,8 +239,7 @@ function _applyPlacement(el, col, row, colSpan, rowSpan) {
 }
 
 function _connectWs(topicPath, format, renderer) {
-  const proto = location.protocol === 'https:' ? 'wss' : 'ws';
-  const wsUrl = `${proto}://${location.host}/ws/bus${topicPath}`;
+  const wsUrl = authenticatedWsUrl(`/ws/bus${topicPath}`);
 
   function create() {
     const ws = new WebSocket(wsUrl);

--- a/agent-core/web/js/sidebar.js
+++ b/agent-core/web/js/sidebar.js
@@ -670,14 +670,31 @@ function _openToolConfigModal(mcpId, toolName, configSchema) {
     });
 
     // Save to per-tool API
+    let saveResult = null;
     try {
       const resp = await fetch(`/api/canvas/tool-config/${encodeURIComponent(mcpId)}/${encodeURIComponent(toolName)}`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(values),
       });
+      saveResult = await resp.json().catch(() => null);
+      if (saveResult?.data?.saved) {
+        _toolConfigs[configKey] = values;
+      }
       if (!resp.ok) {
-        alert(`配置保存失败 (HTTP ${resp.status})`);
+        if (saveResult?.data?.saved) {
+          const card = _scroll.querySelector(`.sidebar-tool-card[data-mcp-id="${mcpId}"][data-tool-name="${toolName}"]`);
+          const statusEl = card?.querySelector('.tool-card-config-status');
+          if (statusEl) {
+            statusEl.className = 'tool-card-config-status configured';
+            statusEl.textContent = '⚠';
+            statusEl.title = 'Saved in Core; Driver apply failed';
+          }
+        }
+        const message = saveResult?.data?.saved
+          ? '配置已保存到 Core，但 Driver 应用失败；请检查 Driver 状态后重试。'
+          : `配置保存失败 (HTTP ${resp.status})`;
+        alert(message);
         return;
       }
     } catch (err) {
@@ -696,8 +713,14 @@ function _openToolConfigModal(mcpId, toolName, configSchema) {
       if (statusEl) {
         statusEl.className = 'tool-card-config-status configured';
         statusEl.textContent = '✓';
-        statusEl.title = 'Configured';
+        statusEl.title = saveResult?.data?.deferred
+          ? 'Saved locally; apply deferred while teleoperation is active'
+          : 'Configured';
       }
+    }
+
+    if (saveResult?.data?.deferred) {
+      alert('配置已保存到 Core；当前遥操会话占用机器人，尚未下发到 Driver。');
     }
 
     close();
@@ -956,14 +979,22 @@ export function openInstanceConfigModal(mcpId, toolName, instanceId, configSchem
       else values[input.dataset.key] = v;
     });
 
+    let saveResult = null;
     try {
       const resp = await fetch(`/api/canvas/tool-config/${encodeURIComponent(mcpId)}/${encodeURIComponent(toolName)}/${encodeURIComponent(instanceId)}`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(values),
       });
+      saveResult = await resp.json().catch(() => null);
+      if (saveResult?.data?.saved) {
+        _toolConfigs[configKey] = values;
+      }
       if (!resp.ok) {
-        alert(`配置保存失败 (HTTP ${resp.status})`);
+        const message = saveResult?.data?.saved
+          ? '实例配置已保存到 Core，但 Driver 应用失败；请检查 Driver 状态后重试。'
+          : `配置保存失败 (HTTP ${resp.status})`;
+        alert(message);
         return;
       }
     } catch (err) {
@@ -973,6 +1004,9 @@ export function openInstanceConfigModal(mcpId, toolName, instanceId, configSchem
     }
 
     _toolConfigs[configKey] = values;
+    if (saveResult?.data?.deferred) {
+      alert('实例配置已保存到 Core；当前遥操会话占用机器人，尚未下发到 Driver。');
+    }
     close();
   };
 

--- a/agent-core/web/js/teleop/app.js
+++ b/agent-core/web/js/teleop/app.js
@@ -1,0 +1,2678 @@
+import { clearToken, getAuthStatus, getToken, setToken } from '../auth.js';
+import {
+  buildRtcFrameV1,
+  createRtcFrameState,
+  isDualSqueezeDeadmanRequested,
+  markRtcFrameDeadmanReleased,
+} from './webxr-frame.js';
+import {
+  captureAssignmentForSession,
+  captureAttachEligibility,
+  captureBootstrapFields,
+} from './capture-console.js';
+
+const notice = document.getElementById('global-notice');
+const loginPanel = document.getElementById('login-panel');
+const loginForm = document.getElementById('login-form');
+const loginError = document.getElementById('login-error');
+const tokenInput = document.getElementById('token-input');
+const content = document.getElementById('content');
+const logoutButton = document.getElementById('logout-button');
+const refreshButton = document.getElementById('refresh-button');
+const webxrSupportElement = document.getElementById('webxr-support');
+const capturePanel = document.getElementById('capture-panel');
+const captureRefreshButton = document.getElementById('capture-refresh-button');
+const capturePairButton = document.getElementById('capture-pair-button');
+const captureLabelInput = document.getElementById('capture-label');
+const captureBootstrap = document.getElementById('capture-bootstrap');
+const captureWssUrl = document.getElementById('capture-wss-url');
+const capturePairingId = document.getElementById('capture-pairing-id');
+const capturePairingCode = document.getElementById('capture-pairing-code');
+const captureCaBase64 = document.getElementById('capture-ca-base64');
+const capturePairingExpiry = document.getElementById('capture-pairing-expiry');
+const captureDeviceSelect = document.getElementById('capture-device-select');
+const captureSessionSelect = document.getElementById('capture-session-select');
+const captureDeviceFacts = document.getElementById('capture-device-facts');
+const captureAttachButton = document.getElementById('capture-attach-button');
+const captureRevokeButton = document.getElementById('capture-revoke-button');
+const captureStatus = document.getElementById('capture-status');
+
+const STATUS_POLL_MS = 1000;
+const SLOW_POLL_MS = 5000;
+const CORE_HEARTBEAT_MS = 5000;
+// Must finish before the next 5s ownership heartbeat opportunity.
+const REQUEST_TIMEOUT_MS = 4000;
+const RTC_SIGNAL_TIMEOUT_MS = 12000;
+const RTC_ICE_GATHER_TIMEOUT_MS = 5000;
+const RTC_PEER_PING_MS = 1000;
+const RTC_PEER_PING_TIMEOUT_MS = 5000;
+const RTC_RTT_SAMPLE_LIMIT = 256;
+const LOGOUT_RELEASE_WAIT_MS = 1500;
+const XR_NORMAL_SEND_HZ = 60;
+const XR_SEND_INTERVAL_MS = 1000 / XR_NORMAL_SEND_HZ;
+const XR_UI_REFRESH_MS = 250;
+const POSE_MESSAGE_LIMIT_BYTES = 64 * 1024;
+const POSE_BUFFER_HIGH_WATER_BYTES = 16 * 1024;
+const CLIENT_ID_KEY = 'motus.teleop.client-id.v1';
+const CANONICAL_UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+const RELEASABLE_SESSION_STATES = new Set([
+  'awaiting_confirmation', 'preparing', 'active', 'paused', 'hold',
+]);
+const TERMINAL_STATES = new Set(['released', 'expired', 'faulted']);
+const RECOVERABLE_DRIVER_HOLD_REASONS = new Set([
+  'command_timeout',
+  'deadman_released',
+  'intent_expired',
+  'pose_timeout',
+  'rtc_closed',
+  'rtc_disconnected',
+  'rtc_failed',
+  'rtc_not_ready',
+  'tracking_lost',
+]);
+
+function generateClientId() {
+  if (typeof crypto.randomUUID === 'function') return crypto.randomUUID().toLowerCase();
+  const bytes = crypto.getRandomValues(new Uint8Array(16));
+  bytes[6] = (bytes[6] & 0x0f) | 0x40;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+  const hex = Array.from(bytes, (value) => value.toString(16).padStart(2, '0')).join('');
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}
+
+function tabClientId() {
+  // Browsers may clone sessionStorage into a tab opened by an opener or by
+  // "Duplicate tab". Never read or reuse that inherited value: rotate before
+  // the first API call so two live documents cannot share browser authority.
+  const generated = generateClientId();
+  if (!CANONICAL_UUID.test(generated)) throw new Error('client UUID generation failed');
+  try {
+    sessionStorage.setItem(CLIENT_ID_KEY, generated);
+  } catch {
+    // A privacy-restricted browser still receives a document-lifetime ID.
+  }
+  return generated;
+}
+
+const TELEOP_CLIENT_ID = tabClientId();
+
+let principal = null;
+let robots = [];
+let statusTimer = null;
+let slowTimer = null;
+let heartbeatTimer = null;
+let requestGeneration = 0;
+let directoryInFlight = false;
+let statusInFlight = false;
+let eventsInFlight = false;
+let heartbeatInFlight = false;
+let actionInFlight = false;
+let captureListInFlight = false;
+let captureActionInFlight = false;
+let captures = [];
+let capturePairing = null;
+let selectedCaptureId = '';
+let selectedCaptureSessionId = '';
+let captureStatusMessage = '尚未读取采集设备。';
+let captureStatusKind = '';
+let peerPingSequence = 0;
+const activeControllers = new Set();
+const sessionViews = new Map();
+const lastSessionByRobot = new Map();
+const sessionEvents = new Map();
+const pendingRobots = new Set();
+const browserHeartbeatFailures = new Map();
+const rtcViews = new Map();
+const rtcInFlight = new Set();
+const rtcFrameStates = new Map();
+const xrSessions = new Map();
+const xrSessionStats = new Map();
+
+const webxrSupport = {
+  secureContext: window.isSecureContext === true,
+  apiAvailable: Boolean(navigator.xr),
+  immersiveVr: 'checking',
+  detail: '正在检测 immersive-vr 与 local-floor…',
+};
+
+const REASON_TEXT = {
+  ready: '可信且声明遥操能力',
+  driver_registration_not_trusted: '注册未受信任，禁止遥操',
+  teleop_session_not_declared: '未显式声明 x-teleop',
+  teleop_descriptor_invalid: 'x-teleop 描述不符合通用遥操协议',
+  driver_transport_invalid: 'Driver 不是安全且受支持的 HTTP 传输目标',
+  driver_runtime_not_trusted: 'Driver 运行时注册尚未通过可信校验',
+  driver_runtime_target_mismatch: 'Driver 运行时目标或遥操能力指纹与配置不一致',
+  driver_offline: 'Driver 当前离线',
+  authority_recovery_required: 'Core 重启后仍保持写入锁定，等待 owner 验证 Driver 已安全停止',
+};
+
+const ERROR_TEXT = {
+  network_error: '网络连接失败；不会自动获取新会话。',
+  request_timeout: '请求超时；控制台不会自动重试控制操作。',
+  request_cancelled: '请求已取消。',
+  teleop_client_required: 'Core 未识别本标签页客户端身份。',
+  robot_busy: '机器人已被其他会话占用。',
+  session_forbidden: '你无权操作这个会话。',
+  session_client_mismatch: '该会话属于另一个浏览器标签页。',
+  session_state_conflict: '当前会话状态不允许执行该操作。',
+  session_not_found: '会话不存在或已不再占用机器人。',
+  session_released: '会话已经释放。',
+  session_expired: '浏览器到 Core 的租约已过期。',
+  session_faulted: '会话因 Driver 或协议故障终止。',
+  session_prepare_stale: '会话准备结果已过期，请重新获取。',
+  driver_not_found: '没有找到对应的 Driver。',
+  driver_not_ready: 'Driver 尚未满足可信遥操条件。',
+  teleop_mode_unavailable: 'Driver 没有提供所选 Shadow/Live 模式。',
+  live_confirmation_mismatch: 'Live 确认与当前会话、标签页或能力配置不一致。',
+  driver_authority_busy: 'Driver 已持有另一份控制权。',
+  robot_recovery_required: '机器人仍处于 Core 重启安全恢复锁定中。',
+  authority_guard_not_found: '这台机器人没有待恢复的安全锁。',
+  authority_guard_target_changed: 'Driver 目标或能力已变化；安全锁保持，禁止自动解除。',
+  authority_guard_not_safe: 'Driver 尚未提供严格的安全停机证明；安全锁保持。',
+  authority_guard_persistence_error: 'Core 无法可靠更新恢复锁；普通写入继续保持锁定。',
+  driver_command_busy: 'Driver 仍有普通控制命令在执行；遥操未获取控制权。',
+  driver_response_invalid: 'Driver 返回了不符合协议的状态。',
+  driver_lease_unsafe: 'Driver 租约不在安全范围内。',
+  driver_epoch_exhausted: 'Driver 防重放 epoch 已耗尽；Core 已拒绝创建新会话。',
+  driver_identity_changed: 'Driver 身份或启动实例已经变化。',
+  driver_prepare_rejected: 'Driver 拒绝准备遥操会话。',
+  driver_session_lost: 'Core 已失去 Driver 会话，当前会话已故障终止。',
+  driver_pause_rejected: 'Driver 未确认 Pause。',
+  driver_soft_stop_rejected: 'Driver 未确认 HOLD。',
+  driver_release_invalid: 'Driver 的 Release 确认不符合协议。',
+  driver_secret_reflected: 'Driver 响应包含私密控制凭据，Core 已拒绝。',
+  driver_timeout: 'Driver 响应超时。',
+  driver_auth_rejected: 'Driver 拒绝了 Core 身份。',
+  driver_unreachable: '当前无法连接 Driver。',
+  driver_protocol_error: 'Driver 协议调用失败。',
+  coordinator_stopping: 'Core 遥操协调器正在停止。',
+  rtc_ice_timeout: 'ICE candidate 收集超时。',
+  rtc_offer_invalid: '浏览器未生成有效的 SDP offer。',
+  rtc_answer_invalid: 'Core 返回的 SDP answer 无效。',
+  teleop_signaling_unavailable: 'Core 尚未配置可用的 WebRTC 遥操信令。',
+  signaling_content_type_required: 'WebRTC offer 必须使用 application/json。',
+  signaling_offer_too_large: 'WebRTC SDP offer 超过大小限制。',
+  invalid_signaling_offer: 'WebRTC SDP offer 格式无效。',
+  webxr_not_secure: 'WebXR immersive-vr 需要 HTTPS 或浏览器认可的安全上下文。',
+  webxr_unavailable: '当前浏览器没有可用的 WebXR immersive-vr。',
+  webxr_not_ready: '只有本标签页 Active 会话与双 RTC 通道全部连接后才能进入 VR。',
+  webxr_setup_failed: 'WebXR local-floor 或 WebGL 图层初始化失败。',
+  webxr_pose_backpressure: 'Pose DataChannel 已超过 16 KiB 安全背压限制。',
+  webxr_pose_too_large: '单个 Pose frame 超过 64 KiB 协议限制。',
+  webxr_pose_send_failed: 'Pose frame 发送失败，RTC 与 XR 已关闭。',
+  webxr_visibility_lost: '页面或 XR runtime 已不可见。',
+  webxr_reference_space_reset: 'local-floor reference space 已被 runtime 重置。',
+  rtc_connection_lost: 'WebRTC peer 或必要 DataChannel 已断开。',
+  capture_tls_bootstrap_unavailable: 'Core 没有可安全提供给 OpenXR 头显 Capture 的当前 TLS 公开证书链。',
+  capture_pairing_limit: '当前身份的一次性配对已达到上限，请等待旧配对过期。',
+  capture_device_limit: '当前身份的采集设备已达到上限。',
+  capture_not_found: '所选采集设备不存在或已撤销。',
+  capture_forbidden: '所选采集设备不属于当前身份。',
+  capture_not_ready: 'OpenXR 头显 Capture 尚未连接并进入 xr_standby。',
+  capture_protocol_mismatch: 'OpenXR 头显 Capture 或 RTC frame 协议不兼容。',
+  capture_assignment_conflict: '采集设备或会话已经有另一个 Capture assignment。',
+  capture_attached: '采集设备仍附着会话；请先在 PC 执行 HOLD/Release。',
+  capture_loss_pending: 'Capture 丢失后的安全 HOLD 尚未完成。',
+  capture_signaling_failed: 'OpenXR 头显 Capture 信令失败；当前会话已 fail-close，必须新建会话。',
+  signaling_source_conflict: '当前会话已选择另一种 RTC source；请 HOLD/Release 后新建会话。',
+};
+
+const HTTP_STATUS_TEXT = {
+  400: '请求格式无效。',
+  401: '登录已失效，请重新登录。',
+  403: '当前身份无权执行该操作。',
+  404: '请求的遥操资源不存在。',
+  409: '当前遥操状态与操作冲突。',
+  410: '会话已经终止。',
+  422: '请求参数未通过校验。',
+  500: 'Core 内部处理失败。',
+  502: 'Driver 响应无效。',
+  503: '遥操服务暂不可用。',
+  504: 'Driver 响应超时。',
+};
+
+const SESSION_STATE_TEXT = {
+  awaiting_confirmation: '等待明确 Live 硬件确认（Driver 尚未调用）',
+  preparing: '准备中',
+  active: '已占用 / Active',
+  paused: '已暂停 / Paused（仍占用）',
+  hold: 'Core HOLD / soft_stop（仍占用；姿态不可恢复）',
+  released: '已释放',
+  expired: '租约已过期',
+  faulted: '故障终止',
+  recovery_required: 'Core 重启恢复锁（普通写入已锁定）',
+};
+
+function canControl() {
+  return Boolean(principal && (principal.role === 'operator' || principal.role === 'owner'));
+}
+
+function showNotice(message, kind = '') {
+  notice.textContent = message;
+  notice.className = `notice${kind ? ` ${kind}` : ''}`;
+}
+
+function resetConsoleData() {
+  closeAllRtcConnections('控制台已重置');
+  robots = [];
+  sessionViews.clear();
+  lastSessionByRobot.clear();
+  sessionEvents.clear();
+  pendingRobots.clear();
+  browserHeartbeatFailures.clear();
+  rtcFrameStates.clear();
+  xrSessions.clear();
+  xrSessionStats.clear();
+  actionInFlight = false;
+  captureListInFlight = false;
+  captureActionInFlight = false;
+  captures = [];
+  capturePairing = null;
+  selectedCaptureId = '';
+  selectedCaptureSessionId = '';
+  captureStatusMessage = '尚未读取采集设备。';
+  captureStatusKind = '';
+  renderCapturePanel();
+}
+
+function apiError(code, status = 0) {
+  const error = new Error(
+    ERROR_TEXT[code]
+    || HTTP_STATUS_TEXT[status]
+    || `请求失败（${code || `HTTP ${status}`}）`,
+  );
+  error.code = code;
+  error.status = status;
+  error.cancelled = code === 'request_cancelled';
+  return error;
+}
+
+async function api(path, options = {}) {
+  const generation = requestGeneration;
+  const controller = new AbortController();
+  const { timeoutMs = REQUEST_TIMEOUT_MS, ...fetchOptions } = options;
+  const headers = new Headers(fetchOptions.headers || {});
+  headers.set('X-Motus-Teleop-Client', TELEOP_CLIENT_ID);
+  let timedOut = false;
+  const timeout = window.setTimeout(() => {
+    timedOut = true;
+    controller.abort();
+  }, timeoutMs);
+  activeControllers.add(controller);
+
+  let response;
+  let data;
+  try {
+    response = await fetch(path, {
+      ...fetchOptions,
+      headers,
+      signal: controller.signal,
+    });
+    data = await response.json().catch(() => ({}));
+  } catch (error) {
+    if (generation !== requestGeneration || (error && error.name === 'AbortError' && !timedOut)) {
+      throw apiError('request_cancelled');
+    }
+    if (timedOut) throw apiError('request_timeout');
+    throw apiError('network_error');
+  } finally {
+    window.clearTimeout(timeout);
+    activeControllers.delete(controller);
+  }
+
+  if (generation !== requestGeneration) throw apiError('request_cancelled');
+  if (timedOut) throw apiError('request_timeout');
+  if (!response.ok) {
+    const detail = data && data.detail;
+    const code = detail && typeof detail === 'object' && typeof detail.code === 'string'
+      ? detail.code
+      : (typeof detail === 'string' ? detail : `http_${response.status}`);
+    throw apiError(code, response.status);
+  }
+  return data.data;
+}
+
+function clearPollingTimers() {
+  if (statusTimer !== null) window.clearInterval(statusTimer);
+  if (slowTimer !== null) window.clearInterval(slowTimer);
+  if (heartbeatTimer !== null) window.clearInterval(heartbeatTimer);
+  statusTimer = null;
+  slowTimer = null;
+  heartbeatTimer = null;
+}
+
+function invalidateApiRequests() {
+  requestGeneration += 1;
+  activeControllers.forEach((controller) => controller.abort());
+  activeControllers.clear();
+  directoryInFlight = false;
+  statusInFlight = false;
+  eventsInFlight = false;
+  heartbeatInFlight = false;
+  captureListInFlight = false;
+}
+
+function stopPolling() {
+  clearPollingTimers();
+  invalidateApiRequests();
+  actionInFlight = false;
+  refreshButton.disabled = false;
+  captureRefreshButton.disabled = false;
+}
+
+function showLogin(message = '') {
+  stopPolling();
+  principal = null;
+  resetConsoleData();
+  content.classList.add('hidden');
+  logoutButton.classList.add('hidden');
+  loginPanel.classList.remove('hidden');
+  loginError.textContent = message;
+  tokenInput.focus();
+}
+
+function fact(label, value) {
+  const dt = document.createElement('dt');
+  dt.textContent = label;
+  const dd = document.createElement('dd');
+  dd.textContent = value;
+  return [dt, dd];
+}
+
+function formatSeconds(value) {
+  if (value === null || value === undefined || value === '') return '—';
+  const seconds = Number(value);
+  if (!Number.isFinite(seconds)) return '—';
+  return `${Math.max(0, seconds).toFixed(1)} 秒`;
+}
+
+function formatMilliseconds(value) {
+  if (value === null || value === undefined || value === '') return '—';
+  const milliseconds = Number(value);
+  if (!Number.isFinite(milliseconds)) return '—';
+  return `${Math.max(0, milliseconds).toFixed(0)} ms`;
+}
+
+function formatTimestamp(value) {
+  const timestamp = Number(value);
+  if (!Number.isFinite(timestamp) || timestamp <= 0) return '尚未确认';
+  try {
+    return new Date(timestamp * 1000).toLocaleTimeString('zh-CN', { hour12: false });
+  } catch {
+    return '时间无效';
+  }
+}
+
+function displayValue(value, fallback = '—') {
+  if (value === null || value === undefined || value === '') return fallback;
+  return String(value);
+}
+
+function setCaptureStatus(message, kind = '') {
+  captureStatusMessage = message;
+  captureStatusKind = kind;
+  renderCapturePanel();
+}
+
+function captureSessionCandidates() {
+  return robots.flatMap((robot) => {
+    const sessionId = robot.session?.id;
+    const snapshot = sessionView(robot);
+    if (!sessionId || !robot.session?.owned_by_client || !snapshot) return [];
+    return [{
+      ...snapshot,
+      id: sessionId,
+      owned_by_client: true,
+      robot_id: robot.robot_id,
+      driver_id: robot.driver_id,
+    }];
+  });
+}
+
+function selectedCapture() {
+  return captures.find((capture) => capture.id === selectedCaptureId) || null;
+}
+
+function selectedCaptureSession() {
+  return captureSessionCandidates().find(
+    (session) => session.id === selectedCaptureSessionId,
+  ) || null;
+}
+
+function replaceSelectOptions(select, options, selectedValue, emptyLabel) {
+  const nextOptions = [];
+  if (options.length === 0) {
+    const empty = document.createElement('option');
+    empty.value = '';
+    empty.textContent = emptyLabel;
+    nextOptions.push(empty);
+  } else {
+    options.forEach(({ value, label }) => {
+      const option = document.createElement('option');
+      option.value = value;
+      option.textContent = label;
+      option.selected = value === selectedValue;
+      nextOptions.push(option);
+    });
+  }
+  select.replaceChildren(...nextOptions);
+}
+
+function captureAttachStatusText(code) {
+  const local = {
+    ready: '可手动 Attach；不会自动执行。',
+    capture_session_required: '请选择本标签页会话。',
+    capture_device_required: '请选择已配对的 OpenXR 头显 Capture。',
+    capture_live_confirmation_required: 'Live 仍等待 PC 二次确认；确认前 Attach 禁用。',
+    capture_session_not_active: '只有本标签页 owned Active 会话可以 Attach。',
+    capture_session_contract_invalid: '会话缺少 mode/profile/capability digest，已 fail-closed。',
+  };
+  return local[code] || ERROR_TEXT[code] || displayValue(code);
+}
+
+function renderCapturePanel() {
+  const visible = canControl();
+  capturePanel.classList.toggle('hidden', !visible);
+  if (!visible) return;
+  if (
+    capturePairing
+    && Number.isFinite(capturePairing.expiresAt)
+    && capturePairing.expiresAt <= Date.now() / 1000
+  ) {
+    capturePairing = null;
+    captureStatusMessage = '一次性配对已过期；如需使用请在 PC 重新生成。';
+    captureStatusKind = 'error';
+  }
+
+  const sessions = captureSessionCandidates();
+  if (!captures.some((capture) => capture.id === selectedCaptureId)) {
+    selectedCaptureId = captures[0]?.id || '';
+  }
+  if (!sessions.some((session) => session.id === selectedCaptureSessionId)) {
+    selectedCaptureSessionId = sessions[0]?.id || '';
+  }
+
+  replaceSelectOptions(
+    captureDeviceSelect,
+    captures.map((capture) => ({
+      value: capture.id,
+      label: `${displayValue(capture.label, capture.id)} · ${capture.connected ? 'connected' : 'offline'} · ${displayValue(capture.observed_state)}`,
+    })),
+    selectedCaptureId,
+    '没有已配对的采集设备',
+  );
+  replaceSelectOptions(
+    captureSessionSelect,
+    sessions.map((session) => ({
+      value: session.id,
+      label: `${displayValue(session.robot_id)} · ${displayValue(session.mode).toUpperCase()} · ${displayValue(session.state)} · ${displayValue(session.profile_id)}`,
+    })),
+    selectedCaptureSessionId,
+    '没有本标签页 owned 会话',
+  );
+
+  const capture = selectedCapture();
+  const session = selectedCaptureSession();
+  const assignment = capture?.assignment || null;
+  captureDeviceFacts.replaceChildren(
+    ...fact('Capture ID', displayValue(capture?.id)),
+    ...fact('连接 / presence', capture ? `${capture.connected ? 'connected' : 'offline'} · ${displayValue(capture.observed_state)}` : '—'),
+    ...fact('客户端', capture ? `${displayValue(capture.client_kind)} · ${displayValue(capture.app_version)}` : '—'),
+    ...fact('协议', capture ? `${displayValue(capture.capture_protocol)} · ${displayValue(capture.frame_protocol)}` : '—'),
+    ...fact('Assignment', assignment ? `${displayValue(assignment.state)} · session ${displayValue(assignment.session_id)}` : 'none'),
+  );
+
+  let eligibility = captureAttachEligibility(session, capture);
+  if (
+    eligibility.allowed
+    && session
+    && (rtcInFlight.has(session.id) || rtcConnectionActive(rtcViews.get(session.id)))
+  ) eligibility = { allowed: false, code: 'signaling_source_conflict' };
+  const busy = captureActionInFlight || actionInFlight;
+  capturePairButton.disabled = busy;
+  captureRefreshButton.disabled = busy || captureListInFlight;
+  captureLabelInput.disabled = busy;
+  captureDeviceSelect.disabled = busy || captures.length === 0;
+  captureSessionSelect.disabled = busy || sessions.length === 0;
+  captureAttachButton.disabled = busy || !eligibility.allowed;
+  captureAttachButton.title = captureAttachStatusText(eligibility.code);
+  captureRevokeButton.disabled = busy || !capture || assignment !== null;
+
+  captureBootstrap.classList.toggle('hidden', capturePairing === null);
+  captureWssUrl.value = capturePairing?.coreWssUrl || '';
+  capturePairingId.value = capturePairing?.pairingId || '';
+  capturePairingCode.value = capturePairing?.pairingCode || '';
+  captureCaBase64.value = capturePairing?.caCertificateBase64 || '';
+  capturePairingExpiry.textContent = capturePairing
+    ? `一次性配对过期：${formatTimestamp(capturePairing.expiresAt)}`
+    : '—';
+  captureStatus.textContent = `${captureStatusMessage} ${captureAttachStatusText(eligibility.code)}`;
+  captureStatus.className = `capture-status${captureStatusKind ? ` ${captureStatusKind}` : ''}`;
+}
+
+async function loadCaptures(announce = false, allowDuringAction = false) {
+  if (
+    !canControl()
+    || captureListInFlight
+    || ((actionInFlight || captureActionInFlight) && !allowDuringAction)
+  ) return;
+  const generation = requestGeneration;
+  captureListInFlight = true;
+  renderCapturePanel();
+  try {
+    const nextCaptures = await api('/api/teleop/captures');
+    if (generation !== requestGeneration) return;
+    captures = Array.isArray(nextCaptures) ? nextCaptures : [];
+    if (
+      announce
+      || captureStatusMessage === '尚未读取采集设备。'
+      || captureStatusKind === 'error'
+    ) {
+      captureStatusMessage = `已读取 ${captures.length} 个采集设备。`;
+      captureStatusKind = announce ? 'success' : '';
+    }
+  } catch (error) {
+    if (error.cancelled || generation !== requestGeneration) return;
+    if (error.status === 401) {
+      showLogin('登录已失效，请重新输入 token。');
+      return;
+    }
+    captureStatusMessage = `采集设备读取失败：${error.message}`;
+    captureStatusKind = 'error';
+  } finally {
+    if (generation === requestGeneration) {
+      captureListInFlight = false;
+      renderCapturePanel();
+      renderDevices();
+    }
+  }
+}
+
+async function createCapturePairing() {
+  if (!canControl() || actionInFlight || captureActionInFlight) return;
+  const label = captureLabelInput.value.trim();
+  if (!label || label.length > 64) {
+    setCaptureStatus('设备标签必须为 1–64 个字符。', 'error');
+    return;
+  }
+  captureActionInFlight = true;
+  renderCapturePanel();
+  try {
+    const pairing = await api('/api/teleop/capture-pairings', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ label }),
+    });
+    capturePairing = captureBootstrapFields(pairing, window.location);
+    captureStatusMessage = '一次性配对已生成；页面不会自动连接 OpenXR 头显 Capture。';
+    captureStatusKind = 'success';
+  } catch (error) {
+    if (!error.cancelled) {
+      capturePairing = null;
+      captureStatusMessage = `生成配对失败：${error.message}`;
+      captureStatusKind = 'error';
+    }
+  } finally {
+    captureActionInFlight = false;
+    renderCapturePanel();
+  }
+}
+
+async function attachSelectedCapture() {
+  if (!canControl() || actionInFlight || captureActionInFlight) return;
+  const capture = selectedCapture();
+  const session = selectedCaptureSession();
+  const eligibility = captureAttachEligibility(session, capture);
+  if (!eligibility.allowed) {
+    setCaptureStatus(captureAttachStatusText(eligibility.code), 'error');
+    return;
+  }
+  if (rtcInFlight.has(session.id) || rtcConnectionActive(rtcViews.get(session.id))) {
+    setCaptureStatus(ERROR_TEXT.signaling_source_conflict, 'error');
+    return;
+  }
+  captureActionInFlight = true;
+  renderCapturePanel();
+  try {
+    await api(
+      `/api/teleop/sessions/${encodeURIComponent(session.id)}/capture-attachment`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          capture_id: capture.id,
+          mode: session.mode,
+          profile_id: session.profile_id,
+          capability_digest: session.capability_digest,
+        }),
+      },
+    );
+    captureStatusMessage = 'Capture assignment 已手动签发；等待 OpenXR 头显 Capture 的一次 SDP offer。';
+    captureStatusKind = 'success';
+    await loadCaptures(false, true);
+  } catch (error) {
+    if (!error.cancelled) {
+      captureStatusMessage = `Attach 失败：${error.message}`;
+      captureStatusKind = 'error';
+    }
+  } finally {
+    captureActionInFlight = false;
+    renderCapturePanel();
+    renderDevices();
+  }
+}
+
+async function revokeSelectedCapture() {
+  if (!canControl() || actionInFlight || captureActionInFlight) return;
+  const capture = selectedCapture();
+  if (!capture || capture.assignment) return;
+  captureActionInFlight = true;
+  renderCapturePanel();
+  try {
+    await api(`/api/teleop/captures/${encodeURIComponent(capture.id)}`, {
+      method: 'DELETE',
+    });
+    capturePairing = null;
+    selectedCaptureId = '';
+    captureStatusMessage = '设备 enrollment 已撤销；旧 credential 立即失效。';
+    captureStatusKind = 'success';
+    await loadCaptures(false, true);
+  } catch (error) {
+    if (!error.cancelled) {
+      captureStatusMessage = `撤销失败：${error.message}`;
+      captureStatusKind = 'error';
+    }
+  } finally {
+    captureActionInFlight = false;
+    renderCapturePanel();
+  }
+}
+
+async function copyCaptureBootstrapField(fieldName) {
+  const value = capturePairing?.[fieldName];
+  if (!value || typeof navigator.clipboard?.writeText !== 'function') {
+    setCaptureStatus('当前浏览器不能安全写入剪贴板。', 'error');
+    return;
+  }
+  try {
+    await navigator.clipboard.writeText(value);
+    setCaptureStatus(
+      fieldName === 'pairingCode'
+        ? '一次性 pairing code 已复制；请勿粘贴到日志或 shell 历史。'
+        : '启动字段已复制。',
+      'success',
+    );
+  } catch {
+    setCaptureStatus('剪贴板写入失败；页面不会把字段写入 console。', 'error');
+  }
+}
+
+function webxrSupportText() {
+  const origin = window.location.origin;
+  if (!webxrSupport.secureContext) return `${origin} · 不可用：当前页面不是安全上下文`;
+  if (!webxrSupport.apiAvailable) return `${origin} · 不可用：navigator.xr 缺失`;
+  if (webxrSupport.immersiveVr === 'checking') {
+    return `${origin} · 检测中：immersive-vr + local-floor`;
+  }
+  if (webxrSupport.immersiveVr !== 'supported') {
+    return `${origin} · 不可用：${webxrSupport.detail}`;
+  }
+  return `${origin} · 支持 immersive-vr；进入时强制请求 local-floor`;
+}
+
+function renderWebxrSupport() {
+  if (webxrSupportElement) webxrSupportElement.textContent = webxrSupportText();
+}
+
+function probeWebxrSupport() {
+  if (!webxrSupport.secureContext) {
+    webxrSupport.immersiveVr = 'unsupported';
+    webxrSupport.detail = '需要 HTTPS 或安全上下文';
+    renderWebxrSupport();
+    return;
+  }
+  if (!webxrSupport.apiAvailable || typeof navigator.xr.isSessionSupported !== 'function') {
+    webxrSupport.immersiveVr = 'unsupported';
+    webxrSupport.detail = 'navigator.xr/isSessionSupported 不可用';
+    renderWebxrSupport();
+    return;
+  }
+  renderWebxrSupport();
+  navigator.xr.isSessionSupported('immersive-vr').then((supported) => {
+    webxrSupport.immersiveVr = supported === true ? 'supported' : 'unsupported';
+    webxrSupport.detail = supported === true
+      ? 'immersive-vr 可用；local-floor 将在用户点击时请求'
+      : 'immersive-vr 不受支持';
+    renderWebxrSupport();
+    renderDevices();
+  }).catch(() => {
+    webxrSupport.immersiveVr = 'unsupported';
+    webxrSupport.detail = 'immersive-vr 能力检测失败';
+    renderWebxrSupport();
+    renderDevices();
+  });
+}
+
+function frameStateForSession(sessionId) {
+  let state = rtcFrameStates.get(sessionId);
+  if (!state) {
+    state = createRtcFrameState();
+    rtcFrameStates.set(sessionId, state);
+  }
+  return state;
+}
+
+function markSessionFrameReleased(sessionId) {
+  if (!sessionId) return;
+  const released = markRtcFrameDeadmanReleased(frameStateForSession(sessionId));
+  rtcFrameStates.set(sessionId, released);
+  const stats = xrSessionStats.get(sessionId);
+  if (stats) {
+    stats.rearmRequired = released.rearmRequired;
+    stats.baseTwist = '本地已归零；RTC/XR 不再发送';
+  }
+}
+
+function formatBaseTwist(value) {
+  const linear = value?.linear;
+  const angular = value?.angular;
+  if (
+    !Array.isArray(linear)
+    || linear.length !== 3
+    || !Array.isArray(angular)
+    || angular.length !== 3
+    || [...linear, ...angular].some((item) => !Number.isFinite(item))
+  ) return 'invalid / fail-closed';
+  const fixed = (item) => (Object.is(item, -0) ? 0 : item).toFixed(3);
+  return `vx ${fixed(linear[0])} m/s · vy ${fixed(linear[1])} m/s · wz ${fixed(angular[2])} rad/s`;
+}
+
+function teleopDescriptor(robot) {
+  const descriptor = robot?.teleop;
+  return descriptor && typeof descriptor === 'object' ? descriptor : {};
+}
+
+function descriptorMode(robot) {
+  const mode = teleopDescriptor(robot).mode;
+  return mode === 'live' ? 'live' : 'shadow';
+}
+
+function descriptorProfile(robot) {
+  const descriptor = teleopDescriptor(robot);
+  return displayValue(descriptor.profile_id, 'recording');
+}
+
+function formatEffectors(capabilities) {
+  const effectors = Array.isArray(capabilities?.effectors) ? capabilities.effectors : [];
+  const outputs = capabilities?.outputs && typeof capabilities.outputs === 'object'
+    ? capabilities.outputs
+    : {};
+  if (effectors.length === 0) return 'none';
+  return effectors.map((name) => {
+    const count = outputs[name]?.joint_count;
+    return Number.isSafeInteger(count) ? `${name} (${count} joints)` : String(name);
+  }).join(' · ');
+}
+
+function formatOutputCapabilities(capabilities) {
+  const outputs = capabilities?.outputs;
+  if (!outputs || typeof outputs !== 'object') return '—';
+  return Object.entries(outputs).map(([name, output]) => {
+    const state = output?.enabled === true ? 'enabled' : 'disabled';
+    const count = Number.isSafeInteger(output?.joint_count)
+      ? ` · ${output.joint_count} joints`
+      : '';
+    return `${name} ${state}${count}`;
+  }).join(' · ') || '—';
+}
+
+function formatJointVector(value) {
+  if (!Array.isArray(value) || value.some((item) => !Number.isFinite(item))) return '—';
+  if (value.length === 0) return '[]';
+  const preview = value.slice(0, 10).map((item) => item.toFixed(3)).join(', ');
+  return `${value.length} joints · [${preview}${value.length > 10 ? ', …' : ''}]`;
+}
+
+function formatLatencySummary(value) {
+  if (!value || typeof value !== 'object') return '—';
+  return [
+    `p50 ${formatMilliseconds(value.p50)}`,
+    `p95 ${formatMilliseconds(value.p95)}`,
+    `p99 ${formatMilliseconds(value.p99)}`,
+    `n ${displayValue(value.count, '0')}`,
+  ].join(' · ');
+}
+
+function percentile(sorted, ratio) {
+  if (sorted.length === 0) return null;
+  const index = Math.min(sorted.length - 1, Math.ceil(sorted.length * ratio) - 1);
+  return sorted[Math.max(0, index)];
+}
+
+function summarizeRttSamples(samples) {
+  const finite = samples.filter((value) => Number.isFinite(value) && value >= 0).sort((a, b) => a - b);
+  if (finite.length === 0) return null;
+  const last = samples[samples.length - 1];
+  return {
+    last: Number.isFinite(last) && last >= 0 ? last : null,
+    p50: percentile(finite, 0.5),
+    p95: percentile(finite, 0.95),
+    p99: percentile(finite, 0.99),
+    count: finite.length,
+  };
+}
+
+function statsForSession(sessionId) {
+  let stats = xrSessionStats.get(sessionId);
+  if (!stats) {
+    stats = {
+      state: 'not-entered',
+      detail: '尚未进入 immersive-vr',
+      tracking: 'head ✕ · left ✕ · right ✕',
+      deadman: false,
+      baseTwist: '尚未发送；是否存在由 capability binding 决定',
+      sent: 0,
+      dropped: 0,
+      lastSequence: null,
+      nextSequence: 0,
+      rearmRequired: true,
+      leftInput: 'left · input source 尚未出现',
+      rightInput: 'right · input source 尚未出现',
+      bufferedAmount: 0,
+      lastSentAtMs: null,
+      lastUiAtMs: 0,
+    };
+    xrSessionStats.set(sessionId, stats);
+  }
+  return stats;
+}
+
+function updateXrStats(sessionId, patch, render = true) {
+  Object.assign(statsForSession(sessionId), patch);
+  if (render) renderDevices();
+}
+
+function rtcReadyForXr(sessionId) {
+  const view = rtcViews.get(sessionId);
+  return Boolean(
+    view
+    && view.pc?.connectionState === 'connected'
+    && view.control?.readyState === 'open'
+    && view.pose?.readyState === 'open'
+    && view.connectionState === 'connected'
+    && view.controlState === 'open'
+    && view.poseState === 'open',
+  );
+}
+
+function ownedActiveRobotSession(robotId, sessionId) {
+  const robot = currentRobot(robotId);
+  const session = robot && sessionView(robot);
+  return Boolean(
+    robot
+    && robot.session?.id === sessionId
+    && robot.session?.owned_by_client
+    && session?.state === 'active'
+    && (session.mode !== 'live' || session.live_confirmed === true),
+  );
+}
+
+function frameConfigurationForSession(session) {
+  if (
+    !session
+    || !['shadow', 'live'].includes(session.mode)
+    || !session.capabilities
+    || typeof session.capabilities !== 'object'
+  ) return null;
+  return { mode: session.mode, capabilities: session.capabilities };
+}
+
+function xrSessionContractMatches(record, sessionId) {
+  const robot = currentRobot(record.robotId);
+  const session = robot && sessionView(robot);
+  return Boolean(
+    ownedActiveRobotSession(record.robotId, sessionId)
+    && session
+    && session.mode === record.mode
+    && session.profile_id === record.profileId
+    && session.capability_digest === record.capabilityDigest,
+  );
+}
+
+function xrEntryReady(robotId, sessionId) {
+  return Boolean(
+    webxrSupport.secureContext
+    && webxrSupport.apiAvailable
+    && webxrSupport.immersiveVr === 'supported'
+    && typeof navigator.xr?.requestSession === 'function'
+    && ownedActiveRobotSession(robotId, sessionId)
+    && rtcReadyForXr(sessionId),
+  );
+}
+
+function uniqueTrackedPointerGripSources(xrSession) {
+  const byHand = { left: [], right: [] };
+  try {
+    for (const source of xrSession.inputSources) {
+      if (
+        !source
+        || source.targetRayMode !== 'tracked-pointer'
+        || !source.gripSpace
+        || !Object.hasOwn(byHand, source.handedness)
+      ) continue;
+      byHand[source.handedness].push(source);
+    }
+  } catch {
+    return { left: null, right: null };
+  }
+  return {
+    left: byHand.left.length === 1 ? byHand.left[0] : null,
+    right: byHand.right.length === 1 ? byHand.right[0] : null,
+  };
+}
+
+function stopXrSession(sessionId, reason) {
+  markSessionFrameReleased(sessionId);
+  const record = xrSessions.get(sessionId);
+  xrSessions.delete(sessionId);
+  updateXrStats(sessionId, {
+    state: 'ended',
+    detail: reason,
+    deadman: false,
+  }, false);
+  if (!record) return;
+  record.ending = true;
+  if (record.session && record.rafId !== null) {
+    try { record.session.cancelAnimationFrame(record.rafId); } catch { /* already ended */ }
+  }
+  if (record.session) {
+    try {
+      const ending = record.session.end();
+      if (ending && typeof ending.catch === 'function') ending.catch(() => null);
+    } catch {
+      // The XR runtime already ended; authority is still released locally.
+    }
+  }
+}
+
+function failSafeCloseXr(sessionId, code, detail) {
+  const message = ERROR_TEXT[code] || detail;
+  closeRtcConnection(sessionId, `${detail}；fail-safe 已关闭 RTC 与 XR`);
+  updateXrStats(sessionId, {
+    state: 'error',
+    detail,
+    deadman: false,
+  });
+  showNotice(`WebXR fail-safe：${message}`, 'error');
+}
+
+function rtcConnectionActive(view) {
+  return Boolean(
+    view
+    && view.pc
+    && !['closed', 'disconnected', 'failed'].includes(view.connectionState),
+  );
+}
+
+function updateRtcView(sessionId, peer, patch) {
+  const current = rtcViews.get(sessionId);
+  if (!current || current.pc !== peer) return;
+  Object.assign(current, patch);
+  renderDevices();
+}
+
+function sendPeerPing(sessionId, peer, control) {
+  const view = rtcViews.get(sessionId);
+  if (!view || view.pc !== peer || control.readyState !== 'open') return;
+  const now = performance.now();
+  for (const [requestId, startedAt] of view.pendingPings) {
+    if (now - startedAt > RTC_PEER_PING_TIMEOUT_MS) view.pendingPings.delete(requestId);
+  }
+  peerPingSequence += 1;
+  const requestId = `browser-${peerPingSequence}`;
+  view.pendingPings.set(requestId, now);
+  try {
+    control.send(JSON.stringify({ type: 'peer_ping', request_id: requestId }));
+  } catch {
+    view.pendingPings.delete(requestId);
+    throw new Error('teleop-control peer_ping send failed');
+  }
+}
+
+function startPeerPings(sessionId, peer, control, onFailure) {
+  const view = rtcViews.get(sessionId);
+  if (!view || view.pc !== peer || view.pingTimer !== null) return;
+  const send = () => {
+    try {
+      sendPeerPing(sessionId, peer, control);
+    } catch {
+      onFailure('teleop-control peer_ping 发送失败');
+    }
+  };
+  send();
+  view.pingTimer = window.setInterval(send, RTC_PEER_PING_MS);
+}
+
+function recordPeerPong(sessionId, peer, payload) {
+  const view = rtcViews.get(sessionId);
+  const requestId = payload?.request_id;
+  if (!view || view.pc !== peer || typeof requestId !== 'string') return;
+  const startedAt = view.pendingPings.get(requestId);
+  if (!Number.isFinite(startedAt)) return;
+  view.pendingPings.delete(requestId);
+  const elapsed = performance.now() - startedAt;
+  if (!Number.isFinite(elapsed) || elapsed < 0 || elapsed > RTC_PEER_PING_TIMEOUT_MS) return;
+  view.rttSamples.push(elapsed);
+  if (view.rttSamples.length > RTC_RTT_SAMPLE_LIMIT) view.rttSamples.shift();
+  view.rttSummary = summarizeRttSamples(view.rttSamples);
+}
+
+function closeRtcConnection(sessionId, reason = '已主动关闭', { skipXrStop = false } = {}) {
+  markSessionFrameReleased(sessionId);
+  if (!skipXrStop) stopXrSession(sessionId, reason);
+  const current = rtcViews.get(sessionId);
+  if (!current) {
+    rtcInFlight.delete(sessionId);
+    renderDevices();
+    return;
+  }
+  current.intentionalClose = true;
+  if (current.pingTimer !== null && current.pingTimer !== undefined) {
+    window.clearInterval(current.pingTimer);
+  }
+  try { current.control?.close(); } catch { /* already closed */ }
+  try { current.pose?.close(); } catch { /* already closed */ }
+  try { current.pc?.close(); } catch { /* already closed */ }
+  rtcViews.set(sessionId, {
+    connectionState: 'closed',
+    controlState: 'closed',
+    poseState: 'closed',
+    detail: reason,
+    rttSummary: current.rttSummary || null,
+  });
+  rtcInFlight.delete(sessionId);
+  renderDevices();
+}
+
+function closeAllRtcConnections(reason = '已关闭') {
+  const sessionIds = new Set([...rtcViews.keys(), ...xrSessions.keys()]);
+  sessionIds.forEach((sessionId) => closeRtcConnection(sessionId, reason));
+  rtcViews.clear();
+  rtcInFlight.clear();
+}
+
+function handleXrSessionEnded(sessionId, record) {
+  if (xrSessions.get(sessionId) !== record) return;
+  xrSessions.delete(sessionId);
+  markSessionFrameReleased(sessionId);
+  updateXrStats(sessionId, {
+    state: 'ended',
+    detail: 'XR runtime 已结束；RTC 已同步关闭',
+    deadman: false,
+  }, false);
+  closeRtcConnection(
+    sessionId,
+    'XR runtime 已结束；不会自动重进 VR 或重连 RTC',
+    { skipXrStop: true },
+  );
+}
+
+function requestNextXrFrame(sessionId, record) {
+  if (xrSessions.get(sessionId) !== record || !record.session || record.ending) return;
+  try {
+    record.rafId = record.session.requestAnimationFrame((timestamp, frame) => {
+      onXrFrame(timestamp, frame, sessionId, record);
+    });
+  } catch {
+    failSafeCloseXr(sessionId, 'webxr_setup_failed', 'XR animation frame 无法继续');
+  }
+}
+
+function poseIsActuallyTracked(pose) {
+  if (!pose || typeof pose !== 'object') return null;
+  try {
+    return pose.emulatedPosition === true ? null : pose;
+  } catch {
+    return null;
+  }
+}
+
+function trackingText(tracking) {
+  const marker = (tracked) => (tracked ? '✓' : '✕');
+  return [
+    `head ${marker(tracking.head)}`,
+    `left ${marker(tracking.left_controller)}`,
+    `right ${marker(tracking.right_controller)}`,
+  ].join(' · ');
+}
+
+function inputSourceDiagnostic(source, expectedHandedness) {
+  if (!source) return `${expectedHandedness} · input source 缺失`;
+  try {
+    const gamepad = source.gamepad;
+    const axesLength = Number.isSafeInteger(gamepad?.axes?.length)
+      ? gamepad.axes.length
+      : 'invalid';
+    const buttonsLength = Number.isSafeInteger(gamepad?.buttons?.length)
+      ? gamepad.buttons.length
+      : 'invalid';
+    const profiles = [];
+    const profileCount = Number.isSafeInteger(source.profiles?.length)
+      ? Math.min(source.profiles.length, 3)
+      : 0;
+    for (let index = 0; index < profileCount; index += 1) {
+      const profile = source.profiles[index];
+      if (typeof profile === 'string') profiles.push(profile.slice(0, 64));
+    }
+    return [
+      `${expectedHandedness}→${displayValue(source.handedness)}`,
+      `ray ${displayValue(source.targetRayMode)}`,
+      `grip ${source.gripSpace ? 'yes' : 'no'}`,
+      `mapping ${displayValue(gamepad?.mapping)}`,
+      `axes ${axesLength}`,
+      `buttons ${buttonsLength}`,
+      `profiles ${profiles.length ? profiles.join(',') : 'none'}`,
+    ].join(' · ');
+  } catch {
+    return `${expectedHandedness} · input source 读取失败`;
+  }
+}
+
+function isTrackingOrDeadmanSafetyTransition(record, frame) {
+  if (record.lastSentDeadman === true && frame.deadman !== true) return true;
+  if (!record.lastSentTracking) return false;
+  return Object.keys(record.lastSentTracking).some((key) => (
+    record.lastSentTracking[key] === true && frame.tracking[key] !== true
+  ));
+}
+
+function rememberDroppedFrameSafetyState(sessionId, previousState, nextState) {
+  rtcFrameStates.set(sessionId, createRtcFrameState({
+    nextSequence: previousState.nextSequence,
+    clutchSequence: previousState.clutchSequence,
+    deadmanActive: previousState.deadmanActive,
+    rearmRequired: nextState.rearmRequired,
+    lastMonotonicNs: previousState.lastMonotonicNs,
+  }));
+}
+
+function renderXrFrame(record, viewerPose) {
+  const baseLayer = record.session?.renderState?.baseLayer;
+  if (!baseLayer || !record.gl) throw new Error('XR render layer missing');
+  const gl = record.gl;
+  gl.bindFramebuffer(gl.FRAMEBUFFER, baseLayer.framebuffer);
+  gl.clearColor(0, 0, 0, 1);
+  if (viewerPose) {
+    for (const view of viewerPose.views) {
+      const viewport = baseLayer.getViewport(view);
+      if (viewport) gl.viewport(viewport.x, viewport.y, viewport.width, viewport.height);
+      gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
+    }
+  } else {
+    gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
+  }
+}
+
+function onXrFrame(timestamp, frame, sessionId, record) {
+  if (xrSessions.get(sessionId) !== record || record.ending) return;
+  record.rafId = null;
+  if (
+    document.visibilityState !== 'visible'
+    || record.session.visibilityState !== 'visible'
+  ) {
+    failSafeCloseXr(sessionId, 'webxr_visibility_lost', '页面或 XR session 已不可见');
+    return;
+  }
+  if (!xrSessionContractMatches(record, sessionId) || !rtcReadyForXr(sessionId)) {
+    failSafeCloseXr(
+      sessionId,
+      'webxr_not_ready',
+      'Core ownership/state/session capability 或 RTC 双通道已失效',
+    );
+    return;
+  }
+
+  const frameTimeMs = Number.isFinite(timestamp) ? timestamp : performance.now();
+  if (frameTimeMs >= record.nextCoreHeartbeatAtMs && !heartbeatInFlight) {
+    record.nextCoreHeartbeatAtMs = frameTimeMs + CORE_HEARTBEAT_MS;
+    void renewOwnedSessions(true);
+  }
+
+  let viewerPose = null;
+  try {
+    viewerPose = frame.getViewerPose(record.referenceSpace);
+    renderXrFrame(record, viewerPose);
+  } catch {
+    failSafeCloseXr(sessionId, 'webxr_setup_failed', 'XR viewer pose 或 WebGL frame 读取失败');
+    return;
+  }
+
+  const sources = uniqueTrackedPointerGripSources(record.session);
+  let leftGripPose = null;
+  let rightGripPose = null;
+  try {
+    if (sources.left) leftGripPose = frame.getPose(sources.left.gripSpace, record.referenceSpace);
+    if (sources.right) rightGripPose = frame.getPose(sources.right.gripSpace, record.referenceSpace);
+  } catch {
+    leftGripPose = null;
+    rightGripPose = null;
+  }
+
+  let built;
+  const previousFrameState = frameStateForSession(sessionId);
+  try {
+    built = buildRtcFrameV1(previousFrameState, {
+      monotonicTimeMs: frameTimeMs,
+      headPose: poseIsActuallyTracked(viewerPose),
+      leftGripPose: poseIsActuallyTracked(leftGripPose),
+      rightGripPose: poseIsActuallyTracked(rightGripPose),
+      leftInputSource: sources.left,
+      rightInputSource: sources.right,
+      deadman: isDualSqueezeDeadmanRequested(sources.left, sources.right),
+    }, record.frameConfiguration);
+  } catch {
+    failSafeCloseXr(sessionId, 'webxr_pose_send_failed', 'Pose frame 构建失败');
+    return;
+  }
+
+  const safetyTransition = isTrackingOrDeadmanSafetyTransition(record, built.frame);
+  if (frameTimeMs < record.nextPoseAtMs && !safetyTransition) {
+    rememberDroppedFrameSafetyState(sessionId, previousFrameState, built.state);
+    const stats = statsForSession(sessionId);
+    stats.dropped += 1;
+    stats.rearmRequired = built.state.rearmRequired;
+    stats.leftInput = inputSourceDiagnostic(sources.left, 'left');
+    stats.rightInput = inputSourceDiagnostic(sources.right, 'right');
+    if (frameTimeMs - stats.lastUiAtMs >= XR_UI_REFRESH_MS) {
+      stats.lastUiAtMs = frameTimeMs;
+      renderDevices();
+    }
+    requestNextXrFrame(sessionId, record);
+    return;
+  }
+  record.nextPoseAtMs = frameTimeMs + XR_SEND_INTERVAL_MS;
+  rtcFrameStates.set(sessionId, built.state);
+
+  const poseChannel = rtcViews.get(sessionId)?.pose;
+  let payload;
+  let payloadBytes;
+  try {
+    payload = JSON.stringify(built.frame);
+    payloadBytes = new TextEncoder().encode(payload).byteLength;
+  } catch {
+    failSafeCloseXr(sessionId, 'webxr_pose_send_failed', 'Pose frame 序列化失败');
+    return;
+  }
+  if (payloadBytes > POSE_MESSAGE_LIMIT_BYTES) {
+    failSafeCloseXr(sessionId, 'webxr_pose_too_large', `Pose frame 为 ${payloadBytes} bytes`);
+    return;
+  }
+  const bufferedAmount = Number(poseChannel?.bufferedAmount);
+  if (
+    !poseChannel
+    || poseChannel.readyState !== 'open'
+    || !Number.isFinite(bufferedAmount)
+    || bufferedAmount < 0
+    || bufferedAmount > POSE_BUFFER_HIGH_WATER_BYTES
+    || bufferedAmount + payloadBytes > POSE_BUFFER_HIGH_WATER_BYTES
+  ) {
+    failSafeCloseXr(sessionId, 'webxr_pose_backpressure', 'Pose DataChannel 未打开或背压超限');
+    return;
+  }
+  try {
+    poseChannel.send(payload);
+  } catch {
+    failSafeCloseXr(sessionId, 'webxr_pose_send_failed', 'Pose DataChannel send() 抛出异常');
+    return;
+  }
+  const bufferedAfterSend = Number(poseChannel.bufferedAmount);
+  if (
+    !Number.isFinite(bufferedAfterSend)
+    || bufferedAfterSend < 0
+    || bufferedAfterSend > POSE_BUFFER_HIGH_WATER_BYTES
+  ) {
+    failSafeCloseXr(sessionId, 'webxr_pose_backpressure', 'Pose send() 后背压超过 16 KiB');
+    return;
+  }
+
+  const stats = statsForSession(sessionId);
+  stats.state = 'active';
+  stats.detail = `正在发送 raw local-floor ${record.mode} frames`;
+  stats.tracking = trackingText(built.frame.tracking);
+  stats.deadman = built.frame.deadman;
+  stats.baseTwist = Object.hasOwn(built.frame, 'base_twist')
+    ? formatBaseTwist(built.frame.base_twist)
+    : 'base capability disabled · field omitted';
+  stats.sent += 1;
+  stats.lastSequence = built.frame.sequence;
+  stats.nextSequence = built.state.nextSequence;
+  stats.rearmRequired = built.state.rearmRequired;
+  stats.leftInput = inputSourceDiagnostic(sources.left, 'left');
+  stats.rightInput = inputSourceDiagnostic(sources.right, 'right');
+  stats.bufferedAmount = bufferedAfterSend;
+  stats.lastSentAtMs = frameTimeMs;
+  record.lastSentDeadman = built.frame.deadman;
+  record.lastSentTracking = { ...built.frame.tracking };
+  if (frameTimeMs - stats.lastUiAtMs >= XR_UI_REFRESH_MS) {
+    stats.lastUiAtMs = frameTimeMs;
+    renderDevices();
+  }
+  requestNextXrFrame(sessionId, record);
+}
+
+async function initializeXrSession(sessionId, record, xrSession) {
+  if (xrSessions.get(sessionId) !== record) {
+    try { await xrSession.end(); } catch { /* request was cancelled while pending */ }
+    return;
+  }
+  record.session = xrSession;
+  const onEnd = () => handleXrSessionEnded(sessionId, record);
+  const onVisibilityChange = () => {
+    if (
+      xrSessions.get(sessionId) === record
+      && xrSession.visibilityState !== 'visible'
+    ) {
+      failSafeCloseXr(sessionId, 'webxr_visibility_lost', 'XR session visibility 已离开 visible');
+    }
+  };
+  xrSession.addEventListener('end', onEnd, { once: true });
+  xrSession.addEventListener('visibilitychange', onVisibilityChange);
+
+  try {
+    if (!xrEntryReady(record.robotId, sessionId)) throw new Error('entry authority changed');
+    const canvas = document.createElement('canvas');
+    const gl = canvas.getContext('webgl', { alpha: false, antialias: false });
+    if (!gl || typeof gl.makeXRCompatible !== 'function' || typeof XRWebGLLayer !== 'function') {
+      throw new Error('WebGL XR compatibility unavailable');
+    }
+    await gl.makeXRCompatible();
+    const referenceSpace = await xrSession.requestReferenceSpace('local-floor');
+    const baseLayer = new XRWebGLLayer(xrSession, gl);
+    xrSession.updateRenderState({ baseLayer });
+    const onReferenceSpaceReset = () => {
+      if (xrSessions.get(sessionId) === record) {
+        failSafeCloseXr(
+          sessionId,
+          'webxr_reference_space_reset',
+          'local-floor reference space reset；禁止自动恢复',
+        );
+      }
+    };
+    referenceSpace.addEventListener('reset', onReferenceSpaceReset, { once: true });
+    if (
+      xrSessions.get(sessionId) !== record
+      || !xrEntryReady(record.robotId, sessionId)
+      || xrSession.visibilityState !== 'visible'
+      || document.visibilityState !== 'visible'
+    ) throw new Error('entry authority or visibility changed');
+
+    record.canvas = canvas;
+    record.gl = gl;
+    record.referenceSpace = referenceSpace;
+    updateXrStats(sessionId, {
+      state: 'active',
+      detail: `immersive-vr active；raw local-floor / ${record.mode}`,
+      deadman: false,
+    });
+    requestNextXrFrame(sessionId, record);
+  } catch (error) {
+    if (xrSessions.get(sessionId) !== record) return;
+    const detail = error && typeof error.message === 'string'
+      ? error.message
+      : 'unknown WebXR setup error';
+    failSafeCloseXr(sessionId, 'webxr_setup_failed', `WebXR 初始化失败：${detail}`);
+  }
+}
+
+function requestImmersiveVr(robotId, sessionId) {
+  if (!webxrSupport.secureContext) {
+    showNotice(ERROR_TEXT.webxr_not_secure, 'error');
+    return;
+  }
+  if (!webxrSupport.apiAvailable || webxrSupport.immersiveVr !== 'supported') {
+    showNotice(ERROR_TEXT.webxr_unavailable, 'error');
+    return;
+  }
+  if (!xrEntryReady(robotId, sessionId) || xrSessions.has(sessionId)) {
+    showNotice(ERROR_TEXT.webxr_not_ready, 'error');
+    return;
+  }
+  const robot = currentRobot(robotId);
+  const session = robot && sessionView(robot);
+  const frameConfiguration = frameConfigurationForSession(session);
+  if (!session || !frameConfiguration) {
+    showNotice(ERROR_TEXT.webxr_not_ready, 'error');
+    return;
+  }
+
+  let sessionPromise;
+  try {
+    sessionPromise = navigator.xr.requestSession(
+      'immersive-vr',
+      { requiredFeatures: ['local-floor'] },
+    );
+  } catch (error) {
+    showNotice(`WebXR requestSession 失败：${displayValue(error?.message)}`, 'error');
+    return;
+  }
+
+  const record = {
+    robotId,
+    mode: session.mode,
+    profileId: session.profile_id,
+    capabilityDigest: session.capability_digest,
+    frameConfiguration,
+    session: null,
+    referenceSpace: null,
+    canvas: null,
+    gl: null,
+    rafId: null,
+    ending: false,
+    nextPoseAtMs: Number.NEGATIVE_INFINITY,
+    nextCoreHeartbeatAtMs: performance.now() + CORE_HEARTBEAT_MS,
+    lastSentDeadman: false,
+    lastSentTracking: null,
+  };
+  xrSessions.set(sessionId, record);
+  updateXrStats(sessionId, {
+    state: 'requesting',
+    detail: '用户已请求 immersive-vr + local-floor',
+    deadman: false,
+  });
+  sessionPromise.then(
+    (xrSession) => initializeXrSession(sessionId, record, xrSession),
+    (error) => {
+      if (xrSessions.get(sessionId) !== record) return;
+      const detail = error && typeof error.message === 'string'
+        ? error.message
+        : 'requestSession rejected';
+      failSafeCloseXr(sessionId, 'webxr_setup_failed', `WebXR 请求被拒绝：${detail}`);
+    },
+  );
+}
+
+function waitForIceGatheringComplete(peer) {
+  if (peer.iceGatheringState === 'complete') return Promise.resolve();
+  return new Promise((resolve, reject) => {
+    const timeout = window.setTimeout(() => {
+      peer.removeEventListener('icegatheringstatechange', onStateChange);
+      reject(apiError('rtc_ice_timeout'));
+    }, RTC_ICE_GATHER_TIMEOUT_MS);
+    function onStateChange() {
+      if (peer.iceGatheringState !== 'complete') return;
+      window.clearTimeout(timeout);
+      peer.removeEventListener('icegatheringstatechange', onStateChange);
+      resolve();
+    }
+    peer.addEventListener('icegatheringstatechange', onStateChange);
+    onStateChange();
+  });
+}
+
+async function connectRtc(robotId, sessionId) {
+  const robot = currentRobot(robotId);
+  if (
+    !robot
+    || !sessionId
+    || !robot.session?.owned_by_client
+    || rtcInFlight.has(sessionId)
+    || captureAssignmentForSession(captures, sessionId) !== null
+    || typeof RTCPeerConnection !== 'function'
+  ) return;
+
+  const session = sessionView(robot);
+  if (!session || !ownedActiveRobotSession(robotId, sessionId)) return;
+  closeRtcConnection(sessionId, '正在重新连接');
+  rtcInFlight.add(sessionId);
+
+  const peer = new RTCPeerConnection();
+  const control = peer.createDataChannel('teleop-control', { ordered: true });
+  const pose = peer.createDataChannel('teleop-pose', {
+    ordered: false,
+    maxRetransmits: 0,
+  });
+  rtcViews.set(sessionId, {
+    pc: peer,
+    control,
+    pose,
+    connectionState: peer.connectionState,
+    controlState: control.readyState,
+    poseState: pose.readyState,
+    detail: '正在生成 SDP offer…',
+    intentionalClose: false,
+    pingTimer: null,
+    pendingPings: new Map(),
+    rttSamples: [],
+    rttSummary: null,
+  });
+  renderDevices();
+
+  const unexpectedRtcFailure = (detail) => {
+    const current = rtcViews.get(sessionId);
+    if (!current || current.pc !== peer || current.intentionalClose) return;
+    failSafeCloseXr(sessionId, 'rtc_connection_lost', detail);
+  };
+  const syncPeerState = () => {
+    updateRtcView(sessionId, peer, { connectionState: peer.connectionState });
+    if (['closed', 'disconnected', 'failed'].includes(peer.connectionState)) {
+      unexpectedRtcFailure(`RTCPeerConnection ${peer.connectionState}`);
+    }
+  };
+  peer.addEventListener('connectionstatechange', syncPeerState);
+  peer.addEventListener('iceconnectionstatechange', () => {
+    updateRtcView(sessionId, peer, {
+      detail: `ICE ${peer.iceConnectionState}`,
+    });
+    if (['closed', 'disconnected', 'failed'].includes(peer.iceConnectionState)) {
+      unexpectedRtcFailure(`ICE ${peer.iceConnectionState}`);
+    }
+  });
+  control.addEventListener('open', () => {
+    updateRtcView(sessionId, peer, {
+      controlState: control.readyState,
+      detail: '控制通道已打开；Pose 通道等待 WebXR 用户点击进入。',
+    });
+    startPeerPings(sessionId, peer, control, unexpectedRtcFailure);
+  });
+  control.addEventListener('close', () => {
+    updateRtcView(sessionId, peer, { controlState: control.readyState });
+    unexpectedRtcFailure('teleop-control 已关闭');
+  });
+  control.addEventListener('error', () => unexpectedRtcFailure('teleop-control 出错'));
+  control.addEventListener('message', (event) => {
+    try {
+      const payload = JSON.parse(String(event.data));
+      recordPeerPong(sessionId, peer, payload);
+      updateRtcView(sessionId, peer, {
+        detail: payload.ok
+          ? `Driver RTC 状态：${displayValue(payload.state)}`
+          : `Driver RTC 拒绝：${displayValue(payload.error?.code)}`,
+      });
+    } catch {
+      updateRtcView(sessionId, peer, { detail: 'Driver RTC 返回了无效消息。' });
+    }
+  });
+  pose.addEventListener('open', () => {
+    updateRtcView(sessionId, peer, { poseState: pose.readyState });
+  });
+  pose.addEventListener('close', () => {
+    updateRtcView(sessionId, peer, { poseState: pose.readyState });
+    unexpectedRtcFailure('teleop-pose 已关闭');
+  });
+  pose.addEventListener('error', () => unexpectedRtcFailure('teleop-pose 出错'));
+
+  try {
+    const offer = await peer.createOffer();
+    await peer.setLocalDescription(offer);
+    updateRtcView(sessionId, peer, { detail: '正在收集 ICE candidates…' });
+    await waitForIceGatheringComplete(peer);
+    const local = peer.localDescription;
+    if (!local || local.type !== 'offer' || !local.sdp) throw apiError('rtc_offer_invalid');
+    updateRtcView(sessionId, peer, { detail: 'Core 正在代理一次性 offer…' });
+    const answer = await api(
+      `/api/teleop/sessions/${encodeURIComponent(sessionId)}/signaling/offer`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ type: 'offer', sdp: local.sdp }),
+        timeoutMs: RTC_SIGNAL_TIMEOUT_MS,
+      },
+    );
+    if (rtcViews.get(sessionId)?.pc !== peer) throw apiError('request_cancelled');
+    if (!answer || answer.type !== 'answer' || typeof answer.sdp !== 'string') {
+      throw apiError('rtc_answer_invalid');
+    }
+    await peer.setRemoteDescription(answer);
+    updateRtcView(sessionId, peer, {
+      connectionState: peer.connectionState,
+      detail: 'SDP answer 已应用，等待双通道打开…',
+    });
+    showNotice(`WebRTC ${session.mode} 已完成信令，正在建立数据通道。`, 'success');
+  } catch (error) {
+    const superseded = rtcViews.get(sessionId)?.pc !== peer;
+    if (!superseded && !error.cancelled) {
+      showNotice(`WebRTC 连接失败：${error.message}`, 'error');
+      closeRtcConnection(sessionId, `连接失败：${error.message}`);
+    }
+  } finally {
+    if (rtcViews.get(sessionId)?.pc === peer) rtcInFlight.delete(sessionId);
+    renderDevices();
+  }
+}
+
+function visibleSessionId(robot) {
+  if (robot.session && robot.session.busy) return robot.session.id || null;
+  return lastSessionByRobot.get(robot.robot_id) || null;
+}
+
+function sessionView(robot) {
+  const sessionId = visibleSessionId(robot);
+  if (!sessionId) return robot.session || null;
+  const record = sessionViews.get(sessionId);
+  return record && record.snapshot ? record.snapshot : robot.session;
+}
+
+function coreRemaining(robot, session) {
+  if (!session) return null;
+  const sessionId = visibleSessionId(robot);
+  const record = sessionId ? sessionViews.get(sessionId) : null;
+  const initial = Number(session.remaining_seconds);
+  if (!Number.isFinite(initial)) return null;
+  if (!record || !record.receivedAt) return initial;
+  return Math.max(0, initial - ((Date.now() - record.receivedAt) / 1000));
+}
+
+function rememberSession(snapshot, statusFailure = '') {
+  if (!snapshot || !snapshot.id) return;
+  const previous = sessionViews.get(snapshot.id) || {};
+  sessionViews.set(snapshot.id, {
+    ...previous,
+    snapshot,
+    receivedAt: Date.now(),
+    statusFailure,
+  });
+  if (snapshot.robot_id) lastSessionByRobot.set(snapshot.robot_id, snapshot.id);
+  if (
+    snapshot.state !== 'active'
+    && (
+      xrSessions.has(snapshot.id)
+      || rtcInFlight.has(snapshot.id)
+      || rtcConnectionActive(rtcViews.get(snapshot.id))
+    )
+  ) {
+    closeRtcConnection(
+      snapshot.id,
+      `Core state=${displayValue(snapshot.state)}；本地已先解除 deadman 并关闭 XR/RTC`,
+    );
+  }
+}
+
+function enforceInteractiveSessionSafety() {
+  const sessionIds = new Set([...rtcViews.keys(), ...rtcInFlight, ...xrSessions.keys()]);
+  sessionIds.forEach((sessionId) => {
+    const view = rtcViews.get(sessionId);
+    if (!xrSessions.has(sessionId) && !rtcInFlight.has(sessionId) && !rtcConnectionActive(view)) {
+      return;
+    }
+    const robot = robots.find((candidate) => candidate.session?.id === sessionId);
+    const session = robot && sessionView(robot);
+    if (!robot || !robot.session?.owned_by_client || session?.state !== 'active') {
+      closeRtcConnection(
+        sessionId,
+        'Core 会话不再是本标签页 owned Active；本地 fail-safe 已关闭',
+      );
+    }
+  });
+}
+
+function markStatusFailure(sessionId, message) {
+  const previous = sessionViews.get(sessionId);
+  if (previous) previous.statusFailure = message;
+}
+
+function makeActionButton(label, action, robot, disabled = false, variant = 'secondary') {
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.className = `button ${variant}`;
+  button.textContent = label;
+  button.dataset.action = action;
+  button.disabled = (
+    disabled
+    || actionInFlight
+    || captureActionInFlight
+    || pendingRobots.has(robot.id)
+  );
+  button.addEventListener('click', () => performAction(robot.id, action));
+  return button;
+}
+
+function makeRtcButton(robot, sessionId, sessionState) {
+  const view = rtcViews.get(sessionId);
+  const connected = rtcConnectionActive(view);
+  const captureAssignment = captureAssignmentForSession(captures, sessionId);
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.className = `button ${connected ? 'warning' : 'secondary'}`;
+  button.textContent = connected
+    ? '断开 Direct RTC（进入 HOLD）'
+    : `Direct WebXR fallback：连接 RTC ${descriptorMode(robot)}`;
+  button.disabled = (
+    actionInFlight
+    || captureActionInFlight
+    || pendingRobots.has(robot.id)
+    || rtcInFlight.has(sessionId)
+    || captureAssignment !== null
+    || typeof RTCPeerConnection !== 'function'
+    || sessionState !== 'active'
+  );
+  button.addEventListener('click', () => {
+    if (connected) {
+      closeRtcConnection(sessionId, '操作员断开；Driver 将进入 HOLD');
+      showNotice('WebRTC 已断开；不会自动重连，Driver 将进入 HOLD。', 'error');
+    } else {
+      connectRtc(robot.id, sessionId);
+    }
+  });
+  return button;
+}
+
+function makeXrButton(robot, sessionId) {
+  const entered = xrSessions.has(sessionId);
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.className = `button ${entered ? 'warning' : 'primary'}`;
+  button.textContent = entered ? '退出 VR（关闭 RTC）' : '进入 Quest VR';
+  button.disabled = entered ? false : (
+    actionInFlight
+    || pendingRobots.has(robot.id)
+    || !xrEntryReady(robot.id, sessionId)
+  );
+  button.addEventListener('click', () => {
+    if (xrSessions.has(sessionId)) {
+      closeRtcConnection(sessionId, '操作员退出 VR；RTC 已同步关闭且不会自动重连');
+      showNotice('已退出 VR 并关闭 RTC；如需继续必须重新手动连接与进入。', 'error');
+      return;
+    }
+    requestImmersiveVr(robot.id, sessionId);
+  });
+  return button;
+}
+
+function appendDriverFacts(facts, session, sessionId) {
+  const driver = session && session.driver;
+  if (!driver) {
+    facts.append(...fact('Driver 状态', '等待 Core 缓存更新'));
+  } else {
+    const lease = driver.lease || {};
+    const leaseState = [
+      lease.fresh ? 'fresh' : 'stale',
+      `age ${formatMilliseconds(lease.age_ms)}`,
+      `timeout ${formatMilliseconds(lease.timeout_ms)}`,
+      lease.expired_latched ? 'expired-latched' : 'not-latched',
+    ].join(' · ');
+    facts.append(
+      ...fact('Driver 状态', displayValue(driver.state)),
+      ...fact('Driver 原因', displayValue(driver.reason, '无')),
+      ...fact('Driver authority', driver.authority_valid ? 'valid' : 'invalid'),
+      ...fact('Driver 租约', leaseState),
+    );
+    const rtc = driver.rtc || {};
+    const channels = rtc.channels || {};
+    facts.append(
+      ...fact('Driver RTC', rtc.connected ? 'connected' : 'disconnected'),
+      ...fact(
+        'Driver channels',
+        `control ${channels['teleop-control'] ? 'open' : 'closed'} · pose ${channels['teleop-pose'] ? 'open' : 'closed'}`,
+      ),
+    );
+    const pose = driver.pose || {};
+    facts.append(
+      ...fact(
+        'Driver pose freshness',
+        `${pose.fresh ? 'fresh' : 'stale'} · age ${formatMilliseconds(pose.age_ms)}`,
+      ),
+      ...fact('Driver pose.latest_sequence', displayValue(pose.latest_sequence, '尚未记录')),
+    );
+    const dispatch = driver.dispatch || {};
+    const decision = displayValue(dispatch.last_decision, '尚无');
+    const sequenceLabel = dispatch.kind === 'hardware'
+      ? 'Driver hardware published sequence'
+      : 'Driver would-apply sequence';
+    const outputSequence = dispatch.kind === 'hardware'
+      ? dispatch.last_published_sequence
+      : dispatch.last_would_apply_sequence;
+    facts.append(
+      ...fact(
+        'Driver dispatch contract',
+        `${displayValue(dispatch.contract)} · ${displayValue(dispatch.kind)}`,
+      ),
+      ...fact('Driver dispatch state', displayValue(dispatch.state)),
+      ...fact('Driver dispatch.last_decision', decision),
+      ...fact('Driver last_admitted_sequence', displayValue(dispatch.last_admitted_sequence, '尚无')),
+      ...fact(sequenceLabel, displayValue(outputSequence, '尚无')),
+      ...fact(
+        'Safe-stop ACK',
+        dispatch.stop_acknowledged === true ? 'acknowledged' : 'NOT ACKNOWLEDGED',
+      ),
+      ...fact('Driver fault code', displayValue(dispatch.fault_code, '无')),
+    );
+
+    const diagnostics = driver.diagnostics;
+    if (diagnostics && typeof diagnostics === 'object') {
+      const transport = diagnostics.transport || {};
+      facts.append(
+        ...fact(
+          'Driver transport timing',
+          `rtc ${formatMilliseconds(transport.rtc_rtt_ms)} · pose age ${formatMilliseconds(transport.pose_age_ms)} · ${displayValue(transport.frame_rate_hz)} Hz`,
+        ),
+        ...fact(
+          'Driver frame counters',
+          `rx ${displayValue(transport.frames_received, '0')} · rejected ${displayValue(transport.frames_rejected, '0')} · gaps ${displayValue(transport.sequence_gaps, '0')} · mailbox replace ${displayValue(transport.mailbox_replacements, '0')}`,
+        ),
+      );
+      const latency = diagnostics.latency_ms || {};
+      const adapterLatencyLabel = dispatch.kind === 'hardware'
+        ? 'Latency adapter publish'
+        : 'Latency adapter projection';
+      for (const [label, key] of [
+        ['Latency receive→admit', 'receive_to_admit'],
+        ['Latency mailbox', 'mailbox_wait'],
+        ['Latency IK', 'ik'],
+        [adapterLatencyLabel, 'adapter_apply'],
+        ['Latency next LowState feedback arrival', 'robot_follow'],
+      ]) facts.append(...fact(label, formatLatencySummary(latency[key])));
+    }
+
+    const output = driver.output;
+    if (output && typeof output === 'object') {
+      facts.append(
+        ...fact('Output evidence profile', displayValue(output.profile_id)),
+        ...fact(
+          'Output evidence hardware path',
+          output.hardware_output === true ? 'true · hardware path' : 'false · recording/shadow path',
+        ),
+        ...fact('Output evidence state', displayValue(output.state)),
+        ...fact('Target joints', formatJointVector(output.target_joint_positions_rad)),
+        ...fact('Measured joints', formatJointVector(output.measured_joint_positions_rad)),
+        ...fact(
+          'Max joint error',
+          Number.isFinite(output.max_abs_error_rad)
+            ? `${output.max_abs_error_rad.toFixed(4)} rad`
+            : '—',
+        ),
+        ...fact('Arm command weight', displayValue(output.arm_sdk_weight)),
+        ...fact('Command age', formatMilliseconds(output.command_age_ms)),
+        ...fact('Output fault / HOLD', displayValue(output.fault_reason, '无')),
+      );
+    }
+  }
+
+  const driverHeartbeat = session && session.driver_heartbeat;
+  if (driverHeartbeat) {
+    facts.append(
+      ...fact('Driver HB 最近确认', formatTimestamp(driverHeartbeat.last_confirmed_at)),
+      ...fact(
+        'Driver HB 失败',
+        `${displayValue(driverHeartbeat.state)} · 连续 ${displayValue(driverHeartbeat.consecutive_failures, '0')} 次`,
+      ),
+    );
+  }
+
+  const statusFailure = sessionId && sessionViews.get(sessionId)?.statusFailure;
+  const browserFailure = sessionId && browserHeartbeatFailures.get(sessionId);
+  if (statusFailure) facts.append(...fact('状态读取失败', statusFailure));
+  if (browserFailure) facts.append(...fact('Core 租约续期失败', browserFailure));
+}
+
+function appendBrowserRtcFacts(facts, sessionId) {
+  if (!sessionId) return;
+  facts.append(...fact('Browser WebXR capability', webxrSupportText()));
+  facts.append(...fact('Transport route', 'Browser ⇄ RTC DataChannel ⇄ Driver（Core 仅代理信令）'));
+  if (typeof RTCPeerConnection !== 'function') {
+    facts.append(...fact('Browser WebRTC', '当前浏览器不支持'));
+  } else {
+    const view = rtcViews.get(sessionId);
+    if (!view) {
+      facts.append(...fact('Browser WebRTC', '尚未连接'));
+    } else {
+      facts.append(
+        ...fact('Browser WebRTC', displayValue(view.connectionState)),
+        ...fact(
+          'Browser channels',
+          `control ${displayValue(view.controlState)} · pose ${displayValue(view.poseState)}`,
+        ),
+        ...fact('WebRTC 诊断', displayValue(view.detail)),
+        ...fact(
+          'Browser peer RTT（同钟）',
+          view.rttSummary ? formatLatencySummary(view.rttSummary) : '尚无匹配 peer_ping 回执',
+        ),
+      );
+    }
+  }
+  const stats = statsForSession(sessionId);
+  facts.append(
+    ...fact('WebXR session', `${displayValue(stats.state)} · ${displayValue(stats.detail)}`),
+    ...fact('WebXR tracking', stats.tracking),
+    ...fact('Quest left input', stats.leftInput),
+    ...fact('Quest right input', stats.rightInput),
+    ...fact('WebXR deadman', stats.deadman ? '双 squeeze 已按下 / true' : 'released / false'),
+    ...fact('WebXR optional base_twist', stats.baseTwist),
+    ...fact(
+      'WebXR re-arm',
+      stats.rearmRequired ? '需松开后重握' : '已观察松开，可重新双握',
+    ),
+    ...fact(
+      'Pose frames',
+      `sent ${stats.sent} · dropped ${stats.dropped} · last ${displayValue(stats.lastSequence)} · next ${displayValue(stats.nextSequence)}`,
+    ),
+    ...fact(
+      'Pose transport',
+      `buffered ${displayValue(stats.bufferedAmount)} B / 16384 B · last send age ${stats.lastSentAtMs === null ? '—' : formatMilliseconds(performance.now() - stats.lastSentAtMs)}`,
+    ),
+  );
+}
+
+function renderSessionFacts(facts, robot, session) {
+  const busy = Boolean(robot.session && robot.session.busy);
+  const sessionId = visibleSessionId(robot);
+  if (!busy) {
+    facts.append(...fact('Core 会话', '空闲'));
+    if (!session || !TERMINAL_STATES.has(session.state)) return;
+    facts.append(...fact('本页最后终态', SESSION_STATE_TEXT[session.state] || displayValue(session.state)));
+    appendDriverFacts(facts, session, sessionId);
+    appendBrowserRtcFacts(facts, sessionId);
+    return;
+  }
+
+  if (robot.authority_guard) {
+    facts.append(
+      ...fact('Core 会话', SESSION_STATE_TEXT.recovery_required),
+      ...fact('恢复 Driver', displayValue(robot.authority_guard.driver_id)),
+      ...fact('恢复阶段', displayValue(robot.authority_guard.phase, 'recovery_required')),
+    );
+    return;
+  }
+
+  facts.append(
+    ...fact('Core 会话', SESSION_STATE_TEXT[session && session.state] || displayValue(session && session.state, '已占用')),
+    ...fact('Core 15s 倒计时', formatSeconds(coreRemaining(robot, session))),
+    ...fact('Session mode', displayValue(session?.mode)),
+    ...fact('Session profile', displayValue(session?.profile_id)),
+    ...fact('Session effectors', formatEffectors(session?.capabilities)),
+    ...fact(
+      'Live hardware confirmation',
+      session?.mode === 'live'
+        ? (session.live_confirmed === true ? 'confirmed' : 'NOT CONFIRMED · no Driver authority')
+        : 'not applicable · Shadow',
+    ),
+  );
+  if (robot.session.principal_id) {
+    let ownership = robot.session.principal_id;
+    if (robot.session.owned_by_client) ownership = '本标签页';
+    else if (robot.session.owned_by_me) ownership = '本人其他标签页';
+    facts.append(...fact('会话持有人', ownership));
+  }
+  appendDriverFacts(facts, session, sessionId);
+  appendBrowserRtcFacts(facts, sessionId);
+}
+
+function renderEvents(sessionId) {
+  const section = document.createElement('section');
+  section.className = 'events-panel';
+  const heading = document.createElement('h4');
+  heading.textContent = '最近会话事件';
+  section.appendChild(heading);
+
+  const events = sessionEvents.get(sessionId) || [];
+  if (events.length === 0) {
+    const empty = document.createElement('p');
+    empty.className = 'events-empty';
+    empty.textContent = '暂无事件或尚未完成首次读取。';
+    section.appendChild(empty);
+    return section;
+  }
+
+  const list = document.createElement('ol');
+  list.className = 'event-list';
+  events.slice(0, 12).forEach((event) => {
+    const item = document.createElement('li');
+    const main = document.createElement('span');
+    main.className = 'event-main';
+    main.textContent = `${displayValue(event.event_type)} · ${displayValue(event.decision)}`;
+    const detail = document.createElement('span');
+    detail.className = 'event-detail';
+    detail.textContent = `${formatTimestamp(event.created_at)} · ${displayValue(event.reason, '无原因')}`;
+    item.append(main, detail);
+    list.appendChild(item);
+  });
+  section.appendChild(list);
+  return section;
+}
+
+function renderControls(robot, session) {
+  if (!canControl()) return null;
+
+  const controls = document.createElement('div');
+  controls.className = 'session-controls';
+  const busy = Boolean(robot.session && robot.session.busy);
+  const sessionId = robot.session && robot.session.id;
+  const ownedByClient = Boolean(robot.session && robot.session.owned_by_client);
+  const ownerOverride = principal.role === 'owner' && Boolean(sessionId) && !ownedByClient;
+
+  if (robot.authority_guard) {
+    if (principal.role === 'owner') {
+      controls.appendChild(makeActionButton(
+        '验证安全并解除重启锁',
+        'reconcile-guard',
+        robot,
+        false,
+        'warning',
+      ));
+    }
+    const hint = document.createElement('p');
+    hint.className = 'control-hint busy';
+    hint.textContent = principal.role === 'owner'
+      ? '只会读取 Driver status，并在必要时调用无旧 fence 的 lifecycle stop；不会恢复旧会话。'
+      : '普通写入已锁定；只有 owner 能验证安全停机并解除恢复锁。';
+    controls.appendChild(hint);
+    return controls;
+  }
+
+  if (!busy) {
+    controls.appendChild(makeActionButton(
+      `Acquire ${descriptorMode(robot).toUpperCase()}`,
+      'acquire',
+      robot,
+      !robot.teleop_ready,
+      'primary',
+    ));
+    if (!robot.teleop_ready) {
+      const hint = document.createElement('p');
+      hint.className = 'control-hint';
+      hint.textContent = '只有 trusted、online 且通用描述协议有效的 Driver 可以 Acquire。';
+      controls.appendChild(hint);
+    }
+    return controls;
+  }
+
+  if (!ownedByClient && !ownerOverride) {
+    const hint = document.createElement('p');
+    hint.className = 'control-hint busy';
+    hint.textContent = robot.session.owned_by_me
+      ? '会话属于本人的另一个标签页；本标签页不能续租或控制。'
+      : '该机器人正由其他操作员占用。';
+    controls.appendChild(hint);
+    return controls;
+  }
+
+  if (ownerOverride) {
+    const warning = document.createElement('p');
+    warning.className = 'owner-warning';
+    warning.textContent = 'Owner 手动 override：自动续租与离页释放仍不会作用于此会话。';
+    controls.appendChild(warning);
+  }
+  const state = session && session.state;
+  if (state === 'awaiting_confirmation') {
+    const warning = document.createElement('section');
+    warning.className = 'live-confirmation';
+    const heading = document.createElement('h4');
+    heading.textContent = 'LIVE 硬件输出尚未确认';
+    const detail = document.createElement('p');
+    detail.textContent = [
+      `Robot ${displayValue(robot.robot_id)}`,
+      `Driver ${displayValue(robot.driver_id)}`,
+      `Profile ${displayValue(session.profile_id)}`,
+      `Effectors ${formatEffectors(session.capabilities)}`,
+      '当前仅内存 reservation；Driver 未 prepare，RTC/heartbeat 禁用',
+    ].join(' · ');
+    warning.append(heading, detail);
+    if (ownedByClient && session.mode === 'live' && session.live_confirmed !== true) {
+      warning.appendChild(makeActionButton(
+        '我确认：启用 LIVE 硬件输出',
+        'confirm-live',
+        robot,
+        false,
+        'danger',
+      ));
+    }
+    controls.append(
+      warning,
+      makeActionButton('Release', 'release', robot, false, 'warning'),
+    );
+    return controls;
+  }
+  if (ownedByClient) {
+    const fallback = document.createElement('p');
+    fallback.className = 'control-hint';
+    fallback.textContent = captureAssignmentForSession(captures, sessionId)
+      ? 'Capture 已作为本会话 RTC source；Direct WebXR fallback 禁用且不会静默切换。'
+      : 'Direct WebXR fallback 是显式同页模式；必须手动连接 RTC、再手动进入 VR。';
+    controls.appendChild(fallback);
+    controls.append(
+      makeRtcButton(robot, sessionId, state),
+      makeXrButton(robot, sessionId),
+    );
+  }
+  controls.append(
+    makeActionButton('Pause', 'pause', robot, !['active', 'hold'].includes(state)),
+    makeActionButton('HOLD', 'soft-stop', robot, state !== 'active', 'danger'),
+    makeActionButton('Release', 'release', robot, false, 'warning'),
+  );
+  if (state === 'paused') {
+    const warning = document.createElement('p');
+    warning.className = 'paused-warning';
+    warning.textContent = 'Pause 仍占用机器人；此控制台没有 Resume。恢复必须先 Release，再重新 Acquire。';
+    controls.appendChild(warning);
+  }
+  if (state === 'hold') {
+    const warning = document.createElement('p');
+    warning.className = 'paused-warning';
+    warning.textContent = 'Core state=hold / Driver reason=soft_stop 时，Pose 或重连不能恢复控制；必须先 Release，再重新 Acquire。';
+    controls.appendChild(warning);
+  }
+  const driverReason = session?.driver?.reason;
+  if (
+    state === 'active'
+    && RECOVERABLE_DRIVER_HOLD_REASONS.has(driverReason)
+  ) {
+    const hint = document.createElement('p');
+    hint.className = 'control-hint';
+    hint.textContent = `Core 仍为 Active，Driver ${driverReason} 可由操作者在需要时手动重连 RTC、重进 VR，先松开再双握以产生更大的 clutch_sequence；不会自动恢复。`;
+    controls.appendChild(hint);
+  }
+  return controls;
+}
+
+function renderRobot(robot) {
+  const card = document.createElement('article');
+  const busy = Boolean(robot.session && robot.session.busy);
+  const mode = descriptorMode(robot);
+  card.className = `device-card ${mode === 'live' ? 'live-mode' : 'shadow-mode'} ${busy ? 'busy' : (robot.teleop_ready ? 'ready' : 'blocked')}`;
+
+  const header = document.createElement('header');
+  const titleWrap = document.createElement('div');
+  const title = document.createElement('h3');
+  title.className = 'device-name';
+  title.textContent = robot.name || robot.id;
+  const id = document.createElement('div');
+  id.className = 'device-id';
+  id.textContent = `Driver: ${robot.driver_id} · Robot: ${robot.robot_id}`;
+  titleWrap.append(title, id);
+
+  const badge = document.createElement('span');
+  badge.className = `status-badge ${busy ? 'busy' : (robot.teleop_ready ? 'ready' : 'blocked')}`;
+  badge.textContent = robot.authority_guard
+    ? '重启安全锁定'
+    : (busy ? `${mode.toUpperCase()} 会话占用中` : (robot.teleop_ready ? `${mode.toUpperCase()} 就绪` : '不可遥操'));
+  header.append(titleWrap, badge);
+
+  const facts = document.createElement('dl');
+  facts.className = 'device-facts';
+  const descriptor = teleopDescriptor(robot);
+  const descriptorCapabilities = descriptor.capabilities || {};
+  facts.append(
+    ...fact('Driver ID', robot.driver_id),
+    ...fact('Robot authority', robot.robot_id),
+    ...fact('信任状态', robot.trust_state),
+    ...fact('在线状态', robot.online ? 'online' : 'offline'),
+    ...fact('遥操声明', robot.teleop_declared ? '已声明' : '未声明'),
+    ...fact('Configured mode', mode),
+    ...fact('Configured profile', descriptorProfile(robot)),
+    ...fact('Configured effectors', formatEffectors(descriptorCapabilities)),
+    ...fact('Configured outputs', formatOutputCapabilities(descriptorCapabilities)),
+    ...fact(
+      'Configured hardware output',
+      descriptor.actuation_enabled === true ? 'true · Live confirmation required' : 'false · Shadow recording',
+    ),
+    ...fact('判定', REASON_TEXT[robot.reason] || robot.reason),
+  );
+  const session = sessionView(robot);
+  renderSessionFacts(facts, robot, session);
+
+  const capabilities = document.createElement('div');
+  capabilities.className = 'capability-list';
+  (robot.tools || []).forEach((tool) => {
+    const chip = document.createElement('span');
+    chip.textContent = tool;
+    capabilities.appendChild(chip);
+  });
+
+  card.append(header, facts, capabilities);
+  const controls = renderControls(robot, session);
+  if (controls) card.appendChild(controls);
+  const sessionId = visibleSessionId(robot);
+  if (sessionId && canControl()) card.appendChild(renderEvents(sessionId));
+  return card;
+}
+
+function renderDevices() {
+  const grid = document.getElementById('device-grid');
+  const empty = document.getElementById('devices-empty');
+  grid.replaceChildren(...robots.map(renderRobot));
+  empty.classList.toggle('hidden', robots.length !== 0);
+  renderCapturePanel();
+}
+
+async function loadDevices(announce = true, allowDuringAction = false) {
+  if (directoryInFlight || (actionInFlight && !allowDuringAction)) return;
+  const generation = requestGeneration;
+  directoryInFlight = true;
+  refreshButton.disabled = true;
+  try {
+    const nextRobots = await api('/api/teleop/robots');
+    if (generation !== requestGeneration) return;
+    robots = Array.isArray(nextRobots) ? nextRobots : [];
+    enforceInteractiveSessionSafety();
+    renderDevices();
+    if (announce) {
+      const permission = canControl()
+        ? '可以显式管理本标签页的 Shadow 或 Live 会话。'
+        : 'viewer 仅可查看。';
+      showNotice(`已发现 ${robots.length} 个 Driver；${permission}`, 'success');
+    }
+  } catch (error) {
+    if (error.cancelled) return;
+    if (error.status === 401) {
+      showLogin('登录已失效，请重新输入 token。');
+      showNotice(HTTP_STATUS_TEXT[401], 'error');
+      return;
+    }
+    if (generation === requestGeneration) showNotice(`设备读取失败：${error.message}`, 'error');
+  } finally {
+    if (generation === requestGeneration) {
+      directoryInFlight = false;
+      refreshButton.disabled = actionInFlight;
+    }
+  }
+}
+
+async function pollOneSession(robot, sessionId, generation) {
+  try {
+    const coreSnapshot = await api(`/api/teleop/sessions/${encodeURIComponent(sessionId)}`);
+    if (generation === requestGeneration) rememberSession(coreSnapshot);
+  } catch (error) {
+    if (error.cancelled || generation !== requestGeneration) return;
+    if (error.status === 401) {
+      showLogin('登录已失效，请重新输入 token。');
+      return;
+    }
+    markStatusFailure(sessionId, error.message);
+  }
+}
+
+async function pollSessions(allowDuringAction = false) {
+  if (!canControl() || statusInFlight || (actionInFlight && !allowDuringAction)) {
+    renderDevices();
+    return;
+  }
+  const generation = requestGeneration;
+  statusInFlight = true;
+  try {
+    const targets = robots.flatMap((robot) => {
+      const sessionId = visibleSessionId(robot);
+      const session = sessionView(robot);
+      if (!sessionId || (!robot.session.busy && session && TERMINAL_STATES.has(session.state))) {
+        return [];
+      }
+      return [{ robot, sessionId }];
+    });
+    await Promise.all(targets.map(({ robot, sessionId }) => (
+      pollOneSession(robot, sessionId, generation)
+    )));
+    if (generation === requestGeneration) renderDevices();
+  } finally {
+    if (generation === requestGeneration) statusInFlight = false;
+  }
+}
+
+async function pollEvents(allowDuringAction = false) {
+  if (!canControl() || eventsInFlight || (actionInFlight && !allowDuringAction)) return;
+  const generation = requestGeneration;
+  eventsInFlight = true;
+  try {
+    const sessionIds = [...new Set(robots.map(visibleSessionId).filter(Boolean))];
+    await Promise.all(sessionIds.map(async (sessionId) => {
+      try {
+        const events = await api(
+          `/api/teleop/sessions/${encodeURIComponent(sessionId)}/events?limit=12`,
+        );
+        if (generation === requestGeneration) {
+          sessionEvents.set(sessionId, Array.isArray(events) ? events : []);
+        }
+      } catch (error) {
+        if (error.cancelled || generation !== requestGeneration) return;
+        if (error.status === 401) showLogin('登录已失效，请重新输入 token。');
+      }
+    }));
+    if (generation === requestGeneration) renderDevices();
+  } finally {
+    if (generation === requestGeneration) eventsInFlight = false;
+  }
+}
+
+async function renewOwnedSessions(allowDuringAction = false) {
+  if (
+    !canControl()
+    || heartbeatInFlight
+    || (actionInFlight && !allowDuringAction)
+  ) return;
+  const generation = requestGeneration;
+  heartbeatInFlight = true;
+  const owned = robots.filter((robot) => {
+    const session = sessionView(robot);
+    return Boolean(
+      robot.session
+      && robot.session.id
+      && robot.session.owned_by_client
+      && session
+      && ['active', 'paused', 'hold'].includes(session.state),
+    );
+  });
+
+  try {
+    await Promise.all(owned.map(async (robot) => {
+      const sessionId = robot.session.id;
+      try {
+        const snapshot = await api(
+          `/api/teleop/sessions/${encodeURIComponent(sessionId)}/heartbeat`,
+          { method: 'POST' },
+        );
+        if (generation !== requestGeneration) return;
+        rememberSession(snapshot);
+        browserHeartbeatFailures.delete(sessionId);
+      } catch (error) {
+        if (error.cancelled || generation !== requestGeneration) return;
+        browserHeartbeatFailures.set(sessionId, error.message);
+        if (error.status === 401) showLogin('登录已失效，请重新输入 token。');
+      }
+    }));
+    if (generation === requestGeneration) renderDevices();
+  } finally {
+    if (generation === requestGeneration) heartbeatInFlight = false;
+  }
+}
+
+function currentRobot(robotId) {
+  return robots.find((robot) => robot.id === robotId) || null;
+}
+
+async function performAction(robotId, action) {
+  const robot = currentRobot(robotId);
+  if (
+    !robot
+    || !canControl()
+    || actionInFlight
+    || captureActionInFlight
+    || pendingRobots.has(robotId)
+  ) return;
+  clearPollingTimers();
+  invalidateApiRequests();
+  const generation = requestGeneration;
+  actionInFlight = true;
+  pendingRobots.add(robotId);
+  refreshButton.disabled = true;
+  renderDevices();
+
+  try {
+    let result;
+    if (action === 'reconcile-guard') {
+      if (principal.role !== 'owner' || !robot.authority_guard) return;
+      result = await api(
+        `/api/teleop/authority-guards/${encodeURIComponent(robot.robot_id)}/reconcile`,
+        { method: 'POST' },
+      );
+      if (generation !== requestGeneration) return;
+      showNotice(
+        result.state === 'clear'
+          ? 'Driver 已提供安全停机证明；重启恢复锁已解除，旧会话没有恢复。'
+          : '恢复锁仍保持。',
+        result.state === 'clear' ? 'success' : 'error',
+      );
+    } else if (action === 'acquire') {
+      if (!robot.teleop_ready || (robot.session && robot.session.busy)) return;
+      const mode = descriptorMode(robot);
+      result = await api('/api/teleop/sessions', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ driver_id: robot.driver_id, mode }),
+      });
+      if (generation !== requestGeneration) return;
+      rememberSession(result.session);
+      showNotice(
+        result.disposition === 'confirmation_required'
+          ? 'LIVE reservation 已创建；Driver 尚未调用。请核对机器人、Driver、Profile 与 Effectors 后明确确认硬件输出。'
+          : `${mode.toUpperCase()} 会话已获取；Core 15 秒租约开始倒计时。`,
+        result.disposition === 'confirmation_required' ? 'error' : 'success',
+      );
+    } else if (action === 'confirm-live') {
+      const sessionId = robot.session && robot.session.id;
+      const session = sessionView(robot);
+      if (
+        !sessionId
+        || !robot.session?.owned_by_client
+        || session?.id !== sessionId
+        || session.mode !== 'live'
+        || session.state !== 'awaiting_confirmation'
+        || session.live_confirmed === true
+        || typeof session.profile_id !== 'string'
+      ) return;
+      result = await api(
+        `/api/teleop/sessions/${encodeURIComponent(sessionId)}/confirm-live`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            confirm_live_actuation: true,
+            profile_id: session.profile_id,
+          }),
+        },
+      );
+      if (generation !== requestGeneration) return;
+      rememberSession(result.session);
+      showNotice(
+        result.disposition === 'existing'
+          ? 'LIVE 确认已存在；没有重复 prepare。RTC 与 VR 仍需手动连接。'
+          : 'LIVE 硬件输出已明确确认；Driver 已准备。RTC 与 VR 仍需手动连接。',
+        'success',
+      );
+    } else {
+      const sessionId = robot.session && robot.session.id;
+      const ownedByClient = Boolean(robot.session && robot.session.owned_by_client);
+      const ownerOverride = principal.role === 'owner' && Boolean(sessionId);
+      if (!sessionId || (!ownedByClient && !ownerOverride)) return;
+      closeRtcConnection(
+        sessionId,
+        `操作员请求 ${action}；REST 前已本地解除 deadman 并关闭 XR/RTC`,
+      );
+      const endpoint = action === 'release' ? '' : `/${action}`;
+      result = await api(`/api/teleop/sessions/${encodeURIComponent(sessionId)}${endpoint}`, {
+        method: action === 'release' ? 'DELETE' : 'POST',
+      });
+      if (generation !== requestGeneration) return;
+      if (action === 'release') {
+        rememberSession(result.session);
+        browserHeartbeatFailures.delete(sessionId);
+        showNotice(
+          result.driver_acknowledged
+            ? '会话已释放，Driver 已确认。'
+            : 'Core 已释放会话；Driver 确认失败，请检查事件。',
+          result.driver_acknowledged ? 'success' : 'error',
+        );
+      } else {
+        rememberSession(result);
+        showNotice(action === 'pause' ? '会话已 Pause，仍占用机器人。' : '会话已进入 HOLD。', 'success');
+      }
+    }
+    await loadDevices(false, true);
+    await pollSessions(true);
+    await pollEvents(true);
+    await loadCaptures(false, true);
+  } catch (error) {
+    if (error.cancelled || generation !== requestGeneration) return;
+    if (error.status === 401) {
+      showLogin('登录已失效，请重新输入 token。');
+      return;
+    }
+    showNotice(`操作失败：${error.message}`, 'error');
+    await loadDevices(false, true);
+  } finally {
+    if (generation === requestGeneration) await renewOwnedSessions(true);
+    if (generation === requestGeneration) {
+      actionInFlight = false;
+      pendingRobots.delete(robotId);
+      refreshButton.disabled = false;
+      renderDevices();
+      startPolling();
+    }
+  }
+}
+
+function ownedClientReleaseTargets() {
+  return robots.flatMap((robot) => {
+    const session = sessionView(robot);
+    if (
+      !robot.session
+      || !robot.session.id
+      || !robot.session.owned_by_client
+      || !session
+      || !RELEASABLE_SESSION_STATES.has(session.state)
+    ) return [];
+    return [robot.session.id];
+  });
+}
+
+function releaseOwnedClientSessions() {
+  return ownedClientReleaseTargets().map((sessionId) => {
+    try {
+      return fetch(`/api/teleop/sessions/${encodeURIComponent(sessionId)}`, {
+        method: 'DELETE',
+        keepalive: true,
+        headers: { 'X-Motus-Teleop-Client': TELEOP_CLIENT_ID },
+      }).catch(() => null);
+    } catch {
+      return Promise.resolve(null);
+    }
+  });
+}
+
+async function waitForBestEffortRelease(requests) {
+  if (requests.length === 0) return;
+  await new Promise((resolve) => {
+    const timeout = window.setTimeout(resolve, LOGOUT_RELEASE_WAIT_MS);
+    Promise.allSettled(requests).then(() => {
+      window.clearTimeout(timeout);
+      resolve();
+    });
+  });
+}
+
+async function refreshSlowState() {
+  await Promise.all([
+    loadDevices(false),
+    loadCaptures(false),
+  ]);
+  await pollEvents();
+}
+
+function startPolling() {
+  clearPollingTimers();
+  statusTimer = window.setInterval(pollSessions, STATUS_POLL_MS);
+  slowTimer = window.setInterval(refreshSlowState, SLOW_POLL_MS);
+  heartbeatTimer = window.setInterval(renewOwnedSessions, CORE_HEARTBEAT_MS);
+}
+
+async function enterApp() {
+  const generation = requestGeneration;
+  try {
+    const me = await api('/api/teleop/me');
+    if (generation !== requestGeneration) return;
+    principal = me.principal;
+    document.getElementById('principal-id').textContent = me.principal.id;
+    document.getElementById('principal-role').textContent = me.principal.role;
+    document.getElementById('principal-permission').textContent = me.permissions.control
+      ? '可管理本标签页显式 Acquire 的 Shadow 或 Live 会话'
+      : 'viewer：只读，不显示会话控制按钮';
+    document.getElementById('teleop-client-id').textContent = TELEOP_CLIENT_ID;
+    loginPanel.classList.add('hidden');
+    content.classList.remove('hidden');
+    logoutButton.classList.remove('hidden');
+    await Promise.all([
+      loadDevices(),
+      loadCaptures(false),
+    ]);
+    if (generation !== requestGeneration || !principal) return;
+    await pollSessions();
+    if (generation !== requestGeneration || !principal) return;
+    await pollEvents();
+    if (generation !== requestGeneration || !principal) return;
+    startPolling();
+  } catch (error) {
+    if (error.cancelled) return;
+    if (error.status === 401) {
+      showLogin('请输入已配置的身份 token。');
+      showNotice('遥操控制台需要认证；未配置人类身份时保持关闭。', 'error');
+      return;
+    }
+    showNotice(`身份读取失败：${error.message}`, 'error');
+  }
+}
+
+loginForm.addEventListener('submit', async (event) => {
+  event.preventDefault();
+  loginError.textContent = '正在验证…';
+  const token = tokenInput.value.trim();
+  const status = await getAuthStatus(token);
+  if (!status.valid || !status.principal) {
+    loginError.textContent = status.authRequired
+      ? 'Token 无效。'
+      : '服务端尚未配置 owner/operator/viewer token。';
+    return;
+  }
+  setToken(token);
+  tokenInput.value = '';
+  loginError.textContent = '';
+  await enterApp();
+});
+
+logoutButton.addEventListener('click', async () => {
+  if (logoutButton.disabled) return;
+  logoutButton.disabled = true;
+  stopPolling();
+  closeAllRtcConnections('退出登录；REST release 前已本地 fail-safe 关闭');
+  const releaseRequests = releaseOwnedClientSessions();
+  await waitForBestEffortRelease(releaseRequests);
+  clearToken();
+  principal = null;
+  resetConsoleData();
+  logoutButton.disabled = false;
+  showLogin('已退出登录；本标签页会话已请求释放。');
+  showNotice('当前未登录。');
+});
+
+refreshButton.addEventListener('click', () => loadDevices(true));
+captureRefreshButton.addEventListener('click', () => loadCaptures(true));
+capturePairButton.addEventListener('click', createCapturePairing);
+captureAttachButton.addEventListener('click', attachSelectedCapture);
+captureRevokeButton.addEventListener('click', revokeSelectedCapture);
+captureDeviceSelect.addEventListener('change', () => {
+  selectedCaptureId = captureDeviceSelect.value;
+  renderCapturePanel();
+  renderDevices();
+});
+captureSessionSelect.addEventListener('change', () => {
+  selectedCaptureSessionId = captureSessionSelect.value;
+  renderCapturePanel();
+});
+document.querySelectorAll('.capture-copy-button').forEach((button) => {
+  button.addEventListener('click', () => {
+    void copyCaptureBootstrapField(button.dataset.copyField);
+  });
+});
+
+document.addEventListener('visibilitychange', () => {
+  if (document.visibilityState !== 'visible') {
+    closeAllRtcConnections('document 已隐藏；不会自动恢复 XR 或 RTC');
+  }
+});
+
+window.addEventListener('pagehide', () => {
+  stopPolling();
+  closeAllRtcConnections('pagehide；REST release 前已本地 fail-safe 关闭');
+  releaseOwnedClientSessions();
+});
+
+window.addEventListener('pageshow', (event) => {
+  if (!event.persisted || !principal) return;
+  startPolling();
+  refreshSlowState().then(pollSessions);
+});
+
+probeWebxrSupport();
+const initialStatus = await getAuthStatus(getToken());
+if (initialStatus.valid && initialStatus.principal) {
+  await enterApp();
+} else {
+  showLogin(initialStatus.authRequired ? '' : '服务端尚未配置人类身份 token。');
+  showNotice('登录后可查看可信 Driver；控制台不会自动 Acquire、确认 Live、连接 RTC 或进入 VR。');
+}

--- a/agent-core/web/js/teleop/capture-console.js
+++ b/agent-core/web/js/teleop/capture-console.js
@@ -1,0 +1,90 @@
+const CAPTURE_PROTOCOL = 'motus.teleop.capture.v1';
+const FRAME_PROTOCOL = 'motus.teleop.rtc-frame.v1';
+const SAFE_CAPTURE_PATH = '/ws/teleop-capture';
+const BASE64_PATTERN = /^[A-Za-z0-9+/]+={0,2}$/;
+
+function stringField(value) {
+  return typeof value === 'string' ? value : '';
+}
+
+export function captureBootstrapFields(pairing, locationLike) {
+  const path = stringField(pairing?.websocket_path);
+  const host = stringField(locationLike?.host);
+  const pairingId = stringField(pairing?.pairing_id);
+  const pairingCode = stringField(pairing?.pairing_code);
+  const caCertificateBase64 = stringField(pairing?.ca_certificate_base64);
+  const expiresAt = Number(pairing?.expires_at);
+  if (
+    path !== SAFE_CAPTURE_PATH
+    || !host
+    || host.includes('/')
+    || !pairingId
+    || pairingCode.length < 32
+    || pairingCode.length > 128
+    || caCertificateBase64.length === 0
+    || caCertificateBase64.length > 48 * 1024
+    || caCertificateBase64.length % 4 !== 0
+    || !BASE64_PATTERN.test(caCertificateBase64)
+    || !Number.isFinite(expiresAt)
+    || expiresAt <= 0
+  ) throw new Error('capture bootstrap response is invalid');
+  return {
+    coreWssUrl: `wss://${host}${path}`,
+    pairingId,
+    pairingCode,
+    caCertificateBase64,
+    expiresAt,
+  };
+}
+
+export function captureAttachEligibility(session, capture) {
+  if (!session || typeof session !== 'object') {
+    return { allowed: false, code: 'capture_session_required' };
+  }
+  if (session.owned_by_client !== true) {
+    return { allowed: false, code: 'session_client_mismatch' };
+  }
+  if (session.state === 'awaiting_confirmation') {
+    return { allowed: false, code: 'capture_live_confirmation_required' };
+  }
+  if (session.state !== 'active') {
+    return { allowed: false, code: 'capture_session_not_active' };
+  }
+  if (session.mode === 'live' && session.live_confirmed !== true) {
+    return { allowed: false, code: 'capture_live_confirmation_required' };
+  }
+  if (!['shadow', 'live'].includes(session.mode)) {
+    return { allowed: false, code: 'capture_session_contract_invalid' };
+  }
+  if (
+    typeof session.profile_id !== 'string'
+    || session.profile_id.length === 0
+    || !/^[0-9a-f]{64}$/.test(stringField(session.capability_digest))
+  ) return { allowed: false, code: 'capture_session_contract_invalid' };
+  if (!capture || typeof capture !== 'object') {
+    return { allowed: false, code: 'capture_device_required' };
+  }
+  if (capture.capture_protocol !== CAPTURE_PROTOCOL || capture.frame_protocol !== FRAME_PROTOCOL) {
+    return { allowed: false, code: 'capture_protocol_mismatch' };
+  }
+  if (capture.connected !== true || capture.observed_state !== 'xr_standby') {
+    return { allowed: false, code: 'capture_not_ready' };
+  }
+  if (capture.assignment !== null && capture.assignment !== undefined) {
+    return { allowed: false, code: 'capture_assignment_conflict' };
+  }
+  return { allowed: true, code: 'ready' };
+}
+
+export function captureAssignmentForSession(captures, sessionId) {
+  if (!Array.isArray(captures) || !sessionId) return null;
+  for (const capture of captures) {
+    if (capture?.assignment?.session_id === sessionId) return capture.assignment;
+  }
+  return null;
+}
+
+export const CAPTURE_CONSOLE_PROTOCOLS = Object.freeze({
+  capture: CAPTURE_PROTOCOL,
+  frame: FRAME_PROTOCOL,
+});

--- a/agent-core/web/js/teleop/webxr-frame.js
+++ b/agent-core/web/js/teleop/webxr-frame.js
@@ -1,0 +1,578 @@
+// Pure WebXR -> motus.teleop.rtc-frame.v1 mapping.
+//
+// The browser wire contract intentionally has no session-authority fields.
+// Core and Driver bind boot_id/session_id/epoch/fence server-side after the
+// WebRTC offer ticket has been verified.
+
+export const RTC_FRAME_PROTOCOL = 'motus.teleop.rtc-frame.v1';
+export const MAX_SAFE_WIRE_INTEGER = Number.MAX_SAFE_INTEGER;
+
+const MAX_AXES = 8;
+const MAX_BUTTONS = 16;
+const MAX_POSITION_METRES = 100;
+const QUATERNION_NORM_MIN = 0.5;
+const QUATERNION_NORM_MAX = 1.5;
+const QUATERNION_COMPONENT_LIMIT = 1.000001;
+const FRAME_MODES = new Set(['shadow', 'live']);
+const BASE_TWIST_AXES = ['linear_x', 'linear_y', 'angular_z'];
+
+function clamp(value, minimum, maximum) {
+  return Math.min(maximum, Math.max(minimum, value));
+}
+
+function isFiniteNumber(value) {
+  return typeof value === 'number' && Number.isFinite(value);
+}
+
+function requireSafeCounter(value, name, { allowMaximum = true } = {}) {
+  const upper = allowMaximum ? MAX_SAFE_WIRE_INTEGER : MAX_SAFE_WIRE_INTEGER - 1;
+  if (!Number.isSafeInteger(value) || value < 0 || value > upper) {
+    throw new RangeError(`${name} must be a non-negative JavaScript safe integer <= ${upper}`);
+  }
+  return value;
+}
+
+function component(object, name) {
+  if (!object || typeof object !== 'object') return null;
+  try {
+    const value = object[name];
+    return isFiniteNumber(value) ? value : null;
+  } catch {
+    return null;
+  }
+}
+
+function property(object, name) {
+  if (!object || typeof object !== 'object') return undefined;
+  try {
+    return object[name];
+  } catch {
+    return undefined;
+  }
+}
+
+function arrayLikeLength(value) {
+  if (!value || typeof value === 'string') return null;
+  try {
+    const length = value.length;
+    if (!Number.isSafeInteger(length) || length < 0) return null;
+    return length;
+  } catch {
+    return null;
+  }
+}
+
+function normalizedScalar(value, minimum, maximum) {
+  if (!isFiniteNumber(value)) return { value: 0, valid: false };
+  return {
+    value: clamp(value, minimum, maximum),
+    valid: value >= minimum && value <= maximum,
+  };
+}
+
+function isQualifiedGripSource(inputSource, expectedHandedness) {
+  if (!expectedHandedness) return true;
+  try {
+    return Boolean(
+      inputSource
+      && typeof inputSource === 'object'
+      && inputSource.handedness === expectedHandedness
+      && inputSource.targetRayMode === 'tracked-pointer'
+      && inputSource.gripSpace,
+    );
+  } catch {
+    return false;
+  }
+}
+
+function normalizeXrStandardInput(inputSource, expectedHandedness = null) {
+  let gamepad;
+  try {
+    gamepad = inputSource && typeof inputSource === 'object' ? inputSource.gamepad : null;
+  } catch {
+    gamepad = null;
+  }
+
+  let mapping;
+  let axesSource;
+  let buttonsSource;
+  try {
+    mapping = gamepad?.mapping;
+    axesSource = gamepad?.axes;
+    buttonsSource = gamepad?.buttons;
+  } catch {
+    mapping = null;
+  }
+
+  const axesLength = arrayLikeLength(axesSource);
+  const buttonsLength = arrayLikeLength(buttonsSource);
+  let valid = mapping === 'xr-standard'
+    && isQualifiedGripSource(inputSource, expectedHandedness)
+    && axesLength !== null
+    && buttonsLength !== null
+    && axesLength <= MAX_AXES
+    && buttonsLength >= 2
+    && buttonsLength <= MAX_BUTTONS;
+
+  const axes = [];
+  for (let index = 0; index < Math.min(axesLength ?? 0, MAX_AXES); index += 1) {
+    let raw;
+    try {
+      raw = axesSource[index];
+    } catch {
+      raw = null;
+    }
+    const normalized = normalizedScalar(raw, -1, 1);
+    axes.push(normalized.value);
+    valid = valid && normalized.valid;
+  }
+
+  const buttons = [];
+  for (let index = 0; index < Math.min(buttonsLength ?? 0, MAX_BUTTONS); index += 1) {
+    let raw;
+    try {
+      const button = buttonsSource[index];
+      raw = button && typeof button === 'object' ? button.value : null;
+    } catch {
+      raw = null;
+    }
+    const normalized = normalizedScalar(raw, 0, 1);
+    buttons.push(normalized.value);
+    valid = valid && normalized.valid;
+  }
+
+  return {
+    controller: { axes, buttons },
+    valid,
+  };
+}
+
+function zeroBaseTwist() {
+  return {
+    linear: [0, 0, 0],
+    angular: [0, 0, 0],
+  };
+}
+
+function remapBoundAxis(value, deadzone) {
+  if (!isFiniteNumber(value) || value < -1 || value > 1) return null;
+  const magnitude = Math.abs(value);
+  if (magnitude <= deadzone) return 0;
+  return Math.sign(value)
+    * ((magnitude - deadzone) / (1 - deadzone));
+}
+
+function scaledBoundAxis(value, binding) {
+  const remapped = remapBoundAxis(value, binding.deadzone);
+  if (remapped === null) return null;
+  if (remapped === 0) return 0;
+  return remapped * binding.scale * binding.direction;
+}
+
+function normalizeAxisBinding(value, name) {
+  if (!value || typeof value !== 'object') {
+    throw new TypeError(`${name} must be an object`);
+  }
+  const keys = Object.keys(value).sort();
+  if (JSON.stringify(keys) !== JSON.stringify([
+    'axis', 'deadzone', 'direction', 'hand', 'scale',
+  ])) {
+    throw new TypeError(`${name} has an invalid shape`);
+  }
+  const hand = property(value, 'hand');
+  const axis = property(value, 'axis');
+  const scale = property(value, 'scale');
+  const deadzone = property(value, 'deadzone');
+  const direction = property(value, 'direction');
+  if (
+    !['left', 'right'].includes(hand)
+    || !Number.isSafeInteger(axis)
+    || axis < 0
+    || axis >= MAX_AXES
+    || !isFiniteNumber(scale)
+    || scale < 0
+    || scale > 10
+    || !isFiniteNumber(deadzone)
+    || deadzone < 0
+    || deadzone > 0.95
+    || ![-1, 1].includes(direction)
+  ) throw new TypeError(`${name} is invalid`);
+  return Object.freeze({ hand, axis, scale, deadzone, direction });
+}
+
+function normalizeFrameConfiguration(configuration) {
+  if (!configuration || typeof configuration !== 'object') {
+    throw new TypeError('frame configuration is required');
+  }
+  const mode = property(configuration, 'mode');
+  if (!FRAME_MODES.has(mode)) throw new TypeError('frame mode must be shadow or live');
+  const capabilities = property(configuration, 'capabilities');
+  if (!capabilities || typeof capabilities !== 'object') {
+    throw new TypeError('frame capabilities are required');
+  }
+  const outputs = property(capabilities, 'outputs');
+  const inputBindings = property(capabilities, 'input_bindings');
+  if (!outputs || typeof outputs !== 'object' || !inputBindings || typeof inputBindings !== 'object') {
+    throw new TypeError('frame capabilities are invalid');
+  }
+  const baseEnabled = property(property(outputs, 'base'), 'enabled') === true;
+  const rawBaseTwist = property(inputBindings, 'base_twist');
+  if (baseEnabled !== Boolean(rawBaseTwist && typeof rawBaseTwist === 'object')) {
+    throw new TypeError('base output and base_twist binding must be enabled together');
+  }
+  let baseTwistBinding = null;
+  if (baseEnabled) {
+    if (
+      JSON.stringify(Object.keys(rawBaseTwist).sort())
+      !== JSON.stringify([...BASE_TWIST_AXES].sort())
+    ) throw new TypeError('base_twist binding is invalid');
+    baseTwistBinding = Object.freeze(Object.fromEntries(BASE_TWIST_AXES.map((name) => [
+      name,
+      normalizeAxisBinding(property(rawBaseTwist, name), `base_twist.${name}`),
+    ])));
+  }
+  return Object.freeze({ mode, baseTwistBinding });
+}
+
+function boundAxisValue(binding, leftInput, rightInput) {
+  const controller = binding.hand === 'left' ? leftInput?.controller : rightInput?.controller;
+  const axes = controller?.axes;
+  if (!Array.isArray(axes) || binding.axis >= axes.length) return null;
+  return axes[binding.axis];
+}
+
+function boundMotionInputsNeutral(leftInput, rightInput, baseTwistBinding) {
+  if (!baseTwistBinding) return true;
+  return BASE_TWIST_AXES.every((name) => {
+    const binding = baseTwistBinding[name];
+    const value = boundAxisValue(binding, leftInput, rightInput);
+    return value !== null && remapBoundAxis(value, binding.deadzone) === 0;
+  });
+}
+
+function boundMotionInputsAvailable(leftInput, rightInput, baseTwistBinding) {
+  if (!baseTwistBinding) return true;
+  return BASE_TWIST_AXES.every((name) => (
+    boundAxisValue(baseTwistBinding[name], leftInput, rightInput) !== null
+  ));
+}
+
+function buildBaseTwist(deadman, inputsValid, leftInput, rightInput, binding) {
+  const zero = zeroBaseTwist();
+  if (deadman !== true || inputsValid !== true || !binding) return zero;
+  const linearX = scaledBoundAxis(
+    boundAxisValue(binding.linear_x, leftInput, rightInput),
+    binding.linear_x,
+  );
+  const linearY = scaledBoundAxis(
+    boundAxisValue(binding.linear_y, leftInput, rightInput),
+    binding.linear_y,
+  );
+  const angularZ = scaledBoundAxis(
+    boundAxisValue(binding.angular_z, leftInput, rightInput),
+    binding.angular_z,
+  );
+  if (linearX === null || linearY === null || angularZ === null) return zero;
+
+  return {
+    linear: [linearX, linearY, 0],
+    angular: [0, 0, angularZ],
+  };
+}
+
+/**
+ * Convert an XRPose (or its XRRigidTransform) into the Driver pose shape.
+ * Invalid, untracked, non-finite, out-of-workspace, or malformed poses become
+ * null so the caller can keep tracking and pose fields consistent.
+ */
+export function xrPoseToWirePose(xrPose) {
+  if (!xrPose || typeof xrPose !== 'object') return null;
+
+  let transform;
+  let position;
+  let orientation;
+  try {
+    if (xrPose.emulatedPosition === true) return null;
+    transform = xrPose.transform && typeof xrPose.transform === 'object'
+      ? xrPose.transform
+      : xrPose;
+    position = transform.position;
+    orientation = transform.orientation;
+  } catch {
+    return null;
+  }
+
+  const positionValues = [
+    component(position, 'x'),
+    component(position, 'y'),
+    component(position, 'z'),
+  ];
+  if (positionValues.some((value) => value === null || Math.abs(value) > MAX_POSITION_METRES)) {
+    return null;
+  }
+
+  const quaternion = [
+    component(orientation, 'x'),
+    component(orientation, 'y'),
+    component(orientation, 'z'),
+    component(orientation, 'w'),
+  ];
+  if (quaternion.some((value) => (
+    value === null || Math.abs(value) > QUATERNION_COMPONENT_LIMIT
+  ))) {
+    return null;
+  }
+
+  const norm = Math.hypot(...quaternion);
+  if (!Number.isFinite(norm) || norm < QUATERNION_NORM_MIN || norm > QUATERNION_NORM_MAX) {
+    return null;
+  }
+  const normalized = quaternion.map((value) => value / norm);
+  const normalizedNorm = Math.hypot(...normalized);
+  if (!Number.isFinite(normalizedNorm) || normalizedNorm === 0) return null;
+  const strictOrientation = normalized.map((value) => clamp(value / normalizedNorm, -1, 1));
+  if (strictOrientation.some((value) => !Number.isFinite(value))) return null;
+
+  return {
+    position: positionValues,
+    orientation: strictOrientation,
+  };
+}
+
+/** Return only the public controller payload; validity remains an internal safety input. */
+export function xrStandardInputToWireController(inputSource) {
+  return normalizeXrStandardInput(inputSource).controller;
+}
+
+function xrStandardSqueezeState(inputSource) {
+  try {
+    const gamepad = inputSource?.gamepad;
+    if (!gamepad || gamepad.mapping !== 'xr-standard') return 'invalid';
+    const squeeze = gamepad.buttons?.[1];
+    if (
+      !squeeze
+      || typeof squeeze !== 'object'
+      || typeof squeeze.pressed !== 'boolean'
+      || !isFiniteNumber(squeeze.value)
+      || squeeze.value < 0
+      || squeeze.value > 1
+    ) return 'invalid';
+    if (squeeze.pressed === true && squeeze.value >= 0.75) return 'pressed';
+    if (squeeze.pressed === false && squeeze.value < 0.75) return 'released';
+    return 'transition';
+  } catch {
+    return 'invalid';
+  }
+}
+
+/** Quest/xr-standard deadman policy: both explicit squeeze buttons are held. */
+export function isDualSqueezeDeadmanRequested(leftInputSource, rightInputSource) {
+  return leftInputSource !== rightInputSource
+    && isQualifiedGripSource(leftInputSource, 'left')
+    && isQualifiedGripSource(rightInputSource, 'right')
+    && xrStandardSqueezeState(leftInputSource) === 'pressed'
+    && xrStandardSqueezeState(rightInputSource) === 'pressed';
+}
+
+/**
+ * Convert a performance.now()/XR predictedDisplayTime value to bounded integer
+ * nanoseconds. Null means the sample was unsafe; the reducer will then advance
+ * from its last known monotonic value instead of emitting invalid JSON.
+ */
+export function performanceMillisecondsToNanoseconds(milliseconds) {
+  if (!isFiniteNumber(milliseconds) || milliseconds < 0) return null;
+  const nanoseconds = Math.round(milliseconds * 1_000_000);
+  if (!Number.isSafeInteger(nanoseconds) || nanoseconds < 0) return null;
+  return nanoseconds;
+}
+
+/**
+ * State is explicit and serializable. nextSequence is the value the next frame
+ * will emit; clutchSequence is the last emitted clutch generation; and
+ * rearmRequired latches entry/tracking/reconnect safety until a valid physical
+ * squeeze release with every available locomotion axis neutral is observed.
+ */
+export function createRtcFrameState({
+  nextSequence = 0,
+  clutchSequence = 0,
+  deadmanActive = false,
+  rearmRequired = true,
+  lastMonotonicNs = 0,
+} = {}) {
+  requireSafeCounter(nextSequence, 'nextSequence');
+  requireSafeCounter(clutchSequence, 'clutchSequence');
+  requireSafeCounter(lastMonotonicNs, 'lastMonotonicNs');
+  if (typeof deadmanActive !== 'boolean') {
+    throw new TypeError('deadmanActive must be a boolean');
+  }
+  if (typeof rearmRequired !== 'boolean') {
+    throw new TypeError('rearmRequired must be a boolean');
+  }
+  return Object.freeze({
+    nextSequence,
+    clutchSequence,
+    deadmanActive,
+    rearmRequired,
+    lastMonotonicNs,
+  });
+}
+
+/**
+ * Persist this state when an XR/RTC stream ends. Counters and the monotonic
+ * watermark are deliberately retained across reconnects. Deadman is cleared
+ * and re-arm is latched so holding squeeze across the boundary cannot recover.
+ */
+export function markRtcFrameDeadmanReleased(previousState) {
+  const state = createRtcFrameState(previousState);
+  if (!state.deadmanActive && state.rearmRequired) return state;
+  return createRtcFrameState({
+    nextSequence: state.nextSequence,
+    clutchSequence: state.clutchSequence,
+    deadmanActive: false,
+    rearmRequired: true,
+    lastMonotonicNs: state.lastMonotonicNs,
+  });
+}
+
+function nextMonotonicNanoseconds(previous, milliseconds) {
+  const candidate = performanceMillisecondsToNanoseconds(milliseconds);
+  if (candidate !== null && candidate > previous) return candidate;
+  if (previous >= MAX_SAFE_WIRE_INTEGER) {
+    throw new RangeError('client_monotonic_ns exhausted the JavaScript safe integer range');
+  }
+  return previous + 1;
+}
+
+/**
+ * Pure reducer from one explicit state plus one WebXR sample to a strict public
+ * RTC frame. `deadman` is opt-in: only the literal boolean true can request it,
+ * and malformed tracking/controller data forces it back to false.
+ */
+export function buildRtcFrameV1(previousState, sample = {}, configuration = {}) {
+  const state = createRtcFrameState(previousState);
+  const source = sample && typeof sample === 'object' ? sample : {};
+  const frameConfiguration = normalizeFrameConfiguration(configuration);
+  requireSafeCounter(state.nextSequence, 'nextSequence', { allowMaximum: false });
+
+  const head = xrPoseToWirePose(property(source, 'headPose'));
+  const leftController = xrPoseToWirePose(property(source, 'leftGripPose'));
+  const rightController = xrPoseToWirePose(property(source, 'rightGripPose'));
+  const leftInputSource = property(source, 'leftInputSource');
+  const rightInputSource = property(source, 'rightInputSource');
+  const leftInput = normalizeXrStandardInput(leftInputSource, 'left');
+  const rightInput = normalizeXrStandardInput(rightInputSource, 'right');
+
+  const tracking = {
+    head: head !== null,
+    left_controller: leftController !== null,
+    right_controller: rightController !== null,
+  };
+  const allTracked = tracking.head && tracking.left_controller && tracking.right_controller;
+  const callerRequestedDeadman = property(source, 'deadman') === true;
+  const leftSqueezeState = xrStandardSqueezeState(leftInputSource);
+  const rightSqueezeState = xrStandardSqueezeState(rightInputSource);
+  const squeezeRequested = isDualSqueezeDeadmanRequested(leftInputSource, rightInputSource);
+  const inputsValid = leftInput.valid
+    && rightInput.valid
+    && leftInputSource !== rightInputSource
+    && boundMotionInputsAvailable(
+      leftInput,
+      rightInput,
+      frameConfiguration.baseTwistBinding,
+    );
+  const explicitReleaseObserved = inputsValid
+    && leftSqueezeState !== 'invalid'
+    && rightSqueezeState !== 'invalid'
+    && (leftSqueezeState === 'released' || rightSqueezeState === 'released');
+  const motionInputsNeutral = boundMotionInputsNeutral(
+    leftInput,
+    rightInput,
+    frameConfiguration.baseTwistBinding,
+  );
+  const nonNeutralEngagementAttempt = !state.deadmanActive
+    && callerRequestedDeadman
+    && squeezeRequested
+    && !motionInputsNeutral;
+  let rearmRequired = state.rearmRequired;
+  if (!allTracked || !inputsValid) {
+    rearmRequired = true;
+  } else if (explicitReleaseObserved) {
+    // Re-arm requires both a physical squeeze release and neutral locomotion
+    // sticks. A held stick cannot preload the first command after reconnect.
+    rearmRequired = !motionInputsNeutral;
+  } else if (
+    (state.deadmanActive && !squeezeRequested)
+    || (!callerRequestedDeadman && squeezeRequested)
+    || nonNeutralEngagementAttempt
+  ) {
+    rearmRequired = true;
+  }
+  const deadman = callerRequestedDeadman
+    && allTracked
+    && inputsValid
+    && squeezeRequested
+    && !rearmRequired;
+
+  let clutchSequence = state.clutchSequence;
+  if (deadman && !state.deadmanActive) {
+    if (clutchSequence >= MAX_SAFE_WIRE_INTEGER) {
+      throw new RangeError('clutch_sequence exhausted the JavaScript safe integer range');
+    }
+    clutchSequence += 1;
+  }
+  const clientMonotonicNs = nextMonotonicNanoseconds(
+    state.lastMonotonicNs,
+    property(source, 'monotonicTimeMs'),
+  );
+  const frame = {
+    schema_version: 1,
+    sequence: state.nextSequence,
+    client_monotonic_ns: clientMonotonicNs,
+    mode: frameConfiguration.mode,
+    deadman,
+    clutch_sequence: clutchSequence,
+    tracking,
+    head,
+    left_controller: leftController,
+    right_controller: rightController,
+    controllers: {
+      left: leftInput.controller,
+      right: rightInput.controller,
+    },
+  };
+  if (frameConfiguration.baseTwistBinding) {
+    frame.base_twist = buildBaseTwist(
+      deadman,
+      inputsValid,
+      leftInput,
+      rightInput,
+      frameConfiguration.baseTwistBinding,
+    );
+  }
+
+  return {
+    frame,
+    state: createRtcFrameState({
+      nextSequence: state.nextSequence + 1,
+      clutchSequence,
+      deadmanActive: deadman,
+      rearmRequired,
+      lastMonotonicNs: clientMonotonicNs,
+    }),
+  };
+}
+
+/** Stateful convenience wrapper; all state remains scoped to this instance. */
+export function createRtcFrameGenerator(options = {}, configuration = {}) {
+  let state = createRtcFrameState(options);
+  return Object.freeze({
+    next(sample = {}) {
+      const result = buildRtcFrameV1(state, sample, configuration);
+      state = result.state;
+      return result.frame;
+    },
+    snapshot() {
+      return state;
+    },
+  });
+}

--- a/agent-core/web/teleop.html
+++ b/agent-core/web/teleop.html
@@ -1,0 +1,141 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+  <title>通用遥操作 · PhanthyMotus</title>
+  <link rel="stylesheet" href="/css/teleop.css">
+</head>
+<body>
+  <main class="teleop-shell">
+    <header class="teleop-header">
+      <div>
+        <p class="eyebrow">PHANTHY MOTUS</p>
+        <h1>通用遥操作控制台</h1>
+        <p class="subtitle">可信 Driver、显式 Shadow / Live 会话、OpenXR Capture 与 Quest WebXR fallback</p>
+      </div>
+      <nav class="header-actions" aria-label="页面操作">
+        <a class="button secondary" href="/">返回主界面</a>
+        <button class="button secondary hidden" id="logout-button" type="button">退出登录</button>
+      </nav>
+    </header>
+
+    <section class="notice" id="global-notice" role="status">正在检查登录状态…</section>
+
+    <section class="login-panel hidden" id="login-panel" aria-labelledby="login-title">
+      <h2 id="login-title">登录</h2>
+      <p>请输入 owner、operator 或 viewer token。viewer 只能查看，operator 与 owner 可以管理本标签页明确获取的遥操作会话。</p>
+      <form id="login-form">
+        <label for="token-input">Access token</label>
+        <div class="login-row">
+          <input id="token-input" type="password" autocomplete="current-password" required>
+          <button class="button primary" type="submit">登录</button>
+        </div>
+        <p class="form-error" id="login-error" role="alert"></p>
+      </form>
+    </section>
+
+    <div class="content hidden" id="content">
+      <section class="identity-card" aria-labelledby="identity-title">
+        <div>
+          <p class="section-label" id="identity-title">当前身份</p>
+          <strong id="principal-id">—</strong>
+          <p class="identity-permission" id="principal-permission">—</p>
+          <p class="client-identity">本页 Client ID：<code id="teleop-client-id">—</code></p>
+        </div>
+        <span class="role-badge" id="principal-role">—</span>
+      </section>
+
+      <section class="safety-card" aria-labelledby="safety-title">
+        <div class="safety-icon" aria-hidden="true">S</div>
+        <div>
+          <p class="section-label" id="safety-title">TELEOP AUTHORITY</p>
+          <h2>Shadow 只记录；Live 必须二次明确确认硬件输出</h2>
+          <p>WebXR 能力：<strong id="webxr-support">正在检测安全上下文与 immersive-vr…</strong></p>
+          <p>本页只在用户点击后从 Quest 的 <code>local-floor</code> 读取头部与唯一左右手柄姿态，按当前会话 mode 生成最高 60 Hz 的 RTC frame。只有有效 <code>xr-standard</code> 双 squeeze、先松开、能力声明的运动轴全部归入各自 deadzone、再空挡重握时 deadman 才能为 true，不能预装首帧运动；tracking、输入或 deadman 退化时会发送 fail-safe frame。</p>
+          <p>Core 不解释厂商 SDK、关节顺序、逆解或速度语义。浏览器只采用可信 Driver descriptor 中的 profile、effectors、outputs 与 input bindings；未启用的 base 或 hands 不会出现在 frame 中。任何能力声明的输入缩放只是浏览器侧投影，最终限幅和硬件适配仍由 Driver 负责。</p>
+          <p>Shadow 的 <code>hardware_output=false</code>，只产生 recording 证据。Live 的 <code>hardware_output=true</code>：第一次 Acquire 只创建短期内存 reservation，并停在 <code>awaiting_confirmation</code>，不会调用 Driver、续租或开放 RTC；操作员核对 Robot、Driver、Profile 与 Effectors 后，必须再次点击醒目的 Live 确认按钮，Core 才会 prepare Driver。</p>
+          <p>本切片进入 VR 后头显只显示诊断黑场：没有机器人视频，也没有头显内 HUD。所有 tracking、deadman、sequence 与 Driver dispatch 证据只显示在 2D 镜像页，需要通过 Quest 投屏或桌面浏览器观察。</p>
+          <p>每次页面加载都会生成独立 Client ID，避免复制标签页继承控制权；本页只为自己的已准备会话每 5 秒续一次 Core 所有权租约，Core 倒计时为 15 秒。Pause/HOLD/Release、RTC/XR 断开、reference-space reset、页面或 XR 不可见都会先本地释放 deadman 并关闭 XR 与 RTC。Pause 仍占用机器人；恢复必须先 Release，再重新 Acquire。刷新、RTC 断线或 XR 退出绝不会自动确认 Live、自动恢复、自动重进 VR、自动重连或自动获取会话。</p>
+          <p>Shadow prepare 或 Live 明确确认后，Core 会持久保存一把不含 fence、令牌或浏览器身份的机器人写入锁；等待 Live 确认时不会写这把锁。若 Core 意外退出，重启后的普通执行器命令仍会被拒绝，页面显示“重启安全锁定”；只有 owner 可以请求 Core 读取同一可信 Driver 的状态，并在必要时执行无旧 fence 的 lifecycle stop。只有严格安全证明与锁记录删除都成功后才会开放写入，旧会话始终不会恢复。</p>
+        </div>
+      </section>
+
+      <section class="capture-section hidden" id="capture-panel" aria-labelledby="capture-title">
+        <div class="section-heading">
+          <div>
+            <p class="section-label">OPENXR CAPTURE</p>
+            <h2 id="capture-title">独立 OpenXR 头显姿态采集设备</h2>
+          </div>
+          <div class="capture-heading-actions">
+            <button class="button secondary" id="capture-refresh-button" type="button">刷新采集设备</button>
+            <button class="button primary" id="capture-pair-button" type="button">生成一次性配对</button>
+          </div>
+        </div>
+        <p class="capture-explanation">PC 标签页始终持有会话与硬件确认权；OpenXR 头显 Capture 只接收当前会话的安全投影并把姿态通过 RTC 直发 Driver。配对、Acquire、Live 确认、Attach、Pause/HOLD 与 Release 都必须在 PC 上手动执行，页面刷新不会自动执行其中任何一步。</p>
+
+        <div class="capture-pair-row">
+          <label for="capture-label">设备标签</label>
+          <input id="capture-label" type="text" maxlength="64" value="OpenXR Headset Capture" autocomplete="off">
+        </div>
+
+        <section class="capture-bootstrap hidden" id="capture-bootstrap" aria-labelledby="capture-bootstrap-title">
+          <h3 id="capture-bootstrap-title">一次性实验室启动信息</h3>
+          <p class="capture-secret-warning">Pairing code 是短期一次性秘密。只通过受控启动参数交给 OpenXR 头显 Capture；不要放入 URL、HTTP header、浏览器 console、日志或 shell 历史。CA 是当前 Core HTTPS 部署的公开证书链，不包含私钥。</p>
+          <div class="capture-bootstrap-grid">
+            <label for="capture-wss-url">core_wss_url</label>
+            <div class="capture-copy-row">
+              <input id="capture-wss-url" type="text" readonly>
+              <button class="button secondary capture-copy-button" type="button" data-copy-field="coreWssUrl">复制</button>
+            </div>
+            <label for="capture-pairing-id">pairing_id</label>
+            <div class="capture-copy-row">
+              <input id="capture-pairing-id" type="text" readonly>
+              <button class="button secondary capture-copy-button" type="button" data-copy-field="pairingId">复制</button>
+            </div>
+            <label for="capture-pairing-code">pairing_code（一次性秘密）</label>
+            <div class="capture-copy-row">
+              <input id="capture-pairing-code" type="password" readonly>
+              <button class="button warning capture-copy-button" type="button" data-copy-field="pairingCode">复制秘密</button>
+            </div>
+            <label for="capture-ca-base64">ca_certificate_base64（公开）</label>
+            <div class="capture-copy-row">
+              <textarea id="capture-ca-base64" rows="3" readonly></textarea>
+              <button class="button secondary capture-copy-button" type="button" data-copy-field="caCertificateBase64">复制</button>
+            </div>
+          </div>
+          <p class="capture-expiry" id="capture-pairing-expiry">—</p>
+        </section>
+
+        <div class="capture-selection-grid">
+          <label for="capture-device-select">采集设备</label>
+          <select id="capture-device-select"></select>
+          <label for="capture-session-select">本标签页会话</label>
+          <select id="capture-session-select"></select>
+        </div>
+        <dl class="capture-facts" id="capture-device-facts"></dl>
+        <div class="capture-actions">
+          <button class="button primary" id="capture-attach-button" type="button">Attach 到所选 Active 会话</button>
+          <button class="button danger" id="capture-revoke-button" type="button">撤销所选设备</button>
+        </div>
+        <p class="capture-status" id="capture-status" role="status">尚未读取采集设备。</p>
+        <p class="capture-fallback"><strong>Direct WebXR fallback（显式同页模式）仍保留：</strong>在机器人卡片中手动连接 RTC、再手动进入 Quest VR。Capture 与 Direct source 在同一会话内互斥，页面不会静默切换；若要切换，先 HOLD/Release，再新建会话。</p>
+      </section>
+
+      <section class="devices-section" aria-labelledby="devices-title">
+        <div class="section-heading">
+          <div>
+            <p class="section-label">SESSION CONTROL</p>
+            <h2 id="devices-title">机器人 Driver 与遥操作会话</h2>
+          </div>
+          <button class="button secondary" id="refresh-button" type="button">刷新</button>
+        </div>
+        <p class="empty hidden" id="devices-empty">尚未发现 category=driver 的服务。控制台不会自动 Acquire。</p>
+        <div class="device-grid" id="device-grid"></div>
+      </section>
+    </div>
+  </main>
+
+  <script type="module" src="/js/teleop/app.js"></script>
+</body>
+</html>

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -25,3 +25,58 @@
 # RESOURCE_CENTER_URL=https://motus.phanthy.com
 # Generate API key at https://motus.phanthy.com/keys (format: rc_xxxx)
 # RESOURCE_CENTER_API_KEY=rc_your_api_key_here
+
+# ── Dashboard principals and trusted drivers ───────────────────────────────
+# ACCESS_TOKEN is the backwards-compatible owner identity. Owner retains
+# access to every existing dashboard/API/WebSocket surface.
+# Any Driver or ticket credential below automatically locks protected APIs;
+# configure this owner or management calls will fail closed with 401.
+# ACCESS_TOKEN=replace-with-a-long-random-owner-token
+
+# Named identities are JSON objects. Operators can use only the dedicated
+# /api/teleop/* session surface; viewers have read-only teleop visibility.
+# Neither role can access legacy APIs, Canvas calls, or WebSockets.
+# MOTUS_OPERATOR_TOKENS={"lab-operator":"replace-with-a-long-random-token"}
+# MOTUS_VIEWER_TOKENS={"auditor":"replace-with-a-long-random-token"}
+
+# Bind each stable Driver MCP id to a unique Bearer. Core accepts a dedicated
+# token only for that exact registration id and selects the same token on every
+# outbound MCP/SSE/teleop/offer request. Duplicate values fail Core startup.
+# Adding or rotating a mapped token quarantines its persisted target until that
+# Driver registers inbound with the selected value; Core never stores the token.
+# MOTUS_DRIVER_TOKENS={"teleop-shadow-lab-a":"replace-with-a-unique-long-random-token","teleop-shadow-lab-b":"replace-with-another-unique-long-random-token"}
+
+# Optional migration fallback for Driver ids not yet present in the map. A
+# mapped id never falls back to this value. Remove it after migration.
+# MOTUS_DRIVER_TOKEN=replace-with-a-legacy-long-random-driver-token
+
+# Bind each teleop Driver id to a unique HMAC secret of at least 32 UTF-8 bytes.
+# These values sign server-side one-use WebRTC tickets and must also be unique.
+# A Driver without an exact entry or legacy fallback is not teleop-ready.
+# MOTUS_TELEOP_TICKET_SECRETS={"teleop-shadow-lab-a":"replace-with-at-least-32-unique-random-bytes-a","teleop-shadow-lab-b":"replace-with-at-least-32-unique-random-bytes-b"}
+
+# Optional migration fallback for unmapped teleop Driver ids.
+# MOTUS_TELEOP_TICKET_SECRET=replace-with-at-least-32-legacy-random-bytes
+
+# Compatibility is the default: legacy MCPs keep running but never gain
+# teleop trust. Enable only after every service authenticates both directions.
+# MOTUS_ENFORCE_DRIVER_AUTH=false
+
+# In-process Bash/Python, local Write/Edit, and arbitrary URL WebFetch are hidden
+# from the LLM by default. This unsafe escape hatch is accepted only when no
+# human, Driver, or teleop credentials exist; never use it in an authenticated deploy.
+# MOTUS_ENABLE_UNSAFE_DESKTOP_CODE_TOOLS=false
+
+# Browser-to-Core ownership lease. Values are bounded to 15..120 seconds;
+# the console renews the default 15-second lease every five seconds.
+# Core-to-Driver heartbeat timing is derived from the Driver's own watchdog.
+# MOTUS_TELEOP_LEASE_SECONDS=15
+
+# ─── Agent Core TLS / Quest WebXR ────────────────────────────────────────
+# Configure both paths or neither. These are container-visible paths; the
+# /opt/phanthy-motus directory is mounted into Agent Core at the same path.
+# The certificate must cover the exact Quest Browser hostname in its SAN and
+# chain to an issuer accepted by that browser. Keep the private key owner-only
+# (chmod 600, or 400 for a read-only managed key). A Core restart loads rotations.
+# MOTUS_TLS_CERT_FILE=/opt/phanthy-motus/tls/fullchain.pem
+# MOTUS_TLS_KEY_FILE=/opt/phanthy-motus/tls/privkey.pem


### PR DESCRIPTION
## 交付结果

本 PR 为 Agent Core 新增可信、适配器无关的遥操作控制面，提供可见的 `/teleop.html` 控制台，以及供 Meta Quest 和 PICO 共用的原生 OpenXR Capture 客户端。

操作员可以在电脑端发现可信机器人、独占获取会话、显式确认 Live 模式、连接已配对头显、查看传输与输出延迟，并执行暂停、HOLD 和释放。Core 负责身份、RBAC、租约、栅栏、恢复保护、审计和 WebRTC 信令；高频姿态帧仍由头显直接发送给 Driver，不经过 Core 转发。

## 包含内容

- 版本化的 Shadow/Live 描述符与状态合同
- 可信 Driver 发现、逐 Driver 凭据和固定信令目标
- MCP、Canvas、项目和遥操作之间的机器人独占控制权
- 显式 Live 二次确认和 Core 崩溃后的控制权恢复
- Capture 配对、在线状态、连接和失联时的故障关闭处理
- 通用电脑控制台，以及显式选择的 Direct WebXR 备用入口
- 一套原生 Android OpenXR 客户端，分别构建 Meta 与 PICO 变体
- 只下发公开 TLS 证书链，不暴露私钥材料

## 安全边界

- 本 PR 不能发布机器人指令，也不包含 G1 IK 或 DDS Publisher。
- Live 模式不会被自动确认。
- Capture 断连、焦点丢失、在线状态过期、租约丢失或 Driver 证据格式错误时，系统会故障关闭到 HOLD 或 fault。
- 未声明保留遥操作描述符的现有 Driver 保持原有行为。

## 验证结果

- `tests/teleop`：在当前 `origin/main` 集成树上 **688 项通过**
- `test_capture_console.mjs`：通过
- `test_webxr_frame.mjs`：通过
- `app.js` 与 `capture-console.js` 的 Node 等价语法检查：通过
- 本次变更的 Python 源码通过 Ruff `F821` 检查
- 从本 PR 原生客户端源码构建了 Meta 与 PICO `arm64-v8a` 调试 APK，并通过包信息、Manifest、ABI、ELF 依赖、zipalign 和 v2 调试签名检查
- `git diff --check`：通过

## 转为可评审状态前仍需完成

- 尚未完成 PICO 真机安装以及 OpenXR、控制器和 RTC 验收。
- Quest 回归受当前无线 ADB 未授权状态阻塞。
- G1 当前关机；本 PR 不声明 G1 真机或 Live 验收完成。
- Android 产物是实验室调试签名版本，不是发布版本。
