### PR TITLE
fix(agent-core): auto-interrupt pending ACP on new user turn

### DIFF
--- a/agent-core/src/event/llm.py
+++ b/agent-core/src/event/llm.py
@@ -787,6 +787,22 @@ class Event:
         # Fire on_thinking hook (non-blocking LED feedback etc.)
         import hooks
         asyncio.create_task(hooks.fire('on_thinking'))
+
+        # ── Auto-interrupt: 新用户 turn 开始时清除旧的 pending ACP ──
+        if mcp_client.get_pending_actions():
+            _int_results = await hooks.fire('on_interrupt_all')
+            if _int_results:
+                for aid in list(mcp_client._pending_actions.keys()):
+                    mcp_client._pending_results[aid] = {
+                        "status": "cancelled",
+                        "reason": "auto-interrupted by new user message",
+                    }
+                    mcp_client._pending_actions[aid].set()
+                print(f'[decision] auto-interrupt: {len(_int_results)} hook(s) fired, pending cleared')
+            else:
+                # Fallback: 没有 hook 注册时用硬编码查找
+                await self._interrupt_active_outputs()
+
         # Subagent status in log
         if self._subagent_mgr:
             _sa_active = self._subagent_mgr.list_active()


### PR DESCRIPTION
## Summary
- 新用户 turn 开始时，如果有 pending ACP（如 TTS 在播），框架自动 fire `on_interrupt_all` hooks 并清除 pending
- 解决两个问题：LLM 误判不调 interrupt 导致 barrier 阻塞 28s；LLM 正确调 interrupt 但推理 8s 延迟
- "停旧输出"是框架机械反应，LLM 仍负责决定回复内容

## Test plan
- [x] 部署到 Tianyi 2.0 测试
- [ ] TTS 播放中发新消息 → TTS 立即停，LLM 直接回复（无 barrier）

🤖 Generated with [Claude Code](https://claude.com/claude-code)