### PR TITLE
feat(hooks): LED state machine with VAD/TTS-driven triggers

### DIFF
--- a/agent-core/src/api/mcp_manage.py
+++ b/agent-core/src/api/mcp_manage.py
@@ -284,6 +284,13 @@ def _guess_data_type(tools: list, resources: list, name: str) -> str:
 
 # ── Endpoints ─────────────────────────────────────────────────────────────────
 
+@router.get('/hooks/status')
+async def hooks_status():
+    """Return hook registry and recent fire log for diagnostics."""
+    import hooks
+    return {'code': 200, 'data': hooks.get_status()}
+
+
 @router.get('')
 async def mcp_list():
     items = [

--- a/agent-core/src/collector.py
+++ b/agent-core/src/collector.py
@@ -383,9 +383,8 @@ async def _drain_loop():
         _extract_perf_timestamps(ev)
         priority = _extract_priority(ev)
 
-        # System hooks: fire on_hearing / on_kws_wakeup for ASR events
+        # KWS wake-word hook (fires regardless of busy state)
         if 'asr' in source.lower():
-            import hooks
             payload = ev.get('payload', {})
             if isinstance(payload, str):
                 try:
@@ -394,9 +393,8 @@ async def _drain_loop():
                 except Exception:
                     payload = {}
             if payload.get('kws_triggered'):
+                import hooks
                 asyncio.create_task(hooks.fire('on_kws_wakeup'))
-            else:
-                asyncio.create_task(hooks.fire('on_hearing'))
 
         # Ring buffer 始终存储（所有事件，供 raw_input_info 查询）
         if source not in _source_ring:

--- a/agent-core/src/event/llm.py
+++ b/agent-core/src/event/llm.py
@@ -650,6 +650,9 @@ class Event:
             finally:
                 collector.set_cancel_event(None)
                 collector.set_busy(False)
+                # Fire on_idle hook (LED state reset etc.)
+                import hooks as _hooks_idle
+                asyncio.create_task(_hooks_idle.fire('on_idle'))
                 # 无论成功失败，只要有消息就持久化
                 if self._current_turn:
                     self._save_current_turn(ev)

--- a/agent-core/src/hooks.py
+++ b/agent-core/src/hooks.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import asyncio
 import time
+from collections import deque
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -26,6 +27,7 @@ class HookBinding:
 # ── Registry ─────────────────────────────────────────────────────────────────
 
 _registry: dict[str, list[HookBinding]] = {}
+_fire_log: deque = deque(maxlen=30)
 
 
 def register(mcp_id: str, tool_name: str, x_hooks: dict):
@@ -89,6 +91,14 @@ def get_hook_for_binding(mcp_id: str, tool: str, action: str) -> str | None:
     return None
 
 
+def get_status() -> dict:
+    """Return hook registry and recent fire log for diagnostics."""
+    return {
+        'registry': list_hooks(),
+        'recent_fires': list(_fire_log),
+    }
+
+
 # ── Executor ─────────────────────────────────────────────────────────────────
 
 async def fire(hook_id: str, extra_params: dict | None = None, exclude_mcp_id: str | None = None) -> list[dict]:
@@ -132,6 +142,11 @@ async def fire(hook_id: str, extra_params: dict | None = None, exclude_mcp_id: s
 
     if bindings:
         print(f'[hooks] fired {hook_id}: {len(bindings)} binding(s)')
+    _fire_log.append({
+        'hook': hook_id, 'ts': time.time(),
+        'bindings': len(bindings),
+        'errors': [r for r in results if 'error' in r],
+    })
     return results
 
 

--- a/perception/plugins/asr.py
+++ b/perception/plugins/asr.py
@@ -677,6 +677,7 @@ def _vad_worker(pcm_q: multiprocessing.Queue, result_q: multiprocessing.Queue,
     start_ts = None
     end_ts = None
     kws_cooldown_until = 0.0
+    _was_speaking = False  # Track speech onset for hook notification
 
     _log.info(f"[vad-worker] process started (pid={os.getpid()}, backend=sherpa_onnx, kws={kws_enabled})")
     audio_count = 0
@@ -775,6 +776,12 @@ def _vad_worker(pcm_q: multiprocessing.Queue, result_q: multiprocessing.Queue,
                 vad.pop()
 
         elif state == 'listening':
+            # Detect speech onset → notify main thread for on_hearing hook
+            _is_speaking = vad.is_speech_detected()
+            if _is_speaking and not _was_speaking:
+                result_q.put(("speech_start", ts, ts, False))
+            _was_speaking = _is_speaking
+
             # Collect completed VAD segments
             while not vad.empty():
                 seg = vad.front
@@ -980,6 +987,25 @@ class _ASRNode(Node):
         while not self._stop_event.is_set():
             try:
                 item = self._utterance_queue.get(timeout=1)
+                # Handle speech onset signal from VAD worker
+                if len(item) >= 2 and item[0] == "speech_start":
+                    try:
+                        import urllib.request as _urllib_req
+                        import json as _json_hook
+                        _hook_req = _urllib_req.Request(
+                            "https://localhost:15678/api/hooks/fire",
+                            data=_json_hook.dumps({"hook": "on_hearing"}).encode(),
+                            headers={"Content-Type": "application/json"},
+                            method="POST"
+                        )
+                        import ssl as _ssl
+                        _ctx = _ssl.create_default_context()
+                        _ctx.check_hostname = False
+                        _ctx.verify_mode = _ssl.CERT_NONE
+                        _urllib_req.urlopen(_hook_req, timeout=2, context=_ctx)
+                    except Exception as _he:
+                        log.debug(f"[asr] fire on_hearing failed: {_he}")
+                    continue
                 if len(item) == 4:
                     utterance, start_ts, end_ts, _kws_from_vad = item
                 else:

--- a/perception/plugins/tts.py
+++ b/perception/plugins/tts.py
@@ -329,6 +329,23 @@ class _TTSNode(Node):
                                 # Flush pre-buffer and start real-time clock
                                 t0 = _time.monotonic()
                                 t0_wall = _time.time()
+                                # Fire on_speaking hook (playback starting)
+                                try:
+                                    import urllib.request as _ureq
+                                    import json as _jhook
+                                    _hreq = _ureq.Request(
+                                        "https://localhost:15678/api/hooks/fire",
+                                        data=_jhook.dumps({"hook": "on_speaking"}).encode(),
+                                        headers={"Content-Type": "application/json"},
+                                        method="POST"
+                                    )
+                                    import ssl as _ssl
+                                    _sctx = _ssl.create_default_context()
+                                    _sctx.check_hostname = False
+                                    _sctx.verify_mode = _ssl.CERT_NONE
+                                    _ureq.urlopen(_hreq, timeout=2, context=_sctx)
+                                except Exception:
+                                    pass
                                 for pf in prebuf:
                                     msg = AudioChunk()
                                     msg.header.stamp = self.get_clock().now().to_msg()
@@ -412,6 +429,7 @@ class _TTSNode(Node):
                     pass
 
                 # ACP: 推送动作完成回调到 Agent Core
+                # Also fire on_idle hook (LED off immediately after playback)
                 if _action_id:
                     try:
                         import urllib.request as _urllib
@@ -421,6 +439,14 @@ class _TTSNode(Node):
                         _ctx = _ssl.create_default_context()
                         _ctx.check_hostname = False
                         _ctx.verify_mode = _ssl.CERT_NONE
+                        # Fire on_idle to turn off LED
+                        _idle_req = _urllib.Request(
+                            f"{_agent_core_url}/api/hooks/fire",
+                            data=json.dumps({"hook": "on_idle"}).encode(),
+                            headers={"Content-Type": "application/json"},
+                            method="POST"
+                        )
+                        _urllib.urlopen(_idle_req, timeout=2, context=_ctx)
                         was_interrupted = self._interrupt_flag.is_set()
                         _payload = json.dumps({
                             "action_id": _action_id,


### PR DESCRIPTION
## Summary
- Perception VAD speech onset → HTTP POST `/api/hooks/fire` fires `on_hearing` (LED green)
- Perception TTS playback start/end → fires `on_speaking`/`on_idle` via same mechanism
- Remove hardcoded TTS tool name detection from llm.py
- Agent-core internal hooks (on_thinking, on_idle, on_error) remain as direct `hooks.fire()` calls
- Collector only retains `on_kws_wakeup` hook firing

## Architecture
External systems trigger hooks via `POST /api/hooks/fire`. Agent-core internal events use direct function calls. Hook registry determines what actions to execute.

## Test plan
- [ ] Say something → LED turns green immediately at speech onset
- [ ] LLM starts reasoning → LED shows rainbow
- [ ] TTS starts playing → LED shows Tiffany blue
- [ ] TTS finishes → LED off (firmware blue blink resumes)
- [ ] Verify no LED blinking during silence

🤖 Generated with [Claude Code](https://claude.com/claude-code)