### PR TITLE
perf(collector): strip ACP result from event text

### DIFF
--- a/agent-core/src/collector.py
+++ b/agent-core/src/collector.py
@@ -273,11 +273,18 @@ def _slim_event_text(text: str) -> str:
         data = _json.loads(text)
     except (ValueError, TypeError):
         return text
-    keys_to_remove = _LLM_IRRELEVANT_KEYS & data.keys()
-    if not keys_to_remove:
+    changed = False
+    # 移除 perf trace 字段
+    for key in _LLM_IRRELEVANT_KEYS:
+        if key in data:
+            del data[key]
+            changed = True
+    # ACP 完成事件：去掉 result 中的冗余内容（LLM 已知自己发出了什么）
+    if data.get('type') == 'action_complete' and 'result' in data:
+        del data['result']
+        changed = True
+    if not changed:
         return text
-    for key in keys_to_remove:
-        del data[key]
     return _json.dumps(data, ensure_ascii=False)
 
 


### PR DESCRIPTION
## Summary

- Strip `result` field from `action_complete` ACP events in `_slim_event_text()` before they enter LLM context
- The result (e.g. full TTS text) is redundant — the LLM authored it and doesn't need it echoed back
- Reduces each ACP event from ~200-300 chars to ~70 chars
- In G1 tour sessions with 21 ACP events in history: saves ~4K chars/request

## Context

G1 analysis showed ACP events occupy 96% of user message volume. Each carries back the full spoken text (which the LLM wrote). Stripping this redundancy is a safe ~5% prompt reduction.

## Test plan

- [ ] Deploy to G1, run tour, verify ACP events in logs are slim: `{"type":"action_complete","action_id":"...","status":"completed"}`
- [ ] Confirm LLM still correctly handles ACP completion (navigates to next stop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)