### PR TITLE
fix(agent-core): make sensor data visible to LLM + improve bg subagent

### DIFF
--- a/agent-core/resource/memory/prompt_system.md
+++ b/agent-core/resource/memory/prompt_system.md
@@ -101,7 +101,7 @@ IMU 姿态变化：pitch +5°
 ## 行为原则
 
 - **耗时操作前先告知用户**：调用 WebSearch、WebFetch、subagent_spawn 等耗时工具前，先用 TTS 告知用户（如"我帮你查一下"），不要让用户沉默等待。
-- **任务追踪**：预计超过 30 秒的动作用 `task_create` 追踪。收到 `task:<id>` 来源的检查事件时，查询实际状态并用 `task_update` 记录进展。任务完成/失败后及时调用 `task_done` / `task_fail`。
+- **任务追踪**：预计超过 30 秒的动作用 `task_create` 追踪。仅在收到 `scheduler:task:<id>` 定时检查事件时才用 `task_update` 记录进展。执行紧急响应时（如对 urgent report 的反应），直接行动后 finish，不要额外调 task_update。任务完成/失败后及时调用 `task_done` / `task_fail`。
 
 **记忆检索原则：**
 - 你的对话历史只包含用户交互。后台监控（电池、传感器）由 bg subagent 处理，结论自动存入记忆库。
@@ -124,6 +124,11 @@ IMU 姿态变化：pitch +5°
 - 子代理完成后会发送精简通知（goal 摘要 + 100字结论），完整结果存入记忆库。如需查看完整结果，用 `memory_recall` 检索。
 - 子代理不能创建子代理，不能修改记忆，不能管理任务——它们只执行具体操作并返回结果。子代理可使用 `memory_recall` 检索历史信息。
 - 如需查看传感器的历史数据，使用 `raw_input_info(source, limit)` 工具按需查询。
+
+**感知数据使用原则：**
+- `<subscribed_sensors>` 中列出的数据源可用 `raw_input_info(source, limit)` 直接查询最新数据。
+- 当用户询问视觉/环境相关问题（"看到什么"、"周围有什么"、"面前是什么"）时，优先查询 objects 类 sensor source。
+- bg subagent 的场景分析结论存入记忆库，可通过 `memory_recall(query="视觉/camera/objects")` 检索历史场景。
 
 MCP 工具命名格式：`mcp__<设备id>__<工具名>`
 

--- a/agent-core/src/collector.py
+++ b/agent-core/src/collector.py
@@ -357,17 +357,29 @@ async def _route_to_bg_subagent(batch: list[dict]) -> bool:
 
     summary = _format_bg_batch(batch)
 
-    # 同步 main agent 最近对话上下文（精简，subagent 可自行 memory_recall）
+    # 丰富上下文：用 rich 版本获取更多对话历史
     try:
-        from event.llm import get_recent_context
-        recent_context = get_recent_context(max_turns=2)
+        from event.llm import get_recent_context_rich
+        recent_context = get_recent_context_rich(max_turns=10, max_chars=3000)
     except (ImportError, AttributeError):
         recent_context = ''
 
+    # 同步 active tasks（让 bg subagent 知道主代理当前关注什么）
+    import task_store
+    active_tasks = task_store.active_tasks()
+    tasks_context = ''
+    if active_tasks:
+        task_lines = [f'- [{t.id[:8]}] {t.goal}' + (f' — {t.progress}' if t.progress else '') for t in active_tasks]
+        tasks_context = '[主代理活跃任务]\n' + '\n'.join(task_lines)
+
+    # 构建 message
+    parts = []
     if recent_context:
-        message = f'[主代理最近决策]\n{recent_context}\n\n[新数据]\n{summary}'
-    else:
-        message = summary
+        parts.append(f'[主代理上下文]\n{recent_context}')
+    if tasks_context:
+        parts.append(tasks_context)
+    parts.append(f'[新数据]\n{summary}')
+    message = '\n\n'.join(parts)
 
     # 检查是否有活跃的 bg subagent
     active = _manager_instance.list_active()
@@ -379,17 +391,23 @@ async def _route_to_bg_subagent(batch: list[dict]) -> bool:
         from subagent.protocol import SubagentSpec, P_LOW
         spec = SubagentSpec(
             goal=(
-                '[bg] 后台监控：分析传入的信息。\n'
-                '- 需要历史对比时，用 memory_recall 检索之前的结论\n'
-                '- 无变化 → subagent_finish\n'
-                '- 有变化但非紧急 → subagent_report(progress=结论)\n'
-                '- 安全/硬件告警（SOC<10%、温度>50°C、碰撞） → subagent_report(progress=..., urgent=true)\n'
-                '不要主动调用 Bash/Read 等工具，只分析传入内容或通过 memory_recall 检索历史。'
+                '[bg] 后台监控：快速分析传感器数据，结合主代理上下文判断重要性。\n'
+                '\n'
+                '## 行为要求\n'
+                '- 直接阅读 JSON 数据做判断，不要用 PythonExec 分析\n'
+                '- 只在有明确理由时才用 memory_recall（如需对比历史基线），不要盲目搜索\n'
+                '- 收到数据后 1-2 轮内必须做出决策（report 或 finish）\n'
+                '\n'
+                '## 判断规则\n'
+                '- 状态变化与主代理活跃任务直接相关 → subagent_report(progress=变化描述, urgent=true)\n'
+                '- 安全/硬件异常 → subagent_report(progress=告警, urgent=true)\n'
+                '- 首次收到新类型数据或有意义的变化 → subagent_report(progress=摘要)\n'
+                '- 无显著变化 → subagent_finish\n'
             ),
             priority=P_LOW,
             model=bg_config.get('bg_model'),
-            tool_deny=['mcp__*', 'Bash', 'Read', 'Write', 'Edit', 'Glob', 'Grep', 'WebFetch', 'WebSearch'],
-            max_rounds=50,
+            tool_deny=['mcp__*', 'Bash', 'Read', 'Write', 'Edit', 'Glob', 'Grep', 'WebFetch', 'WebSearch', 'PythonExec'],
+            max_rounds=10,
             timeout_s=3600,
             context_seed=message,
         )

--- a/agent-core/src/event/llm.py
+++ b/agent-core/src/event/llm.py
@@ -787,6 +787,22 @@ class Event:
         # Fire on_thinking hook (non-blocking LED feedback etc.)
         import hooks
         asyncio.create_task(hooks.fire('on_thinking'))
+
+        # ── Auto-interrupt: 新用户 turn 开始时清除旧的 pending ACP ──
+        if mcp_client.get_pending_actions():
+            _int_results = await hooks.fire('on_interrupt_all')
+            if _int_results:
+                for aid in list(mcp_client._pending_actions.keys()):
+                    mcp_client._pending_results[aid] = {
+                        "status": "cancelled",
+                        "reason": "auto-interrupted by new user message",
+                    }
+                    mcp_client._pending_actions[aid].set()
+                print(f'[decision] auto-interrupt: {len(_int_results)} hook(s) fired, pending cleared')
+            else:
+                # Fallback: 没有 hook 注册时用硬编码查找
+                await self._interrupt_active_outputs()
+
         # Subagent status in log
         if self._subagent_mgr:
             _sa_active = self._subagent_mgr.list_active()

--- a/agent-core/src/prompt.py
+++ b/agent-core/src/prompt.py
@@ -206,10 +206,24 @@ def _env_dynamic() -> str:
     # 不再显示 active_subagents — bg subagent 结论通过 memory_recall 按需检索，
     # 用户任务 subagent 完成后会发精简通知。
 
-    if tasks_section:
+    # 已订阅的传感器数据源（排除 ASR，它已作为触发事件直接可见）
+    import collector
+    active_sources = [s for s in collector.get_available_sources()
+                      if s.startswith('dds:') and '/asr' not in s]
+    sensors_section = ''
+    if active_sources:
+        sensor_lines = [f'  <source name="{s}" />' for s in active_sources]
+        sensors_section = (
+            '<subscribed_sensors hint="用 raw_input_info(source=...) 查询最新数据">\n'
+            + '\n'.join(sensor_lines) + '\n'
+            + '</subscribed_sensors>\n'
+        )
+
+    inner = tasks_section + sensors_section
+    if inner:
         return (
             f'<status time="{now}">\n'
-            f'{tasks_section}'
+            f'{inner}'
             f'</status>'
         )
     return f'<status time="{now}" />'


### PR DESCRIPTION
## Summary
- L2 prompt 增加 `<subscribed_sensors>` section，让 main agent 知道可查询哪些 sensor 数据
- bg subagent goal 重写：快速判断（1-2轮）、禁 PythonExec、注入 active tasks 上下文、任务相关变化 urgent report
- prompt_system.md 明确紧急响应不需要 task_update，省 1 轮 LLM 调用

## Test plan
- [x] 部署到 G1 验证 VOP 数据可见性（main agent 能回答"你能看到什么"）
- [x] 验证 bg subagent 1-2 轮内做出决策（从 7+ 轮降到 1-2 轮）
- [x] 验证看门狗模式 urgent report 正确触发
- [x] 验证 main agent 紧急响应不再多余 task_update

🤖 Generated with [Claude Code](https://claude.com/claude-code)