### PR TITLE
feat(perception): add on-device obstacle distance estimation / 新增端侧障碍物距离估计

### DIFF
--- a/perception/config.yaml
+++ b/perception/config.yaml
@@ -84,7 +84,7 @@ plugins:
     min_interval_ms: 0
 
   obstacle:
-    enabled: false
+    enabled: true
     provider: local
     # Select the deployment domain explicitly; OBSTACLE_FIXED_SCENE overrides it.
     scene_mode: fixed

--- a/perception/config.yaml
+++ b/perception/config.yaml
@@ -82,3 +82,42 @@ plugins:
       det_thresh: 0.1
       det_box_thresh: 0.1
     min_interval_ms: 0
+
+  obstacle:
+    enabled: false
+    provider: local
+    # Select the deployment domain explicitly; OBSTACLE_FIXED_SCENE overrides it.
+    scene_mode: fixed
+    fixed_scene: indoor
+    model_dir: /models/obstacle/zipdepth-int8
+    decision_threshold_m: 2.0
+    fallback_distance_m: 3.0
+    soft_timeout_s: 2.5
+    indoor:
+      roi: [0, 300, 213, 426]
+      roi_reference_size: [480, 640]
+      inverse_depth_percentile: 95.0
+      score_threshold: -0.06
+      # Convert the ZipDepth inverse-depth ROI statistic to a bounded distance.
+      inverse_depth_distance_scale: -27.0
+      inverse_depth_distance_bias_m: 3.7
+      classification_margin_m: 0.001
+      min_output_distance_m: 0.0
+      max_output_distance_m: 10.0
+      min_valid_pixels: 64
+    vehicle:
+      allowed_classes: [person, car, truck, bus, motorcycle, bicycle]
+      min_confidence: 0.25
+      percentile: 1.0
+      min_depth_m: 0.3
+      max_depth_m: 80.0
+      camera_to_bumper_offset_m: 1.0
+      allow_approximate_geometry: true
+      # Apply affine calibration after approximate bumper-offset geometry.
+      distance_calibration:
+        mode: affine
+        scale: 1.2
+        bias: -2.4
+        min_output_m: 0.0
+        max_output_m: 80.0
+      calibration: {}

--- a/perception/main.py
+++ b/perception/main.py
@@ -116,6 +116,11 @@ class PerceptionBundle:
             self._plugins.append(OCRPlugin(plugins_cfg["ocr"], executor))
             log.info("OCRPlugin loaded")
 
+        if plugins_cfg.get("obstacle", {}).get("enabled", False):
+            from plugins.obstacle import ObstacleDistancePlugin
+            self._plugins.append(ObstacleDistancePlugin(plugins_cfg["obstacle"], executor))
+            log.info("ObstacleDistancePlugin loaded")
+
     def get_all_tools(self) -> list:
         tools = []
         for p in self._plugins:

--- a/perception/plugins/obstacle.py
+++ b/perception/plugins/obstacle.py
@@ -58,12 +58,17 @@ TOOLS = [
             },
             "required": ["action"]
         },
+        # Deliberately minimal: only what an operator meaningfully decides.
+        # provider (single valid value), model_dir, ROI/percentile/calibration
+        # tuning and the per-scene expert blocks stay config.yaml-only — the
+        # dispatch below still honors them, they are just not advertised to
+        # the config UI.
         "configSchema": {
             "type": "object",
             "properties": {
-                "provider": {"type": "string", "enum": ["local"], "description": "Distance estimation provider", "scope": "shared"},
+                "fixed_scene": {"type": "string", "enum": ["indoor", "vehicle"], "default": "indoor", "description": "部署场景（固定场景模式下生效）：indoor=室内 ZipDepth，vehicle=车载 YOLO 深度", "scope": "shared"},
+                "decision_threshold_m": {"type": "number", "exclusiveMinimum": 0, "default": 2.0, "description": "近障判定距离(米)：估算距离小于该值时 near_obstacle=true", "scope": "shared"},
             },
-            "required": ["provider"]
         },
         "topic_in":  [{"format": "image/jpeg", "desc": "camera image input"}],
         "topic_out": [{"format": "data/json",  "desc": "obstacle distance estimation result"}],

--- a/perception/plugins/obstacle.py
+++ b/perception/plugins/obstacle.py
@@ -1,0 +1,911 @@
+#!/usr/bin/env python3
+"""
+plugins/obstacle.py — ObstacleDistancePlugin: obstacle distance estimation.
+
+Subscribes to image/jpeg topics, estimates obstacle distance from camera,
+publishes distance results to ROS2 topic.
+Supports multi-instance (one instance per input topic).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import threading
+from copy import deepcopy
+
+from rclpy.node import Node
+from rclpy.qos import QoSProfile, ReliabilityPolicy, HistoryPolicy, DurabilityPolicy
+from sensor_msgs.msg import CompressedImage
+from std_msgs.msg import String
+
+from utils.latest_frame import LatestFrame
+from utils.log_sampling import SampledLogGate, escape_log_text
+from utils.qos import CAMERA_QOS
+from utils.ros_lifecycle import dispose_node
+
+from .obstacle_distance_core.contracts import SceneDomain
+
+log = logging.getLogger(__name__)
+
+
+_PUB_QOS = QoSProfile(
+    reliability=ReliabilityPolicy.RELIABLE,
+    history=HistoryPolicy.KEEP_LAST,
+    depth=10,
+    durability=DurabilityPolicy.VOLATILE,
+)
+
+TOOLS = [
+    {
+        "name": "obstacle",
+        "type": "processor",
+        "multiInstance": True,
+        "description": "Obstacle Distance Estimation — estimate distance to obstacles from camera feed",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": ["start", "stop", "info", "config"],
+                    "description": "Action to perform"
+                },
+                "input_topic": {
+                    "type": "string",
+                    "description": "ROS2 image topic to subscribe (e.g. /hostname/camera/rgb, required for action=start)"
+                },
+            },
+            "required": ["action"]
+        },
+        "configSchema": {
+            "type": "object",
+            "properties": {
+                "provider": {"type": "string", "enum": ["local"], "description": "Distance estimation provider", "scope": "shared"},
+            },
+            "required": ["provider"]
+        },
+        "topic_in":  [{"format": "image/jpeg", "desc": "camera image input"}],
+        "topic_out": [{"format": "data/json",  "desc": "obstacle distance estimation result"}],
+    }
+]
+
+
+# ── Distance Estimation Pipeline ──────────────────────────────────────────────
+
+
+class LocalDistanceAdapter:
+    """本地深度 + 分割管线（基于 obstacle_distance_core 估算器）。
+
+    加载深度与分割后端，由 ObstacleDistanceEstimator
+    计算最近障碍物距离。
+    模型模式初始化失败时直接抛错，禁止用随机值伪装成有效预测。
+    """
+
+    def __init__(self, cfg: dict):
+        from .obstacle_distance_core.estimator import ObstacleDistanceEstimator
+        from .obstacle_distance_core.zipdepth_tensorrt_backends import (
+            create_backends,
+        )
+        from utils.model_downloader import ensure_obstacle_models
+
+        self._cfg = deepcopy(cfg or {})
+        scene_mode = self._cfg.get("scene_mode", "fixed")
+        environment_scene = os.environ.get("OBSTACLE_FIXED_SCENE")
+        self._resolution_scene_map: dict[tuple[int, int], str] = {}
+        if environment_scene or scene_mode == "fixed":
+            configured_scene = (
+                environment_scene
+                or self._cfg.get("fixed_scene")
+                or self._cfg.get("scene_hint")
+            )
+            try:
+                self._scene_hint = SceneDomain(
+                    str(configured_scene).strip().lower()
+                ).value
+            except Exception:
+                raise ValueError(
+                    "fixed_scene must be indoor or vehicle"
+                ) from None
+            self._scene_mode = "fixed"
+        elif scene_mode == "resolution":
+            configured_map = self._cfg.get("resolution_scene_map")
+            if not isinstance(configured_map, dict) or not configured_map:
+                raise ValueError(
+                    "resolution_scene_map must be a nonempty mapping"
+                )
+            for resolution, configured_scene in configured_map.items():
+                try:
+                    width_text, height_text = str(resolution).lower().split("x")
+                    width = int(width_text)
+                    height = int(height_text)
+                    scene = SceneDomain(
+                        str(configured_scene).strip().lower()
+                    ).value
+                except Exception:
+                    raise ValueError(
+                        "resolution_scene_map entries must use WIDTHxHEIGHT "
+                        "and indoor or vehicle"
+                    ) from None
+                if width <= 0 or height <= 0:
+                    raise ValueError(
+                        "resolution_scene_map dimensions must be positive"
+                    )
+                key = (width, height)
+                if key in self._resolution_scene_map:
+                    raise ValueError(
+                        "resolution_scene_map contains duplicate dimensions"
+                    )
+                self._resolution_scene_map[key] = scene
+            self._scene_hint = None
+            self._scene_mode = "resolution"
+            # Unknown resolutions must produce missing_scene rather than silently
+            # falling back to a stale fixed_scene value.
+            self._cfg["fixed_scene"] = None
+        else:
+            raise ValueError(
+                "obstacle ROS input has no scene metadata; scene_mode must be "
+                "fixed or resolution"
+            )
+        engine_paths = ensure_obstacle_models(
+            self._cfg.get("model_dir", "/models/obstacle/zipdepth-int8")
+        )
+        for key, filename in (
+            ("indoor_depth_engine", "zipdepth-base-npu-512x384-int8.engine"),
+            ("vehicle_depth_engine", "yolo26n-depth-int8.engine"),
+            ("segmentation_engine", "yolo26n-seg-int8.engine"),
+        ):
+            self._cfg.setdefault(key, engine_paths[filename])
+        depth_backend, segmentation_backend = create_backends(self._cfg)
+        self._backends = (depth_backend, segmentation_backend)
+        self._estimator = ObstacleDistanceEstimator(
+            depth_backend,
+            segmentation_backend,
+            self._cfg,
+        )
+
+    def close(self) -> None:
+        """Release the TensorRT engines held by the backends."""
+        backends = getattr(self, "_backends", ())
+        self._backends = ()
+        for backend in backends:
+            close = getattr(backend, "close", None)
+            if callable(close):
+                try:
+                    close()
+                except Exception:
+                    log.debug("[obstacle] backend close failed", exc_info=True)
+
+    def estimate(self, image_bytes: bytes) -> dict:
+        """估算最近障碍物距离。"""
+        scene_hint = self._scene_hint
+        estimator_image_bytes = image_bytes
+        if self._scene_mode == "resolution":
+            try:
+                import cv2
+                import numpy as np
+
+                image = cv2.imdecode(
+                    np.frombuffer(image_bytes, dtype=np.uint8),
+                    cv2.IMREAD_COLOR,
+                )
+            except Exception:
+                image = None
+            if image is None or image.size == 0:
+                # Preserve the estimator's structured invalid_image fallback.
+                estimator_image_bytes = b""
+            else:
+                height, width = image.shape[:2]
+                scene_hint = self._resolution_scene_map.get((width, height))
+        result = self._estimator.estimate(
+            estimator_image_bytes,
+            scene_hint=scene_hint,
+        )
+        return {
+            "pred_distance": result.distance_m,
+            "distance_m": result.distance_m,
+            "near_obstacle": result.near_obstacle,
+            "scene": result.scene,
+            "status": result.status,
+            "error_code": result.error_code,
+            "fallback": result.fallback,
+            "approximate_geometry": result.approximate_geometry,
+            "latency_ms": result.latency_ms,
+        }
+
+
+def _build_distance_adapter(cfg: dict) -> LocalDistanceAdapter:
+    if cfg.get("provider", "local") != "local":
+        raise ValueError("obstacle provider must be local")
+    return LocalDistanceAdapter(cfg)
+
+
+# ── ROS2 Node (one per instance/topic) ────────────────────────────────────────
+
+class _ObstacleNode(Node):
+    """Per-topic obstacle distance estimation node."""
+
+    def __init__(self, input_topic: str, node_suffix: str):
+        super().__init__(f"obstacle_{node_suffix}")
+        self._input_topic = input_topic
+        self._output_topic = f"{input_topic}/obstacle"
+        self._pub = self.create_publisher(String, self._output_topic, _PUB_QOS)
+        self._sub: object | None = None
+        # Latest frame wins: the camera callback overwrites, the worker pops.
+        # A FIFO here would make the estimator report stale frames whenever
+        # inference falls behind the camera.
+        self._frames: LatestFrame = LatestFrame()
+        self._frames.close()
+        self._stop_event = threading.Event()
+        self._worker: threading.Thread | None = None
+        self._lifecycle_lock = threading.Lock()
+        self._detect_count = 0
+        self._logged_first_frame = False
+        self._log_gate = SampledLogGate(every=100)
+        self.state = "idle"
+
+    def start(self, adapter: LocalDistanceAdapter) -> dict:
+        with self._lifecycle_lock:
+            if self.state == "running":
+                return {"state": "running", "input": self._input_topic, "output": self._output_topic}
+            if self._worker is not None and self._worker.is_alive():
+                raise RuntimeError("previous obstacle worker is still stopping")
+            if self._sub is None:
+                self._sub = self.create_subscription(
+                    CompressedImage, self._input_topic, self._image_cb, CAMERA_QOS
+                )
+            # Use a distinct event and frame slot for every worker generation.
+            # If an old inference ever outlives stop()'s join timeout, a later
+            # start must not clear that worker's stop signal and revive it.
+            stop_event = threading.Event()
+            frames: LatestFrame = LatestFrame()
+            self._stop_event = stop_event
+            self._frames = frames
+            self._worker = threading.Thread(
+                target=self._inference_worker,
+                args=(stop_event, frames, adapter),
+                daemon=True,
+                name=f"obstacle_worker_{self._input_topic}",
+            )
+            self._worker.start()
+            self.state = "running"
+        log.info(f"[obstacle] started: {self._input_topic} -> {self._output_topic}")
+        return {"state": "running", "input": self._input_topic, "output": self._output_topic}
+
+    def stop(self) -> dict:
+        # stop() only pauses the inference worker; the node itself stays
+        # registered until the plugin retires it (see ObstacleDistancePlugin.
+        # _dispose_node), so a later start on the same topic reuses it.
+        with self._lifecycle_lock:
+            self.state = "idle"
+            self._stop_event.set()
+            self._frames.close()  # drops the pending frame and wakes the worker
+            worker = self._worker
+            if worker and worker.is_alive():
+                worker.join(timeout=3.0)
+            if worker is None or not worker.is_alive():
+                self._worker = None
+            else:
+                log.warning(
+                    "[obstacle] worker still stopping after timeout: %s",
+                    self._input_topic,
+                )
+        log.info(f"[obstacle] stopped: {self._input_topic}")
+        return {"state": "idle", "input": self._input_topic}
+
+    def _image_cb(self, msg: CompressedImage):
+        if self.state != "running":
+            return
+        try:
+            image_bytes = bytes(msg.data)
+        except Exception:
+            log.warning(
+                "[obstacle] received image frame with invalid data on %s",
+                self._input_topic,
+            )
+            return
+        if not self._logged_first_frame:
+            # First frame only: msg.format is externally supplied — escape and
+            # cap it, and never put it in a per-frame log.
+            self._logged_first_frame = True
+            log.info(
+                "[obstacle] first image frame on %s: size=%d bytes, format=%.32r",
+                self._input_topic, len(image_bytes), str(msg.format),
+            )
+        # Latest frame wins (no backpressure, no history).
+        self._frames.push(image_bytes)
+
+    def _inference_worker(
+        self,
+        stop_event: threading.Event,
+        frames: LatestFrame,
+        adapter: LocalDistanceAdapter,
+    ):
+        while not stop_event.is_set():
+            jpeg_bytes = frames.pop(timeout=1.0)
+            if jpeg_bytes is None:
+                continue
+            if stop_event.is_set():
+                break
+            try:
+                result = adapter.estimate(jpeg_bytes)
+                # Hot path: log state transitions unthrottled, sample steady
+                # state (first + every 100th) so camera-rate output cannot
+                # flood the container logs.
+                outcome = "fallback" if result.get("fallback") else "ok"
+                should_log, transition, occurrence = self._log_gate.check(outcome)
+                if should_log:
+                    emit = log.info if transition else log.debug
+                    emit(
+                        "[obstacle] %s scene=%s error_code=%s latency_ms=%.1f "
+                        "distance_m=%s (frame %d)",
+                        outcome,
+                        result.get("scene"),
+                        result.get("error_code"),
+                        float(result.get("latency_ms", 0.0)),
+                        result.get("pred_distance"),
+                        occurrence,
+                    )
+                if not stop_event.is_set():
+                    self._publish_result(result)
+            except Exception as e:
+                outcome = f"error:{type(e).__name__}"
+                should_log, transition, occurrence = self._log_gate.check(outcome)
+                if transition:
+                    # Full traceback only when the error class first appears.
+                    log.error("[obstacle] inference error: %s",
+                              escape_log_text(e), exc_info=True)
+                elif should_log:
+                    log.error("[obstacle] inference error (occurrence %d): %s",
+                              occurrence, escape_log_text(e))
+
+    def _publish_result(self, result: dict):
+        self._detect_count += 1
+        msg = String()
+        # Publish the whole structured result the adapter produced. A bare
+        # distance cannot be told apart from the estimator's fallback (
+        # fallback_distance_m, 3.0 by default), and consumers also need the
+        # near_obstacle/scene/status/error_code/latency fields this plugin
+        # advertises as data/json. pred_distance is still present, so existing
+        # subscribers keep working.
+        msg.data = json.dumps(result, ensure_ascii=False)
+        self._pub.publish(msg)
+
+
+# ── Plugin class ──────────────────────────────────────────────────────────────
+
+class ObstacleDistancePlugin:
+    """Obstacle-distance MCP plugin with the same non-blocking
+    start/stop/load state machine as the OCR plugin:
+
+        idle --start--> loading --ok--> ready/running
+                          |               ^
+                          +----fail--> error (next start retries)
+
+    * first start records the instance as pending, spawns one background
+      loader and immediately returns {"state": "loading"};
+    * concurrent starts only add pending instances — the engines are
+      downloaded and initialised once (single-flight);
+    * info is a pure query and never blocks on the loader;
+    * stop during loading cancels the pending instance; stop of a live
+      instance disposes its node (executor.remove_node + destroy_node);
+    * config bumps a load generation so a stale loader can never install
+      an adapter built from an outdated configuration.
+
+    One shared adapter serves every instance without per-instance
+    configuration; instances that do carry per-instance configuration get
+    their own cached adapter, built by the same background loader (the
+    verified-bundle download is deduplicated by the downloader's file lock,
+    so extra instances never re-download).
+    """
+
+    PREFIX = "obstacle"
+
+    def __init__(self, plugin_cfg: dict, executor):
+        self._executor = executor
+        self._plugin_cfg = deepcopy(plugin_cfg or {})
+        self._provider = self._plugin_cfg.get("provider", "local")
+
+        # Guarded by _state_lock, held for bookkeeping only — never while
+        # building engines or joining workers.
+        self._state_lock = threading.Lock()
+        self._nodes: dict[str, _ObstacleNode] = {}
+        self._instance_configs: dict[str, dict] = {}
+        self._instance_adapters: dict[str, tuple[dict, LocalDistanceAdapter]] = {}
+        self._pending_starts: dict[str, str] = {}   # node_key -> input_topic
+        self._adapter: LocalDistanceAdapter | None = None
+        self._adapter_state = "idle"                # idle|loading|ready|error
+        self._load_error: str | None = None
+        self._load_generation = 0
+        self._loader_thread: threading.Thread | None = None
+
+        log.info("[obstacle] plugin registered: provider=%s", self._provider)
+
+    def get_tools(self) -> list:
+        return TOOLS
+
+    # ── helpers ───────────────────────────────────────────────────────────
+
+    def _effective_cfg_locked(self, node_key: str) -> dict:
+        merged = deepcopy(self._plugin_cfg)
+        merged.update(self._instance_configs.get(node_key, {}))
+        return merged
+
+    def _dispose(self, node_key: str, node: "_ObstacleNode") -> None:
+        """Stop worker and fully destroy the node. Never called under lock."""
+        try:
+            node.stop()
+        finally:
+            dispose_node(self._executor, node, label=f"obstacle/{node_key}")
+        log.info(f"[obstacle] node disposed: {node_key}")
+
+    @staticmethod
+    def _close_adapter(adapter) -> None:
+        if adapter is None:
+            return
+        close = getattr(adapter, "close", None)
+        if callable(close):
+            try:
+                close()
+            except Exception:
+                log.debug("[obstacle] adapter close failed", exc_info=True)
+
+    # ── background loader (single-flight) ────────────────────────────────
+
+    def _spawn_loader_locked(self) -> None:
+        """Ensure the one background loader/bring-up thread is running.
+
+        Caller holds the lock. Single-flight: never two loaders. The loader
+        clears self._loader_thread under the same lock right before exiting,
+        so a pending entry added here is always observed by a live loader.
+        """
+        thread = self._loader_thread
+        if thread is not None and thread.is_alive():
+            return
+        if self._adapter is None or self._adapter_state == "error":
+            self._adapter_state = "loading"
+            self._load_error = None
+        generation = self._load_generation
+        cfg = deepcopy(self._plugin_cfg)
+        thread = threading.Thread(
+            target=self._loader, args=(generation, cfg),
+            name="obstacle-adapter-loader", daemon=True,
+        )
+        self._loader_thread = thread
+        thread.start()
+
+    def _finish_loader_locked(self, generation: int) -> None:
+        """Loader exit handshake. Caller holds the lock.
+
+        Clears the thread handle; if a config change replaced the generation
+        while this loader ran and instances are still pending, respawn a
+        loader for the new configuration so no pending start is stranded.
+        """
+        self._loader_thread = None
+        if generation != self._load_generation and self._pending_starts:
+            self._spawn_loader_locked()
+
+    def _adapter_for_key(self, node_key: str, shared: LocalDistanceAdapter):
+        """Return the adapter serving node_key, building the per-instance one
+        on demand. Runs in the loader thread — never under the lock.
+
+        The build happens outside the lock, so a per-instance config can
+        change mid-build. The result is committed only if the effective
+        config is still the one it was built for; otherwise it is closed and
+        the build retried, so a node never starts on a stale adapter and a
+        replaced cache entry never leaks its engine.
+        """
+        while True:
+            with self._state_lock:
+                if not self._instance_configs.get(node_key):
+                    return shared
+                effective = self._effective_cfg_locked(node_key)
+                cached = self._instance_adapters.get(node_key)
+                if cached is not None and cached[0] == effective:
+                    return cached[1]
+            adapter = _build_distance_adapter(effective)
+            stale = None
+            with self._state_lock:
+                still_wanted = (
+                    bool(self._instance_configs.get(node_key))
+                    and self._effective_cfg_locked(node_key) == effective
+                )
+                if still_wanted:
+                    previous = self._instance_adapters.get(node_key)
+                    if previous is not None and previous[1] is not adapter:
+                        stale = previous[1]
+                    self._instance_adapters[node_key] = (effective, adapter)
+            if still_wanted:
+                if stale is not None:
+                    self._close_adapter(stale)
+                return adapter
+            # Config changed (or the per-instance config was removed) while
+            # building: discard this result and re-evaluate.
+            self._close_adapter(adapter)
+
+    def _loader(self, generation: int, cfg: dict) -> None:
+        with self._state_lock:
+            adapter = self._adapter if generation == self._load_generation else None
+        if adapter is None:
+            try:
+                adapter = _build_distance_adapter(cfg)
+            except Exception as error:  # noqa: BLE001 - surfaced via info
+                log.exception("[obstacle] adapter load failed")
+                with self._state_lock:
+                    if generation == self._load_generation:
+                        self._adapter_state = "error"
+                        self._load_error = str(error)
+                    self._finish_loader_locked(generation)
+                return
+
+            with self._state_lock:
+                if generation != self._load_generation:
+                    stale = adapter
+                else:
+                    self._adapter = adapter
+                    self._adapter_state = "ready"
+                    stale = None
+            if stale is not None:
+                self._close_adapter(stale)
+                with self._state_lock:
+                    self._finish_loader_locked(generation)
+                return
+
+        # Bring up every instance that is still pending.
+        while True:
+            with self._state_lock:
+                if generation != self._load_generation or not self._pending_starts:
+                    self._finish_loader_locked(generation)
+                    return
+                node_key, input_topic = next(iter(self._pending_starts.items()))
+            # README lifecycle rule: register under the lock *before*
+            # starting, so a concurrent stop (or a failure at any later
+            # point) can always locate the node — a started-but-unregistered
+            # worker would be unreachable and leak.
+            try:
+                node_adapter = self._adapter_for_key(node_key, adapter)
+                suffix = node_key.replace("/", "_").replace("-", "_").lstrip("_")
+                node = _ObstacleNode(input_topic, suffix)
+            except Exception as error:  # noqa: BLE001 - keep serving others
+                log.error("[obstacle] failed to build instance %r on %r: %s",
+                          node_key, input_topic, escape_log_text(error))
+                with self._state_lock:
+                    if self._pending_starts.get(node_key) == input_topic:
+                        del self._pending_starts[node_key]
+                continue
+            registered = False
+            with self._state_lock:
+                entry_valid = (
+                    generation == self._load_generation
+                    and self._pending_starts.get(node_key) == input_topic
+                )
+                still_wanted = entry_valid and node_key not in self._nodes
+                if still_wanted:
+                    try:
+                        self._executor.add_node(node)
+                    except Exception as error:  # noqa: BLE001
+                        log.error("[obstacle] failed to register instance %r: %s",
+                                  node_key, escape_log_text(error))
+                        del self._pending_starts[node_key]
+                    else:
+                        self._nodes[node_key] = node
+                        del self._pending_starts[node_key]
+                        registered = True
+                elif entry_valid:
+                    # A concurrent start already owns a live node for this
+                    # key; drop the entry so the loop can progress.
+                    del self._pending_starts[node_key]
+            if not registered:
+                try:
+                    node.destroy_node()   # never started, never registered
+                except Exception:  # noqa: BLE001
+                    pass
+                continue
+            try:
+                node.start(node_adapter)
+            except Exception as error:  # noqa: BLE001
+                log.error("[obstacle] failed to start instance %r: %s",
+                          node_key, escape_log_text(error))
+                with self._state_lock:
+                    if self._nodes.get(node_key) is node:
+                        del self._nodes[node_key]
+                self._dispose(node_key, node)
+                continue
+            with self._state_lock:
+                still_ours = self._nodes.get(node_key) is node
+            if not still_ours:
+                # A concurrent stop retired the node while start() ran; its
+                # dispose handled teardown — stop the worker start spawned.
+                node.stop()
+
+    # ── per-instance status (lock held) ───────────────────────────────────
+
+    def _instance_state_locked(self, node_key: str) -> str:
+        node = self._nodes.get(node_key)
+        if node is not None:
+            return node.state
+        if node_key in self._pending_starts:
+            return "error" if self._adapter_state == "error" else "loading"
+        return "idle"
+
+    # ── MCP dispatch ──────────────────────────────────────────────────────
+
+    def dispatch(self, name: str, args: dict) -> dict | None:
+        action = args.get("action", name)
+        instance_id = args.get("instance_id", "")
+
+        if action == "info":
+            return self._do_info(instance_id, args)
+        if action == "start":
+            return self._do_start(instance_id, args)
+        if action == "stop":
+            return self._do_stop(instance_id)
+        if action == "config":
+            return self._do_config(instance_id, args)
+        return None
+
+    _DESC = "Obstacle distance estimation from camera feed"
+
+    def _desc_for(self, state: str, load_error: str | None) -> str:
+        """Dashboard-facing description, mirroring the ASR plugin (#113): the
+        static blurb normally, a reason while loading or after a failure."""
+        if state == "loading":
+            return "Loading obstacle models and TensorRT engines..."
+        if state == "error" and load_error:
+            return f"Model load failed: {load_error}"
+        return self._DESC
+
+    def _do_info(self, instance_id: str, args: dict) -> dict:
+        input_topic = args.get("input_topic", "")
+        if not input_topic:
+            topics_list = args.get("input_topics") or []
+            if topics_list:
+                input_topic = topics_list[0]
+
+        with self._state_lock:
+            instances: dict[str, dict] = {}
+            for key, node in self._nodes.items():
+                instances[key] = {
+                    "input": node._input_topic,
+                    "output": node._output_topic,
+                    "detect_count": node._detect_count,
+                    "state": node.state,
+                }
+            for key, topic in self._pending_starts.items():
+                if key in instances:
+                    continue
+                state = self._instance_state_locked(key)
+                entry = {
+                    "input": topic,
+                    "output": f"{topic}/obstacle",
+                    "detect_count": 0,
+                    "state": state,
+                }
+                if state == "error" and self._load_error:
+                    entry["error"] = self._load_error
+                instances[key] = entry
+
+            if instance_id and instance_id in instances:
+                input_topic = instances[instance_id]["input"]
+            elif not input_topic and instances:
+                input_topic = next(iter(instances.values()))["input"]
+
+            states = {entry["state"] for entry in instances.values()}
+            if "loading" in states or self._adapter_state == "loading":
+                state = "loading"
+            elif "running" in states:
+                state = "running"
+            elif "error" in states or self._adapter_state == "error":
+                state = "error"
+            else:
+                state = "idle"
+            load_error = self._load_error
+
+        topics_in = [{"topic": input_topic, "format": "image/jpeg"}] if input_topic else []
+        topics_out = [{"topic": f"{input_topic}/obstacle", "format": "data/json"}] if input_topic else []
+        result = {
+            "name": "ObstacleDistance", "manufacture": "Embodied", "model": "obstacle",
+            "state": state,
+            "instances": instances,
+            "topic_in": topics_in,
+            "topic_out": topics_out,
+            "desc": self._desc_for(state, load_error),
+        }
+        if state == "error" and load_error:
+            result["error"] = load_error
+        return result
+
+    def _do_start(self, instance_id: str, args: dict) -> dict:
+        input_topic = args.get("input_topic")
+        if not input_topic:
+            topics_list = args.get("input_topics") or []
+            if topics_list:
+                input_topic = topics_list[0]
+        if not input_topic:
+            raise ValueError("input_topic is required")
+        node_key = instance_id or input_topic
+
+        retired = None
+        with self._state_lock:
+            previous = self._nodes.get(node_key)
+            if previous is not None and previous._input_topic != input_topic:
+                # Topics are fixed at node construction; rebind the key.
+                retired = self._nodes.pop(node_key)
+        if retired is not None:
+            self._dispose(node_key, retired)
+
+        start_node = None
+        with self._state_lock:
+            existing = self._nodes.get(node_key)
+            instance_cfg = self._instance_configs.get(node_key)
+            cached = self._instance_adapters.get(node_key)
+            adapter_available = self._adapter_state == "ready" and (
+                not instance_cfg
+                or (cached is not None and cached[0] == self._effective_cfg_locked(node_key))
+            )
+            if existing is not None:
+                start_node = existing        # idempotent re-start
+                shared = self._adapter
+            elif adapter_available:
+                # Claim the key before leaving the lock: a concurrent stop
+                # must always find the instance in _pending_starts or
+                # _nodes, never in an invisible in-between state.
+                self._pending_starts[node_key] = input_topic
+                shared = self._adapter
+                generation = self._load_generation
+            else:
+                # Cold start, error retry, or an instance whose per-instance
+                # adapter is not built yet — all go through the background
+                # loader so start never blocks on engine initialisation.
+                self._pending_starts[node_key] = input_topic
+                self._spawn_loader_locked()
+                return {
+                    "state": "loading",
+                    "input": input_topic,
+                    "output": f"{input_topic}/obstacle",
+                }
+
+        node_adapter = self._adapter_for_key(node_key, shared)
+        if start_node is not None:
+            return start_node.start(node_adapter)
+
+        suffix_source = node_key if retired is None else f"{node_key}_{input_topic}"
+        suffix = suffix_source.replace("/", "_").replace("-", "_").lstrip("_")
+        node = _ObstacleNode(input_topic, suffix)
+        # README lifecycle rule: register before start, so a concurrent stop
+        # (or an add_node/start failure) can always locate the node instead of
+        # leaking a started worker that nothing tracks.
+        with self._state_lock:
+            claimed = self._pending_starts.get(node_key) == input_topic
+            current = self._nodes.get(node_key)
+            fresh = generation == self._load_generation
+            registered = False
+            if claimed and current is None and fresh:
+                try:
+                    self._executor.add_node(node)
+                except Exception as error:  # noqa: BLE001
+                    log.error("[obstacle] failed to register instance %r: %s",
+                              node_key, escape_log_text(error))
+                    del self._pending_starts[node_key]
+                else:
+                    self._nodes[node_key] = node
+                    del self._pending_starts[node_key]
+                    registered = True
+            elif claimed and not fresh:
+                # A config change invalidated the adapter mid-start; keep the
+                # claim so the loader brings this instance up on the new one.
+                pass
+            elif claimed:
+                del self._pending_starts[node_key]
+        if not registered:
+            try:
+                node.destroy_node()   # never started, never registered
+            except Exception:  # noqa: BLE001
+                pass
+            if current is not None:
+                return current.start(node_adapter)
+            if claimed and not fresh:
+                return {"state": "loading", "input": input_topic,
+                        "output": f"{input_topic}/obstacle"}
+            return {"state": "idle", "input": input_topic,
+                    "output": f"{input_topic}/obstacle"}
+        try:
+            result = node.start(node_adapter)
+        except Exception:
+            with self._state_lock:
+                if self._nodes.get(node_key) is node:
+                    del self._nodes[node_key]
+            self._dispose(node_key, node)
+            raise
+        with self._state_lock:
+            still_ours = self._nodes.get(node_key) is node
+        if not still_ours:
+            # A concurrent stop retired the node while start() ran; its
+            # dispose handled teardown — stop the worker this start spawned.
+            node.stop()
+            return {"state": "idle", "input": input_topic,
+                    "output": f"{input_topic}/obstacle"}
+        return result
+
+    def _do_stop(self, instance_id: str) -> dict:
+        to_dispose: list[tuple[str, _ObstacleNode]] = []
+        with self._state_lock:
+            if instance_id:
+                self._pending_starts.pop(instance_id, None)
+                node = self._nodes.pop(instance_id, None)
+                if node is not None:
+                    to_dispose.append((instance_id, node))
+                stopped = [instance_id]
+            else:
+                self._pending_starts.clear()
+                stopped = list(self._nodes)
+                to_dispose.extend(self._nodes.items())
+                self._nodes = {}
+        for node_key, node in to_dispose:
+            self._dispose(node_key, node)
+        if instance_id:
+            return {"state": "idle"}
+        return {"state": "idle", "stopped_instances": stopped}
+
+    def _do_config(self, instance_id: str, args: dict) -> dict:
+        cfg = {
+            k: v for k, v in args.items()
+            if k not in ('action', 'instance_id') and v is not None and v != ''
+        }
+
+        if instance_id:
+            retired = None
+            stale_adapter = None
+            with self._state_lock:
+                previous_cfg = self._instance_configs.get(instance_id, {})
+                merged_cfg = deepcopy(previous_cfg)
+                merged_cfg.update(cfg)
+                self._instance_configs[instance_id] = merged_cfg
+                retired = self._nodes.pop(instance_id, None)
+                if merged_cfg != previous_cfg:
+                    dropped = self._instance_adapters.pop(instance_id, None)
+                    if dropped is not None:
+                        stale_adapter = dropped[1]
+            if retired is not None:
+                # The instance goes back to idle; the next start rebuilds it
+                # with the merged per-instance configuration.
+                self._dispose(instance_id, retired)
+            self._close_adapter(stale_adapter)
+            return {
+                "status": "configured",
+                "instance_id": instance_id,
+                "config": merged_cfg,
+            }
+
+        with self._state_lock:
+            merged_cfg = deepcopy(self._plugin_cfg)
+            merged_cfg.update(cfg)
+            if merged_cfg == self._plugin_cfg:
+                log.debug("[obstacle] configuration unchanged")
+                return {"status": "configured", "config": cfg}
+
+            self._plugin_cfg = merged_cfg
+            self._provider = merged_cfg.get("provider", "local")
+            # Invalidate any in-flight load and every cached adapter; nodes
+            # built on the old adapters are retired. Pending starts stay
+            # pending and are served by a fresh loader for the new config.
+            self._load_generation += 1
+            stale_adapters = [self._adapter]
+            stale_adapters.extend(
+                adapter for _cfg, adapter in self._instance_adapters.values()
+            )
+            self._adapter = None
+            self._instance_adapters = {}
+            disposed = list(self._nodes.items())
+            self._nodes = {}
+            if self._pending_starts:
+                self._spawn_loader_locked()
+            else:
+                self._adapter_state = "idle"
+                self._load_error = None
+        for node_key, node in disposed:
+            self._dispose(node_key, node)
+        for adapter in stale_adapters:
+            self._close_adapter(adapter)
+        log.info("[obstacle] configuration updated")
+        return {"status": "configured", "config": cfg}

--- a/perception/plugins/obstacle_distance_core/__init__.py
+++ b/perception/plugins/obstacle_distance_core/__init__.py
@@ -1,0 +1,21 @@
+from .contracts import (
+    CameraCalibration,
+    DepthBackend,
+    DepthPrediction,
+    ErrorCode,
+    InstanceMask,
+    InstanceSegmentationBackend,
+    ObstacleDistanceError,
+    SceneDomain,
+)
+
+__all__ = (
+    "SceneDomain",
+    "ErrorCode",
+    "ObstacleDistanceError",
+    "DepthPrediction",
+    "InstanceMask",
+    "CameraCalibration",
+    "DepthBackend",
+    "InstanceSegmentationBackend",
+)

--- a/perception/plugins/obstacle_distance_core/backend_validation.py
+++ b/perception/plugins/obstacle_distance_core/backend_validation.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import inspect
+
+from .contracts import (
+    DepthBackend,
+    IndoorDistanceBackend,
+    InstanceSegmentationBackend,
+    SceneDomain,
+)
+
+
+def _accepts_protocol_call(
+    backend: object,
+    protocol: type,
+    method_name: str,
+    arguments: tuple[object, ...],
+) -> bool:
+    try:
+        if not isinstance(backend, protocol):
+            return False
+        method = getattr(backend, method_name)
+        if not callable(method):
+            return False
+        inspect.signature(method).bind(*arguments)
+    except Exception:
+        return False
+    return True
+
+
+def is_valid_depth_backend(backend: object) -> bool:
+    return _accepts_protocol_call(
+        backend,
+        DepthBackend,
+        "predict_depth",
+        (b"", SceneDomain.INDOOR, 0.0),
+    )
+
+
+def is_valid_indoor_distance_backend(backend: object) -> bool:
+    return _accepts_protocol_call(
+        backend,
+        IndoorDistanceBackend,
+        "predict_indoor_distance",
+        (b"", 0.0),
+    )
+
+
+def is_valid_segmentation_backend(backend: object) -> bool:
+    return _accepts_protocol_call(
+        backend,
+        InstanceSegmentationBackend,
+        "predict_instances",
+        (b"", 0.0),
+    )

--- a/perception/plugins/obstacle_distance_core/contracts.py
+++ b/perception/plugins/obstacle_distance_core/contracts.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from enum import Enum
+from numbers import Real
+from typing import Protocol, Sequence, runtime_checkable
+
+
+class SceneDomain(str, Enum):
+    INDOOR = "indoor"
+    VEHICLE = "vehicle"
+
+
+class ErrorCode(str, Enum):
+    INVALID_IMAGE = "invalid_image"
+    MISSING_SCENE = "missing_scene"
+    MODEL_ERROR = "model_error"
+    TIMEOUT = "timeout"
+    INVALID_DEPTH = "invalid_depth"
+    NO_VALID_DEPTH = "no_valid_depth"
+    NO_TARGET_INSTANCE = "no_target_instance"
+    MISSING_CALIBRATION = "missing_calibration"
+    INVALID_CALIBRATION = "invalid_calibration"
+
+
+class ObstacleDistanceError(Exception):
+    def __init__(self, code: ErrorCode, message: str) -> None:
+        self.code = code
+        self.message = message
+        super().__init__(message)
+
+
+def _is_finite_number(value: object) -> bool:
+    if isinstance(value, bool) or not isinstance(value, Real):
+        return False
+    try:
+        return math.isfinite(value)
+    except (TypeError, ValueError, OverflowError):
+        return False
+
+
+@dataclass(frozen=True)
+class DepthPrediction:
+    depth_m: object
+    source_height: int
+    source_width: int
+    uncertainty: object | None = None
+
+    def __post_init__(self) -> None:
+        if self.depth_m is None:
+            raise ValueError("depth_m must not be None")
+        if (
+            type(self.source_height) is not int
+            or self.source_height <= 0
+            or type(self.source_width) is not int
+            or self.source_width <= 0
+        ):
+            raise ValueError("source dimensions must be positive integers")
+
+
+@dataclass(frozen=True)
+class InstanceMask:
+    class_name: str
+    confidence: float
+    mask: object
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.class_name, str) or not self.class_name.strip():
+            raise ValueError("class_name must be nonempty")
+        if (
+            not _is_finite_number(self.confidence)
+            or self.confidence < 0
+            or self.confidence > 1
+        ):
+            raise ValueError("confidence must be finite and between 0 and 1")
+        if self.mask is None:
+            raise ValueError("mask must not be None")
+
+
+def _invalid_calibration(message: str) -> ObstacleDistanceError:
+    return ObstacleDistanceError(ErrorCode.INVALID_CALIBRATION, message)
+
+
+@dataclass(frozen=True)
+class CameraCalibration:
+    fx: float
+    fy: float
+    cx: float
+    cy: float
+    camera_to_ego: tuple[float, ...]
+    bumper_xy: tuple[float, float]
+
+    def __post_init__(self) -> None:
+        if (
+            not _is_finite_number(self.fx)
+            or self.fx <= 0
+            or not _is_finite_number(self.fy)
+            or self.fy <= 0
+        ):
+            raise _invalid_calibration(
+                "fx and fy must be finite positive numbers"
+            )
+        if not _is_finite_number(self.cx) or not _is_finite_number(self.cy):
+            raise _invalid_calibration("cx and cy must be finite numbers")
+        if (
+            not isinstance(self.camera_to_ego, tuple)
+            or len(self.camera_to_ego) != 16
+            or not all(_is_finite_number(value) for value in self.camera_to_ego)
+        ):
+            raise _invalid_calibration(
+                "camera_to_ego must contain 16 finite numbers"
+            )
+        if (
+            not isinstance(self.bumper_xy, tuple)
+            or len(self.bumper_xy) != 2
+            or not all(_is_finite_number(value) for value in self.bumper_xy)
+        ):
+            raise _invalid_calibration(
+                "bumper_xy must contain 2 finite numbers"
+            )
+
+
+@runtime_checkable
+class DepthBackend(Protocol):
+    def predict_depth(
+        self,
+        image_bytes: bytes,
+        domain: SceneDomain,
+        deadline_monotonic: float,
+    ) -> DepthPrediction:
+        ...
+
+
+@runtime_checkable
+class IndoorDistanceBackend(Protocol):
+    """Direct indoor decision for non-metric depth models.
+
+    Implementations return the protocol-facing distance directly instead of
+    pretending that an affine-invariant depth map is measured in metres.
+    """
+
+    def predict_indoor_distance(
+        self,
+        image_bytes: bytes,
+        deadline_monotonic: float,
+    ) -> float:
+        ...
+
+
+@runtime_checkable
+class InstanceSegmentationBackend(Protocol):
+    def predict_instances(
+        self,
+        image_bytes: bytes,
+        deadline_monotonic: float,
+    ) -> Sequence[InstanceMask]:
+        ...

--- a/perception/plugins/obstacle_distance_core/estimator.py
+++ b/perception/plugins/obstacle_distance_core/estimator.py
@@ -1,0 +1,509 @@
+from __future__ import annotations
+
+import math
+import time
+from collections.abc import Sequence
+from copy import deepcopy
+from dataclasses import dataclass
+from numbers import Real
+from typing import Callable, Mapping
+
+from .backend_validation import (
+    is_valid_depth_backend,
+    is_valid_indoor_distance_backend,
+    is_valid_segmentation_backend,
+)
+from .contracts import (
+    CameraCalibration,
+    DepthBackend,
+    ErrorCode,
+    InstanceMask,
+    InstanceSegmentationBackend,
+    ObstacleDistanceError,
+    SceneDomain,
+)
+from .geometry import approximate_vehicle_distance_m, vehicle_distance_m
+from .routing import resolve_scene
+
+
+@dataclass(frozen=True)
+class DistanceResult:
+    distance_m: float
+    near_obstacle: bool
+    decision_threshold_m: float
+    scene: str
+    status: str
+    error_code: str | None
+    fallback: bool
+    approximate_geometry: bool
+    latency_ms: float
+    timestamp: float
+
+
+def _finite_number(
+    value: object,
+    *,
+    name: str,
+    positive: bool = False,
+    nonnegative: bool = False,
+) -> float:
+    if isinstance(value, bool) or not isinstance(value, Real):
+        raise ValueError(f"{name} must be a finite number")
+    try:
+        converted = float(value)
+    except (TypeError, ValueError, OverflowError):
+        raise ValueError(f"{name} must be a finite number") from None
+    if not math.isfinite(converted):
+        raise ValueError(f"{name} must be a finite number")
+    if positive and converted <= 0:
+        raise ValueError(f"{name} must be positive")
+    if nonnegative and converted < 0:
+        raise ValueError(f"{name} must be nonnegative")
+    return converted
+
+
+def _invalid_calibration(message: str) -> ObstacleDistanceError:
+    return ObstacleDistanceError(ErrorCode.INVALID_CALIBRATION, message)
+
+
+def _time_value(value: object) -> float:
+    if isinstance(value, bool) or not isinstance(value, Real):
+        raise ObstacleDistanceError(
+            ErrorCode.MODEL_ERROR,
+            "time source returned an invalid value",
+        )
+    try:
+        converted = float(value)
+    except (TypeError, ValueError, OverflowError):
+        raise ObstacleDistanceError(
+            ErrorCode.MODEL_ERROR,
+            "time source returned an invalid value",
+        ) from None
+    if not math.isfinite(converted):
+        raise ObstacleDistanceError(
+            ErrorCode.MODEL_ERROR,
+            "time source returned an invalid value",
+        )
+    return converted
+
+
+def _camera_calibration(value: object) -> CameraCalibration:
+    if isinstance(value, CameraCalibration):
+        return value
+    if not isinstance(value, Mapping):
+        raise _invalid_calibration("camera calibration is invalid")
+    try:
+        return CameraCalibration(
+            fx=value["fx"],
+            fy=value["fy"],
+            cx=value["cx"],
+            cy=value["cy"],
+            camera_to_ego=tuple(value["camera_to_ego"]),
+            bumper_xy=tuple(value["bumper_xy"]),
+        )
+    except ObstacleDistanceError:
+        raise
+    except Exception:
+        raise _invalid_calibration("camera calibration is invalid") from None
+
+
+class ObstacleDistanceEstimator:
+    def __init__(
+        self,
+        depth_backend: DepthBackend | None,
+        segmentation_backend: InstanceSegmentationBackend | None,
+        config: Mapping[str, object],
+        *,
+        monotonic: Callable[[], float] = time.monotonic,
+        wall_time: Callable[[], float] = time.time,
+    ) -> None:
+        if not isinstance(config, Mapping):
+            raise ValueError("estimator config must be a mapping")
+        self._config = deepcopy(dict(config))
+        self._monotonic = monotonic
+        self._wall_time = wall_time
+        self._decision_threshold_m = _finite_number(
+            self._config.get("decision_threshold_m", 1.0),
+            name="decision_threshold_m",
+            positive=True,
+        )
+        self._fallback_distance_m = _finite_number(
+            self._config.get("fallback_distance_m", 3.0),
+            name="fallback_distance_m",
+            nonnegative=True,
+        )
+        self._soft_timeout_s = _finite_number(
+            self._config.get("soft_timeout_s", 2.5),
+            name="soft_timeout_s",
+            positive=True,
+        )
+
+        if not is_valid_depth_backend(depth_backend):
+            raise ValueError("estimator requires a depth backend")
+        if not is_valid_segmentation_backend(segmentation_backend):
+            raise ValueError("estimator requires a segmentation backend")
+
+        self._depth_backend = depth_backend
+        self._segmentation_backend = segmentation_backend
+
+    def _latency_ms(
+        self,
+        started_monotonic: float | None,
+        *,
+        finished_monotonic: float | None,
+        suppress_clock_errors: bool,
+    ) -> float:
+        if started_monotonic is None:
+            return 0.0
+        if finished_monotonic is None:
+            try:
+                finished_monotonic = _time_value(self._monotonic())
+            except Exception:
+                if suppress_clock_errors:
+                    return 0.0
+                raise ObstacleDistanceError(
+                    ErrorCode.MODEL_ERROR,
+                    "time source failed",
+                ) from None
+        elapsed = (finished_monotonic - started_monotonic) * 1000.0
+        if elapsed < 0:
+            return 0.0
+        return elapsed
+
+    def _result(
+        self,
+        *,
+        distance_m: float,
+        scene: str,
+        status: str,
+        error_code: str | None,
+        fallback: bool,
+        approximate_geometry: bool,
+        started_monotonic: float | None,
+        timestamp: float,
+        finished_monotonic: float | None = None,
+    ) -> DistanceResult:
+        return DistanceResult(
+            distance_m=distance_m,
+            near_obstacle=distance_m < self._decision_threshold_m,
+            decision_threshold_m=self._decision_threshold_m,
+            scene=scene,
+            status=status,
+            error_code=error_code,
+            fallback=fallback,
+            approximate_geometry=approximate_geometry,
+            latency_ms=self._latency_ms(
+                started_monotonic,
+                finished_monotonic=finished_monotonic,
+                suppress_clock_errors=fallback,
+            ),
+            timestamp=timestamp,
+        )
+
+    def _fallback(
+        self,
+        *,
+        code: ErrorCode,
+        scene: str,
+        started_monotonic: float | None,
+        timestamp: float,
+    ) -> DistanceResult:
+        safe_code = code if isinstance(code, ErrorCode) else ErrorCode.MODEL_ERROR
+        try:
+            safe_timestamp = _time_value(timestamp)
+        except Exception:
+            safe_timestamp = 0.0
+        return self._result(
+            distance_m=self._fallback_distance_m,
+            scene=scene,
+            status="error",
+            error_code=safe_code.value,
+            fallback=True,
+            approximate_geometry=False,
+            started_monotonic=started_monotonic,
+            timestamp=safe_timestamp,
+        )
+
+    def _check_deadline(self, deadline_monotonic: float) -> float:
+        observed_monotonic = _time_value(self._monotonic())
+        if observed_monotonic >= deadline_monotonic:
+            raise ObstacleDistanceError(
+                ErrorCode.TIMEOUT,
+                "obstacle distance inference timed out",
+            )
+        return observed_monotonic
+
+    @staticmethod
+    def _validated_instances(value: object) -> tuple[InstanceMask, ...]:
+        if (
+            isinstance(value, (str, bytes, bytearray, memoryview, Mapping))
+            or not isinstance(value, Sequence)
+        ):
+            raise ObstacleDistanceError(
+                ErrorCode.MODEL_ERROR,
+                "segmentation output is invalid",
+            )
+        try:
+            instances = tuple(value[index] for index in range(len(value)))
+        except Exception:
+            raise ObstacleDistanceError(
+                ErrorCode.MODEL_ERROR,
+                "segmentation output is invalid",
+            ) from None
+        if any(not isinstance(instance, InstanceMask) for instance in instances):
+            raise ObstacleDistanceError(
+                ErrorCode.MODEL_ERROR,
+                "segmentation output is invalid",
+            )
+        return instances
+
+    @staticmethod
+    def _apply_distance_calibration(
+        distance: float,
+        section: Mapping,
+    ) -> float:
+        calibration = section.get("distance_calibration")
+        if calibration is not None and not isinstance(calibration, Mapping):
+            raise ObstacleDistanceError(
+                ErrorCode.INVALID_DEPTH,
+                "distance_calibration must be a mapping",
+            )
+        if isinstance(calibration, Mapping) and calibration:
+            try:
+                mode = calibration.get("mode", "affine")
+                minimum_value = calibration.get("min_output_m")
+                maximum_value = calibration.get("max_output_m")
+                minimum = (
+                    None if minimum_value is None else float(minimum_value)
+                )
+                maximum = (
+                    None if maximum_value is None else float(maximum_value)
+                )
+            except (TypeError, ValueError, OverflowError):
+                raise ObstacleDistanceError(
+                    ErrorCode.INVALID_DEPTH,
+                    "distance_calibration must contain numeric values",
+                ) from None
+            if not isinstance(mode, str) or mode not in {"affine", "power"}:
+                raise ObstacleDistanceError(
+                    ErrorCode.INVALID_DEPTH,
+                    "distance_calibration mode is invalid",
+                )
+            if (
+                (
+                    minimum is not None
+                    and (not math.isfinite(minimum) or minimum < 0)
+                )
+                or (
+                    maximum is not None
+                    and (not math.isfinite(maximum) or maximum < 0)
+                )
+                or (
+                    minimum is not None
+                    and maximum is not None
+                    and maximum < minimum
+                )
+            ):
+                raise ObstacleDistanceError(
+                    ErrorCode.INVALID_DEPTH,
+                    "distance_calibration values or output range are invalid",
+                )
+            try:
+                if mode == "affine":
+                    scale = float(calibration.get("scale", 1.0))
+                    bias = float(calibration.get("bias", 0.0))
+                    if (
+                        not math.isfinite(scale)
+                        or scale <= 0
+                        or not math.isfinite(bias)
+                    ):
+                        raise ValueError
+                    distance = scale * distance + bias
+                else:
+                    input_anchor = float(calibration["input_anchor_m"])
+                    output_anchor = float(calibration["output_anchor_m"])
+                    power = float(calibration["power"])
+                    if (
+                        not math.isfinite(distance)
+                        or distance < 0
+                        or not math.isfinite(input_anchor)
+                        or input_anchor <= 0
+                        or not math.isfinite(output_anchor)
+                        or output_anchor <= 0
+                        or not math.isfinite(power)
+                        or power <= 0
+                    ):
+                        raise ValueError
+                    distance = output_anchor * math.pow(
+                        distance / input_anchor,
+                        power,
+                    )
+                if not math.isfinite(distance):
+                    raise ValueError
+            except (KeyError, TypeError, ValueError, OverflowError):
+                raise ObstacleDistanceError(
+                    ErrorCode.INVALID_DEPTH,
+                    "distance_calibration values are invalid",
+                ) from None
+            if minimum is not None:
+                distance = max(distance, minimum)
+            if maximum is not None:
+                distance = min(distance, maximum)
+        return distance
+
+    def _vehicle_distance(self, prediction, instances) -> tuple[float, bool]:
+        config = self._config.get("vehicle")
+        if not isinstance(config, Mapping):
+            raise ObstacleDistanceError(
+                ErrorCode.INVALID_DEPTH,
+                "vehicle configuration is invalid",
+            )
+        allowed_classes = config.get("allowed_classes")
+        try:
+            allowed = set(allowed_classes)
+        except Exception:
+            allowed = allowed_classes
+        common = {
+            "instances": instances,
+            "allowed_classes": allowed,
+            "min_confidence": config.get("min_confidence"),
+            "percentile": config.get("percentile"),
+            "min_depth_m": config.get("min_depth_m"),
+            "max_depth_m": config.get("max_depth_m"),
+        }
+
+        calibration_value = config.get("calibration")
+        calibration_missing = calibration_value is None or (
+            isinstance(calibration_value, Mapping)
+            and len(calibration_value) == 0
+        )
+        if calibration_missing:
+            if config.get("allow_approximate_geometry") is not True:
+                raise ObstacleDistanceError(
+                    ErrorCode.MISSING_CALIBRATION,
+                    "camera calibration is required for vehicle geometry",
+                )
+            distance = approximate_vehicle_distance_m(
+                prediction.depth_m,
+                camera_to_bumper_offset_m=config.get(
+                    "camera_to_bumper_offset_m"
+                ),
+                **common,
+            )
+            return self._apply_distance_calibration(distance, config), True
+
+        calibration = _camera_calibration(calibration_value)
+        distance = vehicle_distance_m(
+            prediction.depth_m,
+            calibration=calibration,
+            **common,
+        )
+        return self._apply_distance_calibration(distance, config), False
+
+    @staticmethod
+    def _validated_distance(value: object) -> float:
+        if isinstance(value, bool) or not isinstance(value, Real):
+            raise ObstacleDistanceError(
+                ErrorCode.MODEL_ERROR,
+                "estimated distance is invalid",
+            )
+        try:
+            distance = float(value)
+        except (TypeError, ValueError, OverflowError):
+            raise ObstacleDistanceError(
+                ErrorCode.MODEL_ERROR,
+                "estimated distance is invalid",
+            ) from None
+        if not math.isfinite(distance) or distance < 0:
+            raise ObstacleDistanceError(
+                ErrorCode.MODEL_ERROR,
+                "estimated distance is invalid",
+            )
+        return distance
+
+    def estimate(
+        self,
+        image_bytes: bytes,
+        scene_hint: SceneDomain | str | None = None,
+        timestamp: float | None = None,
+    ) -> DistanceResult:
+        started_monotonic = None
+        result_timestamp = 0.0
+        scene = "unknown"
+        try:
+            if not isinstance(image_bytes, bytes) or not image_bytes:
+                raise ObstacleDistanceError(
+                    ErrorCode.INVALID_IMAGE,
+                    "image bytes must be nonempty",
+                )
+            domain = resolve_scene(
+                scene_hint=scene_hint,
+                fixed_scene=self._config.get("fixed_scene"),
+            )
+            scene = domain.value
+            started_monotonic = _time_value(self._monotonic())
+            result_timestamp = _time_value(
+                timestamp if timestamp is not None else self._wall_time()
+            )
+            deadline_monotonic = started_monotonic + self._soft_timeout_s
+
+            approximate_geometry = False
+            self._check_deadline(deadline_monotonic)
+            if domain is SceneDomain.INDOOR:
+                if not is_valid_indoor_distance_backend(self._depth_backend):
+                    raise ObstacleDistanceError(
+                        ErrorCode.MODEL_ERROR,
+                        "indoor inference requires a direct distance backend",
+                    )
+                distance = self._depth_backend.predict_indoor_distance(
+                    image_bytes,
+                    deadline_monotonic,
+                )
+                self._check_deadline(deadline_monotonic)
+            else:
+                prediction = self._depth_backend.predict_depth(
+                    image_bytes,
+                    domain,
+                    deadline_monotonic,
+                )
+                self._check_deadline(deadline_monotonic)
+
+            if domain is SceneDomain.VEHICLE:
+                self._check_deadline(deadline_monotonic)
+                instances = self._segmentation_backend.predict_instances(
+                    image_bytes,
+                    deadline_monotonic,
+                )
+                self._check_deadline(deadline_monotonic)
+                instances = self._validated_instances(instances)
+                distance, approximate_geometry = self._vehicle_distance(
+                    prediction,
+                    instances,
+                )
+            distance = self._validated_distance(distance)
+            finished_monotonic = self._check_deadline(deadline_monotonic)
+            return self._result(
+                distance_m=distance,
+                scene=scene,
+                status="ok",
+                error_code=None,
+                fallback=False,
+                approximate_geometry=approximate_geometry,
+                started_monotonic=started_monotonic,
+                timestamp=result_timestamp,
+                finished_monotonic=finished_monotonic,
+            )
+        except ObstacleDistanceError as error:
+            return self._fallback(
+                code=error.code,
+                scene=scene,
+                started_monotonic=started_monotonic,
+                timestamp=result_timestamp,
+            )
+        except Exception:
+            return self._fallback(
+                code=ErrorCode.MODEL_ERROR,
+                scene=scene,
+                started_monotonic=started_monotonic,
+                timestamp=result_timestamp,
+            )

--- a/perception/plugins/obstacle_distance_core/geometry.py
+++ b/perception/plugins/obstacle_distance_core/geometry.py
@@ -1,0 +1,369 @@
+from __future__ import annotations
+
+import math
+import warnings
+from numbers import Real
+from typing import Iterable, Iterator
+
+import numpy as np
+
+from .contracts import (
+    CameraCalibration,
+    ErrorCode,
+    InstanceMask,
+    ObstacleDistanceError,
+)
+
+
+_GEOMETRY_CHUNK_ROWS = 64
+
+
+def _invalid_depth(message: str) -> ObstacleDistanceError:
+    return ObstacleDistanceError(ErrorCode.INVALID_DEPTH, message)
+
+
+def _invalid_calibration(message: str) -> ObstacleDistanceError:
+    return ObstacleDistanceError(ErrorCode.INVALID_CALIBRATION, message)
+
+
+def _finite_number(value: object, name: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, Real):
+        raise _invalid_depth(f"{name} must be a finite number")
+    try:
+        converted = float(value)
+    except (TypeError, ValueError, OverflowError):
+        raise _invalid_depth(f"{name} must be a finite number") from None
+    if not math.isfinite(converted):
+        raise _invalid_depth(f"{name} must be a finite number")
+    return converted
+
+
+def _validate_depth_map(depth: object) -> np.ndarray:
+    try:
+        source_array = np.asarray(depth)
+    except Exception:
+        raise _invalid_depth(
+            "depth map must be convertible to a numeric array"
+        ) from None
+    if source_array.dtype.kind == "O" or np.iscomplexobj(source_array):
+        raise _invalid_depth("depth map must use a real numeric dtype")
+    try:
+        with np.errstate(over="ignore", invalid="ignore"):
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", RuntimeWarning)
+                depth_array = np.asarray(source_array, dtype=np.float32)
+    except Exception:
+        raise _invalid_depth(
+            "depth map must be convertible to a numeric array"
+        ) from None
+    if depth_array.ndim != 2 or depth_array.size == 0:
+        raise _invalid_depth("depth map must be a nonempty two-dimensional array")
+    if not np.isfinite(depth_array).any():
+        raise _invalid_depth("depth map must contain at least one finite value")
+    return depth_array
+
+
+def _configuration(
+    *,
+    allowed_classes: object,
+    min_confidence: object,
+    percentile: object,
+    min_depth_m: object,
+    max_depth_m: object,
+) -> tuple[set[str] | frozenset[str], float, float, float, float]:
+    if (
+        not isinstance(allowed_classes, (set, frozenset))
+        or not allowed_classes
+        or any(
+            not isinstance(class_name, str) or not class_name.strip()
+            for class_name in allowed_classes
+        )
+    ):
+        raise _invalid_depth(
+            "allowed_classes must be a nonempty set of class names"
+        )
+
+    confidence = _finite_number(min_confidence, "min_confidence")
+    percentile_value = _finite_number(percentile, "percentile")
+    minimum = _finite_number(min_depth_m, "min_depth_m")
+    maximum = _finite_number(max_depth_m, "max_depth_m")
+    if not 0 <= confidence <= 1:
+        raise _invalid_depth("min_confidence must be between 0 and 1")
+    if not 0 <= percentile_value <= 100:
+        raise _invalid_depth("percentile must be between 0 and 100")
+    if minimum < 0 or maximum <= minimum:
+        raise _invalid_depth(
+            "depth range must satisfy 0 <= min_depth_m < max_depth_m"
+        )
+    return allowed_classes, confidence, percentile_value, minimum, maximum
+
+
+def _valid_target_depth(
+    depth_m: object,
+    *,
+    instances: Iterable[InstanceMask],
+    allowed_classes: object,
+    min_confidence: object,
+    percentile: object,
+    min_depth_m: object,
+    max_depth_m: object,
+) -> tuple[np.ndarray, np.ndarray, float]:
+    (
+        allowed,
+        confidence,
+        percentile_value,
+        minimum,
+        maximum,
+    ) = _configuration(
+        allowed_classes=allowed_classes,
+        min_confidence=min_confidence,
+        percentile=percentile,
+        min_depth_m=min_depth_m,
+        max_depth_m=max_depth_m,
+    )
+    depth_array = _validate_depth_map(depth_m)
+
+    try:
+        instance_values = tuple(instances)
+    except Exception:
+        raise _invalid_depth("instances must contain instance masks") from None
+    if any(not isinstance(value, InstanceMask) for value in instance_values):
+        raise _invalid_depth("instances must contain instance masks")
+
+    selected = [
+        value
+        for value in instance_values
+        if value.class_name in allowed and value.confidence >= confidence
+    ]
+    if not selected:
+        raise ObstacleDistanceError(
+            ErrorCode.NO_TARGET_INSTANCE,
+            "no target instance passed class and confidence filters",
+        )
+
+    merged_mask = np.zeros(depth_array.shape, dtype=bool)
+    for value in selected:
+        try:
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                mask = np.asarray(value.mask)
+        except Exception:
+            raise _invalid_depth(
+                "instance mask must be a two-dimensional boolean array"
+            ) from None
+        if (
+            mask.dtype.kind in {"O", "c"}
+            or mask.dtype != np.dtype(bool)
+            or mask.ndim != 2
+            or mask.shape != depth_array.shape
+        ):
+            raise _invalid_depth(
+                "instance mask must match depth shape and use boolean dtype"
+            )
+        np.logical_or(merged_mask, mask, out=merged_mask)
+
+    valid_mask = (
+        merged_mask
+        & np.isfinite(depth_array)
+        & (depth_array >= minimum)
+        & (depth_array <= maximum)
+    )
+    if not valid_mask.any():
+        raise ObstacleDistanceError(
+            ErrorCode.NO_VALID_DEPTH,
+            "target masks contain no valid depth pixels",
+        )
+    return depth_array, valid_mask, percentile_value
+
+
+def _valid_pixel_chunks(
+    depth_array: np.ndarray,
+    valid_mask: np.ndarray,
+) -> Iterator[tuple[int, np.ndarray, np.ndarray, np.ndarray]]:
+    for row_start in range(0, valid_mask.shape[0], _GEOMETRY_CHUNK_ROWS):
+        row_end = min(row_start + _GEOMETRY_CHUNK_ROWS, valid_mask.shape[0])
+        block = valid_mask[row_start:row_end]
+        local_rows, columns = np.nonzero(block)
+        if columns.size:
+            yield (
+                row_start,
+                local_rows,
+                columns,
+                depth_array[row_start + local_rows, columns],
+            )
+
+
+def _rigid_camera_to_ego(calibration: object) -> tuple[np.ndarray, tuple[float, float]]:
+    if calibration is None:
+        raise ObstacleDistanceError(
+            ErrorCode.MISSING_CALIBRATION,
+            "camera calibration is required for vehicle geometry",
+        )
+    if not isinstance(calibration, CameraCalibration):
+        raise _invalid_calibration("camera calibration is invalid")
+
+    matrix = np.asarray(calibration.camera_to_ego, dtype=np.float64).reshape(4, 4)
+    rotation = matrix[:3, :3]
+    if not np.allclose(
+        matrix[3],
+        np.array([0.0, 0.0, 0.0, 1.0]),
+        rtol=0.0,
+        atol=1e-5,
+    ):
+        raise _invalid_calibration(
+            "camera_to_ego must have a homogeneous final row"
+        )
+    if not np.allclose(
+        rotation.T @ rotation,
+        np.eye(3),
+        rtol=1e-5,
+        atol=1e-4,
+    ):
+        raise _invalid_calibration(
+            "camera_to_ego rotation must be orthogonal"
+        )
+    determinant = float(np.linalg.det(rotation))
+    if not math.isclose(determinant, 1.0, rel_tol=1e-5, abs_tol=1e-4):
+        raise _invalid_calibration(
+            "camera_to_ego rotation must be a proper rotation"
+        )
+    return matrix, calibration.bumper_xy
+
+
+def _finite_percentile(values: np.ndarray, percentile: float) -> float:
+    with np.errstate(over="ignore", invalid="ignore"):
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", RuntimeWarning)
+            result = float(np.percentile(values, percentile))
+    if not math.isfinite(result):
+        raise ObstacleDistanceError(
+            ErrorCode.NO_VALID_DEPTH,
+            "distance percentile is not finite",
+        )
+    return result
+
+
+def vehicle_distance_m(
+    depth_m: object,
+    *,
+    instances: Iterable[InstanceMask],
+    calibration: CameraCalibration | None,
+    allowed_classes: object,
+    min_confidence: object,
+    percentile: object,
+    min_depth_m: object,
+    max_depth_m: object,
+) -> float:
+    matrix, bumper_xy = _rigid_camera_to_ego(calibration)
+    depth_array, valid_mask, percentile_value = _valid_target_depth(
+        depth_m,
+        instances=instances,
+        allowed_classes=allowed_classes,
+        min_confidence=min_confidence,
+        percentile=percentile,
+        min_depth_m=min_depth_m,
+        max_depth_m=max_depth_m,
+    )
+
+    horizontal = np.empty(
+        int(np.count_nonzero(valid_mask)),
+        dtype=np.float64,
+    )
+    cursor = 0
+    for row_start, local_rows, columns, block_depth in _valid_pixel_chunks(
+        depth_array,
+        valid_mask,
+    ):
+        z_camera = block_depth.astype(np.float64, copy=False)
+        x_camera = (
+            (columns.astype(np.float64) - calibration.cx) / calibration.fx
+        ) * z_camera
+        rows = local_rows.astype(np.float64)
+        rows += row_start
+        y_camera = ((rows - calibration.cy) / calibration.fy) * z_camera
+        with np.errstate(over="ignore", invalid="ignore"):
+            ego_x = (
+                matrix[0, 0] * x_camera
+                + matrix[0, 1] * y_camera
+                + matrix[0, 2] * z_camera
+                + matrix[0, 3]
+            )
+            ego_y = (
+                matrix[1, 0] * x_camera
+                + matrix[1, 1] * y_camera
+                + matrix[1, 2] * z_camera
+                + matrix[1, 3]
+            )
+            block_horizontal = np.hypot(
+                ego_x - bumper_xy[0],
+                ego_y - bumper_xy[1],
+            )
+        finite = np.isfinite(block_horizontal)
+        finite_count = int(np.count_nonzero(finite))
+        if finite_count:
+            horizontal[cursor : cursor + finite_count] = block_horizontal[
+                finite
+            ]
+            cursor += finite_count
+
+    horizontal = horizontal[:cursor]
+    if horizontal.size == 0:
+        raise ObstacleDistanceError(
+            ErrorCode.NO_VALID_DEPTH,
+            "target geometry contains no finite horizontal distances",
+        )
+    return _finite_percentile(horizontal, percentile_value)
+
+
+def approximate_vehicle_distance_m(
+    depth_m: object,
+    *,
+    instances: Iterable[InstanceMask],
+    allowed_classes: object,
+    min_confidence: object,
+    percentile: object,
+    min_depth_m: object,
+    max_depth_m: object,
+    camera_to_bumper_offset_m: object,
+) -> float:
+    offset = _finite_number(
+        camera_to_bumper_offset_m,
+        "camera_to_bumper_offset_m",
+    )
+    if offset < 0:
+        raise _invalid_depth(
+            "camera_to_bumper_offset_m must be nonnegative"
+        )
+    depth_array, valid_mask, percentile_value = _valid_target_depth(
+        depth_m,
+        instances=instances,
+        allowed_classes=allowed_classes,
+        min_confidence=min_confidence,
+        percentile=percentile,
+        min_depth_m=min_depth_m,
+        max_depth_m=max_depth_m,
+    )
+    approximate = np.empty(
+        int(np.count_nonzero(valid_mask)),
+        dtype=np.float64,
+    )
+    cursor = 0
+    for _, _, _, block_depth in _valid_pixel_chunks(depth_array, valid_mask):
+        z_camera = block_depth.astype(np.float64, copy=False)
+        with np.errstate(over="ignore", invalid="ignore"):
+            block_approximate = np.maximum(z_camera - offset, 0.0)
+        finite = np.isfinite(block_approximate)
+        finite_count = int(np.count_nonzero(finite))
+        if finite_count:
+            approximate[cursor : cursor + finite_count] = block_approximate[
+                finite
+            ]
+            cursor += finite_count
+
+    approximate = approximate[:cursor]
+    if approximate.size == 0:
+        raise ObstacleDistanceError(
+            ErrorCode.NO_VALID_DEPTH,
+            "target geometry contains no finite approximate distances",
+        )
+    return _finite_percentile(approximate, percentile_value)

--- a/perception/plugins/obstacle_distance_core/native_tensorrt_backends.py
+++ b/perception/plugins/obstacle_distance_core/native_tensorrt_backends.py
@@ -1,0 +1,354 @@
+"""Obstacle TensorRT backends (YOLO seg / depth) on the shared TensorRT runtime.
+
+Engine deserialization, dtype mapping, CUDA buffers/stream and execution live
+in utils.tensorrt_runtime.TensorRTEngine (shared with the OCR plugin); this
+module only adds the fixed-shape contract, Ultralytics metadata checks and
+the YOLO/ZipDepth pre/post-processing.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+import threading
+import time
+from typing import Sequence
+
+import numpy as np
+
+from utils.tensorrt_runtime import TensorRTEngine, TensorRTError
+
+from .contracts import (
+    ErrorCode,
+    InstanceMask,
+    ObstacleDistanceError,
+)
+from .runtime_utils import (
+    SEG_CONF_FLOOR,
+    SEG_INPUT_SIZE,
+    check_deadline,
+    decode_image,
+    letterbox,
+)
+
+
+log = logging.getLogger(__name__)
+
+_YOLO_DEPTH_INPUT_SIZE = 768
+
+
+class _NativeTensorRTEngine:
+    """Fixed-shape view over a shared TensorRTEngine with obstacle error mapping.
+
+    Obstacle engines are exported with static input/output shapes; anything
+    dynamic is rejected up front so the estimator reports a structured
+    model_error instead of failing on the first frame.
+    """
+
+    def __init__(self, path: str, expected_task: str | None = None) -> None:
+        try:
+            self._engine = TensorRTEngine(path)
+        except TensorRTError as error:
+            raise ObstacleDistanceError(ErrorCode.MODEL_ERROR, str(error)) from None
+        try:
+            self.metadata = self._engine.metadata
+            if expected_task and self.metadata.get("task") != expected_task:
+                raise ObstacleDistanceError(
+                    ErrorCode.MODEL_ERROR,
+                    f"TensorRT engine task must be {expected_task}",
+                )
+            if not self._engine.is_static:
+                raise ObstacleDistanceError(
+                    ErrorCode.MODEL_ERROR,
+                    "native TensorRT backend requires fixed input shapes",
+                )
+            self.input_name = self._engine.input_name
+            self.input_shape = tuple(self._engine.input_shape)
+            self.input_dtype = self._engine.input_dtype
+            self.output_names = list(self._engine.output_names)
+            self.output_dtypes = dict(self._engine.output_dtypes)
+        except Exception:
+            self._engine.close()
+            raise
+
+    def infer(self, image: np.ndarray) -> tuple[np.ndarray, ...]:
+        image = np.ascontiguousarray(image, dtype=self.input_dtype)
+        if tuple(image.shape) != self.input_shape:
+            raise ObstacleDistanceError(
+                ErrorCode.MODEL_ERROR,
+                f"TensorRT input shape mismatch: {image.shape} != {self.input_shape}",
+            )
+        try:
+            return tuple(self._engine.infer(image))
+        except TensorRTError as error:
+            raise ObstacleDistanceError(ErrorCode.MODEL_ERROR, str(error)) from None
+
+    def close(self) -> None:
+        engine = getattr(self, "_engine", None)
+        if engine is not None:
+            engine.close()
+
+    def __del__(self) -> None:
+        try:
+            self.close()
+        except Exception:
+            pass
+
+
+def _prepare_yolo_image(image: np.ndarray, size: int) -> tuple[np.ndarray, float, int, int]:
+    letterboxed, ratio, dw, dh = letterbox(image, size)
+    rgb = letterboxed[:, :, ::-1]
+    chw = np.transpose(rgb, (2, 0, 1))
+    tensor = np.ascontiguousarray(chw, dtype=np.float32)[None] / 255.0
+    return tensor, ratio, dw, dh
+
+
+def _resize_align_corners(image: np.ndarray, height: int, width: int) -> np.ndarray:
+    import cv2
+
+    if image.shape == (height, width):
+        return image.astype(np.float32, copy=False)
+    source_height, source_width = image.shape
+    x = np.linspace(0, source_width - 1, width, dtype=np.float32)
+    y = np.linspace(0, source_height - 1, height, dtype=np.float32)
+    map_x, map_y = np.meshgrid(x, y)
+    return cv2.remap(
+        image.astype(np.float32, copy=False),
+        map_x,
+        map_y,
+        interpolation=cv2.INTER_LINEAR,
+        borderMode=cv2.BORDER_REPLICATE,
+    )
+
+
+def _scale_depth_to_original(
+    depth: np.ndarray,
+    original_height: int,
+    original_width: int,
+) -> np.ndarray:
+    import cv2
+
+    input_height, input_width = depth.shape
+    gain = min(input_height / original_height, input_width / original_width)
+    pad_w = (input_width - round(original_width * gain)) / 2
+    pad_h = (input_height - round(original_height * gain)) / 2
+    top = round(pad_h - 0.1)
+    left = round(pad_w - 0.1)
+    bottom = input_height - round(pad_h + 0.1)
+    right = input_width - round(pad_w + 0.1)
+    cropped = depth[top:bottom, left:right]
+    return cv2.resize(
+        cropped.astype(np.float32, copy=False),
+        (original_width, original_height),
+        interpolation=cv2.INTER_LINEAR,
+    )
+
+
+def _process_yolo_masks(
+    detections: np.ndarray,
+    prototypes: np.ndarray,
+    original_height: int,
+    original_width: int,
+    ratio: float,
+    dw: int,
+    dh: int,
+    *,
+    confidence_floor: float = SEG_CONF_FLOOR,
+    allowed_class_ids: frozenset[int] | None = None,
+) -> list[tuple[int, float, np.ndarray]]:
+    import cv2
+
+    detections = np.asarray(detections, dtype=np.float32)
+    prototypes = np.asarray(prototypes, dtype=np.float32)
+    if detections.ndim == 3:
+        detections = detections[0]
+    if prototypes.ndim == 4:
+        prototypes = prototypes[0]
+    selected_mask = detections[:, 4] > SEG_CONF_FLOOR
+    selected_mask &= detections[:, 4] >= confidence_floor
+    if allowed_class_ids is not None:
+        selected_mask &= np.isin(
+            detections[:, 5].astype(np.int64),
+            tuple(allowed_class_ids),
+        )
+    selected = detections[selected_mask]
+    if not len(selected):
+        return []
+    channels, mask_height, mask_width = prototypes.shape
+    coefficients = selected[:, 6 : 6 + channels]
+    logits = (coefficients @ prototypes.reshape(channels, -1)).reshape(
+        -1,
+        mask_height,
+        mask_width,
+    )
+    unpad_height = min(
+        int(round(original_height * ratio)),
+        SEG_INPUT_SIZE - dh,
+    )
+    unpad_width = min(
+        int(round(original_width * ratio)),
+        SEG_INPUT_SIZE - dw,
+    )
+    rows = np.arange(SEG_INPUT_SIZE, dtype=np.float32)[:, None]
+    columns = np.arange(SEG_INPUT_SIZE, dtype=np.float32)[None, :]
+    results = []
+    for detection, logit in zip(selected, logits):
+        upsampled = cv2.resize(
+            logit,
+            (SEG_INPUT_SIZE, SEG_INPUT_SIZE),
+            interpolation=cv2.INTER_LINEAR,
+        )
+        x1, y1, x2, y2 = detection[:4]
+        mask = upsampled > 0.0
+        mask &= columns >= x1
+        mask &= columns < x2
+        mask &= rows >= y1
+        mask &= rows < y2
+        if not mask.any():
+            continue
+        mask = mask[dh : dh + unpad_height, dw : dw + unpad_width]
+        mask = cv2.resize(
+            mask.astype(np.uint8),
+            (original_width, original_height),
+            interpolation=cv2.INTER_NEAREST,
+        ).astype(bool)
+        results.append((int(detection[5]), float(detection[4]), mask))
+    return results
+
+
+class NativeTensorRTSegBackend:
+    def __init__(
+        self,
+        engine: str,
+        *,
+        allowed_classes: object = None,
+        min_confidence: object = None,
+    ) -> None:
+        self._engine_path = engine
+        self._allowed_classes = allowed_classes
+        self._names: dict[int, str] = {}
+        self._allowed_class_ids: frozenset[int] | None = None
+        self._confidence_floor = self._configured_confidence(min_confidence)
+        # Load the engine on the first vehicle frame so an indoor-only
+        # deployment does not pay for segmentation residency.
+        self._model: _NativeTensorRTEngine | None = None
+        self._engine_init_lock = threading.Lock()
+        log.info("[obstacle] native TensorRT segmentation configured %s", engine)
+
+    def _get_model(self) -> _NativeTensorRTEngine:
+        model = self._model
+        if model is None:
+            with self._engine_init_lock:
+                if self._model is None:
+                    started = time.monotonic()
+                    model = _NativeTensorRTEngine(
+                        self._engine_path,
+                        expected_task="segment",
+                    )
+                    if model.input_shape != (
+                        1,
+                        3,
+                        SEG_INPUT_SIZE,
+                        SEG_INPUT_SIZE,
+                    ):
+                        raise ObstacleDistanceError(
+                            ErrorCode.MODEL_ERROR,
+                            "YOLO segmentation TensorRT engine input shape is incompatible",
+                        )
+                    names = model.metadata.get("names", {})
+                    if not isinstance(names, dict):
+                        raise ObstacleDistanceError(
+                            ErrorCode.MODEL_ERROR,
+                            "YOLO segmentation metadata does not contain class names",
+                        )
+                    self._names = {
+                        int(key): str(value) for key, value in names.items()
+                    }
+                    self._allowed_class_ids = self._configured_class_ids(
+                        self._allowed_classes
+                    )
+                    self._model = model
+                    log.info(
+                        "[obstacle] native TensorRT segmentation loaded %s "
+                        "in %.1fms",
+                        self._engine_path,
+                        1000.0 * (time.monotonic() - started),
+                    )
+                model = self._model
+        return model
+
+    def _configured_class_ids(
+        self,
+        allowed_classes: object,
+    ) -> frozenset[int] | None:
+        if not isinstance(allowed_classes, (list, tuple, set, frozenset)):
+            return None
+        if not allowed_classes or any(
+            not isinstance(value, str) for value in allowed_classes
+        ):
+            return None
+        allowed = set(allowed_classes)
+        return frozenset(
+            class_id
+            for class_id, class_name in self._names.items()
+            if class_name in allowed
+        )
+
+    @staticmethod
+    def _configured_confidence(min_confidence: object) -> float:
+        if (
+            isinstance(min_confidence, bool)
+            or not isinstance(min_confidence, (int, float))
+        ):
+            return SEG_CONF_FLOOR
+        confidence = float(min_confidence)
+        if not math.isfinite(confidence) or not 0 <= confidence <= 1:
+            return SEG_CONF_FLOOR
+        return max(SEG_CONF_FLOOR, confidence)
+
+    def close(self) -> None:
+        """Release the segmentation engine and its CUDA buffers."""
+        with self._engine_init_lock:
+            model = self._model
+            self._model = None
+        if model is not None:
+            model.close()
+
+    def predict_instances(
+        self,
+        image_bytes: bytes,
+        deadline_monotonic: float,
+    ) -> Sequence[InstanceMask]:
+        check_deadline(deadline_monotonic)
+        image = decode_image(image_bytes)
+        height, width = image.shape[:2]
+        tensor, ratio, dw, dh = _prepare_yolo_image(image, SEG_INPUT_SIZE)
+        model = self._get_model()
+        outputs = model.infer(tensor)
+        detection_outputs = [output for output in outputs if output.ndim == 3]
+        prototype_outputs = [output for output in outputs if output.ndim == 4]
+        if len(detection_outputs) != 1 or len(prototype_outputs) != 1:
+            raise ObstacleDistanceError(
+                ErrorCode.MODEL_ERROR,
+                "YOLO segmentation engine outputs are incompatible",
+            )
+        processed = _process_yolo_masks(
+            detection_outputs[0],
+            prototype_outputs[0],
+            height,
+            width,
+            ratio,
+            dw,
+            dh,
+            confidence_floor=self._confidence_floor,
+            allowed_class_ids=self._allowed_class_ids,
+        )
+        check_deadline(deadline_monotonic)
+        return tuple(
+            InstanceMask(
+                class_name=self._names.get(class_id, str(class_id)),
+                confidence=confidence,
+                mask=mask,
+            )
+            for class_id, confidence, mask in processed
+        )

--- a/perception/plugins/obstacle_distance_core/routing.py
+++ b/perception/plugins/obstacle_distance_core/routing.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from .contracts import ErrorCode, ObstacleDistanceError, SceneDomain
+
+
+def _missing_scene(message: str) -> ObstacleDistanceError:
+    return ObstacleDistanceError(ErrorCode.MISSING_SCENE, message)
+
+
+def _coerce_scene(value: SceneDomain | str) -> SceneDomain:
+    if isinstance(value, SceneDomain):
+        return value
+    if isinstance(value, str):
+        try:
+            return SceneDomain(value.strip().lower())
+        except ValueError:
+            pass
+    raise _missing_scene("scene selection is invalid")
+
+
+def resolve_scene(
+    *,
+    scene_hint: SceneDomain | str | None = None,
+    fixed_scene: SceneDomain | str | None = None,
+) -> SceneDomain:
+    if scene_hint is not None:
+        return _coerce_scene(scene_hint)
+
+    if fixed_scene is not None:
+        return _coerce_scene(fixed_scene)
+
+    raise _missing_scene("scene selection is required")

--- a/perception/plugins/obstacle_distance_core/runtime_utils.py
+++ b/perception/plugins/obstacle_distance_core/runtime_utils.py
@@ -1,0 +1,70 @@
+"""Shared image and configuration helpers for obstacle inference backends."""
+
+from __future__ import annotations
+
+import os
+import time
+from typing import Mapping
+
+import numpy as np
+
+from .contracts import ErrorCode, ObstacleDistanceError
+
+
+SEG_INPUT_SIZE = 640
+SEG_CONF_FLOOR = 0.05
+
+
+def check_deadline(deadline_monotonic: float) -> None:
+    if deadline_monotonic > 0 and time.monotonic() >= deadline_monotonic:
+        raise ObstacleDistanceError(ErrorCode.TIMEOUT, "model inference timed out")
+
+
+def decode_image(image_bytes: bytes) -> np.ndarray:
+    import cv2
+
+    try:
+        image = cv2.imdecode(
+            np.frombuffer(image_bytes, dtype=np.uint8),
+            cv2.IMREAD_COLOR,
+        )
+    except Exception:
+        image = None
+    if image is None or image.size == 0:
+        raise ObstacleDistanceError(
+            ErrorCode.INVALID_IMAGE,
+            "image bytes could not be decoded",
+        )
+    return image
+
+
+def letterbox(
+    image: np.ndarray,
+    size: int,
+) -> tuple[np.ndarray, float, int, int]:
+    import cv2
+
+    height, width = image.shape[:2]
+    ratio = min(size / height, size / width)
+    unpad_h = int(round(height * ratio))
+    unpad_w = int(round(width * ratio))
+    dw = (size - unpad_w) // 2
+    dh = (size - unpad_h) // 2
+    resized = cv2.resize(
+        image,
+        (unpad_w, unpad_h),
+        interpolation=cv2.INTER_LINEAR,
+    )
+    canvas = np.full((size, size, 3), 114, dtype=np.uint8)
+    canvas[dh : dh + unpad_h, dw : dw + unpad_w] = resized
+    return canvas, ratio, dw, dh
+
+
+def model_path(config: Mapping, key: str) -> str:
+    value = config.get(key)
+    if not isinstance(value, str) or not value or not os.path.isfile(value):
+        raise ObstacleDistanceError(
+            ErrorCode.MODEL_ERROR,
+            f"{key} does not identify a model file",
+        )
+    return value

--- a/perception/plugins/obstacle_distance_core/zipdepth_tensorrt_backends.py
+++ b/perception/plugins/obstacle_distance_core/zipdepth_tensorrt_backends.py
@@ -1,0 +1,403 @@
+"""Independent TensorRT backends for ZipDepth indoor decisions and YOLO vehicle depth.
+
+ZipDepth predicts affine-invariant inverse depth, not metric depth. The indoor
+branch converts a calibrated ROI statistic to a distance while preserving the
+configured decision boundary. Vehicle images use metric YOLO depth and
+segmentation.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+import threading
+import time
+from numbers import Real
+from typing import Mapping
+
+import numpy as np
+
+from .contracts import (
+    DepthBackend,
+    DepthPrediction,
+    ErrorCode,
+    InstanceSegmentationBackend,
+    ObstacleDistanceError,
+    SceneDomain,
+)
+from .native_tensorrt_backends import (
+    NativeTensorRTSegBackend,
+    _NativeTensorRTEngine,
+    _YOLO_DEPTH_INPUT_SIZE,
+    _prepare_yolo_image,
+    _resize_align_corners,
+    _scale_depth_to_original,
+)
+from .runtime_utils import check_deadline, decode_image, model_path
+
+
+_ZIPDEPTH_INPUT_HEIGHT = 384
+_ZIPDEPTH_INPUT_WIDTH = 512
+
+log = logging.getLogger(__name__)
+
+
+def _finite_number(
+    value: object,
+    *,
+    name: str,
+    minimum: float | None = None,
+    maximum: float | None = None,
+) -> float:
+    if isinstance(value, bool) or not isinstance(value, Real):
+        raise ObstacleDistanceError(ErrorCode.MODEL_ERROR, f"{name} is invalid")
+    converted = float(value)
+    if (
+        not math.isfinite(converted)
+        or (minimum is not None and converted < minimum)
+        or (maximum is not None and converted > maximum)
+    ):
+        raise ObstacleDistanceError(ErrorCode.MODEL_ERROR, f"{name} is invalid")
+    return converted
+
+
+def _positive_integer(value: object, *, name: str) -> int:
+    if type(value) is not int or value <= 0:
+        raise ObstacleDistanceError(ErrorCode.MODEL_ERROR, f"{name} is invalid")
+    return value
+
+
+def _roi(value: object) -> tuple[int, int, int, int]:
+    if (
+        not isinstance(value, (list, tuple))
+        or len(value) != 4
+        or any(type(item) is not int for item in value)
+    ):
+        raise ObstacleDistanceError(ErrorCode.MODEL_ERROR, "ZipDepth ROI is invalid")
+    row_start, row_end, col_start, col_end = value
+    if row_start < 0 or col_start < 0 or row_end <= row_start or col_end <= col_start:
+        raise ObstacleDistanceError(ErrorCode.MODEL_ERROR, "ZipDepth ROI is invalid")
+    return row_start, row_end, col_start, col_end
+
+
+def _prepare_zipdepth_image(image: np.ndarray) -> np.ndarray:
+    import cv2
+
+    resized = cv2.resize(
+        image,
+        (_ZIPDEPTH_INPUT_WIDTH, _ZIPDEPTH_INPUT_HEIGHT),
+        interpolation=cv2.INTER_LINEAR,
+    )
+    rgb = resized[:, :, ::-1]
+    chw = np.transpose(rgb, (2, 0, 1))
+    return np.ascontiguousarray(chw, dtype=np.float32)[None] / 255.0
+
+
+class ZipDepthYoloTensorRTDepthBackend:
+    """ZipDepth direct indoor classifier plus metric YOLO vehicle depth."""
+
+    def __init__(
+        self,
+        indoor_engine: str,
+        vehicle_engine: str,
+        *,
+        indoor_config: Mapping[str, object],
+        decision_threshold_m: object = 1.0,
+    ) -> None:
+        # Load each engine on first use so a single-domain deployment does not
+        # pay for the other domain's TensorRT engine and CUDA allocations.
+        self._indoor_engine_path = indoor_engine
+        self._vehicle_engine_path = vehicle_engine
+        self._indoor: _NativeTensorRTEngine | None = None
+        self._vehicle: _NativeTensorRTEngine | None = None
+        self._engine_init_lock = threading.Lock()
+
+        self._roi = _roi(indoor_config.get("roi"))
+        reference_size = indoor_config.get("roi_reference_size", (480, 640))
+        if (
+            not isinstance(reference_size, (list, tuple))
+            or len(reference_size) != 2
+        ):
+            raise ObstacleDistanceError(
+                ErrorCode.MODEL_ERROR,
+                "ZipDepth ROI reference size is invalid",
+            )
+        self._reference_height = _positive_integer(
+            reference_size[0], name="ZipDepth ROI reference height"
+        )
+        self._reference_width = _positive_integer(
+            reference_size[1], name="ZipDepth ROI reference width"
+        )
+        self._percentile = _finite_number(
+            indoor_config.get("inverse_depth_percentile", 95.0),
+            name="ZipDepth percentile",
+            minimum=0.0,
+            maximum=100.0,
+        )
+        self._score_threshold = _finite_number(
+            indoor_config.get("score_threshold", -0.06),
+            name="ZipDepth score threshold",
+        )
+        self._distance_scale = _finite_number(
+            indoor_config.get(
+                "inverse_depth_distance_scale",
+                -27.0,
+            ),
+            name="ZipDepth distance scale",
+        )
+        self._distance_bias_m = _finite_number(
+            indoor_config.get(
+                "inverse_depth_distance_bias_m",
+                3.7,
+            ),
+            name="ZipDepth distance bias",
+        )
+        self._decision_threshold_m = _finite_number(
+            decision_threshold_m,
+            name="obstacle decision threshold",
+            minimum=0.0,
+        )
+        if self._decision_threshold_m <= 0:
+            raise ObstacleDistanceError(
+                ErrorCode.MODEL_ERROR,
+                "obstacle decision threshold is invalid",
+            )
+        self._classification_margin_m = _finite_number(
+            indoor_config.get("classification_margin_m", 0.001),
+            name="ZipDepth classification margin",
+            minimum=0.0,
+        )
+        if not 0 < self._classification_margin_m < self._decision_threshold_m:
+            raise ObstacleDistanceError(
+                ErrorCode.MODEL_ERROR,
+                "ZipDepth classification margin is invalid",
+            )
+        self._min_output_distance_m = _finite_number(
+            indoor_config.get("min_output_distance_m", 0.0),
+            name="ZipDepth minimum output distance",
+            minimum=0.0,
+        )
+        self._max_output_distance_m = _finite_number(
+            indoor_config.get("max_output_distance_m", 10.0),
+            name="ZipDepth maximum output distance",
+            minimum=0.0,
+        )
+        if (
+            self._min_output_distance_m
+            > self._decision_threshold_m - self._classification_margin_m
+            or self._max_output_distance_m < self._decision_threshold_m
+        ):
+            raise ObstacleDistanceError(
+                ErrorCode.MODEL_ERROR,
+                "ZipDepth output range is incompatible with the decision threshold",
+            )
+        self._min_valid_pixels = _positive_integer(
+            indoor_config.get("min_valid_pixels", 64),
+            name="ZipDepth minimum valid pixels",
+        )
+
+    def _scaled_roi(self, height: int, width: int) -> tuple[int, int, int, int]:
+        row_start, row_end, col_start, col_end = self._roi
+        scaled = (
+            round(height * row_start / self._reference_height),
+            round(height * row_end / self._reference_height),
+            round(width * col_start / self._reference_width),
+            round(width * col_end / self._reference_width),
+        )
+        r0, r1, c0, c1 = scaled
+        if (
+            r0 < 0
+            or c0 < 0
+            or r1 > height
+            or c1 > width
+            or r1 <= r0
+            or c1 <= c0
+        ):
+            raise ObstacleDistanceError(
+                ErrorCode.INVALID_DEPTH,
+                "scaled ZipDepth ROI is outside the image",
+            )
+        return scaled
+
+    def _get_indoor_engine(self) -> _NativeTensorRTEngine:
+        engine = self._indoor
+        if engine is None:
+            with self._engine_init_lock:
+                if self._indoor is None:
+                    started = time.monotonic()
+                    indoor = _NativeTensorRTEngine(self._indoor_engine_path)
+                    if indoor.input_shape != (
+                        1,
+                        3,
+                        _ZIPDEPTH_INPUT_HEIGHT,
+                        _ZIPDEPTH_INPUT_WIDTH,
+                    ):
+                        raise ObstacleDistanceError(
+                            ErrorCode.MODEL_ERROR,
+                            "ZipDepth TensorRT engine input shape is incompatible",
+                        )
+                    if len(indoor.output_names) != 1:
+                        raise ObstacleDistanceError(
+                            ErrorCode.MODEL_ERROR,
+                            "ZipDepth TensorRT engine must have one output",
+                        )
+                    log.info(
+                        "[obstacle] ZipDepth indoor engine loaded in %.1fms",
+                        1000.0 * (time.monotonic() - started),
+                    )
+                    self._indoor = indoor
+                engine = self._indoor
+        return engine
+
+    def _get_vehicle_engine(self) -> _NativeTensorRTEngine:
+        engine = self._vehicle
+        if engine is None:
+            with self._engine_init_lock:
+                if self._vehicle is None:
+                    started = time.monotonic()
+                    vehicle = _NativeTensorRTEngine(
+                        self._vehicle_engine_path,
+                        expected_task="depth",
+                    )
+                    if vehicle.input_shape != (
+                        1,
+                        3,
+                        _YOLO_DEPTH_INPUT_SIZE,
+                        _YOLO_DEPTH_INPUT_SIZE,
+                    ):
+                        raise ObstacleDistanceError(
+                            ErrorCode.MODEL_ERROR,
+                            "YOLO depth TensorRT engine input shape is incompatible",
+                        )
+                    log.info(
+                        "[obstacle] YOLO depth engine loaded in %.1fms",
+                        1000.0 * (time.monotonic() - started),
+                    )
+                    self._vehicle = vehicle
+                engine = self._vehicle
+        return engine
+
+    def close(self) -> None:
+        """Release both depth engines and their CUDA buffers."""
+        with self._engine_init_lock:
+            engines = [self._indoor, self._vehicle]
+            self._indoor = None
+            self._vehicle = None
+        for engine in engines:
+            if engine is not None:
+                engine.close()
+
+    def predict_indoor_distance(
+        self,
+        image_bytes: bytes,
+        deadline_monotonic: float,
+    ) -> float:
+        check_deadline(deadline_monotonic)
+        image = decode_image(image_bytes)
+        height, width = image.shape[:2]
+        outputs = self._get_indoor_engine().infer(
+            _prepare_zipdepth_image(image)
+        )
+        if len(outputs) != 1:
+            raise ObstacleDistanceError(
+                ErrorCode.MODEL_ERROR,
+                "ZipDepth TensorRT engine must have one output",
+            )
+        inverse_depth = np.asarray(outputs[0]).squeeze()
+        if inverse_depth.ndim != 2:
+            raise ObstacleDistanceError(
+                ErrorCode.INVALID_DEPTH,
+                "ZipDepth output must be a two-dimensional map",
+            )
+        inverse_depth = _resize_align_corners(inverse_depth, height, width)
+        r0, r1, c0, c1 = self._scaled_roi(height, width)
+        values = inverse_depth[r0:r1, c0:c1]
+        values = values[np.isfinite(values)]
+        if values.size < self._min_valid_pixels:
+            raise ObstacleDistanceError(
+                ErrorCode.NO_VALID_DEPTH,
+                "ZipDepth ROI does not contain enough valid values",
+            )
+        inverse_depth_percentile = float(
+            np.percentile(values, self._percentile)
+        )
+        score = -inverse_depth_percentile
+        distance_m = (
+            self._distance_scale * inverse_depth_percentile
+            + self._distance_bias_m
+        )
+        distance_m = float(
+            np.clip(
+                distance_m,
+                self._min_output_distance_m,
+                self._max_output_distance_m,
+            )
+        )
+        if score < self._score_threshold:
+            distance_m = min(
+                distance_m,
+                self._decision_threshold_m - self._classification_margin_m,
+            )
+        else:
+            distance_m = max(distance_m, self._decision_threshold_m)
+        check_deadline(deadline_monotonic)
+        return distance_m
+
+    def predict_depth(
+        self,
+        image_bytes: bytes,
+        domain: SceneDomain,
+        deadline_monotonic: float,
+    ) -> DepthPrediction:
+        if domain is not SceneDomain.VEHICLE:
+            raise ObstacleDistanceError(
+                ErrorCode.MODEL_ERROR,
+                "ZipDepth indoor inference requires predict_indoor_distance",
+            )
+        check_deadline(deadline_monotonic)
+        image = decode_image(image_bytes)
+        height, width = image.shape[:2]
+        tensor, _, _, _ = _prepare_yolo_image(image, _YOLO_DEPTH_INPUT_SIZE)
+        outputs = self._get_vehicle_engine().infer(tensor)
+        if len(outputs) != 1:
+            raise ObstacleDistanceError(
+                ErrorCode.MODEL_ERROR,
+                "YOLO depth TensorRT engine must have one output",
+            )
+        depth = _scale_depth_to_original(outputs[0].squeeze(), height, width)
+        check_deadline(deadline_monotonic)
+        return DepthPrediction(
+            depth_m=np.ascontiguousarray(depth, dtype=np.float32),
+            source_height=height,
+            source_width=width,
+        )
+
+
+def create_backends(
+    config: Mapping,
+) -> tuple[DepthBackend, InstanceSegmentationBackend]:
+    indoor_engine = model_path(config, "indoor_depth_engine")
+    vehicle_engine = model_path(config, "vehicle_depth_engine")
+    segmentation_engine = model_path(config, "segmentation_engine")
+    indoor_config = config.get("indoor", {})
+    vehicle_config = config.get("vehicle", {})
+    if not isinstance(indoor_config, Mapping):
+        raise ObstacleDistanceError(
+            ErrorCode.MODEL_ERROR,
+            "indoor configuration must be a mapping",
+        )
+    if not isinstance(vehicle_config, Mapping):
+        vehicle_config = {}
+    return (
+        ZipDepthYoloTensorRTDepthBackend(
+            indoor_engine,
+            vehicle_engine,
+            indoor_config=indoor_config,
+            decision_threshold_m=config.get("decision_threshold_m", 1.0),
+        ),
+        NativeTensorRTSegBackend(
+            segmentation_engine,
+            allowed_classes=vehicle_config.get("allowed_classes"),
+            min_confidence=vehicle_config.get("min_confidence"),
+        ),
+    )

--- a/perception/tests/test_obstacle_plugin.py
+++ b/perception/tests/test_obstacle_plugin.py
@@ -395,3 +395,36 @@ def test_obstacle_model_dir_confined_to_models_tree(monkeypatch):
         md.ensure_obstacle_models("/etc/cron.d")
     with pytest.raises(ValueError):
         md.ensure_obstacle_models("/models/../root")
+
+
+# ── config surface (培育→配置) ───────────────────────────────────────────────
+
+def test_obstacle_config_schema_exposes_only_operator_fields():
+    """The config UI renders configSchema verbatim. provider (one valid
+    value) and the expert tuning blocks live in config.yaml only; what
+    remains are the two genuine operator decisions, and no object-typed
+    property may appear (the frontend renders those as [object Object])."""
+    from plugins.obstacle import TOOLS
+
+    schema = TOOLS[0]["configSchema"]
+    assert set(schema["properties"]) == {"fixed_scene", "decision_threshold_m"}
+    for name, spec in schema["properties"].items():
+        assert spec["type"] != "object", name
+    assert "required" not in schema
+    assert schema["properties"]["fixed_scene"]["enum"] == ["indoor", "vehicle"]
+
+
+def test_obstacle_config_fields_reach_the_adapter(monkeypatch):
+    """fixed_scene / decision_threshold_m set via the config action land in
+    the adapter cfg on the next start (adapter rebuild path)."""
+    plugin, executor, builder = _make_obstacle(monkeypatch)
+    plugin.dispatch("obstacle", {
+        "action": "config",
+        "fixed_scene": "vehicle",
+        "decision_threshold_m": 3.5,
+    })
+    _obstacle_start_and_wait(plugin, executor, "/cam/a")
+    cfg = builder.built[-1].cfg
+    assert cfg["fixed_scene"] == "vehicle"
+    assert cfg["decision_threshold_m"] == 3.5
+    plugin.dispatch("obstacle", {"action": "stop"})

--- a/perception/tests/test_obstacle_plugin.py
+++ b/perception/tests/test_obstacle_plugin.py
@@ -1,0 +1,397 @@
+"""
+tests/test_obstacle_plugin.py — obstacle plugin lifecycle/concurrency tests.
+
+ROS stubs come from vision_stubs (installed by conftest before collection).
+Run: python -m pytest perception/tests -q
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+
+import pytest
+
+from utils.qos import CAMERA_QOS
+
+from vision_stubs import (  # noqa: F401
+    _FakeCompressedImage,
+    _FakeExecutor,
+    _FakeNode,
+    _FakeString,
+    _wait_until,
+)
+
+# ── Obstacle ─────────────────────────────────────────────────────────────────
+
+import plugins.obstacle as obstacle_plugin  # noqa: E402
+
+
+class _FakeDistanceAdapter:
+    def __init__(self):
+        self.closed = False
+        self.estimates = 0
+
+    def estimate(self, image_bytes: bytes) -> dict:
+        self.estimates += 1
+        return {"pred_distance": 3.0, "status": "ok", "fallback": False}
+
+    def close(self):
+        self.closed = True
+
+
+class _ObstacleBuilderProbe:
+    def __init__(self, delay=0.0):
+        self.delay = delay
+        self.calls = 0
+        self.built = []
+        self.lock = threading.Lock()
+
+    def __call__(self, cfg):
+        with self.lock:
+            self.calls += 1
+        if self.delay:
+            time.sleep(self.delay)
+        adapter = _FakeDistanceAdapter()
+        adapter.cfg = dict(cfg)
+        self.built.append(adapter)
+        return adapter
+
+
+def _make_obstacle(monkeypatch, builder=None, cfg=None):
+    builder = builder or _ObstacleBuilderProbe()
+    monkeypatch.setattr(obstacle_plugin, "_build_distance_adapter", builder)
+    executor = _FakeExecutor()
+    plugin = obstacle_plugin.ObstacleDistancePlugin(
+        dict(cfg or {"provider": "local"}), executor
+    )
+    return plugin, executor, builder
+
+
+def _obstacle_start_and_wait(plugin, executor, topic, instance_id="", count=1):
+    args = {"action": "start", "input_topic": topic}
+    if instance_id:
+        args["instance_id"] = instance_id
+    plugin.dispatch("obstacle", args)
+    # Registration now precedes start (README lifecycle rule), so a node can
+    # briefly sit in the executor as "idle"; wait for it to actually run.
+    assert _wait_until(
+        lambda: len(executor.nodes) >= count
+        and all(n.state == "running" for n in executor.nodes)
+    ), "node never came up"
+
+
+@pytest.fixture
+def obstacle(monkeypatch):
+    plugin, executor, builder = _make_obstacle(monkeypatch)
+    yield plugin, executor, builder
+    plugin.dispatch("obstacle", {"action": "stop"})
+
+
+def test_obstacle_camera_subscription_uses_shared_qos(obstacle):
+    plugin, executor, _ = obstacle
+    _obstacle_start_and_wait(plugin, executor, "/cam/a")
+    assert executor.nodes[0].subscriptions[0].qos is CAMERA_QOS
+
+
+def test_obstacle_start_returns_loading_without_blocking(monkeypatch):
+    plugin, executor, builder = _make_obstacle(monkeypatch, _ObstacleBuilderProbe(delay=1.0))
+    started = time.monotonic()
+    result = plugin.dispatch("obstacle", {"action": "start", "input_topic": "/cam/a"})
+    elapsed = time.monotonic() - started
+    assert elapsed < 0.1, f"start blocked for {elapsed:.3f}s"
+    assert result == {"state": "loading", "input": "/cam/a", "output": "/cam/a/obstacle"}
+    assert _wait_until(lambda: len(executor.nodes) == 1)
+    plugin.dispatch("obstacle", {"action": "stop"})
+
+
+def test_obstacle_ten_concurrent_starts_single_flight(monkeypatch):
+    plugin, executor, builder = _make_obstacle(monkeypatch, _ObstacleBuilderProbe(delay=0.3))
+    results = []
+
+    def call(index):
+        results.append(plugin.dispatch("obstacle", {
+            "action": "start",
+            "input_topic": f"/cam/{index}",
+            "instance_id": f"inst{index}",
+        }))
+
+    threads = [threading.Thread(target=call, args=(i,)) for i in range(10)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=2)
+    assert all(res["state"] == "loading" for res in results)
+    assert _wait_until(lambda: len(executor.nodes) == 10)
+    assert builder.calls == 1, "ten starts must share one engine load"
+    plugin.dispatch("obstacle", {"action": "stop"})
+
+
+def test_obstacle_info_does_not_block_while_loading(monkeypatch):
+    plugin, executor, builder = _make_obstacle(monkeypatch, _ObstacleBuilderProbe(delay=0.8))
+    plugin.dispatch("obstacle", {"action": "start", "input_topic": "/cam/a", "instance_id": "a"})
+    started = time.monotonic()
+    info = plugin.dispatch("obstacle", {"action": "info"})
+    elapsed = time.monotonic() - started
+    assert elapsed < 0.1, f"info blocked for {elapsed:.3f}s"
+    assert info["state"] == "loading"
+    assert info["instances"]["a"]["state"] == "loading"
+    assert _wait_until(
+        lambda: plugin.dispatch("obstacle", {"action": "info"})["state"] == "running"
+    )
+    plugin.dispatch("obstacle", {"action": "stop"})
+
+
+def test_obstacle_stop_during_loading_cancels_pending(monkeypatch):
+    plugin, executor, builder = _make_obstacle(monkeypatch, _ObstacleBuilderProbe(delay=0.3))
+    plugin.dispatch("obstacle", {"action": "start", "input_topic": "/cam/a", "instance_id": "a"})
+    plugin.dispatch("obstacle", {"action": "start", "input_topic": "/cam/b", "instance_id": "b"})
+    plugin.dispatch("obstacle", {"action": "stop", "instance_id": "a"})
+    assert _wait_until(lambda: len(executor.nodes) == 1)
+    time.sleep(0.2)  # loader must not resurrect the stopped instance
+    assert len(executor.nodes) == 1
+    assert executor.nodes[0].subscriptions[0].topic == "/cam/b"
+    info = plugin.dispatch("obstacle", {"action": "info"})
+    assert "a" not in info["instances"]
+    plugin.dispatch("obstacle", {"action": "stop"})
+
+
+def test_obstacle_config_during_loading_discards_stale_adapter(monkeypatch):
+    builder = _ObstacleBuilderProbe(delay=0.3)
+    plugin, executor, _ = _make_obstacle(
+        monkeypatch, builder, cfg={"provider": "local", "fixed_scene": "indoor"}
+    )
+    plugin.dispatch("obstacle", {"action": "start", "input_topic": "/cam/a", "instance_id": "a"})
+    plugin.dispatch("obstacle", {"action": "config", "fixed_scene": "vehicle"})
+    assert _wait_until(lambda: len(executor.nodes) == 1, timeout=4)
+    assert builder.calls == 2, "config change during load must trigger a reload"
+    assert _wait_until(lambda: len(builder.built) == 2)
+    stale = next(a for a in builder.built if a.cfg["fixed_scene"] == "indoor")
+    fresh = next(a for a in builder.built if a.cfg["fixed_scene"] == "vehicle")
+    assert _wait_until(lambda: stale.closed), "stale adapter must be closed"
+    assert plugin._adapter is fresh
+    plugin.dispatch("obstacle", {"action": "stop"})
+
+
+def test_obstacle_plain_stop_fully_disposes_node(obstacle):
+    plugin, executor, _ = obstacle
+    _obstacle_start_and_wait(plugin, executor, "/cam/a", instance_id="a")
+    node = executor.nodes[0]
+    plugin.dispatch("obstacle", {"action": "stop", "instance_id": "a"})
+    assert executor.nodes == []
+    assert node.destroyed
+    assert plugin._nodes == {}
+
+
+def test_obstacle_repeated_start_stop_does_not_grow(obstacle):
+    plugin, executor, builder = obstacle
+    for _ in range(20):
+        _obstacle_start_and_wait(plugin, executor, "/cam/a", instance_id="a")
+        plugin.dispatch("obstacle", {"action": "stop", "instance_id": "a"})
+    assert executor.nodes == []
+    assert builder.calls == 1, "engines must be loaded once and cached"
+    created = [n for n in _FakeNode.instances if n.subscriptions]
+    assert all(node.destroyed for node in created)
+
+
+def test_obstacle_topic_rebind_disposes_old_node(obstacle):
+    plugin, executor, _ = obstacle
+    _obstacle_start_and_wait(plugin, executor, "/cam/a", instance_id="x")
+    old = executor.nodes[0]
+    plugin.dispatch("obstacle", {"action": "start", "input_topic": "/cam/b", "instance_id": "x"})
+    assert _wait_until(
+        lambda: executor.nodes and executor.nodes[-1].subscriptions
+        and executor.nodes[-1].subscriptions[0].topic == "/cam/b"
+    )
+    assert old not in executor.nodes and old.destroyed
+    assert len(executor.nodes) == 1
+
+
+def test_obstacle_per_instance_config_builds_own_adapter(obstacle):
+    plugin, executor, builder = obstacle
+    _obstacle_start_and_wait(plugin, executor, "/cam/a", instance_id="a")
+    plugin.dispatch("obstacle", {
+        "action": "config", "instance_id": "b", "fixed_scene": "vehicle",
+    })
+    _obstacle_start_and_wait(plugin, executor, "/cam/b", instance_id="b", count=2)
+    assert builder.calls == 2, "instance with own config gets its own adapter"
+    cfgs = sorted(a.cfg.get("fixed_scene", "") for a in builder.built)
+    assert cfgs[-1] == "vehicle"
+    plugin.dispatch("obstacle", {"action": "stop"})
+
+
+def test_obstacle_stop_during_ready_path_start_leaves_no_orphan(monkeypatch):
+    """Same orphan-node class as PR #113: stop racing a fast-path start."""
+    plugin, executor, builder = _make_obstacle(monkeypatch)
+    _obstacle_start_and_wait(plugin, executor, "/cam/a", instance_id="a")
+
+    real_start = obstacle_plugin._ObstacleNode.start
+
+    def slow_start(self, *a, **k):
+        time.sleep(0.2)
+        return real_start(self, *a, **k)
+
+    monkeypatch.setattr(obstacle_plugin._ObstacleNode, "start", slow_start)
+    thread = threading.Thread(target=plugin.dispatch, args=(
+        "obstacle", {"action": "start", "input_topic": "/cam/b", "instance_id": "b"}))
+    thread.start()
+    time.sleep(0.05)
+    plugin.dispatch("obstacle", {"action": "stop", "instance_id": "b"})
+    thread.join(timeout=3)
+    monkeypatch.setattr(obstacle_plugin._ObstacleNode, "start", real_start)
+
+    assert "b" not in plugin._nodes
+    b_nodes = [n for n in _FakeNode.instances
+               if n.subscriptions and n.subscriptions[0].topic == "/cam/b"]
+    assert all(node.destroyed for node in b_nodes), "orphan node left running"
+    plugin.dispatch("obstacle", {"action": "stop"})
+
+
+def test_obstacle_instance_config_start_does_not_block(monkeypatch):
+    """After the shared adapter is ready, starting an instance whose
+    per-instance adapter is not built yet must still return loading
+    immediately instead of building TensorRT engines in the MCP thread."""
+    builder = _ObstacleBuilderProbe(delay=0.4)
+    plugin, executor, _ = _make_obstacle(monkeypatch, builder)
+    _obstacle_start_and_wait(plugin, executor, "/cam/a", instance_id="a")
+    assert builder.calls == 1
+
+    plugin.dispatch("obstacle", {
+        "action": "config", "instance_id": "b", "fixed_scene": "vehicle",
+    })
+    started = time.monotonic()
+    result = plugin.dispatch("obstacle", {
+        "action": "start", "input_topic": "/cam/b", "instance_id": "b",
+    })
+    elapsed = time.monotonic() - started
+    assert elapsed < 0.1, f"per-instance start blocked for {elapsed:.3f}s"
+    assert result["state"] == "loading"
+    assert _wait_until(lambda: len(executor.nodes) == 2, timeout=4)
+    assert builder.calls == 2
+    plugin.dispatch("obstacle", {"action": "stop"})
+
+
+def test_obstacle_info_desc_explains_loading_and_error(monkeypatch):
+    """desc carries the reason while loading / after failure, like ASR (#113)."""
+    builder = _ObstacleBuilderProbe(delay=0.5)
+    plugin, executor, _ = _make_obstacle(monkeypatch, builder)
+    plugin.dispatch("obstacle", {"action": "start", "input_topic": "/cam/a", "instance_id": "a"})
+
+    info = plugin.dispatch("obstacle", {"action": "info"})
+    assert info["state"] == "loading" and "Loading" in info["desc"]
+
+    assert _wait_until(
+        lambda: plugin.dispatch("obstacle", {"action": "info"})["state"] == "running",
+        timeout=4,
+    )
+    ready = plugin.dispatch("obstacle", {"action": "info"})
+    assert ready["state"] == "running" and ready["desc"] == plugin._DESC
+    plugin.dispatch("obstacle", {"action": "stop"})
+
+
+def test_obstacle_instance_config_racing_adapter_build(monkeypatch):
+    """config(instance_id=...) landing while that instance's per-instance
+    adapter is being built must not install/serve the stale adapter, and the
+    discarded build must be closed (no engine leak)."""
+    builder = _ObstacleBuilderProbe(delay=0.3)
+    plugin, executor, _ = _make_obstacle(monkeypatch, builder)
+    _obstacle_start_and_wait(plugin, executor, "/cam/a", instance_id="a")
+    assert builder.calls == 1  # shared adapter
+
+    plugin.dispatch("obstacle", {
+        "action": "config", "instance_id": "b", "fixed_scene": "vehicle",
+    })
+    plugin.dispatch("obstacle", {
+        "action": "start", "input_topic": "/cam/b", "instance_id": "b",
+    })
+    # per-instance build for b is now sleeping in the loader; change b's
+    # config mid-build
+    time.sleep(0.05)
+    plugin.dispatch("obstacle", {
+        "action": "config", "instance_id": "b", "fixed_scene": "indoor",
+    })
+    plugin.dispatch("obstacle", {
+        "action": "start", "input_topic": "/cam/b", "instance_id": "b",
+    })
+    assert _wait_until(lambda: "b" in plugin._nodes, timeout=5)
+
+    with plugin._state_lock:
+        cached_cfg, cached_adapter = plugin._instance_adapters["b"]
+    assert cached_cfg.get("fixed_scene") == "indoor", "stale adapter installed"
+    # every adapter built with the superseded config must be closed
+    stale = [a for a in builder.built
+             if getattr(a, "cfg", {}).get("fixed_scene") == "vehicle"]
+    assert stale, "expected at least one stale build"
+    assert all(a.closed for a in stale), "stale per-instance adapter leaked"
+    assert not cached_adapter.closed
+    plugin.dispatch("obstacle", {"action": "stop"})
+
+
+def test_obstacle_add_node_failure_leaks_nothing(monkeypatch):
+    """If executor.add_node raises during bring-up, the node must be
+    destroyed and untracked with no started worker (bot P1: a started but
+    unregistered worker would be unreachable forever)."""
+    plugin, executor, builder = _make_obstacle(monkeypatch)
+
+    original_add = executor.add_node
+    calls = {"n": 0}
+
+    def flaky_add(node):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise RuntimeError("executor shutting down")
+        return original_add(node)
+
+    monkeypatch.setattr(executor, "add_node", flaky_add)
+    plugin.dispatch("obstacle", {"action": "start", "input_topic": "/cam/a", "instance_id": "a"})
+    assert _wait_until(lambda: calls["n"] >= 1, timeout=4)
+    time.sleep(0.1)
+
+    assert "a" not in plugin._nodes
+    assert "a" not in plugin._pending_starts, "failed instance stuck as loading"
+    failed = [n for n in _FakeNode.instances
+              if n.subscriptions == [] or (n.subscriptions and n.subscriptions[0].topic == "/cam/a")]
+    assert all(n.destroyed for n in failed if not n.subscriptions), "unregistered node leaked"
+    # worker was never started on the failed node (register-before-start)
+    assert all(not n.subscriptions for n in _FakeNode.instances if n.destroyed)
+
+    # the plugin recovers: a later start succeeds
+    plugin.dispatch("obstacle", {"action": "start", "input_topic": "/cam/a", "instance_id": "a"})
+    assert _wait_until(lambda: "a" in plugin._nodes, timeout=4)
+    plugin.dispatch("obstacle", {"action": "stop"})
+
+
+def test_obstacle_load_failure_reports_error_and_retries(monkeypatch):
+    calls = {"n": 0}
+
+    def flaky_builder(cfg):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise RuntimeError("engine download failed")
+        return _FakeDistanceAdapter()
+
+    monkeypatch.setattr(obstacle_plugin, "_build_distance_adapter", flaky_builder)
+    executor = _FakeExecutor()
+    plugin = obstacle_plugin.ObstacleDistancePlugin({"provider": "local"}, executor)
+    plugin.dispatch("obstacle", {"action": "start", "input_topic": "/cam/a", "instance_id": "a"})
+    assert _wait_until(
+        lambda: plugin.dispatch("obstacle", {"action": "info"})["state"] == "error"
+    )
+    info = plugin.dispatch("obstacle", {"action": "info"})
+    assert "engine download failed" in info["instances"]["a"].get("error", "")
+    plugin.dispatch("obstacle", {"action": "start", "input_topic": "/cam/a", "instance_id": "a"})
+    assert _wait_until(
+        lambda: plugin.dispatch("obstacle", {"action": "info"})["state"] == "running"
+    )
+    plugin.dispatch("obstacle", {"action": "stop"})
+
+
+def test_obstacle_model_dir_confined_to_models_tree(monkeypatch):
+    """MCP-supplied model_dir cannot point the root-run downloader outside
+    /models (bot P2): the wrapper rejects out-of-tree paths before download."""
+    import utils.model_downloader as md
+    with pytest.raises(ValueError):
+        md.ensure_obstacle_models("/etc/cron.d")
+    with pytest.raises(ValueError):
+        md.ensure_obstacle_models("/models/../root")

--- a/perception/utils/model_downloader.py
+++ b/perception/utils/model_downloader.py
@@ -594,6 +594,51 @@ OCR_MODEL_BUNDLES = {
 }
 
 
+# ── Obstacle distance (ZipDepth + YOLO26n TensorRT INT8 engines) ─────────
+OBSTACLE_MODEL_REVISION = "b8ba6d69a819b5ed6f0c1c5723b37c8775fa737b"
+OBSTACLE_MODEL_BASE = os.environ.get(
+    "OBSTACLE_MODEL_BASE_URL",
+    "https://www.modelscope.cn/models/Flame4pd/"
+    f"obstacle-distance-jetson-int8/resolve/{OBSTACLE_MODEL_REVISION}",
+)
+OBSTACLE_MODEL_BUNDLES = {
+    "jp61": {
+        "base_url": f"{OBSTACLE_MODEL_BASE}/jp61",
+        "files": {
+            "zipdepth-base-npu-512x384-int8.engine": {
+                "size": 7935428,
+                "sha256": "aa34296bcaeed28a5176b423f074da3923c996e7be06702a3952d475000a8887",
+            },
+            "yolo26n-depth-int8.engine": {
+                "size": 7778158,
+                "sha256": "8174652d6ba72af15c10caccf95629d585d33245e5242aa1f1734317d5a23f7c",
+            },
+            "yolo26n-seg-int8.engine": {
+                "size": 5641961,
+                "sha256": "7cb85598bc50b82ab5835102dab9214f6e58a0061c6a1891ee018387346bae30",
+            },
+        },
+    },
+    "jp511": {
+        "base_url": f"{OBSTACLE_MODEL_BASE}/jp511",
+        "files": {
+            "zipdepth-base-npu-512x384-int8.engine": {
+                "size": 7936960,
+                "sha256": "61d9b81c81bcd26660d3647bfb86fd133f865ad5b73b4177efcad2884f7a2d1c",
+            },
+            "yolo26n-depth-int8.engine": {
+                "size": 6746230,
+                "sha256": "816ca14c23af37ee2961ec09db51a54888462c5e4bb296bbaba2a569e6f2bb64",
+            },
+            "yolo26n-seg-int8.engine": {
+                "size": 4920200,
+                "sha256": "ed5e0f8dcb968440866f5b0433f7b813d14f2e89f810be6e8910945e0af42635",
+            },
+        },
+    },
+}
+
+
 def ensure_ocr_model(model_dir: str, family: str | None = None) -> dict[str, str]:
     """Ensure the OCR TensorRT bundle matching the runtime TensorRT is present."""
     model_dir = require_models_subpath(model_dir)
@@ -742,3 +787,22 @@ def ensure_vits2_model(model_dir: str, family: str | None = None) -> str:
         entry,
     )
     return os.path.join(model_dir, "engines", key)
+
+
+def ensure_obstacle_models(
+    model_dir: str, bundle: str | None = None
+) -> dict[str, str]:
+    """Ensure the obstacle TensorRT engines matching the runtime TensorRT.
+
+    ``bundle`` (or the OBSTACLE_MODEL_BUNDLE environment variable) is an
+    explicit test override such as "jp61"/"jp511"; production deployments
+    leave it unset and follow the importable TensorRT version.
+    """
+    family = bundle or os.environ.get("OBSTACLE_MODEL_BUNDLE") or None
+    model_dir = require_models_subpath(model_dir)
+    key = select_bundle_family(OBSTACLE_MODEL_BUNDLES, family)
+    entry = OBSTACLE_MODEL_BUNDLES[key]
+    log.info(f"[model_downloader] obstacle: using {key} bundle")
+    return ensure_verified_bundle(
+        f"obstacle/{key}", model_dir, entry["base_url"], entry["files"]
+    )

--- a/perception/utils/model_downloader.py
+++ b/perception/utils/model_downloader.py
@@ -594,8 +594,8 @@ OCR_MODEL_BUNDLES = {
 }
 
 
-# ── Obstacle distance (ZipDepth + YOLO26n TensorRT INT8 engines) ─────────
-OBSTACLE_MODEL_REVISION = "b8ba6d69a819b5ed6f0c1c5723b37c8775fa737b"
+# ── Obstacle distance (ZipDepth + YOLO26n TensorRT engines) ─────────────
+OBSTACLE_MODEL_REVISION = "8c50e1f5faf6b588b90e0bab4b6a696b5ef207ac"
 OBSTACLE_MODEL_BASE = os.environ.get(
     "OBSTACLE_MODEL_BASE_URL",
     "https://www.modelscope.cn/models/Flame4pd/"
@@ -623,8 +623,8 @@ OBSTACLE_MODEL_BUNDLES = {
         "base_url": f"{OBSTACLE_MODEL_BASE}/jp511",
         "files": {
             "zipdepth-base-npu-512x384-int8.engine": {
-                "size": 7936960,
-                "sha256": "61d9b81c81bcd26660d3647bfb86fd133f865ad5b73b4177efcad2884f7a2d1c",
+                "size": 14259938,
+                "sha256": "2b3f81cf5162136e25b0d26e2a8bb453d13158d2884c2eacbf17e0105682f684",
             },
             "yolo26n-depth-int8.engine": {
                 "size": 6746230,


### PR DESCRIPTION
> **更新 2026-08-23 — head `d327bb7`**,再次 rebase:#112(VITS2 TTS)及数个 perception 修复合入 main 后,model_downloader 文件尾再次撞车(main 新增 VITS2 archive 辅助函数 vs 本 PR 的 ensure_obstacle_models,两块均保留)。仍为 3 个 obstacle 专属 commit、对 main 纯增量;本机全套测试与 origin/main 基线失败集合完全一致(零新增)。
>
> **更新 2026-08-22 20:00(北京时间)** — head `84a00dc`,已 rebase 到 #103 合并后的 main(`e3637e0`)。共享 utils commit 与 symlink 修复随 #103 进入 main 后自动去重,本 PR 现在只剩 3 个 obstacle 专属 commit,对 main 为**纯增量**(14 文件 +3424 行,零删改);config.yaml/main.py/model_downloader 的相邻追加块冲突已按"两块都保留"解决。冲突状态已消除(MERGEABLE)。
>
> **更新 2026-08-22 14:00(北京时间)** — head `84935cd`。响应内部评审(陈雨强)对配置界面的反馈新增 1 个 commit,见下方"配置界面收敛"一节。历史评论中引用旧 commit 的结果均已过时,以本 head 为准。
>
> **更新 2026-08-21 10:45(北京时间)** — head `c437a52`,基于 main `4278296`,与 #103 平行(共享同一 utils commit,无合并顺序依赖)。新增一个 commit:obstacle 默认启用(与 asr/tts/htmsg/vop 一致)。 另新增:`model_dir` 限域改为解析符号链接后比较(修 bot 指出的 symlink 逃逸)。

## 配置界面收敛(内部评审反馈,`84935cd`)

与 #103 同一标准:配置 UI 只暴露操作者真正需要决策的参数。原 configSchema 唯一一项是 `provider` —— required + 枚举仅一个值 `local` 的下拉框,纯摆设,已撤下(config.yaml 仍设置、dispatch 仍认)。换上两个真正的操作决策,均已验证经 config action 通到 estimator:

- `fixed_scene`(indoor | vehicle):部署场景,决定走 ZipDepth 室内管线还是 YOLO 车载深度管线(固定场景模式下生效);
- `decision_threshold_m`(米,>0,默认 2.0):近障判定线,估算距离低于它即报 `near_obstacle=true`。

model_dir、ROI/percentile/标定等专家块保持 config.yaml-only。新增 2 个测试:schema 守卫(字段集合精确匹配、无 object 类型属性)+ 两字段经 config action 到达 adapter cfg 的链路验证。

## 概述

新增 TensorRT 障碍物距离估计插件(默认启用,注册廉价、引擎首次 start 才加载,见"默认启用"一节):ZipDepth 深度 + YOLO 分割/检测,室内/车载双域路由(`scene_mode: fixed` + `OBSTACLE_FIXED_SCENE` 环境覆盖)。engine 不进 Git,按 JetPack 家族运行时下载,逐文件 SHA256 校验。

## 生命周期与并发(与 #103 同一套,对齐 #113)

- `start` 立即返回 `loading`(真机实测 3ms),单飞后台 loader;10 并发 start = 1 次引擎初始化。
- **带 per-instance 配置的实例同样不阻塞**:专属 adapter 也走后台 bring-up(单飞退出握手,config 换代时 pending 不搁浅,有专项测试)。
- `info` 纯查询含实例级状态,`desc` 在 loading/error 时给出原因(与 asr 同款);`stop` 撤销 pending 或完整销毁(`remove_node + destroy_node`);同 instance 换 `input_topic` 重启会重绑新话题(旧节点退役,不再静默吃旧话题,回归测试覆盖)。
- 相机订阅 BEST_EFFORT(RELIABLE 与相机发布端不匹配的问题已在 #103 真机复现并修复)。

## 结果发布

发布完整结构化 JSON(9 字段:`pred_distance / distance_m / near_obstacle / scene / status / error_code / fallback / approximate_geometry / latency_ms`)。仅发 `pred_distance` 时,真实测距 3.0m 与超时兜底 3.0m(`fallback_distance_m` 默认值)对下游不可区分;现在靠 `fallback/status/error_code` 区分,`pred_distance` 保留兼容老订阅方。per-instance `config` 为累积合并(先配 `scene_mode` 再配 `fixed_scene` 不丢前者)。

## 模型分发

3 个 engine(zipdepth-int8 / yolo26n-depth / yolo26n-seg)× 2 JetPack 家族,固定 revision + 逐文件 size/SHA256 + 跨实例文件锁,家族由运行时可 import 的 TensorRT 决定。当前 ModelScope 托管。

## 边界

本 PR **零 Dockerfile 改动**(obstacle 运行时依赖 base 已全部具备,diff 可验证);`main.py` 仅 +5 行注册;既有插件 / `ensure_model` / 部署文件 0 行差异;无 Fast DDS;默认 `enabled: true`(见"默认启用"一节)。共享 utils commit 与 #103 完全相同(同 SHA),后合并的一方 rebase 时自动去重,`config.yaml`/`main.py`/`model_downloader` 的追加块可能产生相邻行琐碎冲突,按块保留即可。

## 默认启用(本轮新增 commit)

`config.yaml` 里既有的 asr/tts/htmsg/vop 全部 `enabled: true`,obstacle 原本是唯一的例外。改为一致,理由不只是风格:

- **默认关闭在实践中等于不可用**:`main.py` 只在 `enabled` 为真时 import 插件,关闭的插件不会注册 MCP 工具、不出现在控制台的 processor 列表里,因此**无法从控制台开启** —— 唯一入口是重建容器并挂载改过的 config.yaml。
- **开启不产生静态开销**:注册 MCP 工具是廉价的;TensorRT 引擎只在首次成功 `start` 时下载并初始化(loading → running 路径),未被使用的部署不付出显存/内存/启动时间。

真机验证(jetson-orin-02,JP6.1):插件随容器启动注册,控制台出现 processor 卡片,画布连线后 start → loading → running 正常;indoor 与 vehicle 两种 `fixed_scene` 分别加载 ZipDepth 与 YOLO 引擎并给出真实测距(1.999 m / 6.103 m),`fallback` 字段正确区分真实结果与兜底。


## 验证

- **Orin NX(JP5.11)真机**:引擎现场下载 + TensorRT 初始化 → running;真实图片推理输出 `pred_distance=2.56m, scene=indoor, status=ok, fallback=false` 全字段;MCP 起停/换话题/config 合并均实测。
- **CI**:本 head(`335ceee`)双 target 构建成功;code review 仅剩 COS 一条 P1(bot 并确认"零 Dockerfile、不增镜像")。本轮新增:MCP 传入的 `model_dir` 限定于 `/models` 子树(上轮唯一 P2 建议),含拒绝用例测试。
- **单测 45 个**(含 obstacle 19 个;本轮 +2:schema 守卫、config 字段到 adapter 链路):非阻塞 start、10 并发 single-flight、loading 期 stop/config(generation 作废)、完整销毁、start/stop×20 无增长、ready 快路径孤儿窗口回归、per-instance 实例非阻塞启动、desc 状态迁移;macOS 与 .14 真机 Python 3.8.10 双环境通过。

## 合并前待办(bot P1)

- **engine 迁 COS**(与 #103 相同):等 bucket 权限;manifest 只改 base URL,SHA256 校验不变。

  **自助上传清单(6 文件,41.0 MB)**:

| COS 目标路径(public/ 下) | 字节 | SHA256 | 当前源 |
|---|---|---|---|
| `obstacle-distance-trt/jp61/zipdepth-base-npu-512x384-int8.engine` | 7,935,428 | `aa34296bcaeed28a5176b423f074da3923c996e7be06702a3952d475000a8887` | [源](https://www.modelscope.cn/models/Flame4pd/obstacle-distance-jetson-int8/resolve/b8ba6d69a819b5ed6f0c1c5723b37c8775fa737b/jp61/zipdepth-base-npu-512x384-int8.engine) |
| `obstacle-distance-trt/jp61/yolo26n-depth-int8.engine` | 7,778,158 | `8174652d6ba72af15c10caccf95629d585d33245e5242aa1f1734317d5a23f7c` | [源](https://www.modelscope.cn/models/Flame4pd/obstacle-distance-jetson-int8/resolve/b8ba6d69a819b5ed6f0c1c5723b37c8775fa737b/jp61/yolo26n-depth-int8.engine) |
| `obstacle-distance-trt/jp61/yolo26n-seg-int8.engine` | 5,641,961 | `7cb85598bc50b82ab5835102dab9214f6e58a0061c6a1891ee018387346bae30` | [源](https://www.modelscope.cn/models/Flame4pd/obstacle-distance-jetson-int8/resolve/b8ba6d69a819b5ed6f0c1c5723b37c8775fa737b/jp61/yolo26n-seg-int8.engine) |
| `obstacle-distance-trt/jp511/zipdepth-base-npu-512x384-int8.engine` | 7,936,960 | `61d9b81c81bcd26660d3647bfb86fd133f865ad5b73b4177efcad2884f7a2d1c` | [源](https://www.modelscope.cn/models/Flame4pd/obstacle-distance-jetson-int8/resolve/b8ba6d69a819b5ed6f0c1c5723b37c8775fa737b/jp511/zipdepth-base-npu-512x384-int8.engine) |
| `obstacle-distance-trt/jp511/yolo26n-depth-int8.engine` | 6,746,230 | `816ca14c23af37ee2961ec09db51a54888462c5e4bb296bbaba2a569e6f2bb64` | [源](https://www.modelscope.cn/models/Flame4pd/obstacle-distance-jetson-int8/resolve/b8ba6d69a819b5ed6f0c1c5723b37c8775fa737b/jp511/yolo26n-depth-int8.engine) |
| `obstacle-distance-trt/jp511/yolo26n-seg-int8.engine` | 4,920,200 | `ed5e0f8dcb968440866f5b0433f7b813d14f2e89f810be6e8910945e0af42635` | [源](https://www.modelscope.cn/models/Flame4pd/obstacle-distance-jetson-int8/resolve/b8ba6d69a819b5ed6f0c1c5723b37c8775fa737b/jp511/yolo26n-seg-int8.engine) |

  下载各"当前源"链接的文件,校验 SHA256 一致后按"COS 目标路径"上传;完成后告知,manifest 只需改一处 base URL 常量(校验逻辑零改动)。

- 与 #103 无合并顺序依赖;后合并的一方 rebase 去重共享 utils commit。












