### PR TITLE
feat(perception): add on-device OCR / 新增端侧 OCR（PP-OCRv6 TensorRT）

### DIFF
--- a/perception/Dockerfile.jetson
+++ b/perception/Dockerfile.jetson
@@ -12,7 +12,7 @@ ARG PYPI_MIRROR=https://pypi.tuna.tsinghua.edu.cn/simple/
 ARG APT_MIRROR=mirrors.tuna.tsinghua.edu.cn
 ARG JP_VERSION=511
 FROM bj-warehouse.tencentcloudcr.com/phanthy-motus/jetson-base:jp${JP_VERSION}-torch
-ARG PYPI_MIRROR APT_MIRROR
+ARG PYPI_MIRROR APT_MIRROR JP_VERSION
 
 # ── APT mirror (conditional) ─────────────────────────────────────
 RUN if [ -n "${APT_MIRROR}" ]; then \
@@ -50,7 +50,7 @@ RUN rm -f /etc/apt/sources.list.d/* && rm -rf /var/cache/apt/archives/* /var/lib
     printf '#!/bin/sh\nexit 0\n' > /usr/sbin/ldconfig && \
     chmod +x /usr/sbin/ldconfig && \
     apt-get -o Acquire::AllowInsecureRepositories=true update && \
-    apt-get install -y --no-install-recommends --allow-unauthenticated ffmpeg && \
+    apt-get install -y --no-install-recommends --allow-unauthenticated ffmpeg libvips42 && \
     mv -f /usr/sbin/ldconfig.real /usr/sbin/ldconfig && \
     { ldconfig || echo '[build] ldconfig skipped — emulated build, using default search path'; } && \
     apt-get clean && rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
@@ -118,6 +118,26 @@ ENV YOLO_CONFIG_DIR=/work
 
 # ── sherpa-onnx (on-device ASR/TTS/KWS) ──────────────────────────
 RUN pip3 install --no-cache-dir -i ${PYPI_MIRROR} sherpa-onnx
+
+# ── OCR runtime deps (PP-OCRv6 TensorRT engines; TensorRT/CUDA come from base) ──
+# libvips42 (apt, above) is the runtime library pyvips dlopens for JPEG decode
+# + downscale; rapidocr is used --no-deps for its pure-Python DB/CTC post-
+# processing only (its bundled ONNX models are deleted, onnxruntime is not
+# installed). Every package is version-pinned; six and Pillow are NOT listed
+# because both bases already ship them (jp511: 1.14.0/10.4.0 via the VOP
+# layer, jp61: 1.16.0/9.0.1) and re-listing them unpinned would make the
+# resolution nondeterministic. numpy is pinned to the version each JetPack's
+# torch/cv2 stack already ships so nothing in the base image is upgraded.
+# Measured layer growth: apt (ffmpeg+libvips42) 17.2 MB + this step 24.5 MB
+# ≈ 42 MB on a ~14.6 GB image (<0.3%).
+RUN if [ "${JP_VERSION}" = "61" ]; then NUMPY_VERSION=1.26.4; else NUMPY_VERSION=1.24.4; fi; \
+    pip3 install --no-cache-dir -i ${PYPI_MIRROR} \
+      "numpy==${NUMPY_VERSION}" pyclipper==1.3.0.post3 Shapely==2.0.5 \
+      omegaconf==2.3.0 colorlog==6.12.0 && \
+    pip3 install --no-cache-dir --no-deps -i ${PYPI_MIRROR} rapidocr==3.9.1 && \
+    pip3 install --no-cache-dir -i ${PYPI_MIRROR} "pyvips==3.1.0" && \
+    RAPIDOCR_MODELS="$(python3 -c 'from pathlib import Path; import rapidocr; print(Path(rapidocr.__file__).resolve().parent / "models")')" && \
+    find "${RAPIDOCR_MODELS}" -type f -name '*.onnx' -delete
 
 # ── phonemizer (multilingual IPA via espeak-ng for asr_kws mode) ──
 # ldconfig shimmed for the same reason as the ffmpeg step above — this is the

--- a/perception/config.yaml
+++ b/perception/config.yaml
@@ -48,7 +48,7 @@ plugins:
     fps: 5
 
   ocr:
-    enabled: false
+    enabled: true
     provider: rapidocr
     model_dir: /models/ocr/ppocrv6-small-trt
     device_id: 0

--- a/perception/config.yaml
+++ b/perception/config.yaml
@@ -46,3 +46,27 @@ plugins:
     confidence: 0.3
     classes: []         # empty = default broad set
     fps: 5
+
+  ocr:
+    enabled: false
+    provider: rapidocr
+    model_dir: /models/ocr/ppocrv6-small-trt
+    device_id: 0
+    language: zh
+    use_angle_cls: true
+    max_side_len: 1600
+    det_unclip_ratio: 0.7
+    det_thresh: 0.3
+    det_box_thresh: 0.5
+    rec_min_score: 0.9
+    crop_refinement:
+      enabled: true
+      min_score: 0.9
+      min_gain: 0.12
+      min_text_length: 2
+      profiles: [prefix_65, upper_center, upper_tight]
+    empty_result_retry:
+      enabled: true
+      det_thresh: 0.1
+      det_box_thresh: 0.1
+    min_interval_ms: 0

--- a/perception/main.py
+++ b/perception/main.py
@@ -114,6 +114,11 @@ class PerceptionBundle:
             self._plugins.append(plugin)
             log.info("VideoObjectPerceptionPlugin loaded (namespace=%s)", namespace)
 
+        if plugins_cfg.get("ocr", {}).get("enabled", False):
+            from plugins.ocr import OCRPlugin
+            self._plugins.append(OCRPlugin(plugins_cfg["ocr"], executor))
+            log.info("OCRPlugin loaded")
+
     def get_all_tools(self) -> list:
         tools = []
         for p in self._plugins:

--- a/perception/plugins/ocr.py
+++ b/perception/plugins/ocr.py
@@ -159,11 +159,27 @@ class _OCRNode(Node):
         self._stop_event.set()
         self._generation = 0
         self._worker_threads: list[threading.Thread] = []
+        # Serializes start/stop/retire on this node. The plugin calls these
+        # outside its _state_lock, so without a per-node lock two concurrent
+        # starts could both pass the running check and overwrite each other's
+        # stop event / frame slot (obstacle's node has carried this lock from
+        # the start; same pattern here).
+        self._node_lock = threading.RLock()
+        self._retired = False
         self._log_gate = SampledLogGate(every=100)
         self._last_error_log_at: float | None = None
         log.info(f"[ocr] node created: subscribing={self._input_topic}, publishing={self._output_topic}")
 
     def start(self) -> dict:
+        with self._node_lock:
+            return self._start_locked()
+
+    def _start_locked(self) -> dict:
+        if self._retired:
+            # A concurrent stop retired (destroyed) this node between the
+            # plugin registering it and this call; report idle without
+            # touching the destroyed rclpy handle.
+            return self._status_dict()
         if self.state == "running":
             return self._status_dict()
 
@@ -196,25 +212,37 @@ class _OCRNode(Node):
         return self._status_dict()
 
     def stop(self) -> dict:
-        self.state = "idle"
-        self._stop_event.set()
-        self._frames.close()  # drops the pending frame and wakes the worker
-        deadline = time.monotonic() + 3.0
-        for thread in self._worker_threads:
-            if thread.is_alive():
-                thread.join(timeout=max(0.0, deadline - time.monotonic()))
-        self._worker_threads = [
-            thread for thread in self._worker_threads if thread.is_alive()
-        ]
-        if self._worker_threads:
-            log.warning(
-                "[ocr] %d worker(s) still stopping after timeout: %s",
-                len(self._worker_threads),
-                self._input_topic,
-            )
+        with self._node_lock:
+            self.state = "idle"
+            self._stop_event.set()
+            self._frames.close()  # drops the pending frame and wakes the worker
+            deadline = time.monotonic() + 3.0
+            for thread in self._worker_threads:
+                if thread.is_alive():
+                    thread.join(timeout=max(0.0, deadline - time.monotonic()))
+            self._worker_threads = [
+                thread for thread in self._worker_threads if thread.is_alive()
+            ]
+            if self._worker_threads:
+                log.warning(
+                    "[ocr] %d worker(s) still stopping after timeout: %s",
+                    len(self._worker_threads),
+                    self._input_topic,
+                )
 
-        log.info(f"[ocr] stopped: {self._input_topic}")
-        return {"state": "idle"}
+            log.info(f"[ocr] stopped: {self._input_topic}")
+            return {"state": "idle"}
+
+    def retire(self) -> dict:
+        """Stop the node and mark it dead-for-good before it is destroyed.
+
+        Set the flag and stop under one lock acquisition, so a start()
+        waiting on the lock cannot run between them and revive a worker on a
+        node that is about to be destroyed.
+        """
+        with self._node_lock:
+            self._retired = True
+            return self.stop()
 
     @property
     def worker_alive(self) -> bool:
@@ -463,7 +491,10 @@ class OCRPlugin:
     def _dispose(self, node_key: str, node: "_OCRNode") -> None:
         """Stop and fully destroy one node (worker, executor entry, handle)."""
         try:
-            node.stop()
+            # retire (not plain stop): marks the node dead under its lock so
+            # an in-flight start that lost the race reports idle instead of
+            # creating a subscription/worker on the destroyed handle.
+            node.retire()
         finally:
             dispose_node(self._executor, node, label=f"ocr/{node_key}")
         log.info(f"[ocr] node disposed: {node_key}")

--- a/perception/plugins/ocr.py
+++ b/perception/plugins/ocr.py
@@ -70,10 +70,13 @@ TOOLS = [
         # Expert knobs (model_dir, device_id, DB thresholds, crop refinement,
         # empty-result retry, ...) stay config.yaml-only — the dispatch below
         # still honors them, they are just not advertised to the config UI.
+        # language is also yaml-only: the TensorRT pipeline runs one bilingual
+        # zh/en model, so the value only annotates the published payload and
+        # offering it in the UI would suggest a recognition switch that does
+        # not exist.
         "configSchema": {
             "type": "object",
             "properties": {
-                "language": {"type": "string", "description": "默认语言", "default": "zh", "scope": "instance"},
                 "min_interval_ms": {"type": "integer", "minimum": 0, "default": 0, "description": "帧处理最小间隔(ms)，限制 GPU 占用，0=不限", "scope": "instance"},
             },
         },

--- a/perception/plugins/ocr.py
+++ b/perception/plugins/ocr.py
@@ -24,16 +24,9 @@ from utils.qos import CAMERA_QOS
 from utils.ros_lifecycle import dispose_node
 
 from plugins.ocr_runtime import (
-    DEFAULT_CROP_REFINEMENT_ENABLED,
-    DEFAULT_CROP_REFINEMENT_MIN_GAIN,
-    DEFAULT_CROP_REFINEMENT_MIN_SCORE,
-    DEFAULT_CROP_REFINEMENT_PROFILES,
     DEFAULT_DET_BOX_THRESH,
     DEFAULT_DET_THRESH,
     DEFAULT_DET_UNCLIP_RATIO,
-    DEFAULT_EMPTY_RESULT_RETRY_DET_BOX_THRESH,
-    DEFAULT_EMPTY_RESULT_RETRY_DET_THRESH,
-    DEFAULT_EMPTY_RESULT_RETRY_ENABLED,
     DEFAULT_MAX_SIDE_LEN,
     DEFAULT_REC_MIN_SCORE,
     RapidOCRAdapter,
@@ -73,63 +66,16 @@ TOOLS = [
             },
             "required": ["action"]
         },
+        # Deliberately minimal: only what an operator meaningfully decides.
+        # Expert knobs (model_dir, device_id, DB thresholds, crop refinement,
+        # empty-result retry, ...) stay config.yaml-only — the dispatch below
+        # still honors them, they are just not advertised to the config UI.
         "configSchema": {
             "type": "object",
             "properties": {
-                "model_dir": {"type": "string", "description": "OCR 模型或 TensorRT engine 目录", "scope": "shared"},
-                "device_id": {"type": "integer", "minimum": 0, "default": 0, "scope": "shared"},
-                "use_angle_cls": {"type": "boolean", "default": True, "description": "启用 0/180 度文字方向分类", "scope": "shared"},
-                "provider": {"type": "string", "enum": ["rapidocr"], "description": "OCR 运行时", "scope": "shared"},
                 "language": {"type": "string", "description": "默认语言", "default": "zh", "scope": "instance"},
-                "max_side_len": {"type": "integer", "minimum": 32, "default": DEFAULT_MAX_SIDE_LEN, "description": "检测输入最长边", "scope": "shared"},
-                "det_thresh": {"type": "number", "minimum": 0, "maximum": 1, "default": DEFAULT_DET_THRESH, "description": "DB 文本像素阈值", "scope": "shared"},
-                "det_box_thresh": {"type": "number", "minimum": 0, "maximum": 1, "default": DEFAULT_DET_BOX_THRESH, "description": "DB 文本框阈值", "scope": "shared"},
-                "det_unclip_ratio": {"type": "number", "exclusiveMinimum": 0, "default": DEFAULT_DET_UNCLIP_RATIO, "description": "DB 文本框扩张比例", "scope": "shared"},
-                "rec_min_score": {"type": "number", "minimum": 0, "maximum": 1, "default": DEFAULT_REC_MIN_SCORE, "description": "识别结果最低置信度", "scope": "shared"},
-                "enable_preprocess": {"type": "boolean", "default": True, "description": "启用 OCR 图像预处理", "scope": "shared"},
-                "crop_refinement": {
-                    "type": "object",
-                    "description": "TensorRT 低置信文本框二次裁剪识别",
-                    "scope": "shared",
-                    "default": {
-                        "enabled": DEFAULT_CROP_REFINEMENT_ENABLED,
-                        "min_score": DEFAULT_CROP_REFINEMENT_MIN_SCORE,
-                        "min_gain": DEFAULT_CROP_REFINEMENT_MIN_GAIN,
-                        "min_text_length": 2,
-                        "profiles": list(DEFAULT_CROP_REFINEMENT_PROFILES),
-                    },
-                    "properties": {
-                        "enabled": {"type": "boolean"},
-                        "min_score": {"type": "number", "minimum": 0, "maximum": 1},
-                        "min_gain": {"type": "number", "minimum": 0},
-                        "min_text_length": {"type": "integer", "minimum": 1},
-                        "profiles": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "enum": ["prefix_65", "upper_center", "upper_tight"],
-                            },
-                        },
-                    },
-                },
-                "empty_result_retry": {
-                    "type": "object",
-                    "description": "TensorRT 主流程空输出时复用检测图进行低阈值后处理",
-                    "scope": "shared",
-                    "default": {
-                        "enabled": DEFAULT_EMPTY_RESULT_RETRY_ENABLED,
-                        "det_thresh": DEFAULT_EMPTY_RESULT_RETRY_DET_THRESH,
-                        "det_box_thresh": DEFAULT_EMPTY_RESULT_RETRY_DET_BOX_THRESH,
-                    },
-                    "properties": {
-                        "enabled": {"type": "boolean"},
-                        "det_thresh": {"type": "number", "minimum": 0, "maximum": 1},
-                        "det_box_thresh": {"type": "number", "minimum": 0, "maximum": 1},
-                    },
-                },
                 "min_interval_ms": {"type": "integer", "minimum": 0, "default": 0, "description": "帧处理最小间隔(ms)，限制 GPU 占用，0=不限", "scope": "instance"},
             },
-            "required": ["provider"]
         },
         "topic_in":  [{"format": "image/jpeg", "desc": "camera image input"}],
         "topic_out": [{"format": "data/json",  "desc": "OCR result with text boxes"}],

--- a/perception/plugins/ocr.py
+++ b/perception/plugins/ocr.py
@@ -1,0 +1,799 @@
+#!/usr/bin/env python3
+"""
+plugins/ocr.py — OCRPlugin: OCR 文字识别封装。
+
+订阅 image/jpeg topic，持续进行 OCR 识别并发布结果到 ROS2 topic。
+参考 asr.py 架构设计。
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import threading
+import time
+
+from rclpy.node import Node
+from rclpy.qos import QoSProfile, ReliabilityPolicy, HistoryPolicy, DurabilityPolicy
+from sensor_msgs.msg import CompressedImage
+from std_msgs.msg import String
+
+from utils.latest_frame import LatestFrame
+from utils.log_sampling import SampledLogGate, escape_log_text
+from utils.qos import CAMERA_QOS
+from utils.ros_lifecycle import dispose_node
+
+from plugins.ocr_runtime import (
+    DEFAULT_CROP_REFINEMENT_ENABLED,
+    DEFAULT_CROP_REFINEMENT_MIN_GAIN,
+    DEFAULT_CROP_REFINEMENT_MIN_SCORE,
+    DEFAULT_CROP_REFINEMENT_PROFILES,
+    DEFAULT_DET_BOX_THRESH,
+    DEFAULT_DET_THRESH,
+    DEFAULT_DET_UNCLIP_RATIO,
+    DEFAULT_EMPTY_RESULT_RETRY_DET_BOX_THRESH,
+    DEFAULT_EMPTY_RESULT_RETRY_DET_THRESH,
+    DEFAULT_EMPTY_RESULT_RETRY_ENABLED,
+    DEFAULT_MAX_SIDE_LEN,
+    DEFAULT_REC_MIN_SCORE,
+    RapidOCRAdapter,
+    recognize_to_payload,
+)
+
+log = logging.getLogger(__name__)
+
+DEFAULT_OCR_MODEL_DIR = "/models/ocr/ppocrv6-small-trt"
+_ERROR_LOG_INTERVAL_SECONDS = 10.0
+
+_RESULT_QOS = QoSProfile(
+    reliability=ReliabilityPolicy.RELIABLE,
+    history=HistoryPolicy.KEEP_LAST,
+    depth=1,
+    durability=DurabilityPolicy.VOLATILE,
+)
+
+TOOLS = [
+    {
+        "name": "ocr",
+        "type": "processor",
+        "multiInstance": True,
+        "description": "OCR — recognize text in camera feed via image topic subscription",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": ["start", "stop", "info", "config"],
+                    "description": "Action to perform"
+                },
+                "input_topic": {
+                    "type": "string",
+                    "description": "ROS2 image topic to subscribe (e.g. /hostname/camera/rgb, required for action=start)"
+                },
+            },
+            "required": ["action"]
+        },
+        "configSchema": {
+            "type": "object",
+            "properties": {
+                "model_dir": {"type": "string", "description": "OCR 模型或 TensorRT engine 目录", "scope": "shared"},
+                "device_id": {"type": "integer", "minimum": 0, "default": 0, "scope": "shared"},
+                "use_angle_cls": {"type": "boolean", "default": True, "description": "启用 0/180 度文字方向分类", "scope": "shared"},
+                "provider": {"type": "string", "enum": ["rapidocr"], "description": "OCR 运行时", "scope": "shared"},
+                "language": {"type": "string", "description": "默认语言", "default": "zh", "scope": "instance"},
+                "max_side_len": {"type": "integer", "minimum": 32, "default": DEFAULT_MAX_SIDE_LEN, "description": "检测输入最长边", "scope": "shared"},
+                "det_thresh": {"type": "number", "minimum": 0, "maximum": 1, "default": DEFAULT_DET_THRESH, "description": "DB 文本像素阈值", "scope": "shared"},
+                "det_box_thresh": {"type": "number", "minimum": 0, "maximum": 1, "default": DEFAULT_DET_BOX_THRESH, "description": "DB 文本框阈值", "scope": "shared"},
+                "det_unclip_ratio": {"type": "number", "exclusiveMinimum": 0, "default": DEFAULT_DET_UNCLIP_RATIO, "description": "DB 文本框扩张比例", "scope": "shared"},
+                "rec_min_score": {"type": "number", "minimum": 0, "maximum": 1, "default": DEFAULT_REC_MIN_SCORE, "description": "识别结果最低置信度", "scope": "shared"},
+                "enable_preprocess": {"type": "boolean", "default": True, "description": "启用 OCR 图像预处理", "scope": "shared"},
+                "crop_refinement": {
+                    "type": "object",
+                    "description": "TensorRT 低置信文本框二次裁剪识别",
+                    "scope": "shared",
+                    "default": {
+                        "enabled": DEFAULT_CROP_REFINEMENT_ENABLED,
+                        "min_score": DEFAULT_CROP_REFINEMENT_MIN_SCORE,
+                        "min_gain": DEFAULT_CROP_REFINEMENT_MIN_GAIN,
+                        "min_text_length": 2,
+                        "profiles": list(DEFAULT_CROP_REFINEMENT_PROFILES),
+                    },
+                    "properties": {
+                        "enabled": {"type": "boolean"},
+                        "min_score": {"type": "number", "minimum": 0, "maximum": 1},
+                        "min_gain": {"type": "number", "minimum": 0},
+                        "min_text_length": {"type": "integer", "minimum": 1},
+                        "profiles": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "enum": ["prefix_65", "upper_center", "upper_tight"],
+                            },
+                        },
+                    },
+                },
+                "empty_result_retry": {
+                    "type": "object",
+                    "description": "TensorRT 主流程空输出时复用检测图进行低阈值后处理",
+                    "scope": "shared",
+                    "default": {
+                        "enabled": DEFAULT_EMPTY_RESULT_RETRY_ENABLED,
+                        "det_thresh": DEFAULT_EMPTY_RESULT_RETRY_DET_THRESH,
+                        "det_box_thresh": DEFAULT_EMPTY_RESULT_RETRY_DET_BOX_THRESH,
+                    },
+                    "properties": {
+                        "enabled": {"type": "boolean"},
+                        "det_thresh": {"type": "number", "minimum": 0, "maximum": 1},
+                        "det_box_thresh": {"type": "number", "minimum": 0, "maximum": 1},
+                    },
+                },
+                "min_interval_ms": {"type": "integer", "minimum": 0, "default": 0, "description": "帧处理最小间隔(ms)，限制 GPU 占用，0=不限", "scope": "instance"},
+            },
+            "required": ["provider"]
+        },
+        "topic_in":  [{"format": "image/jpeg", "desc": "camera image input"}],
+        "topic_out": [{"format": "data/json",  "desc": "OCR result with text boxes"}],
+    }
+]
+
+
+# ── OCR Adapters ──────────────────────────────────────────────────────────────
+
+def _ocr_output_topic(input_topic: str) -> str:
+    return f"{input_topic}/ocr"
+
+
+def _adapter_options(cfg: dict) -> dict:
+    return {
+        "model_dir": str(cfg.get("model_dir", DEFAULT_OCR_MODEL_DIR)),
+        "device_id": int(cfg.get("device_id", 0)),
+        "use_angle_cls": bool(cfg.get("use_angle_cls", True)),
+        "max_side_len": int(cfg.get("max_side_len", DEFAULT_MAX_SIDE_LEN)),
+        "rec_min_score": float(
+            cfg.get("rec_min_score", DEFAULT_REC_MIN_SCORE)
+        ),
+        "enable_preprocess": bool(cfg.get("enable_preprocess", True)),
+        "det_thresh": float(cfg.get("det_thresh", DEFAULT_DET_THRESH)),
+        "det_box_thresh": float(
+            cfg.get("det_box_thresh", DEFAULT_DET_BOX_THRESH)
+        ),
+        "det_unclip_ratio": float(
+            cfg.get("det_unclip_ratio", DEFAULT_DET_UNCLIP_RATIO)
+        ),
+        "crop_refinement": dict(cfg.get("crop_refinement") or {}),
+        "empty_result_retry": dict(cfg.get("empty_result_retry") or {}),
+    }
+
+
+def _adapter_signature(cfg: dict) -> tuple:
+    provider = cfg.get('provider', 'rapidocr')
+    return provider, _adapter_options(cfg)
+
+
+def _build_ocr_adapter(cfg: dict) -> RapidOCRAdapter:
+    """根据配置创建 OCR 适配器"""
+    provider = cfg.get('provider', 'rapidocr')
+    if provider != 'rapidocr':
+        raise ValueError(f"unsupported OCR provider: {provider}")
+    options = _adapter_options(cfg)
+    from utils.model_downloader import ensure_ocr_model
+    ensure_ocr_model(options["model_dir"])
+    return RapidOCRAdapter(**options)
+
+
+# ── ROS2 Node (订阅模式) ───────────────────────────────────────────────────────
+
+class _OCRNode(Node):
+    """订阅 image/jpeg topic，持续进行 OCR 识别"""
+
+    def __init__(self, input_topic: str, adapter: RapidOCRAdapter, language: str = "zh",
+                 node_suffix: str = '', min_interval: float = 0.0):
+        node_name = f"ocr_{node_suffix}" if node_suffix else "ocr"
+        super().__init__(node_name)
+
+        self._input_topic = input_topic
+        self._output_topic = _ocr_output_topic(input_topic)
+        self._adapter = adapter
+        self._language = language
+        # 帧处理最小间隔（秒）：限制 GPU 占用，0 = 不限
+        self._min_interval = max(0.0, float(min_interval))
+        self.state = "idle"
+
+        self._sub = None
+        self._pub = self.create_publisher(String, self._output_topic, _RESULT_QOS)
+
+        # Latest frame wins: the camera callback overwrites, the worker pops.
+        self._frames: LatestFrame = LatestFrame()
+        self._frames.close()
+        self._worker_thread: threading.Thread | None = None
+        self._stop_event = threading.Event()
+        self._stop_event.set()
+        self._generation = 0
+        self._worker_threads: list[threading.Thread] = []
+        self._log_gate = SampledLogGate(every=100)
+        self._last_error_log_at: float | None = None
+        log.info(f"[ocr] node created: subscribing={self._input_topic}, publishing={self._output_topic}")
+
+    def start(self) -> dict:
+        if self.state == "running":
+            return self._status_dict()
+
+        if not self._adapter:
+            raise RuntimeError("OCR adapter not configured")
+
+        self._generation += 1
+        generation = self._generation
+        stop_event = threading.Event()
+        frames: LatestFrame = LatestFrame()
+        self._stop_event = stop_event
+        self._frames = frames
+        if self._sub is None:
+            self._sub = self.create_subscription(
+                CompressedImage, self._input_topic, self._image_cb, CAMERA_QOS
+            )
+        self.state = "running"
+        self._worker_threads = [
+            thread for thread in self._worker_threads if thread.is_alive()
+        ]
+        self._worker_thread = threading.Thread(
+            target=self._worker,
+            args=(generation, stop_event, frames),
+            daemon=True,
+        )
+        self._worker_threads.append(self._worker_thread)
+        self._worker_thread.start()
+
+        log.info(f"[ocr] started: {self._input_topic} → {self._output_topic}")
+        return self._status_dict()
+
+    def stop(self) -> dict:
+        self.state = "idle"
+        self._stop_event.set()
+        self._frames.close()  # drops the pending frame and wakes the worker
+        deadline = time.monotonic() + 3.0
+        for thread in self._worker_threads:
+            if thread.is_alive():
+                thread.join(timeout=max(0.0, deadline - time.monotonic()))
+        self._worker_threads = [
+            thread for thread in self._worker_threads if thread.is_alive()
+        ]
+        if self._worker_threads:
+            log.warning(
+                "[ocr] %d worker(s) still stopping after timeout: %s",
+                len(self._worker_threads),
+                self._input_topic,
+            )
+
+        log.info(f"[ocr] stopped: {self._input_topic}")
+        return {"state": "idle"}
+
+    @property
+    def worker_alive(self) -> bool:
+        return any(thread.is_alive() for thread in self._worker_threads)
+
+    def _image_cb(self, msg: CompressedImage):
+        """接收图片帧：只保留最新一帧"""
+        stop_event = self._stop_event
+        frames = self._frames
+        if self.state != "running" or stop_event.is_set():
+            return
+        frames.push((bytes(msg.data), time.time()))
+
+    def _is_generation_active(
+        self, generation: int, stop_event: threading.Event
+    ) -> bool:
+        return (
+            self.state == "running"
+            and self._generation == generation
+            and self._stop_event is stop_event
+            and not stop_event.is_set()
+        )
+
+    def _worker(
+        self,
+        generation: int,
+        stop_event: threading.Event,
+        frames: LatestFrame,
+    ):
+        """后台工作线程：取最新一帧进行 OCR"""
+        while not stop_event.is_set():
+            frame = frames.pop(timeout=1.0)
+            if frame is None:
+                continue
+            image_bytes, ts = frame
+
+            t_start = time.time()
+            payload = recognize_to_payload(
+                self._adapter, image_bytes, self._language, ts
+            )
+            if not self._is_generation_active(generation, stop_event):
+                continue
+            msg = String()
+            msg.data = json.dumps(payload, ensure_ascii=False)
+            self._pub.publish(msg)
+            # Hot path: transitions log unthrottled, steady state is sampled
+            # (first + every 100th) so camera-rate output cannot flood the
+            # container logs even at DEBUG.
+            outcome = "error" if "error" in payload else "ok"
+            should_log, transition, occurrence = self._log_gate.check(outcome)
+            if outcome == "error":
+                now = time.monotonic()
+                if transition or (
+                    self._last_error_log_at is None
+                    or now - self._last_error_log_at >= _ERROR_LOG_INTERVAL_SECONDS
+                ):
+                    log.error("[ocr] recognition error (occurrence %d): %s",
+                              occurrence, escape_log_text(payload["error"]))
+                    self._last_error_log_at = now
+                elif should_log:
+                    log.debug("[ocr] recognition error (occurrence %d): %s",
+                              occurrence, escape_log_text(payload["error"]))
+            elif should_log:
+                log.debug(
+                    "[ocr] published result to %s: %d items (frame %d%s)",
+                    self._output_topic,
+                    len(payload["items"]),
+                    occurrence,
+                    ", recovered" if transition and occurrence == 1 else "",
+                )
+
+            # 限帧：距上一帧开始不足 min_interval 则等待（降低 GPU 占用）
+            if self._min_interval > 0:
+                remaining = self._min_interval - (time.time() - t_start)
+                if remaining > 0:
+                    stop_event.wait(remaining)
+
+    def _status_dict(self) -> dict:
+        return {
+            "state": self.state,
+            "topic_in": [{"topic": self._input_topic, "format": "image/jpeg", "desc": "image input"}],
+            "topic_out": [{"topic": self._output_topic, "format": "data/json", "desc": "OCR result"}],
+        }
+
+
+# ── Plugin ────────────────────────────────────────────────────────────────────
+
+class OCRPlugin:
+    """OCR MCP plugin with a non-blocking start/stop/load state machine.
+
+    dispatch() only mutates bookkeeping under a short-lived lock; the slow
+    work (model download + three TensorRT engines) runs in one background
+    loader shared by every instance:
+
+        idle --start--> loading --ok--> ready/running
+                          |               ^
+                          +----fail--> error (next start retries)
+
+    * first start records the instance as pending, spawns the single loader
+      and immediately returns {"state": "loading"};
+    * concurrent starts only add pending instances — one download, one
+      engine build, N instances;
+    * info never blocks and never loads anything;
+    * stop during loading cancels the pending instance; stop of a live
+      instance disposes its node (executor.remove_node + destroy_node);
+    * config bumps a generation token so a stale loader can never install
+      an adapter built from an outdated configuration.
+    """
+
+    PREFIX = "ocr"
+
+    def __init__(self, plugin_cfg: dict, executor):
+        self._plugin_cfg = dict(plugin_cfg)
+        self._language = plugin_cfg.get('language', 'zh')
+        self._executor = executor
+
+        # All fields below are guarded by _state_lock. The lock is only ever
+        # held for dict/flag updates — never while downloading, building
+        # engines, or joining workers — so info/start/stop stay responsive.
+        self._state_lock = threading.Lock()
+        self._nodes: dict[str, _OCRNode] = {}
+        self._instance_configs: dict[str, dict] = {}
+        self._pending_starts: dict[str, str] = {}   # node_key -> input_topic
+        self._adapter: RapidOCRAdapter | None = None
+        self._adapter_state = "idle"                # idle|loading|ready|error
+        self._load_error: str | None = None
+        self._load_generation = 0
+
+        log.info(
+            f"[ocr] plugin init: provider={plugin_cfg.get('provider')}, "
+            f"language={self._language}"
+        )
+
+    def get_tools(self) -> list:
+        return TOOLS
+
+    # ── background loader (single-flight) ────────────────────────────────
+
+    def _spawn_loader_locked(self) -> None:
+        """Start the one background adapter loader. Caller holds the lock."""
+        self._adapter_state = "loading"
+        self._load_error = None
+        generation = self._load_generation
+        cfg = dict(self._plugin_cfg)
+        thread = threading.Thread(
+            target=self._loader, args=(generation, cfg),
+            name="ocr-adapter-loader", daemon=True,
+        )
+        thread.start()
+
+    def _loader(self, generation: int, cfg: dict) -> None:
+        try:
+            adapter = _build_ocr_adapter(cfg)
+        except Exception as error:  # noqa: BLE001 - surfaced via state/info
+            log.exception("[ocr] adapter load failed")
+            with self._state_lock:
+                if generation == self._load_generation:
+                    self._adapter_state = "error"
+                    self._load_error = str(error)
+            return
+
+        with self._state_lock:
+            if generation != self._load_generation:
+                stale = adapter
+            else:
+                self._adapter = adapter
+                self._adapter_state = "ready"
+                stale = None
+        if stale is not None:
+            # A config change superseded this load; never install the result.
+            _close_quietly(stale)
+            return
+
+        # Bring up every instance that is still pending. Nodes are created
+        # outside the lock; each one is committed only if its start was not
+        # cancelled in the meantime.
+        while True:
+            with self._state_lock:
+                if generation != self._load_generation or not self._pending_starts:
+                    return
+                node_key, input_topic = next(iter(self._pending_starts.items()))
+            # README lifecycle rule: register under the lock *before*
+            # starting, so a concurrent stop (or a failure at any later
+            # point) can always locate the node — a started-but-unregistered
+            # worker would be unreachable and leak.
+            try:
+                node = self._create_node(node_key, input_topic, adapter)
+            except Exception as error:  # noqa: BLE001 - keep serving others
+                log.error("[ocr] failed to build instance %r on %r: %s",
+                          node_key, input_topic, escape_log_text(error))
+                with self._state_lock:
+                    if self._pending_starts.get(node_key) == input_topic:
+                        del self._pending_starts[node_key]
+                continue
+            registered = False
+            with self._state_lock:
+                still_wanted = (
+                    generation == self._load_generation
+                    and self._pending_starts.get(node_key) == input_topic
+                )
+                if still_wanted:
+                    try:
+                        self._executor.add_node(node)
+                    except Exception as error:  # noqa: BLE001
+                        log.error("[ocr] failed to register instance %r: %s",
+                                  node_key, escape_log_text(error))
+                        del self._pending_starts[node_key]
+                    else:
+                        self._nodes[node_key] = node
+                        del self._pending_starts[node_key]
+                        registered = True
+            if not registered:
+                try:
+                    node.destroy_node()   # never started, never registered
+                except Exception:  # noqa: BLE001
+                    pass
+                continue
+            try:
+                node.start()
+            except Exception as error:  # noqa: BLE001
+                log.error("[ocr] failed to start instance %r: %s",
+                          node_key, escape_log_text(error))
+                with self._state_lock:
+                    if self._nodes.get(node_key) is node:
+                        del self._nodes[node_key]
+                self._dispose(node_key, node)
+                continue
+            with self._state_lock:
+                still_ours = self._nodes.get(node_key) is node
+            if not still_ours:
+                # A concurrent stop retired the node while start() ran;
+                # its dispose already handled teardown — just make sure the
+                # worker this start spawned is gone too.
+                node.stop()
+
+    def _create_node(self, node_key: str, input_topic: str, adapter) -> "_OCRNode":
+        cfg = {**self._plugin_cfg, **self._instance_configs.get(node_key, {})}
+        return _OCRNode(
+            input_topic,
+            adapter,
+            cfg.get("language", self._language),
+            node_suffix=node_key.replace('/', '_').replace('-', '_'),
+            min_interval=float(cfg.get('min_interval_ms', 0)) / 1000.0,
+        )
+
+    def _dispose(self, node_key: str, node: "_OCRNode") -> None:
+        """Stop and fully destroy one node (worker, executor entry, handle)."""
+        try:
+            node.stop()
+        finally:
+            dispose_node(self._executor, node, label=f"ocr/{node_key}")
+        log.info(f"[ocr] node disposed: {node_key}")
+
+    # ── per-instance status (lock held) ───────────────────────────────────
+
+    def _instance_state_locked(self, node_key: str) -> str:
+        node = self._nodes.get(node_key)
+        if node is not None:
+            return node.state
+        if node_key in self._pending_starts:
+            return "error" if self._adapter_state == "error" else "loading"
+        return "idle"
+
+    # ── MCP dispatch ──────────────────────────────────────────────────────
+
+    def dispatch(self, name: str, args: dict) -> dict | None:
+        action = args.get("action") if name == "ocr" else name
+        instance_id = args.get("instance_id", "")
+
+        if action == "info":
+            return self._do_info(instance_id, args.get("input_topic", ""))
+        if action == "start":
+            return self._do_start(instance_id, args)
+        if action == "stop":
+            return self._do_stop(instance_id)
+        if action == "config":
+            return self._do_config(instance_id, args)
+        return None
+
+    _DESC = "OCR service — extracts text from images"
+
+    def _desc_locked(self, state: str) -> str:
+        """Dashboard-facing description, mirroring the ASR plugin (#113): the
+        static blurb normally, a reason while loading or after a failure."""
+        if state == "loading":
+            return "Loading OCR model and TensorRT engines..."
+        if state == "error" and self._load_error:
+            return f"Model load failed: {self._load_error}"
+        return self._DESC
+
+    def _do_info(self, instance_id: str, input_topic: str) -> dict:
+        base = {"name": "OCR", "manufacture": "Embodied", "model": "ocr"}
+        with self._state_lock:
+            if instance_id:
+                node = self._nodes.get(instance_id)
+                topic = (
+                    node._input_topic if node is not None
+                    else self._pending_starts.get(instance_id, input_topic)
+                )
+                out = f"{topic}/ocr" if topic else ""
+                state = self._instance_state_locked(instance_id)
+                result = {
+                    **base,
+                    "state": state,
+                    "desc": self._desc_locked(state),
+                    "topic_in": [{"topic": topic, "format": "image/jpeg", "desc": ""}] if topic else [],
+                    "topic_out": [{"topic": out, "format": "data/json", "desc": ""}] if out else [],
+                }
+                if state == "error" and self._load_error:
+                    result["error"] = self._load_error
+                return result
+
+            keys = list(self._nodes) + [
+                k for k in self._pending_starts if k not in self._nodes
+            ]
+            instances = {k: {"state": self._instance_state_locked(k)} for k in keys}
+            topics_in, topics_out = [], []
+            for key in keys:
+                node = self._nodes.get(key)
+                topic = node._input_topic if node else self._pending_starts[key]
+                topics_in.append({"topic": topic, "format": "image/jpeg", "desc": ""})
+                topics_out.append({"topic": f"{topic}/ocr", "format": "data/json", "desc": ""})
+            states = {entry["state"] for entry in instances.values()}
+            if "loading" in states or self._adapter_state == "loading":
+                state = "loading"
+            elif "running" in states:
+                state = "running"
+            elif "error" in states or self._adapter_state == "error":
+                state = "error"
+            else:
+                state = "idle"
+            if not keys and input_topic:
+                topics_in = [{"topic": input_topic, "format": "image/jpeg", "desc": ""}]
+                topics_out = [{"topic": f"{input_topic}/ocr", "format": "data/json", "desc": ""}]
+            result = {
+                **base,
+                "state": state,
+                "desc": self._desc_locked(state),
+                "topic_in": topics_in,
+                "topic_out": topics_out,
+            }
+            if instances:
+                result["instances"] = instances
+            if self._load_error and state == "error":
+                result["error"] = self._load_error
+            return result
+
+    def _do_start(self, instance_id: str, args: dict) -> dict:
+        input_topic = args.get("input_topic")
+        if not input_topic:
+            raise ValueError("input_topic is required for start action")
+        node_key = instance_id or input_topic
+
+        retired = None
+        with self._state_lock:
+            existing = self._nodes.get(node_key)
+            if existing is not None and existing._input_topic != input_topic:
+                # Topics are fixed at node construction; rebind the key.
+                retired = self._nodes.pop(node_key)
+                existing = None
+        if retired is not None:
+            self._dispose(node_key, retired)
+
+        start_node = None
+        with self._state_lock:
+            existing = self._nodes.get(node_key)
+            if existing is not None:
+                start_node = existing        # idempotent re-start
+            elif self._adapter_state == "ready":
+                # Claim the key before leaving the lock: a concurrent stop
+                # must always find the instance in _pending_starts or _nodes,
+                # never in an invisible in-between state (the orphan-node
+                # window PR #113 documents for the ASR plugin).
+                self._pending_starts[node_key] = input_topic
+            else:
+                self._pending_starts[node_key] = input_topic
+                if self._adapter_state in ("idle", "error"):
+                    self._spawn_loader_locked()
+                return {
+                    "state": "loading",
+                    "input": input_topic,
+                    "output": _ocr_output_topic(input_topic),
+                }
+            adapter = self._adapter
+            generation = self._load_generation
+
+        if start_node is not None:
+            return start_node.start()
+
+        node = self._create_node(node_key, input_topic, adapter)
+        # README lifecycle rule: register before start, so a concurrent stop
+        # (or an add_node/start failure) can always locate the node instead of
+        # leaking a started worker that nothing tracks.
+        with self._state_lock:
+            claimed = self._pending_starts.get(node_key) == input_topic
+            current = self._nodes.get(node_key)
+            fresh = generation == self._load_generation
+            registered = False
+            if claimed and current is None and fresh:
+                try:
+                    self._executor.add_node(node)
+                except Exception as error:  # noqa: BLE001
+                    log.error("[ocr] failed to register instance %r: %s",
+                              node_key, escape_log_text(error))
+                    del self._pending_starts[node_key]
+                else:
+                    self._nodes[node_key] = node
+                    del self._pending_starts[node_key]
+                    registered = True
+            elif claimed and not fresh:
+                # A config change invalidated the adapter mid-start. Keep the
+                # pending claim: the loader spawned by config brings this
+                # instance up on the new adapter.
+                pass
+            elif claimed:
+                del self._pending_starts[node_key]
+        if not registered:
+            try:
+                node.destroy_node()   # never started, never registered
+            except Exception:  # noqa: BLE001
+                pass
+            if current is not None:
+                return current.start()
+            if claimed and not fresh:
+                return {"state": "loading", "input": input_topic,
+                        "output": _ocr_output_topic(input_topic)}
+            return {"state": "idle", "input": input_topic,
+                    "output": _ocr_output_topic(input_topic)}
+        try:
+            result = node.start()
+        except Exception:
+            with self._state_lock:
+                if self._nodes.get(node_key) is node:
+                    del self._nodes[node_key]
+            self._dispose(node_key, node)
+            raise
+        with self._state_lock:
+            still_ours = self._nodes.get(node_key) is node
+        if not still_ours:
+            # A concurrent stop retired the node while start() ran; its
+            # dispose handled teardown — stop the worker this start spawned.
+            node.stop()
+            return {"state": "idle", "input": input_topic,
+                    "output": _ocr_output_topic(input_topic)}
+        return result
+
+    def _do_stop(self, instance_id: str) -> dict:
+        to_dispose: list[tuple[str, _OCRNode]] = []
+        with self._state_lock:
+            if instance_id:
+                self._pending_starts.pop(instance_id, None)
+                node = self._nodes.pop(instance_id, None)
+                if node is not None:
+                    to_dispose.append((instance_id, node))
+            else:
+                self._pending_starts.clear()
+                to_dispose.extend(self._nodes.items())
+                self._nodes = {}
+        for node_key, node in to_dispose:
+            self._dispose(node_key, node)
+        return {"state": "idle"}
+
+    def _do_config(self, instance_id: str, args: dict) -> dict:
+        cfg = {
+            k: v for k, v in args.items()
+            if k not in ('action', 'instance_id') and v is not None and v != ''
+        }
+
+        if instance_id:
+            shared = set(cfg) - {"language", "min_interval_ms"}
+            if shared:
+                raise ValueError(
+                    "OCR inference settings are shared: " + ", ".join(sorted(shared))
+                )
+            retired = None
+            with self._state_lock:
+                previous = self._instance_configs.get(instance_id, {})
+                self._instance_configs[instance_id] = {**previous, **cfg}
+                retired = self._nodes.pop(instance_id, None)
+            if retired is not None:
+                # The instance goes back to idle; the next start picks up the
+                # merged per-instance configuration.
+                self._dispose(instance_id, retired)
+            return {"status": "configured", "instance_id": instance_id}
+
+        with self._state_lock:
+            updated_cfg = {**self._plugin_cfg, **cfg}
+            rebuild = (
+                _adapter_signature(updated_cfg)
+                != _adapter_signature(self._plugin_cfg)
+            )
+            self._plugin_cfg = updated_cfg
+            self._language = updated_cfg.get('language', self._language)
+            if not rebuild:
+                # Lightweight fields only — apply to live nodes in place.
+                for node_key, node in self._nodes.items():
+                    inst = self._instance_configs.get(node_key, {})
+                    merged = {**updated_cfg, **inst}
+                    node._language = merged.get("language", self._language)
+                    node._min_interval = max(
+                        0.0, float(merged.get("min_interval_ms", 0)) / 1000.0
+                    )
+                return {"status": "configured", "adapter_loaded": self._adapter is not None, "reused": self._adapter is not None}
+
+            # Model-affecting change: invalidate any in-flight load, drop the
+            # cached adapter and retire nodes built on it. Pending starts stay
+            # pending and are served by a fresh loader for the new config.
+            self._load_generation += 1
+            stale_adapter = self._adapter
+            self._adapter = None
+            disposed = list(self._nodes.items())
+            self._nodes = {}
+            if self._pending_starts:
+                self._spawn_loader_locked()
+            else:
+                self._adapter_state = "idle"
+                self._load_error = None
+        for node_key, node in disposed:
+            self._dispose(node_key, node)
+        if stale_adapter is not None:
+            _close_quietly(stale_adapter)
+        return {"status": "configured", "adapter_loaded": False, "reused": False}
+
+
+def _close_quietly(adapter) -> None:
+    close = getattr(adapter, "close", None)
+    if callable(close):
+        try:
+            close()
+        except Exception:  # noqa: BLE001 - best-effort release
+            log.warning("[ocr] adapter close failed", exc_info=True)

--- a/perception/plugins/ocr_preprocess.py
+++ b/perception/plugins/ocr_preprocess.py
@@ -1,0 +1,47 @@
+"""Shape-preserving image enhancement used before text detection."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import numpy as np
+
+
+def preprocess_for_ocr(image: np.ndarray) -> np.ndarray:
+    import cv2
+    import numpy as np
+
+    if image is None or image.size == 0:
+        raise ValueError("invalid image")
+
+    gray = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
+    result = image
+
+    if float(np.mean(gray)) < 90 and np.count_nonzero(gray < 90) / gray.size > 0.6:
+        result = 255 - result
+        gray = cv2.cvtColor(result, cv2.COLOR_BGR2GRAY)
+
+    if float(np.std(gray)) > 60:
+        kernel = max(result.shape[:2]) // 30
+        kernel = kernel if kernel % 2 else kernel + 1
+        value = result.astype(np.float32)
+        background = np.maximum(
+            cv2.GaussianBlur(value, (kernel, kernel), 0), 1.0
+        )
+        value /= background
+        value /= np.percentile(value, 99.5)
+        result = np.clip(value * 255, 0, 255).astype(np.uint8)
+
+    if float(np.mean(gray)) < 100:
+        lab = cv2.cvtColor(result, cv2.COLOR_BGR2LAB)
+        lightness, channel_a, channel_b = cv2.split(lab)
+        lightness = cv2.createCLAHE(
+            clipLimit=2.0, tileGridSize=(8, 8)
+        ).apply(lightness)
+        result = cv2.cvtColor(
+            cv2.merge([lightness, channel_a, channel_b]),
+            cv2.COLOR_LAB2BGR,
+        )
+
+    return result

--- a/perception/plugins/ocr_runtime.py
+++ b/perception/plugins/ocr_runtime.py
@@ -1,0 +1,911 @@
+from __future__ import annotations
+
+import logging
+import math
+import threading
+from dataclasses import dataclass
+from io import BytesIO
+from pathlib import Path
+
+from plugins.ocr_preprocess import preprocess_for_ocr
+from utils.tensorrt_runtime import TensorRTEngine
+
+_log = logging.getLogger(__name__)
+
+
+TENSORRT_MODEL_FILES = ("det.engine", "rec.engine", "keys.txt")
+TENSORRT_CLASSIFIER_MODEL_FILE = "cls.engine"
+MAX_RECOGNITION_WIDTH = 2048
+_OCR_MEAN = (127.5, 127.5, 127.5)
+_OCR_NORMAL = (1 / 127.5, 1 / 127.5, 1 / 127.5)
+DEFAULT_MAX_SIDE_LEN = 1600
+DEFAULT_REC_MIN_SCORE = 0.9
+DEFAULT_DET_THRESH = 0.3
+DEFAULT_DET_BOX_THRESH = 0.5
+DEFAULT_DET_UNCLIP_RATIO = 0.7
+DEFAULT_CLS_THRESH = 0.9
+DEFAULT_CROP_REFINEMENT_ENABLED = True
+DEFAULT_CROP_REFINEMENT_MIN_SCORE = 0.9
+DEFAULT_CROP_REFINEMENT_MIN_GAIN = 0.12
+DEFAULT_CROP_REFINEMENT_PROFILES = (
+    "prefix_65",
+    "upper_center",
+    "upper_tight",
+)
+DEFAULT_EMPTY_RESULT_RETRY_ENABLED = True
+DEFAULT_EMPTY_RESULT_RETRY_DET_THRESH = 0.1
+DEFAULT_EMPTY_RESULT_RETRY_DET_BOX_THRESH = 0.1
+
+_CROP_REFINEMENT_PROFILE_BOXES = {
+    "prefix_65": (0.05, 0.00, 0.70, 1.00),
+    "upper_center": (0.20, 0.05, 0.80, 0.68),
+    "upper_tight": (0.28, 0.10, 0.72, 0.64),
+}
+
+
+@dataclass(frozen=True)
+class CropRefinementConfig:
+    enabled: bool = DEFAULT_CROP_REFINEMENT_ENABLED
+    min_score: float = DEFAULT_CROP_REFINEMENT_MIN_SCORE
+    min_gain: float = DEFAULT_CROP_REFINEMENT_MIN_GAIN
+    min_text_length: int = 2
+    profiles: tuple[str, ...] = DEFAULT_CROP_REFINEMENT_PROFILES
+
+    @classmethod
+    def from_mapping(cls, value: dict | None) -> "CropRefinementConfig":
+        mapping = dict(value or {})
+        profiles = tuple(
+            str(profile).strip()
+            for profile in mapping.get(
+                "profiles", DEFAULT_CROP_REFINEMENT_PROFILES
+            )
+            if str(profile).strip()
+        )
+        unknown = set(profiles) - set(_CROP_REFINEMENT_PROFILE_BOXES)
+        if unknown:
+            raise ValueError(
+                "unknown OCR crop refinement profiles: "
+                + ", ".join(sorted(unknown))
+            )
+        min_score = float(
+            mapping.get("min_score", DEFAULT_CROP_REFINEMENT_MIN_SCORE)
+        )
+        min_gain = float(
+            mapping.get("min_gain", DEFAULT_CROP_REFINEMENT_MIN_GAIN)
+        )
+        min_text_length = int(mapping.get("min_text_length", 2))
+        if not 0.0 <= min_score <= 1.0:
+            raise ValueError("OCR crop refinement min_score must be in [0, 1]")
+        if min_gain < 0.0:
+            raise ValueError("OCR crop refinement min_gain must be non-negative")
+        if min_text_length < 1:
+            raise ValueError(
+                "OCR crop refinement min_text_length must be positive"
+            )
+        return cls(
+            enabled=bool(
+                mapping.get("enabled", DEFAULT_CROP_REFINEMENT_ENABLED)
+            ),
+            min_score=min_score,
+            min_gain=min_gain,
+            min_text_length=min_text_length,
+            profiles=profiles,
+        )
+
+
+@dataclass(frozen=True)
+class EmptyResultRetryConfig:
+    enabled: bool = DEFAULT_EMPTY_RESULT_RETRY_ENABLED
+    det_thresh: float = DEFAULT_EMPTY_RESULT_RETRY_DET_THRESH
+    det_box_thresh: float = DEFAULT_EMPTY_RESULT_RETRY_DET_BOX_THRESH
+
+    @classmethod
+    def from_mapping(cls, value: dict | None) -> "EmptyResultRetryConfig":
+        mapping = dict(value or {})
+        det_thresh = float(
+            mapping.get("det_thresh", DEFAULT_EMPTY_RESULT_RETRY_DET_THRESH)
+        )
+        det_box_thresh = float(
+            mapping.get(
+                "det_box_thresh", DEFAULT_EMPTY_RESULT_RETRY_DET_BOX_THRESH
+            )
+        )
+        if not 0.0 <= det_thresh <= 1.0:
+            raise ValueError("OCR empty-result retry det_thresh must be in [0, 1]")
+        if not 0.0 <= det_box_thresh <= 1.0:
+            raise ValueError(
+                "OCR empty-result retry det_box_thresh must be in [0, 1]"
+            )
+        return cls(
+            enabled=bool(
+                mapping.get("enabled", DEFAULT_EMPTY_RESULT_RETRY_ENABLED)
+            ),
+            det_thresh=det_thresh,
+            det_box_thresh=det_box_thresh,
+        )
+
+
+def decode_vips_overview(image_bytes: bytes, max_side: int):
+    import numpy as np
+    import pyvips
+
+    if max_side <= 0:
+        raise ValueError("max_side must be positive")
+    # no_rotate=True: keep the stored pixel orientation. Boxes are scaled back
+    # with the JPEG header size (probe_image_header), so applying the EXIF
+    # orientation here would swap width/height and misplace every bbox on
+    # rotated frames. Robot cameras publish upright frames; consumers that
+    # need EXIF orientation must transform coordinates themselves.
+    image = pyvips.Image.thumbnail_buffer(
+        image_bytes,
+        max_side,
+        size="down",
+        no_rotate=True,
+    )
+    if image.hasalpha():
+        image = image.flatten(background=[255, 255, 255])
+    image = image.colourspace("srgb")
+    try:
+        rgb = image.numpy()
+    except ValueError:
+        memory = image.write_to_memory()
+        rgb = np.frombuffer(memory, dtype=np.uint8).reshape(
+            image.height, image.width, min(image.bands, 4)
+        )
+    if rgb.ndim != 3 or rgb.shape[2] != 3:
+        raise ValueError("decoded image must have three color channels")
+    return np.ascontiguousarray(rgb[:, :, ::-1], dtype=np.uint8)
+
+
+def probe_image_header(image_bytes: bytes) -> tuple[int, int]:
+    try:
+        from PIL import Image
+
+        with Image.open(BytesIO(image_bytes)) as image:
+            width, height = image.size
+    except Exception as exc:
+        raise ValueError("invalid or unsupported compressed image header") from exc
+
+    if width <= 0 or height <= 0:
+        raise ValueError("compressed image has invalid dimensions")
+    return width, height
+
+
+def scale_ocr_items(
+    items: list[dict], scale_x: float, scale_y: float
+) -> list[dict]:
+    scaled_items = []
+    for item in items:
+        x1, y1, x2, y2 = item["bbox"]
+        scaled_items.append(
+            {
+                **item,
+                "bbox": [
+                    math.floor(x1 * scale_x),
+                    math.floor(y1 * scale_y),
+                    math.ceil(x2 * scale_x),
+                    math.ceil(y2 * scale_y),
+                ],
+            }
+        )
+    return scaled_items
+
+
+def build_ocr_payload(results, timestamp, language, error=None) -> dict:
+    payload = {
+        "text": " ".join(item["text"] for item in results if item.get("text")),
+        "items": results,
+        "timestamp": timestamp,
+        "language": language,
+    }
+    if error is not None:
+        payload["error"] = str(error)
+    return payload
+
+
+def recognize_to_payload(
+    adapter, image_bytes: bytes, language: str, timestamp: float
+) -> dict:
+    try:
+        return build_ocr_payload(
+            adapter.recognize(image_bytes, language), timestamp, language
+        )
+    except Exception as exc:
+        return build_ocr_payload([], timestamp, language, error=exc)
+
+
+class _TensorRTModelSession:
+    """OCR view over one shared TensorRTEngine: uint8 HWC in, normalized NCHW.
+
+    Everything CUDA/TensorRT related (deserialize, profiles, buffers, stream,
+    execution, cleanup) lives in utils.tensorrt_runtime.TensorRTEngine; this
+    class only adds PP-OCR's mean/normal preprocessing and the image-shape
+    helpers the detector/recognizer/classifier need.
+    """
+
+    def __init__(
+        self,
+        engine_path: Path,
+        *,
+        device_id: int,
+        mean: tuple[float, float, float],
+        normal: tuple[float, float, float],
+    ):
+        import numpy as np
+
+        self._np = np
+        self._engine = TensorRTEngine(engine_path, device_id=device_id)
+        if len(self._engine.output_names) != 1:
+            self._engine.close()
+            raise RuntimeError(
+                "OCR TensorRT engine must have exactly one output; got "
+                f"{self._engine.output_names}"
+            )
+        self._mean = np.asarray(mean, dtype=np.float32).reshape(1, 3, 1, 1)
+        self._normal = np.asarray(normal, dtype=np.float32).reshape(1, 3, 1, 1)
+
+    @property
+    def _profiles(self):
+        return self._engine.profiles
+
+    @property
+    def optimization_shape(self) -> tuple[int, ...]:
+        return self._engine.optimization_shape
+
+    def fit_input_image_shape(
+        self, height: int, width: int
+    ) -> tuple[int, int]:
+        """Return the smallest profile-compatible HWC canvas for an image."""
+        height = int(height)
+        width = int(width)
+        if height <= 0 or width <= 0:
+            raise ValueError("OCR TensorRT image dimensions must be positive")
+
+        candidates = []
+        for minimum, _optimum, maximum in self._profiles:
+            if (
+                len(minimum) == 4
+                and minimum[0] <= 1 <= maximum[0]
+                and minimum[1] <= 3 <= maximum[1]
+            ):
+                candidate = (
+                    max(height, minimum[2]), max(width, minimum[3])
+                )
+                if candidate[0] <= maximum[2] and candidate[1] <= maximum[3]:
+                    candidates.append(candidate)
+
+        if candidates:
+            return min(candidates, key=lambda shape: shape[0] * shape[1])
+
+        # Reuse the standard diagnostic, including all supported ranges.
+        self._engine.select_profile((1, 3, height, width))
+        raise AssertionError("unreachable")
+
+    def max_batch_size(self, height: int, width: int) -> int:
+        compatible = [
+            maximum[0]
+            for minimum, _optimum, maximum in self._profiles
+            if len(minimum) == 4
+            and minimum[1] <= 3 <= maximum[1]
+            and minimum[2] <= height <= maximum[2]
+            and minimum[3] <= width <= maximum[3]
+            and minimum[0] <= 1 <= maximum[0]
+        ]
+        if not compatible:
+            self._engine.select_profile((1, 3, int(height), int(width)))
+        return max(compatible)
+
+    def run_uint8(self, image, shape: tuple[int, ...]):
+        image = self._np.ascontiguousarray(image, dtype=self._np.uint8)
+        if len(shape) != 4 or shape[0] != 1 or shape[1] != 3:
+            raise ValueError(f"invalid OCR TensorRT NCHW shape: {shape}")
+        if image.shape[:2] != (shape[2], shape[3]):
+            raise ValueError(
+                f"OCR TensorRT image/shape mismatch: {image.shape} vs {shape}"
+            )
+        return self.run_uint8_batch(image[None], shape)
+
+    def run_uint8_batch(self, images, shape: tuple[int, ...]):
+        np = self._np
+        images = np.ascontiguousarray(images, dtype=np.uint8)
+        if len(shape) != 4 or shape[1] != 3:
+            raise ValueError(f"invalid OCR TensorRT NCHW shape: {shape}")
+        if images.ndim != 4 or images.shape != (
+            shape[0], shape[2], shape[3], shape[1]
+        ):
+            raise ValueError(
+                f"OCR TensorRT image batch/shape mismatch: {images.shape} vs "
+                f"{shape}"
+            )
+        nchw = images.transpose(0, 3, 1, 2)
+        if self._engine.input_dtype == np.dtype(np.float32):
+            array = np.empty(nchw.shape, dtype=np.float32)
+            np.subtract(nchw, self._mean, out=array)
+            np.multiply(array, self._normal, out=array)
+        else:
+            value = (nchw.astype(np.float32) - self._mean) * self._normal
+            array = np.ascontiguousarray(value, dtype=self._engine.input_dtype)
+        return self._engine.infer(array)[0]
+
+    def close(self) -> None:
+        engine = getattr(self, "_engine", None)
+        if engine is not None:
+            engine.close()
+
+    def __del__(self):
+        try:
+            self.close()
+        except Exception:
+            # Interpreter shutdown can unload CUDA before Python finalizers run.
+            pass
+
+
+class _TensorRTPipeline:
+    @staticmethod
+    def _multiple_of_32(value: float) -> int:
+        return max(32, int(round(value / 32)) * 32)
+
+    def _detector_input(self, image):
+        import cv2
+        import numpy as np
+
+        height, width = image.shape[:2]
+        scale = min(1.0, self._max_side_len / max(height, width))
+        target_height = self._multiple_of_32(height * scale)
+        target_width = self._multiple_of_32(width * scale)
+        canvas_height, canvas_width = self._det.fit_input_image_shape(
+            target_height, target_width
+        )
+
+        # Uniformly enlarge small images until one canvas edge is filled, then
+        # pad the remaining edge. This preserves aspect ratio while satisfying
+        # TensorRT profiles whose minimum dimensions exceed the camera frame.
+        fit_scale = min(
+            canvas_height / target_height,
+            canvas_width / target_width,
+        )
+        content_height = min(
+            canvas_height,
+            max(target_height, int(round(target_height * fit_scale))),
+        )
+        content_width = min(
+            canvas_width,
+            max(target_width, int(round(target_width * fit_scale))),
+        )
+
+        if (content_width, content_height) == (width, height):
+            resized = image
+        else:
+            shrinking = content_height <= height and content_width <= width
+            resized = cv2.resize(
+                image,
+                (content_width, content_height),
+                interpolation=(
+                    cv2.INTER_AREA if shrinking else cv2.INTER_LINEAR
+                ),
+            )
+
+        if (content_height, content_width) == (
+            canvas_height,
+            canvas_width,
+        ):
+            return resized, (content_height, content_width)
+
+        padded = np.full(
+            (canvas_height, canvas_width, 3), 128, dtype=np.uint8
+        )
+        padded[:content_height, :content_width] = resized
+        return padded, (content_height, content_width)
+
+    @staticmethod
+    def _crop_detector_prediction(
+        prediction, input_shape, content_shape
+    ):
+        if input_shape == content_shape:
+            return prediction
+
+        import numpy as np
+
+        input_height, input_width = input_shape
+        content_height, content_width = content_shape
+        output_height, output_width = prediction.shape[-2:]
+        crop_height = min(
+            output_height,
+            max(1, int(round(output_height * content_height / input_height))),
+        )
+        crop_width = min(
+            output_width,
+            max(1, int(round(output_width * content_width / input_width))),
+        )
+        return np.ascontiguousarray(
+            prediction[..., :crop_height, :crop_width]
+        )
+
+    def _run_detector(self, image):
+        detector_input, content_shape = self._detector_input(image)
+        height, width = detector_input.shape[:2]
+        prediction = self._det.run_uint8(
+            detector_input, (1, 3, height, width)
+        )
+        prediction = self._crop_detector_prediction(
+            prediction, (height, width), content_shape
+        )
+        return prediction, image.shape[:2]
+
+    @staticmethod
+    def _postprocess_detection(prediction, image_shape, postprocess):
+        import numpy as np
+
+        boxes, scores = postprocess(prediction, image_shape)
+        if len(boxes) == 0:
+            return np.empty((0, 4, 2), dtype=np.float32), []
+        order = sorted(
+            range(len(boxes)),
+            key=lambda index: (boxes[index][0][1], boxes[index][0][0]),
+        )
+        return boxes[order], [scores[index] for index in order]
+
+    @staticmethod
+    def _prepare_recognition_crop(crop):
+        import cv2
+        import numpy as np
+
+        height, width = crop.shape[:2]
+        if height <= 0 or width <= 0:
+            return None
+        ratio = width / float(height)
+        target_height = 48
+        target_width = min(
+            MAX_RECOGNITION_WIDTH,
+            max(320, int(math.ceil(target_height * ratio))),
+        )
+        target_width = max(32, int(math.ceil(target_width / 8)) * 8)
+        resized_width = min(
+            target_width, max(1, int(math.ceil(target_height * ratio)))
+        )
+        resized = cv2.resize(
+            crop,
+            (resized_width, target_height),
+            interpolation=cv2.INTER_LINEAR,
+        )
+        padded = np.full(
+            (target_height, target_width, 3), 128, dtype=np.uint8
+        )
+        padded[:, :resized_width] = resized
+        return padded, ratio
+
+    def __init__(
+        self,
+        root: Path,
+        *,
+        device_id: int,
+        max_side_len: int,
+        rec_min_score: float = DEFAULT_REC_MIN_SCORE,
+        enable_preprocess: bool = True,
+        det_thresh: float = DEFAULT_DET_THRESH,
+        det_box_thresh: float = DEFAULT_DET_BOX_THRESH,
+        det_unclip_ratio: float = DEFAULT_DET_UNCLIP_RATIO,
+        crop_refinement: CropRefinementConfig | None = None,
+        empty_result_retry: EmptyResultRetryConfig | None = None,
+        use_angle_cls: bool = False,
+        cls_thresh: float = DEFAULT_CLS_THRESH,
+    ):
+        from rapidocr.ch_ppocr_det.utils import DBPostProcess
+        from rapidocr.ch_ppocr_rec.utils import CTCLabelDecode
+        from rapidocr.utils.process_img import get_rotate_crop_image
+
+        self._det = _TensorRTModelSession(
+            root / "det.engine",
+            device_id=device_id,
+            mean=_OCR_MEAN,
+            normal=_OCR_NORMAL,
+        )
+        try:
+            self._rec = _TensorRTModelSession(
+                root / "rec.engine",
+                device_id=device_id,
+                mean=_OCR_MEAN,
+                normal=_OCR_NORMAL,
+            )
+        except Exception:
+            self._det.close()
+            raise
+        self._cls = None
+        if use_angle_cls:
+            try:
+                self._cls = _TensorRTModelSession(
+                    root / TENSORRT_CLASSIFIER_MODEL_FILE,
+                    device_id=device_id,
+                    mean=_OCR_MEAN,
+                    normal=_OCR_NORMAL,
+                )
+            except Exception:
+                self._rec.close()
+                self._det.close()
+                raise
+        self._det_postprocess = DBPostProcess(
+            thresh=float(det_thresh),
+            box_thresh=float(det_box_thresh),
+            max_candidates=1000,
+            unclip_ratio=float(det_unclip_ratio),
+            use_dilation=True,
+            score_mode="fast",
+        )
+        self._rec_decode = CTCLabelDecode(character_path=root / "keys.txt")
+        self._crop = get_rotate_crop_image
+        self._rec_min_score = float(rec_min_score)
+        self._enable_preprocess = bool(enable_preprocess)
+        self._max_side_len = max(32, int(max_side_len))
+        self._cls_thresh = float(cls_thresh)
+        self._crop_refinement = (
+            crop_refinement
+            if crop_refinement is not None
+            else CropRefinementConfig()
+        )
+        retry = (
+            empty_result_retry
+            if empty_result_retry is not None
+            else EmptyResultRetryConfig()
+        )
+        self._empty_result_retry_postprocess = None
+        if retry.enabled:
+            self._empty_result_retry_postprocess = DBPostProcess(
+                thresh=retry.det_thresh,
+                box_thresh=retry.det_box_thresh,
+                max_candidates=1000,
+                unclip_ratio=float(det_unclip_ratio),
+                use_dilation=True,
+                score_mode="fast",
+            )
+
+    def warm_up(self) -> None:
+        import numpy as np
+
+        det_shape = self._det.optimization_shape
+        rec_shape = self._rec.optimization_shape
+        self._det.run_uint8_batch(
+            np.zeros(
+                (det_shape[0], det_shape[2], det_shape[3], 3),
+                dtype=np.uint8,
+            ),
+            det_shape,
+        )
+        self._rec.run_uint8_batch(
+            np.zeros(
+                (rec_shape[0], rec_shape[2], rec_shape[3], 3),
+                dtype=np.uint8,
+            ),
+            rec_shape,
+        )
+        if self._cls is not None:
+            cls_shape = self._cls.optimization_shape
+            self._cls.run_uint8_batch(
+                np.zeros(
+                    (cls_shape[0], cls_shape[2], cls_shape[3], 3),
+                    dtype=np.uint8,
+                ),
+                cls_shape,
+            )
+
+    @staticmethod
+    def _prepare_classifier_crop(crop):
+        import cv2
+        import numpy as np
+
+        height, width = crop.shape[:2]
+        if height <= 0 or width <= 0:
+            return None
+        target_height = 48
+        target_width = 192
+        resized_width = min(
+            target_width,
+            max(1, int(math.ceil(target_height * width / float(height)))),
+        )
+        resized = cv2.resize(
+            crop,
+            (resized_width, target_height),
+            interpolation=cv2.INTER_LINEAR,
+        )
+        padded = np.zeros(
+            (target_height, target_width, 3), dtype=np.uint8
+        )
+        padded[:, :resized_width] = resized
+        return padded
+
+    def _orient_crops(self, crops):
+        import cv2
+        import numpy as np
+
+        classifier = getattr(self, "_cls", None)
+        if classifier is None:
+            return crops
+        oriented = list(crops)
+        prepared = []
+        for index, crop in enumerate(crops):
+            value = self._prepare_classifier_crop(crop)
+            if value is not None:
+                prepared.append((index, value))
+        max_batch = classifier.max_batch_size(48, 192)
+        for offset in range(0, len(prepared), max_batch):
+            chunk = prepared[offset:offset + max_batch]
+            images = np.stack([entry[1] for entry in chunk])
+            prediction = classifier.run_uint8_batch(
+                images,
+                (len(chunk), 3, 48, 192),
+            )
+            for entry, probabilities in zip(chunk, prediction):
+                label = int(np.argmax(probabilities))
+                score = float(probabilities[label])
+                if label == 1 and score > self._cls_thresh:
+                    oriented[entry[0]] = cv2.rotate(
+                        crops[entry[0]], cv2.ROTATE_180
+                    )
+        return oriented
+
+    def _recognize_boxes(self, image, boxes):
+        import copy
+        from collections import defaultdict
+
+        import numpy as np
+
+        prepared_by_width = defaultdict(list)
+        recognized = [("", 0.0)] * len(boxes)
+        crops = [
+            self._crop(image, copy.deepcopy(box)) for box in boxes
+        ]
+        for index, crop in enumerate(self._orient_crops(crops)):
+            prepared = self._prepare_recognition_crop(crop)
+            if prepared is None:
+                continue
+            padded, ratio = prepared
+            prepared_by_width[padded.shape[1]].append((index, padded, ratio))
+
+        for target_width, group in prepared_by_width.items():
+            max_batch = self._rec.max_batch_size(48, target_width)
+            for offset in range(0, len(group), max_batch):
+                chunk = group[offset:offset + max_batch]
+                images = np.stack([entry[1] for entry in chunk])
+                ratios = tuple(entry[2] for entry in chunk)
+                prediction = self._rec.run_uint8_batch(
+                    images,
+                    (len(chunk), 3, 48, target_width),
+                )
+                line_results, _ = self._rec_decode(
+                    prediction,
+                    False,
+                    wh_ratio_list=ratios,
+                    max_wh_ratio=target_width / 48,
+                )
+                for entry, result in zip(chunk, line_results):
+                    text, score = result
+                    recognized[entry[0]] = str(text), float(score)
+        return recognized
+
+    def close(self) -> None:
+        classifier = getattr(self, "_cls", None)
+        if classifier is not None:
+            classifier.close()
+            self._cls = None
+        self._rec.close()
+        self._det.close()
+
+    @staticmethod
+    def _sub_quad(box, x0: float, y0: float, x1: float, y1: float):
+        import numpy as np
+
+        def point(u: float, v: float):
+            top = box[0] * (1.0 - u) + box[1] * u
+            bottom = box[3] * (1.0 - u) + box[2] * u
+            return top * (1.0 - v) + bottom * v
+
+        return np.asarray(
+            [
+                point(x0, y0),
+                point(x1, y0),
+                point(x1, y1),
+                point(x0, y1),
+            ],
+            dtype=np.float32,
+        )
+
+    @staticmethod
+    def _item(box, text: str, score: float) -> dict:
+        import numpy as np
+
+        xs = box[:, 0]
+        ys = box[:, 1]
+        return {
+            "text": text,
+            "bbox": [
+                float(np.min(xs)),
+                float(np.min(ys)),
+                float(np.max(xs)),
+                float(np.max(ys)),
+            ],
+            "score": score,
+        }
+
+    def _recognize_with_refinement(self, image, boxes) -> list[dict]:
+        recognized = self._recognize_boxes(image, boxes)
+        refinement = getattr(
+            self, "_crop_refinement", CropRefinementConfig(enabled=False)
+        )
+        if not refinement.enabled:
+            return [
+                self._item(box, text, score)
+                for box, (text, score) in zip(boxes, recognized)
+                if text.strip() and score >= self._rec_min_score
+            ]
+
+        refined_boxes = []
+        refined_sources = []
+        for box_index, (box, (_, score)) in enumerate(
+            zip(boxes, recognized)
+        ):
+            if score >= self._rec_min_score:
+                continue
+            for profile in refinement.profiles:
+                refined_boxes.append(
+                    self._sub_quad(
+                        box, *_CROP_REFINEMENT_PROFILE_BOXES[profile]
+                    )
+                )
+                refined_sources.append(box_index)
+
+        refined_results = self._recognize_boxes(image, refined_boxes)
+        candidates_by_box = {}
+        for box, source, result in zip(
+            refined_boxes, refined_sources, refined_results
+        ):
+            text, score = result
+            if len(text.strip()) < refinement.min_text_length:
+                continue
+            candidate = candidates_by_box.get(source)
+            if candidate is None or score > candidate[2]:
+                candidates_by_box[source] = (box, text, score)
+
+        items = []
+        for box_index, (box, (text, score)) in enumerate(
+            zip(boxes, recognized)
+        ):
+            selected_box = box
+            selected_text = text
+            selected_score = score
+            candidate = candidates_by_box.get(box_index)
+            if (
+                candidate is not None
+                and candidate[2] >= refinement.min_score
+                and candidate[2] >= score + refinement.min_gain
+            ):
+                selected_box, selected_text, selected_score = candidate
+
+            score_floor = (
+                refinement.min_score
+                if selected_box is not box
+                else self._rec_min_score
+            )
+            if not selected_text.strip() or selected_score < score_floor:
+                continue
+            items.append(
+                self._item(selected_box, selected_text, selected_score)
+            )
+        return items
+
+    def infer(self, image) -> list[dict]:
+        det_image = image
+        if self._enable_preprocess:
+            try:
+                det_image = preprocess_for_ocr(image)
+            except Exception:
+                _log.debug("preprocess failed, using original image", exc_info=True)
+
+        prediction, image_shape = self._run_detector(det_image)
+        boxes, _ = self._postprocess_detection(
+            prediction, image_shape, self._det_postprocess
+        )
+        items = self._recognize_with_refinement(image, boxes)
+        retry_postprocess = getattr(
+            self, "_empty_result_retry_postprocess", None
+        )
+        if items or retry_postprocess is None:
+            return items
+
+        retry_boxes, _ = self._postprocess_detection(
+            prediction, image_shape, retry_postprocess
+        )
+        return self._recognize_with_refinement(image, retry_boxes)
+
+
+class RapidOCRAdapter:
+    def __init__(
+        self,
+        model_dir: str,
+        device_id: int = 0,
+        use_angle_cls: bool = True,
+        max_side_len: int = DEFAULT_MAX_SIDE_LEN,
+        rec_min_score: float = DEFAULT_REC_MIN_SCORE,
+        enable_preprocess: bool = True,
+        det_thresh: float = DEFAULT_DET_THRESH,
+        det_box_thresh: float = DEFAULT_DET_BOX_THRESH,
+        det_unclip_ratio: float = DEFAULT_DET_UNCLIP_RATIO,
+        crop_refinement: dict | None = None,
+        empty_result_retry: dict | None = None,
+    ):
+        root = Path(model_dir)
+        self._max_side_len = max_side_len
+        self._request_lock = threading.Lock()
+        self._inference_lock = threading.Lock()
+        crop_refinement_config = CropRefinementConfig.from_mapping(
+            crop_refinement
+        )
+        empty_result_retry_config = EmptyResultRetryConfig.from_mapping(
+            empty_result_retry
+        )
+        required_files = TENSORRT_MODEL_FILES + (
+            (TENSORRT_CLASSIFIER_MODEL_FILE,) if use_angle_cls else ()
+        )
+        missing = [name for name in required_files if not (root / name).is_file()]
+        if missing:
+            raise FileNotFoundError(
+                f"OCR TensorRT model files missing: {', '.join(missing)}"
+            )
+        pipeline = _TensorRTPipeline(
+            root,
+            device_id=device_id,
+            crop_refinement=crop_refinement_config,
+            empty_result_retry=empty_result_retry_config,
+            use_angle_cls=use_angle_cls,
+            max_side_len=max_side_len,
+            rec_min_score=rec_min_score,
+            enable_preprocess=enable_preprocess,
+            det_thresh=det_thresh,
+            det_box_thresh=det_box_thresh,
+            det_unclip_ratio=det_unclip_ratio,
+        )
+        try:
+            pipeline.warm_up()
+        except Exception:
+            pipeline.close()
+            raise
+        self._pipeline = pipeline
+
+    @staticmethod
+    def _probe_image_header(image_bytes: bytes) -> tuple[int, int]:
+        return probe_image_header(image_bytes)
+
+    def _infer_image(self, image) -> list[dict]:
+        with self._inference_lock:
+            return self._pipeline.infer(image)
+
+    def _recognize_single_pass(self, image_bytes: bytes) -> list[dict]:
+        source_size = self._probe_image_header(image_bytes)
+        image = decode_vips_overview(image_bytes, self._max_side_len)
+        decoded_height, decoded_width = image.shape[:2]
+        items = self._infer_image(image)
+        source_width, source_height = source_size
+        return scale_ocr_items(
+            items,
+            scale_x=source_width / decoded_width,
+            scale_y=source_height / decoded_height,
+        )
+
+    def recognize(self, image_bytes: bytes, language: str = "zh") -> list:
+        request_lock = getattr(self, "_request_lock", None)
+        if request_lock is None:
+            return self._recognize_single_pass(image_bytes)
+        with request_lock:
+            return self._recognize_single_pass(image_bytes)
+
+    def close(self) -> None:
+        request_lock = getattr(self, "_request_lock", None)
+        if request_lock is None:
+            self._close_resources()
+            return
+        with request_lock:
+            self._close_resources()
+
+    def _close_resources(self) -> None:
+        pipeline = getattr(self, "_pipeline", None)
+        self._pipeline = None
+        if pipeline is not None:
+            pipeline.close()

--- a/perception/plugins/ocr_runtime.py
+++ b/perception/plugins/ocr_runtime.py
@@ -191,13 +191,70 @@ def scale_ocr_items(
     return scaled_items
 
 
-def build_ocr_payload(results, timestamp, language, error=None) -> dict:
+def annotate_ocr_items(items: list[dict]) -> list[dict]:
+    """Attach the size/hierarchy fields an LLM consumer needs to rank text.
+
+    Detection returns items in reading order (top-to-bottom, then left) with
+    only bbox+score, so a downstream LLM cannot tell a headline from fine
+    print. Each item gains:
+
+    - ``height``: bbox height in source pixels — a font-size proxy.
+    - ``prominence``: height relative to the largest text on the frame,
+      rounded to 2 decimals (1.0 = the most prominent text).
+    - ``line``: visual line index; an item joins the current line when its
+      vertical center falls inside that line's band.
+    """
+    annotated: list[dict] = []
+    band: tuple[float, float] | None = None
+    line = -1
+    for item in items:
+        x1, y1, x2, y2 = item["bbox"]
+        height = max(1, round(y2 - y1))
+        center = (y1 + y2) / 2
+        if band is None or not band[0] <= center <= band[1]:
+            line += 1
+            band = (y1, y2)
+        else:
+            band = (min(band[0], y1), max(band[1], y2))
+        annotated.append({**item, "height": height, "line": line})
+    if annotated:
+        max_height = max(item["height"] for item in annotated)
+        for item in annotated:
+            item["prominence"] = round(item["height"] / max_height, 2)
+    return annotated
+
+
+def build_ocr_payload(
+    results, timestamp, language, error=None, image_size=None
+) -> dict:
+    """Assemble the published OCR result.
+
+    ``text`` joins recognized fragments per visual line (left-to-right)
+    with newlines between lines; ``items`` carry bbox (source-pixel
+    [x1,y1,x2,y2]), score, height, prominence and line so consumers can
+    reason about size and importance; ``image_size`` ([width, height]) is
+    the coordinate reference frame for every bbox.
+    """
+    items = annotate_ocr_items(results)
+    lines: dict[int, list[dict]] = {}
+    for item in items:
+        if item.get("text"):
+            lines.setdefault(item["line"], []).append(item)
+    text = "\n".join(
+        " ".join(
+            item["text"]
+            for item in sorted(members, key=lambda entry: entry["bbox"][0])
+        )
+        for _line, members in sorted(lines.items())
+    )
     payload = {
-        "text": " ".join(item["text"] for item in results if item.get("text")),
-        "items": results,
+        "text": text,
+        "items": items,
         "timestamp": timestamp,
         "language": language,
     }
+    if image_size is not None:
+        payload["image_size"] = [int(image_size[0]), int(image_size[1])]
     if error is not None:
         payload["error"] = str(error)
     return payload
@@ -207,8 +264,13 @@ def recognize_to_payload(
     adapter, image_bytes: bytes, language: str, timestamp: float
 ) -> dict:
     try:
+        items = adapter.recognize(image_bytes, language)
+        try:
+            image_size = probe_image_header(image_bytes)
+        except ValueError:
+            image_size = None
         return build_ocr_payload(
-            adapter.recognize(image_bytes, language), timestamp, language
+            items, timestamp, language, image_size=image_size
         )
     except Exception as exc:
         return build_ocr_payload([], timestamp, language, error=exc)

--- a/perception/tests/conftest.py
+++ b/perception/tests/conftest.py
@@ -1,0 +1,13 @@
+"""Shared pytest wiring for perception tests (stubs + node-registry reset)."""
+
+import pytest
+
+import vision_stubs  # noqa: F401  (importing installs the ROS stubs)
+from vision_stubs import _FakeNode
+
+
+@pytest.fixture(autouse=True)
+def _reset_nodes():
+    _FakeNode.instances.clear()
+    yield
+    _FakeNode.instances.clear()

--- a/perception/tests/test_ocr_plugin.py
+++ b/perception/tests/test_ocr_plugin.py
@@ -422,12 +422,13 @@ def test_ocr_payload_empty_and_error():
 
 def test_ocr_config_schema_exposes_only_operator_fields():
     """The config UI renders configSchema verbatim; expert TensorRT/DB knobs
-    live in config.yaml only, and no object-typed property may appear (the
-    frontend renders those as [object Object])."""
+    and the recognition-neutral `language` tag live in config.yaml only, and
+    no object-typed property may appear (the frontend renders those as
+    [object Object])."""
     from plugins.ocr import TOOLS
 
     schema = TOOLS[0]["configSchema"]
-    assert set(schema["properties"]) == {"language", "min_interval_ms"}
+    assert set(schema["properties"]) == {"min_interval_ms"}
     for name, spec in schema["properties"].items():
         assert spec["type"] != "object", name
     assert "required" not in schema

--- a/perception/tests/test_ocr_plugin.py
+++ b/perception/tests/test_ocr_plugin.py
@@ -1,0 +1,372 @@
+"""
+tests/test_ocr_plugin.py — OCR plugin lifecycle/concurrency tests (host-side).
+
+ROS stubs come from vision_stubs (installed by conftest before collection).
+Run: python -m pytest perception/tests -q
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+
+import pytest
+
+from vision_stubs import (  # noqa: F401
+    _FakeCompressedImage,
+    _FakeExecutor,
+    _FakeNode,
+    _FakeString,
+    _wait_until,
+)
+
+from utils.qos import CAMERA_QOS  # noqa: E402
+import plugins.ocr as ocr_plugin  # noqa: E402
+
+
+class _SlowOCRAdapter:
+    def __init__(self, delay=0.15):
+        self.delay = delay
+        self.seen = []
+        self.closed = False
+
+    def recognize(self, image_bytes: bytes, language: str = "zh") -> list:
+        self.seen.append(image_bytes)
+        time.sleep(self.delay)
+        return [{"text": image_bytes.decode(), "bbox": [0, 0, 1, 1], "score": 0.99}]
+
+    def close(self):
+        self.closed = True
+
+
+class _BuilderProbe:
+    """Counts _build_ocr_adapter calls; optional delay simulates the real
+    model download + TensorRT engine build."""
+
+    def __init__(self, delay=0.0):
+        self.delay = delay
+        self.calls = 0
+        self.built = []
+        self.lock = threading.Lock()
+
+    def __call__(self, cfg):
+        with self.lock:
+            self.calls += 1
+        if self.delay:
+            time.sleep(self.delay)
+        adapter = _SlowOCRAdapter(delay=0.01)
+        adapter.cfg = dict(cfg)
+        self.built.append(adapter)
+        return adapter
+
+
+def _make_plugin(monkeypatch, builder=None, cfg=None):
+    builder = builder or _BuilderProbe()
+    monkeypatch.setattr(ocr_plugin, "_build_ocr_adapter", builder)
+    executor = _FakeExecutor()
+    plugin = ocr_plugin.OCRPlugin(dict(cfg or {"provider": "rapidocr"}), executor)
+    return plugin, executor, builder
+
+
+def _start_and_wait(plugin, executor, topic, instance_id="", count=1):
+    args = {"action": "start", "input_topic": topic}
+    if instance_id:
+        args["instance_id"] = instance_id
+    plugin.dispatch("ocr", args)
+    # Registration now precedes start (README lifecycle rule), so a node can
+    # briefly sit in the executor as "idle"; wait for it to actually run.
+    assert _wait_until(
+        lambda: len(executor.nodes) >= count
+        and all(n.state == "running" for n in executor.nodes)
+    ), "node never came up"
+
+
+@pytest.fixture
+def ocr(monkeypatch):
+    plugin, executor, builder = _make_plugin(monkeypatch)
+    yield plugin, executor, builder
+    plugin.dispatch("ocr", {"action": "stop"})
+
+
+def test_ocr_camera_subscription_uses_shared_qos(ocr):
+    plugin, executor, _ = ocr
+    _start_and_wait(plugin, executor, "/cam/a")
+    node = executor.nodes[0]
+    assert node.subscriptions[0].qos is CAMERA_QOS
+
+
+def test_ocr_topic_change_disposes_old_node(ocr):
+    plugin, executor, _ = ocr
+    _start_and_wait(plugin, executor, "/cam/a", instance_id="x")
+    old = executor.nodes[0]
+    plugin.dispatch("ocr", {"action": "start", "input_topic": "/cam/b", "instance_id": "x"})
+    assert _wait_until(
+        lambda: executor.nodes and executor.nodes[-1].subscriptions
+        and executor.nodes[-1].subscriptions[0].topic == "/cam/b"
+    )
+    assert old not in executor.nodes and old.destroyed
+    assert len(executor.nodes) == 1
+
+
+def test_ocr_latest_frame_wins(ocr):
+    plugin, executor, builder = ocr
+    _start_and_wait(plugin, executor, "/cam/a")
+    node = executor.nodes[0]
+    adapter = builder.built[0]
+    callback = node.subscriptions[0].callback
+    callback(_FakeCompressedImage(b"f0"))
+    assert _wait_until(lambda: adapter.seen == [b"f0"])
+    for index in range(1, 6):
+        callback(_FakeCompressedImage(f"f{index}".encode()))
+    assert _wait_until(lambda: len(adapter.seen) >= 2)
+    time.sleep(0.2)
+    assert adapter.seen == [b"f0", b"f5"], adapter.seen
+    payload = json.loads(node.publishers[0].messages[-1])
+    assert payload["text"] == "f5"
+
+
+def test_ocr_stop_wakes_worker_promptly(ocr):
+    plugin, executor, _ = ocr
+    _start_and_wait(plugin, executor, "/cam/a")
+    node = executor.nodes[0]
+    started = time.monotonic()
+    node.stop()
+    assert time.monotonic() - started < 1.0  # no 1s poll timeout wait
+    assert not node.worker_alive
+
+
+# ── OCR start/stop/load state machine ────────────────────────────────────────
+
+def test_ocr_start_returns_loading_without_blocking(monkeypatch):
+    plugin, executor, builder = _make_plugin(monkeypatch, _BuilderProbe(delay=1.0))
+    started = time.monotonic()
+    result = plugin.dispatch("ocr", {"action": "start", "input_topic": "/cam/a"})
+    elapsed = time.monotonic() - started
+    assert elapsed < 0.1, f"start blocked for {elapsed:.3f}s"
+    assert result == {"state": "loading", "input": "/cam/a", "output": "/cam/a/ocr"}
+    assert _wait_until(lambda: len(executor.nodes) == 1)
+    plugin.dispatch("ocr", {"action": "stop"})
+
+
+def test_ocr_ten_concurrent_starts_single_flight(monkeypatch):
+    plugin, executor, builder = _make_plugin(monkeypatch, _BuilderProbe(delay=0.3))
+    results = []
+
+    def call(index):
+        results.append(plugin.dispatch("ocr", {
+            "action": "start",
+            "input_topic": f"/cam/{index}",
+            "instance_id": f"inst{index}",
+        }))
+
+    threads = [threading.Thread(target=call, args=(i,)) for i in range(10)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=2)
+    assert all(res["state"] == "loading" for res in results)
+    assert _wait_until(lambda: len(executor.nodes) == 10)
+    assert builder.calls == 1, "ten starts must share one model load"
+    plugin.dispatch("ocr", {"action": "stop"})
+
+
+def test_ocr_info_does_not_block_while_loading(monkeypatch):
+    plugin, executor, builder = _make_plugin(monkeypatch, _BuilderProbe(delay=0.8))
+    plugin.dispatch("ocr", {"action": "start", "input_topic": "/cam/a", "instance_id": "a"})
+    started = time.monotonic()
+    info = plugin.dispatch("ocr", {"action": "info"})
+    elapsed = time.monotonic() - started
+    assert elapsed < 0.1, f"info blocked for {elapsed:.3f}s"
+    assert info["state"] == "loading"
+    assert info["instances"]["a"]["state"] == "loading"
+    assert _wait_until(
+        lambda: plugin.dispatch("ocr", {"action": "info"})["state"] == "running"
+    )
+    plugin.dispatch("ocr", {"action": "stop"})
+
+
+def test_ocr_stop_during_loading_cancels_pending(monkeypatch):
+    plugin, executor, builder = _make_plugin(monkeypatch, _BuilderProbe(delay=0.3))
+    plugin.dispatch("ocr", {"action": "start", "input_topic": "/cam/a", "instance_id": "a"})
+    plugin.dispatch("ocr", {"action": "start", "input_topic": "/cam/b", "instance_id": "b"})
+    plugin.dispatch("ocr", {"action": "stop", "instance_id": "a"})
+    assert _wait_until(lambda: len(executor.nodes) == 1)
+    time.sleep(0.2)  # loader must not resurrect the stopped instance
+    assert len(executor.nodes) == 1
+    assert executor.nodes[0].subscriptions[0].topic == "/cam/b"
+    assert plugin.dispatch(
+        "ocr", {"action": "info", "instance_id": "a"}
+    )["state"] == "idle"
+    plugin.dispatch("ocr", {"action": "stop"})
+
+
+def test_ocr_config_during_loading_discards_stale_adapter(monkeypatch):
+    builder = _BuilderProbe(delay=0.3)
+    plugin, executor, _ = _make_plugin(
+        monkeypatch, builder, cfg={"provider": "rapidocr", "det_thresh": 0.3}
+    )
+    plugin.dispatch("ocr", {"action": "start", "input_topic": "/cam/a", "instance_id": "a"})
+    plugin.dispatch("ocr", {"action": "config", "det_thresh": 0.9})
+    assert _wait_until(lambda: len(executor.nodes) == 1, timeout=4)
+    assert builder.calls == 2, "config change during load must trigger a reload"
+    assert _wait_until(lambda: len(builder.built) == 2)
+    stale = next(a for a in builder.built if a.cfg["det_thresh"] == 0.3)
+    fresh = next(a for a in builder.built if a.cfg["det_thresh"] == 0.9)
+    assert _wait_until(lambda: stale.closed), "stale adapter must be closed"
+    assert plugin._adapter is fresh
+    plugin.dispatch("ocr", {"action": "stop"})
+
+
+def test_ocr_plain_stop_fully_disposes_node(ocr):
+    plugin, executor, _ = ocr
+    _start_and_wait(plugin, executor, "/cam/a", instance_id="a")
+    node = executor.nodes[0]
+    plugin.dispatch("ocr", {"action": "stop", "instance_id": "a"})
+    assert executor.nodes == []
+    assert node.destroyed
+    assert not node.worker_alive
+    assert plugin._nodes == {}
+
+
+def test_ocr_repeated_start_stop_does_not_grow(ocr):
+    plugin, executor, builder = ocr
+    for _ in range(20):
+        _start_and_wait(plugin, executor, "/cam/a", instance_id="a")
+        plugin.dispatch("ocr", {"action": "stop", "instance_id": "a"})
+    assert executor.nodes == []
+    assert builder.calls == 1, "adapter must be loaded once and cached"
+    assert threading.active_count() < 15
+    created = [n for n in _FakeNode.instances if n.subscriptions]
+    assert all(node.destroyed for node in created)
+
+
+def test_ocr_repeated_start_is_idempotent(ocr):
+    plugin, executor, _ = ocr
+    _start_and_wait(plugin, executor, "/cam/a", instance_id="a")
+    first = executor.nodes[0]
+    result = plugin.dispatch("ocr", {"action": "start", "input_topic": "/cam/a", "instance_id": "a"})
+    assert result["state"] == "running"
+    assert executor.nodes == [first]
+
+
+def test_ocr_stop_during_ready_path_start_leaves_no_orphan(monkeypatch):
+    """PR #113's orphan-node class: a stop racing a fast-path start must not
+    end with an invisible running node (stop must always see the instance in
+    _pending_starts or _nodes)."""
+    plugin, executor, builder = _make_plugin(monkeypatch)
+    _start_and_wait(plugin, executor, "/cam/a", instance_id="a")  # adapter ready
+
+    real_start = ocr_plugin._OCRNode.start
+
+    def slow_start(self, *a, **k):
+        time.sleep(0.2)
+        return real_start(self, *a, **k)
+
+    monkeypatch.setattr(ocr_plugin._OCRNode, "start", slow_start)
+    thread = threading.Thread(target=plugin.dispatch, args=(
+        "ocr", {"action": "start", "input_topic": "/cam/b", "instance_id": "b"}))
+    thread.start()
+    time.sleep(0.05)                       # start is inside node.start()
+    plugin.dispatch("ocr", {"action": "stop", "instance_id": "b"})
+    thread.join(timeout=3)
+    monkeypatch.setattr(ocr_plugin._OCRNode, "start", real_start)
+
+    assert "b" not in plugin._nodes
+    assert plugin.dispatch("ocr", {"action": "info", "instance_id": "b"})["state"] == "idle"
+    b_nodes = [n for n in _FakeNode.instances
+               if n.subscriptions and n.subscriptions[0].topic == "/cam/b"]
+    assert all(node.destroyed for node in b_nodes), "orphan node left running"
+    plugin.dispatch("ocr", {"action": "stop"})
+
+
+def test_ocr_info_desc_explains_loading_and_error(monkeypatch):
+    """desc carries the reason while loading / after failure, like ASR (#113)."""
+    builder = _BuilderProbe(delay=0.5)
+    plugin, executor, _ = _make_plugin(monkeypatch, builder)
+    plugin.dispatch("ocr", {"action": "start", "input_topic": "/cam/a", "instance_id": "a"})
+
+    info = plugin.dispatch("ocr", {"action": "info"})
+    assert info["state"] == "loading" and "Loading" in info["desc"]
+    inst = plugin.dispatch("ocr", {"action": "info", "instance_id": "a"})
+    assert "Loading" in inst["desc"]
+
+    assert _wait_until(
+        lambda: plugin.dispatch("ocr", {"action": "info"})["state"] == "running",
+        timeout=4,
+    )
+    ready = plugin.dispatch("ocr", {"action": "info"})
+    assert ready["state"] == "running" and ready["desc"] == plugin._DESC
+    plugin.dispatch("ocr", {"action": "stop"})
+
+
+def test_ocr_add_node_failure_leaks_nothing(monkeypatch):
+    """If executor.add_node raises during bring-up, the node must be
+    destroyed and untracked with no started worker (bot P1: a started but
+    unregistered worker would be unreachable forever)."""
+    plugin, executor, builder = _make_plugin(monkeypatch)
+
+    original_add = executor.add_node
+    calls = {"n": 0}
+
+    def flaky_add(node):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise RuntimeError("executor shutting down")
+        return original_add(node)
+
+    monkeypatch.setattr(executor, "add_node", flaky_add)
+    plugin.dispatch("ocr", {"action": "start", "input_topic": "/cam/a", "instance_id": "a"})
+    assert _wait_until(lambda: calls["n"] >= 1, timeout=4)
+    time.sleep(0.1)
+
+    assert "a" not in plugin._nodes
+    assert "a" not in plugin._pending_starts, "failed instance stuck as loading"
+    failed = [n for n in _FakeNode.instances
+              if n.subscriptions == [] or (n.subscriptions and n.subscriptions[0].topic == "/cam/a")]
+    assert all(n.destroyed for n in failed if not n.subscriptions), "unregistered node leaked"
+    # worker was never started on the failed node (register-before-start)
+    assert all(not n.subscriptions for n in _FakeNode.instances if n.destroyed)
+
+    # the plugin recovers: a later start succeeds
+    plugin.dispatch("ocr", {"action": "start", "input_topic": "/cam/a", "instance_id": "a"})
+    assert _wait_until(lambda: "a" in plugin._nodes, timeout=4)
+    plugin.dispatch("ocr", {"action": "stop"})
+
+
+def test_ocr_load_failure_reports_error_and_retries(monkeypatch):
+    calls = {"n": 0}
+
+    def flaky_builder(cfg):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise RuntimeError("download failed")
+        return _SlowOCRAdapter(delay=0.01)
+
+    monkeypatch.setattr(ocr_plugin, "_build_ocr_adapter", flaky_builder)
+    executor = _FakeExecutor()
+    plugin = ocr_plugin.OCRPlugin({"provider": "rapidocr"}, executor)
+    plugin.dispatch("ocr", {"action": "start", "input_topic": "/cam/a", "instance_id": "a"})
+    assert _wait_until(
+        lambda: plugin.dispatch("ocr", {"action": "info"})["state"] == "error"
+    )
+    info = plugin.dispatch("ocr", {"action": "info", "instance_id": "a"})
+    assert info["state"] == "error" and "download failed" in info.get("error", "")
+    # a later start retries the load and succeeds
+    plugin.dispatch("ocr", {"action": "start", "input_topic": "/cam/a", "instance_id": "a"})
+    assert _wait_until(
+        lambda: plugin.dispatch("ocr", {"action": "info"})["state"] == "running"
+    )
+    plugin.dispatch("ocr", {"action": "stop"})
+
+
+
+
+def test_ocr_model_dir_confined_to_models_tree(monkeypatch):
+    """MCP-supplied model_dir cannot point the root-run downloader outside
+    /models (bot P2): the wrapper rejects out-of-tree paths before download."""
+    import utils.model_downloader as md
+    with pytest.raises(ValueError):
+        md.ensure_ocr_model("/etc/cron.d")
+    with pytest.raises(ValueError):
+        md.ensure_ocr_model("/models/../root")

--- a/perception/tests/test_ocr_plugin.py
+++ b/perception/tests/test_ocr_plugin.py
@@ -370,3 +370,64 @@ def test_ocr_model_dir_confined_to_models_tree(monkeypatch):
         md.ensure_ocr_model("/etc/cron.d")
     with pytest.raises(ValueError):
         md.ensure_ocr_model("/models/../root")
+
+
+# ── result payload structure (LLM-consumable) ────────────────────────────────
+
+def test_ocr_payload_carries_size_and_hierarchy():
+    """Items gain height/prominence/line and the payload names its coordinate
+    frame, so an LLM consumer can tell a headline from fine print."""
+    from plugins.ocr_runtime import build_ocr_payload
+
+    items = [
+        {"text": "大标题", "bbox": [100, 40, 500, 120], "score": 0.99},   # h=80
+        {"text": "左栏", "bbox": [80, 300, 200, 340], "score": 0.95},     # h=40
+        {"text": "右栏", "bbox": [260, 305, 380, 335], "score": 0.94},    # 同一行
+        {"text": "小字注脚", "bbox": [90, 600, 220, 620], "score": 0.90}, # h=20
+    ]
+    payload = build_ocr_payload(items, 1.0, "zh", image_size=(640, 800))
+
+    assert payload["image_size"] == [640, 800]
+    heights = [item["height"] for item in payload["items"]]
+    assert heights == [80, 40, 30, 20]
+    assert payload["items"][0]["prominence"] == 1.0
+    assert payload["items"][3]["prominence"] == 0.25
+    # 同一水平带的两段并入一行，text 按行拼接
+    lines = [item["line"] for item in payload["items"]]
+    assert lines == [0, 1, 1, 2]
+    assert payload["text"] == "大标题\n左栏 右栏\n小字注脚"
+
+
+def test_ocr_payload_line_join_sorts_left_to_right():
+    from plugins.ocr_runtime import build_ocr_payload
+
+    items = [
+        {"text": "second", "bbox": [300, 10, 400, 50], "score": 0.9},
+        {"text": "first", "bbox": [10, 12, 120, 48], "score": 0.9},
+    ]
+    payload = build_ocr_payload(items, 0.0, "en")
+    assert payload["text"] == "first second"
+    assert "image_size" not in payload
+
+
+def test_ocr_payload_empty_and_error():
+    from plugins.ocr_runtime import build_ocr_payload
+
+    payload = build_ocr_payload([], 0.0, "zh", error=RuntimeError("boom"))
+    assert payload["text"] == "" and payload["items"] == []
+    assert payload["error"] == "boom"
+
+
+# ── config surface (培育→配置) ───────────────────────────────────────────────
+
+def test_ocr_config_schema_exposes_only_operator_fields():
+    """The config UI renders configSchema verbatim; expert TensorRT/DB knobs
+    live in config.yaml only, and no object-typed property may appear (the
+    frontend renders those as [object Object])."""
+    from plugins.ocr import TOOLS
+
+    schema = TOOLS[0]["configSchema"]
+    assert set(schema["properties"]) == {"language", "min_interval_ms"}
+    for name, spec in schema["properties"].items():
+        assert spec["type"] != "object", name
+    assert "required" not in schema

--- a/perception/tests/test_ocr_plugin.py
+++ b/perception/tests/test_ocr_plugin.py
@@ -432,3 +432,57 @@ def test_ocr_config_schema_exposes_only_operator_fields():
     for name, spec in schema["properties"].items():
         assert spec["type"] != "object", name
     assert "required" not in schema
+
+
+# ── node-level start/stop races (bot P1, 2026-08-22) ─────────────────────────
+
+def test_ocr_concurrent_starts_yield_exactly_one_worker(ocr):
+    """_OCRNode.start() is serialized by the node lock: N concurrent starts
+    on the same instance must produce one subscription and one live worker,
+    never overwrite each other's stop event / frame slot."""
+    plugin, executor, _ = ocr
+    _start_and_wait(plugin, executor, "/cam/a", instance_id="x")
+    node = executor.nodes[0]
+
+    barrier = threading.Barrier(8)
+    results = []
+
+    def racer():
+        barrier.wait()
+        results.append(
+            plugin.dispatch("ocr", {"action": "start", "input_topic": "/cam/a",
+                                    "instance_id": "x"})
+        )
+
+    threads = [threading.Thread(target=racer) for _ in range(8)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=5)
+    assert not any(thread.is_alive() for thread in threads)
+
+    assert len(executor.nodes) == 1 and executor.nodes[0] is node
+    assert len(node.subscriptions) == 1
+    live_workers = [t for t in node._worker_threads if t.is_alive()]
+    assert len(live_workers) == 1
+    assert all(r["state"] == "running" for r in results)
+
+    plugin.dispatch("ocr", {"action": "stop"})
+    assert _wait_until(lambda: not node.worker_alive)
+
+
+def test_ocr_start_on_retired_node_is_inert(ocr):
+    """A start that loses the race to stop must not touch the destroyed
+    node: retire() marks it dead under the node lock, and a late start()
+    reports idle without creating a subscription or worker."""
+    plugin, executor, _ = ocr
+    _start_and_wait(plugin, executor, "/cam/a", instance_id="x")
+    node = executor.nodes[0]
+    plugin.dispatch("ocr", {"action": "stop", "instance_id": "x"})
+    assert node.destroyed and node not in executor.nodes
+
+    subscriptions_before = len(node.subscriptions)
+    result = node.start()   # the in-flight start that lost the race
+    assert result["state"] == "idle"
+    assert len(node.subscriptions) == subscriptions_before
+    assert not node.worker_alive

--- a/perception/tests/test_shared_utils.py
+++ b/perception/tests/test_shared_utils.py
@@ -1,0 +1,585 @@
+"""
+Host-side unit tests for the shared perception utils (no Jetson required).
+
+Run from the repo root:
+    python -m pytest perception/tests -q
+
+`tensorrt` and `libcudart` are replaced by small fakes so the engine
+bookkeeping (profile selection, buffer growth, output ordering, close) and
+the verified-bundle downloader can be exercised anywhere.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import hashlib
+import os
+import sys
+import threading
+import time
+import types
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+PERCEPTION_ROOT = Path(__file__).resolve().parents[1]
+if str(PERCEPTION_ROOT) not in sys.path:
+    sys.path.insert(0, str(PERCEPTION_ROOT))
+
+from utils import model_downloader  # noqa: E402
+from utils.latest_frame import LatestFrame  # noqa: E402
+from utils import tensorrt_runtime as trt_rt  # noqa: E402
+
+
+# ── tensorrt_family ──────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize(
+    "version, family",
+    [("8.5.2.2", "jp511"), ("8.6.1", "jp511"), ("10.3.0", "jp61"), ("10.7.0.23", "jp61")],
+)
+def test_tensorrt_family_from_version(version, family):
+    assert trt_rt.tensorrt_family(version) == family
+
+
+@pytest.mark.parametrize("version", ["7.2.3", "9.0.0", "", "abc"])
+def test_tensorrt_family_rejects_unknown(version):
+    with pytest.raises(trt_rt.TensorRTError):
+        trt_rt.tensorrt_family(version)
+
+
+def test_normalize_family_aliases():
+    assert trt_rt.normalize_family("61") == "jp61"
+    assert trt_rt.normalize_family("JP511") == "jp511"
+    assert trt_rt.normalize_family("511") == "jp511"
+    assert trt_rt.normalize_family("bogus") is None
+    assert trt_rt.normalize_family(None) is None
+
+
+# ── read_engine_file ─────────────────────────────────────────────────────────
+
+def test_read_engine_file_strips_ultralytics_header(tmp_path):
+    payload = b"\x00\x01\x02engine-bytes"
+    meta = b'{"task": "segment", "names": {"0": "person"}}'
+    path = tmp_path / "x.engine"
+    path.write_bytes(len(meta).to_bytes(4, "little") + meta + payload)
+    metadata, serialized = trt_rt.read_engine_file(path)
+    assert metadata["task"] == "segment"
+    assert serialized == payload
+
+
+def test_read_engine_file_plain_engine(tmp_path):
+    payload = bytes(range(64))
+    path = tmp_path / "plain.engine"
+    path.write_bytes(payload)
+    metadata, serialized = trt_rt.read_engine_file(path)
+    assert metadata == {}
+    assert serialized == payload
+
+
+# ── fake TensorRT + CUDA ─────────────────────────────────────────────────────
+
+class _FakeDataType:
+    FLOAT, HALF, INT8, INT32, BOOL, UINT8 = range(6)
+
+
+class _FakeIOMode:
+    INPUT, OUTPUT = 0, 1
+
+
+class _FakeEngine:
+    """Single input "images" [-1,3,-1,-1] with two profiles, two outputs."""
+
+    def __init__(self, static=False):
+        self.static = static
+        self.num_io_tensors = 3
+        self.names = ["images", "out_a", "out_b"]
+        self.num_optimization_profiles = 2
+        self.profiles = [
+            ((1, 3, 32, 32), (1, 3, 64, 64), (4, 3, 128, 128)),
+            ((1, 3, 128, 128), (2, 3, 256, 256), (8, 3, 512, 512)),
+        ]
+
+    def get_tensor_name(self, i):
+        return self.names[i]
+
+    def get_tensor_mode(self, name):
+        return _FakeIOMode.INPUT if name == "images" else _FakeIOMode.OUTPUT
+
+    def get_tensor_dtype(self, name):
+        return {"images": _FakeDataType.FLOAT, "out_a": _FakeDataType.HALF,
+                "out_b": _FakeDataType.INT32}[name]
+
+    def get_tensor_shape(self, name):
+        if name == "images":
+            return (1, 3, 64, 64) if self.static else (-1, 3, -1, -1)
+        return (-1, 8) if name == "out_a" else (-1, 1)
+
+    def get_tensor_profile_shape(self, name, index):
+        return self.profiles[index]
+
+    def create_execution_context(self):
+        return _FakeContext(self)
+
+
+class _FakeContext:
+    def __init__(self, engine):
+        self.engine = engine
+        self.shape = None
+        self.profile = 0
+        self.addresses = {}
+        self.executions = 0
+        self.profile_switches = 0
+
+    def set_optimization_profile_async(self, index, stream):
+        self.profile = index
+        self.profile_switches += 1
+        return True
+
+    def set_input_shape(self, name, shape):
+        self.shape = tuple(shape)
+        return True
+
+    def get_tensor_shape(self, name):
+        if name == "images":
+            return self.shape
+        n = self.shape[0]
+        return (n, 8) if name == "out_a" else (n, 1)
+
+    def set_tensor_address(self, name, pointer):
+        self.addresses[name] = pointer
+
+    def execute_async_v3(self, stream):
+        self.executions += 1
+        return True
+
+
+class _FakeRuntime:
+    def __init__(self, logger):
+        pass
+
+    def deserialize_cuda_engine(self, data):
+        return _FakeEngine(static=(data == b"static"))
+
+
+class _FakeLogger:
+    WARNING = 1
+
+    def __init__(self, level):
+        pass
+
+
+def _install_fake_tensorrt(monkeypatch, version="8.5.2.2"):
+    module = types.ModuleType("tensorrt")
+    module.__version__ = version
+    module.DataType = _FakeDataType
+    module.TensorIOMode = _FakeIOMode
+    module.Runtime = _FakeRuntime
+    module.Logger = _FakeLogger
+    module.nptype = lambda dtype: np.float32
+    monkeypatch.setitem(sys.modules, "tensorrt", module)
+    return module
+
+
+class _FakeCudart:
+    """Records cudaMalloc/cudaFree so buffer growth and cleanup can be asserted."""
+
+    def __init__(self):
+        self.allocs = {}
+        self.freed = []
+        self.streams_created = 0
+        self.streams_destroyed = 0
+        self.copies = []
+        self._next = 0x1000
+
+    # ctypes-style attribute assignments must be accepted
+    class _Fn:
+        def __init__(self, impl):
+            self.impl = impl
+            self.argtypes = None
+            self.restype = None
+
+        def __call__(self, *args):
+            return self.impl(*args)
+
+    def __getattr__(self, name):
+        impl = getattr(self, "_" + name, None)
+        if impl is None:
+            raise AttributeError(name)
+        fn = _FakeCudart._Fn(impl)
+        setattr(self, name, fn)
+        return fn
+
+    def _cudaGetErrorString(self, code):
+        return b"fake error"
+
+    def _cudaSetDevice(self, device):
+        return 0
+
+    def _cudaStreamCreateWithFlags(self, ptr, flags):
+        self.streams_created += 1
+        ptr._obj.value = 0xBEEF
+        return 0
+
+    def _cudaStreamDestroy(self, stream):
+        self.streams_destroyed += 1
+        return 0
+
+    def _cudaStreamSynchronize(self, stream):
+        return 0
+
+    def _cudaMalloc(self, ptr, size):
+        pointer = self._next
+        self._next += 0x1000
+        self.allocs[pointer] = int(size.value if hasattr(size, "value") else size)
+        ptr._obj.value = pointer
+        return 0
+
+    def _cudaFree(self, pointer):
+        value = pointer.value if hasattr(pointer, "value") else pointer
+        self.freed.append(value)
+        return 0
+
+    def _cudaMemcpyAsync(self, dst, src, size, kind, stream):
+        self.copies.append(kind)
+        return 0
+
+
+@pytest.fixture
+def fake_cuda(monkeypatch):
+    fake = _FakeCudart()
+    monkeypatch.setattr(trt_rt.ctypes, "CDLL", lambda name: fake)
+    monkeypatch.setattr(trt_rt.ctypes.util, "find_library", lambda name: "libcudart.so")
+    return fake
+
+
+def test_engine_dynamic_profiles_and_buffer_growth(tmp_path, monkeypatch, fake_cuda):
+    _install_fake_tensorrt(monkeypatch)
+    path = tmp_path / "dyn.engine"
+    path.write_bytes(b"dynamic")
+    engine = trt_rt.TensorRTEngine(path)
+    assert engine.input_name == "images"
+    assert engine.output_names == ["out_a", "out_b"]
+    assert not engine.is_static
+    assert engine.input_shape is None
+    assert engine.optimization_shape == (1, 3, 64, 64)
+    assert engine.input_dtype == np.float32
+    assert engine.output_dtypes["out_a"] == np.float16
+
+    # profile 0 covers 64x64; profile 1 covers 256x256; nothing covers 1024.
+    assert engine.select_profile((1, 3, 64, 64)) == 0
+    assert engine.select_profile((2, 3, 256, 256)) == 1
+    with pytest.raises(trt_rt.TensorRTShapeError):
+        engine.select_profile((1, 3, 1024, 1024))
+
+    outputs = engine.infer(np.zeros((1, 3, 64, 64), dtype=np.uint8))
+    assert [o.shape for o in outputs] == [(1, 8), (1, 1)]
+    assert outputs[0].dtype == np.float16 and outputs[1].dtype == np.int32
+    allocs_after_first = dict(fake_cuda.allocs)
+    assert len(allocs_after_first) == 3  # input + 2 outputs
+
+    # Same shape again: no new allocations, no profile switch.
+    engine.infer(np.zeros((1, 3, 64, 64), dtype=np.float32))
+    assert fake_cuda.allocs == allocs_after_first
+    assert engine._context.profile_switches == 0
+
+    # Larger batch on the other profile: input buffer grows, old one freed.
+    outputs = engine.infer(np.zeros((3, 3, 256, 256), dtype=np.float32))
+    assert [o.shape for o in outputs] == [(3, 8), (3, 1)]
+    assert engine._context.profile == 1
+    assert len(fake_cuda.freed) >= 1
+
+    engine.close()
+    assert set(fake_cuda.freed) >= set(allocs_after_first)
+    assert fake_cuda.streams_destroyed == 1
+    with pytest.raises(trt_rt.TensorRTError):
+        engine.infer(np.zeros((1, 3, 64, 64), dtype=np.float32))
+    engine.close()  # idempotent
+
+
+def test_engine_static_shape(tmp_path, monkeypatch, fake_cuda):
+    _install_fake_tensorrt(monkeypatch, version="10.3.0")
+    path = tmp_path / "static.engine"
+    path.write_bytes(b"static")
+    engine = trt_rt.TensorRTEngine(path)
+    assert engine.is_static
+    assert engine.input_shape == (1, 3, 64, 64)
+    with pytest.raises(trt_rt.TensorRTShapeError):
+        engine.infer(np.zeros((1, 3, 32, 32), dtype=np.float32))
+    outputs = engine.infer(np.zeros((1, 3, 64, 64), dtype=np.float32))
+    assert len(outputs) == 2
+    engine.close()
+
+
+def test_engine_rejects_multi_input(tmp_path, monkeypatch, fake_cuda):
+    module = _install_fake_tensorrt(monkeypatch)
+
+    class TwoInputEngine(_FakeEngine):
+        def get_tensor_mode(self, name):
+            return _FakeIOMode.INPUT if name in ("images", "out_a") else _FakeIOMode.OUTPUT
+
+    monkeypatch.setattr(
+        module.Runtime, "deserialize_cuda_engine",
+        lambda self, data: TwoInputEngine(),
+    )
+    path = tmp_path / "two.engine"
+    path.write_bytes(b"x")
+    with pytest.raises(trt_rt.TensorRTError, match="exactly one input"):
+        trt_rt.TensorRTEngine(path)
+    # resources released even though construction failed
+    assert fake_cuda.streams_destroyed == fake_cuda.streams_created == 1
+
+
+def test_trt_dtype_to_numpy_without_nptype():
+    class DT:
+        FLOAT, HALF, INT8, INT32, BOOL, UINT8, INT64 = range(7)
+
+    module = types.SimpleNamespace(DataType=DT, nptype=lambda d: (_ for _ in ()).throw(AttributeError))
+    assert trt_rt.trt_dtype_to_numpy(module, DT.BOOL) == np.bool_
+    assert trt_rt.trt_dtype_to_numpy(module, DT.INT64) == np.int64
+    assert trt_rt.trt_dtype_to_numpy(module, DT.UINT8) == np.uint8
+
+
+# ── LatestFrame ──────────────────────────────────────────────────────────────
+
+def test_latest_frame_keeps_only_newest():
+    buffer = LatestFrame()
+    assert buffer.pop(timeout=0) is None
+    for index in range(10):
+        buffer.push(index)
+    assert buffer.pop(timeout=0) == 9
+    assert buffer.dropped == 9
+    assert buffer.pop(timeout=0) is None
+
+
+def test_latest_frame_wakes_waiter_and_close():
+    buffer = LatestFrame()
+    seen = []
+
+    def worker():
+        seen.append(buffer.pop(timeout=5))
+        seen.append(buffer.pop(timeout=5))
+
+    thread = threading.Thread(target=worker)
+    thread.start()
+    time.sleep(0.05)
+    buffer.push("frame")
+    time.sleep(0.05)
+    buffer.close()
+    thread.join(timeout=2)
+    assert not thread.is_alive()
+    assert seen == ["frame", None]
+    buffer.push("ignored")
+    assert buffer.pop(timeout=0) is None and buffer.closed
+
+
+# ── model_downloader verified bundles ────────────────────────────────────────
+
+def _manifest(payloads: dict[str, bytes]) -> dict:
+    return {
+        name: {"size": len(data), "sha256": hashlib.sha256(data).hexdigest()}
+        for name, data in payloads.items()
+    }
+
+
+class _FakeResponse:
+    def __init__(self, data):
+        self._data = data
+        self._offset = 0
+
+    def read(self, size):
+        chunk = self._data[self._offset : self._offset + size]
+        self._offset += size
+        return chunk
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+def _serve(monkeypatch, payloads: dict[str, bytes], calls: list):
+    def fake_urlopen(url, timeout=0):
+        calls.append(url)
+        name = url.rsplit("/", 1)[1]
+        return _FakeResponse(payloads[name])
+
+    monkeypatch.setattr(model_downloader, "urlopen", fake_urlopen)
+    monkeypatch.setattr(model_downloader.time, "sleep", lambda s: None)
+
+
+def test_bundle_matches_requires_size_and_sha(tmp_path):
+    payloads = {"det.engine": b"detector", "keys.txt": b"a\nb\n"}
+    manifest = _manifest(payloads)
+    for name, data in payloads.items():
+        (tmp_path / name).write_bytes(data)
+    assert model_downloader._bundle_matches(str(tmp_path), manifest)
+
+    # non-empty but truncated file must NOT count as a valid cache
+    (tmp_path / "det.engine").write_bytes(b"det")
+    assert not model_downloader._bundle_matches(str(tmp_path), manifest)
+    # same size, different content
+    (tmp_path / "det.engine").write_bytes(b"detectoX")
+    assert not model_downloader._bundle_matches(str(tmp_path), manifest)
+
+
+def test_ensure_verified_bundle_downloads_repairs_and_reuses(tmp_path, monkeypatch):
+    payloads = {"det.engine": b"detector-bytes", "keys.txt": b"a\nb\n"}
+    manifest = _manifest(payloads)
+    calls: list[str] = []
+    _serve(monkeypatch, payloads, calls)
+    model_dir = tmp_path / "ocr"
+
+    paths = model_downloader.ensure_verified_bundle(
+        "ocr/jp511", str(model_dir), "https://example/base/", manifest
+    )
+    assert set(paths) == set(payloads)
+    assert (model_dir / "det.engine").read_bytes() == payloads["det.engine"]
+    assert calls == ["https://example/base/det.engine", "https://example/base/keys.txt"]
+    assert not [p for p in model_dir.iterdir() if p.name.startswith(".ocr") and p.is_dir()]
+
+    # valid cache → no network
+    calls.clear()
+    model_downloader.ensure_verified_bundle(
+        "ocr/jp511", str(model_dir), "https://example/base/", manifest
+    )
+    assert calls == []
+
+    # corrupted engine (nonempty, wrong hash) → re-downloaded
+    (model_dir / "det.engine").write_bytes(b"detector-bytes"[:-1] + b"X")
+    model_downloader.ensure_verified_bundle(
+        "ocr/jp511", str(model_dir), "https://example/base/", manifest
+    )
+    assert calls  # network used
+    assert (model_dir / "det.engine").read_bytes() == payloads["det.engine"]
+
+
+def test_ensure_verified_bundle_retries_then_fails(tmp_path, monkeypatch):
+    payloads = {"det.engine": b"detector-bytes"}
+    manifest = _manifest(payloads)
+    calls: list[str] = []
+    _serve(monkeypatch, {"det.engine": b"garbage"}, calls)  # never matches sha
+    with pytest.raises(RuntimeError, match="failed to download det.engine"):
+        model_downloader.ensure_verified_bundle(
+            "ocr/jp511", str(tmp_path / "m"), "https://example/base", manifest
+        )
+    assert len(calls) == 3
+    assert not (tmp_path / "m" / "det.engine").exists()
+
+
+def test_select_bundle_family(tmp_path, monkeypatch):
+    bundles = {
+        "jp511": {"base_url": "https://x/jp511", "files": {}},
+        "jp61": {"base_url": "https://x/jp61", "files": {}},
+    }
+
+    # explicit override wins and accepts aliases
+    assert model_downloader.select_bundle_family(bundles, family="61") == "jp61"
+    assert model_downloader.select_bundle_family(bundles, family="JP511") == "jp511"
+
+    # runtime TensorRT decides otherwise
+    _install_fake_tensorrt(monkeypatch, version="8.5.2.2")
+    assert model_downloader.select_bundle_family(bundles) == "jp511"
+    _install_fake_tensorrt(monkeypatch, version="10.3.0")
+    assert model_downloader.select_bundle_family(bundles) == "jp61"
+
+    # unknown alias / missing family raise
+    with pytest.raises(ValueError):
+        model_downloader.select_bundle_family(bundles, family="jp7")
+    with pytest.raises(RuntimeError):
+        model_downloader.select_bundle_family({"jp61": bundles["jp61"]}, family="511")
+
+
+# ── SampledLogGate ───────────────────────────────────────────────────────────
+
+def test_sampled_log_gate_transitions_and_sampling():
+    from utils.log_sampling import SampledLogGate
+
+    gate = SampledLogGate(every=100)
+    # first occurrence logs, and is a transition
+    assert gate.check("ok") == (True, True, 1)
+    # steady state: 2..99 stay quiet, 100th logs
+    decisions = [gate.check("ok") for _ in range(2, 101)]
+    assert all(not d[0] for d in decisions[:-1])
+    assert decisions[-1] == (True, False, 100)
+    # outcome change logs immediately regardless of counters
+    assert gate.check("error:Timeout") == (True, True, 1)
+    # flapping back is a transition again
+    assert gate.check("ok") == (True, True, 1)
+
+
+def test_escape_log_text_caps_and_escapes():
+    from utils.log_sampling import escape_log_text
+
+    assert escape_log_text("plain error") == "plain error"
+    # control characters and ANSI escapes become visible escapes
+    assert escape_log_text("bad\x00\x1b[31mvalue\n") == "bad\\x00\\x1b[31mvalue\\n"
+    # long values are capped
+    out = escape_log_text("x" * 500, cap=200)
+    assert len(out) == 203 and out.endswith("...")
+
+
+def test_engine_close_waits_for_inflight_infer(monkeypatch, tmp_path):
+    """close() must synchronize with infer(): freeing CUDA buffers under an
+    in-flight execution is a use-after-free (bot P1). close() blocks until the
+    running infer finishes; a later infer raises cleanly."""
+    import threading, time
+    _install_fake_tensorrt(monkeypatch)
+    fake_cudart = _FakeCudart()
+    monkeypatch.setattr(trt_rt.ctypes, "CDLL", lambda name: fake_cudart)
+    monkeypatch.setattr(trt_rt.ctypes.util, "find_library", lambda name: "libcudart.so")
+
+    engine_path = tmp_path / "e.engine"
+    engine_path.write_bytes(b"static")
+    engine = trt_rt.TensorRTEngine(str(engine_path))
+
+    entered = threading.Event()
+    release = threading.Event()
+    def slow_execute(*a, **k):
+        entered.set()
+        release.wait(timeout=5)
+        return True
+
+    monkeypatch.setattr(engine._context, "execute_async_v3", slow_execute)
+
+    freed_during_infer = []
+    worker_error = []
+
+    def run_infer():
+        try:
+            engine.infer(np.zeros((1, 3, 64, 64), dtype=np.float32))
+        except Exception as error:  # noqa: BLE001
+            worker_error.append(error)
+
+    t1 = threading.Thread(target=run_infer)
+    t1.start()
+    assert entered.wait(timeout=5), "infer never reached execution"
+
+    closer = threading.Thread(target=engine.close)
+    closer.start()
+    time.sleep(0.2)
+    # close must NOT have freed anything while infer is still executing
+    freed_during_infer = list(fake_cudart.freed)
+    assert not freed_during_infer, "CUDA buffers freed under in-flight infer"
+    assert closer.is_alive(), "close() returned while infer was executing"
+
+    release.set()
+    t1.join(timeout=5)
+    closer.join(timeout=5)
+    assert not closer.is_alive()
+    assert fake_cudart.freed, "buffers were never freed after close"
+
+    with pytest.raises(trt_rt.TensorRTError):
+        engine.infer(np.zeros((1, 3, 64, 64), dtype=np.float32))
+
+
+def test_require_models_subpath():
+    from utils.model_downloader import require_models_subpath
+
+    assert require_models_subpath("/models/ocr/x") == "/models/ocr/x"
+    assert require_models_subpath("/models") == "/models"
+    # traversal and out-of-tree paths are rejected
+    for bad in ("/etc/cron.d", "/models/../etc", "relative/dir", "/modelsevil"):
+        with pytest.raises(ValueError):
+            require_models_subpath(bad)

--- a/perception/tests/test_shared_utils.py
+++ b/perception/tests/test_shared_utils.py
@@ -583,3 +583,34 @@ def test_require_models_subpath():
     for bad in ("/etc/cron.d", "/models/../etc", "relative/dir", "/modelsevil"):
         with pytest.raises(ValueError):
             require_models_subpath(bad)
+
+
+def test_require_models_subpath_rejects_symlink_escape(tmp_path):
+    """A lexical check passes /models/link while link points outside the tree;
+    every later makedirs/open/replace would follow it as root."""
+    from utils.model_downloader import require_models_subpath
+
+    root = tmp_path / "models"
+    root.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+
+    # symlinked directory inside the tree
+    (root / "link").symlink_to(outside)
+    with pytest.raises(ValueError):
+        require_models_subpath(str(root / "link"), root=str(root))
+    # and a not-yet-created child under that symlink
+    with pytest.raises(ValueError):
+        require_models_subpath(str(root / "link" / "bundle"), root=str(root))
+
+    # a symlink that stays inside the tree is still allowed
+    (root / "inner").mkdir()
+    (root / "alias").symlink_to(root / "inner")
+    assert require_models_subpath(str(root / "alias"), root=str(root)) == str(
+        (root / "inner").resolve()
+    )
+
+    # plain paths, existing or not, keep working
+    assert require_models_subpath(str(root / "new" / "bundle"), root=str(root)) == str(
+        root.resolve() / "new" / "bundle"
+    )

--- a/perception/tests/vision_stubs.py
+++ b/perception/tests/vision_stubs.py
@@ -1,0 +1,134 @@
+"""
+tests/vision_stubs.py — Shared fakes for vision-plugin unit tests.
+
+Importing this module installs fake rclpy / sensor_msgs / std_msgs modules
+into sys.modules (so plugin modules import cleanly off-robot) and puts the
+perception root on sys.path. test_ocr_plugin.py and test_obstacle_plugin.py
+both import from here; conftest.py imports it first so the stubs are in place
+before any plugin module is imported.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import threading
+import time
+import types
+from pathlib import Path
+
+import pytest
+
+PERCEPTION_ROOT = Path(__file__).resolve().parents[1]
+if str(PERCEPTION_ROOT) not in sys.path:
+    sys.path.insert(0, str(PERCEPTION_ROOT))
+
+
+# ── fake ROS ─────────────────────────────────────────────────────────────────
+
+class _FakePublisher:
+    def __init__(self, topic):
+        self.topic = topic
+        self.messages = []
+
+    def publish(self, msg):
+        self.messages.append(msg.data)
+
+
+class _FakeSubscription:
+    def __init__(self, topic, callback, qos):
+        self.topic = topic
+        self.callback = callback
+        self.qos = qos
+
+
+class _FakeNode:
+    instances: list = []
+
+    def __init__(self, name):
+        self._name = name
+        self.publishers = []
+        self.subscriptions = []
+        self.destroyed = False
+        _FakeNode.instances.append(self)
+
+    def get_name(self):
+        return self._name
+
+    def create_publisher(self, msg_type, topic, qos):
+        publisher = _FakePublisher(topic)
+        self.publishers.append(publisher)
+        return publisher
+
+    def create_subscription(self, msg_type, topic, callback, qos):
+        subscription = _FakeSubscription(topic, callback, qos)
+        self.subscriptions.append(subscription)
+        return subscription
+
+    def destroy_node(self):
+        self.destroyed = True
+
+
+class _FakeExecutor:
+    def __init__(self):
+        self.nodes = []
+
+    def add_node(self, node):
+        self.nodes.append(node)
+
+    def remove_node(self, node):
+        self.nodes.remove(node)
+
+
+class _FakeString:
+    def __init__(self):
+        self.data = ""
+
+
+class _FakeCompressedImage:
+    def __init__(self, data: bytes, fmt="jpeg"):
+        self.data = data
+        self.format = fmt
+
+
+def _install_fake_ros():
+    rclpy = types.ModuleType("rclpy")
+    node_mod = types.ModuleType("rclpy.node")
+    node_mod.Node = _FakeNode
+    qos_mod = types.ModuleType("rclpy.qos")
+
+    class QoSProfile:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+
+        def __eq__(self, other):
+            return isinstance(other, QoSProfile) and self.__dict__ == other.__dict__
+
+    qos_mod.QoSProfile = QoSProfile
+    qos_mod.ReliabilityPolicy = types.SimpleNamespace(BEST_EFFORT="best_effort", RELIABLE="reliable")
+    qos_mod.HistoryPolicy = types.SimpleNamespace(KEEP_LAST="keep_last", KEEP_ALL="keep_all")
+    qos_mod.DurabilityPolicy = types.SimpleNamespace(VOLATILE="volatile", TRANSIENT_LOCAL="tl")
+    sensor_msgs = types.ModuleType("sensor_msgs")
+    sensor_msgs_msg = types.ModuleType("sensor_msgs.msg")
+    sensor_msgs_msg.CompressedImage = _FakeCompressedImage
+    std_msgs = types.ModuleType("std_msgs")
+    std_msgs_msg = types.ModuleType("std_msgs.msg")
+    std_msgs_msg.String = _FakeString
+    for name, module in {
+        "rclpy": rclpy, "rclpy.node": node_mod, "rclpy.qos": qos_mod,
+        "sensor_msgs": sensor_msgs, "sensor_msgs.msg": sensor_msgs_msg,
+        "std_msgs": std_msgs, "std_msgs.msg": std_msgs_msg,
+    }.items():
+        sys.modules[name] = module
+
+
+_install_fake_ros()
+
+
+def _wait_until(predicate, timeout=3.0):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.01)
+    return predicate()

--- a/perception/utils/latest_frame.py
+++ b/perception/utils/latest_frame.py
@@ -1,0 +1,82 @@
+"""
+utils/latest_frame.py — Single-slot "latest frame wins" buffer.
+
+Real-time vision plugins must not accumulate sensor history: when the
+inference worker is slower than the camera, every frame that arrives while
+the worker is busy replaces the previous one, and the worker always picks
+up the newest frame. Replaces the `queue.Queue(maxsize=N)` + drop-oldest
+juggling in the ROS callbacks.
+
+    camera callback → LatestFrame.push(frame)     (overwrites, never blocks)
+    worker loop     → LatestFrame.pop(timeout)    (newest frame or None)
+    stop()          → LatestFrame.close()          (wakes the worker, pop → None)
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Generic, Optional, TypeVar
+
+T = TypeVar("T")
+
+
+class LatestFrame(Generic[T]):
+    """Thread-safe single-slot buffer where push() overwrites the pending frame."""
+
+    def __init__(self) -> None:
+        self._cond = threading.Condition()
+        self._frame: Optional[T] = None
+        self._has_frame = False
+        self._closed = False
+        self._dropped = 0
+
+    def push(self, frame: T) -> None:
+        """Store `frame`, replacing any frame not yet consumed. Never blocks."""
+        with self._cond:
+            if self._closed:
+                return
+            if self._has_frame:
+                self._dropped += 1
+            self._frame = frame
+            self._has_frame = True
+            self._cond.notify()
+
+    def pop(self, timeout: Optional[float] = None) -> Optional[T]:
+        """Return the newest frame, waiting up to `timeout` seconds.
+
+        Returns None on timeout or once the buffer is closed.
+        """
+        with self._cond:
+            if not self._has_frame and not self._closed:
+                self._cond.wait(timeout)
+            if not self._has_frame:
+                return None
+            frame = self._frame
+            self._frame = None
+            self._has_frame = False
+            return frame
+
+    def clear(self) -> None:
+        with self._cond:
+            self._frame = None
+            self._has_frame = False
+
+    def close(self) -> None:
+        """Discard the pending frame and wake every waiter; pop() returns None."""
+        with self._cond:
+            self._closed = True
+            self._frame = None
+            self._has_frame = False
+            self._cond.notify_all()
+
+    @property
+    def closed(self) -> bool:
+        return self._closed
+
+    @property
+    def dropped(self) -> int:
+        """Number of frames overwritten before being consumed (diagnostics)."""
+        return self._dropped
+
+
+__all__ = ["LatestFrame"]

--- a/perception/utils/log_sampling.py
+++ b/perception/utils/log_sampling.py
@@ -1,0 +1,53 @@
+"""
+utils/log_sampling.py — Transition-plus-sampling gate for hot-path logs.
+
+Vision plugins process frames at camera rate; logging every result floods the
+container logs (and with docker's json driver, dominates CPU). The repo rule
+is: log state *transitions* unthrottled, and within a steady state log only a
+sample (the first occurrence and every Nth thereafter).
+"""
+
+from __future__ import annotations
+
+
+class SampledLogGate:
+    """Decide whether a hot-path event is worth a log line.
+
+    check(outcome) returns (should_log, is_transition, occurrence):
+    - is_transition: outcome differs from the previous call — always loggable,
+      callers may attach detail (e.g. a traceback) only here.
+    - occurrence: 1-based count of consecutive same-outcome events; sampling
+      passes the first and every `every`-th.
+    """
+
+    def __init__(self, every: int = 100):
+        self.every = max(1, int(every))
+        self._outcome: str | None = None
+        self._count = 0
+
+    def check(self, outcome: str) -> tuple[bool, bool, int]:
+        transition = outcome != self._outcome
+        if transition:
+            self._outcome = outcome
+            self._count = 1
+        else:
+            self._count += 1
+        should = transition or self._count % self.every == 0
+        return should, transition, self._count
+
+
+def escape_log_text(value: object, cap: int = 200) -> str:
+    """Render externally-influenced text safe for a single log line.
+
+    Error strings derived from remotely supplied payloads (camera frames,
+    decoder output) may contain control characters or be arbitrarily long;
+    both corrupt or bloat the container log stream. Escape C0/ANSI bytes and
+    cap the length before logging.
+    """
+    text = str(value).encode("unicode_escape").decode("ascii")
+    if len(text) > cap:
+        return text[:cap] + "..."
+    return text
+
+
+__all__ = ["SampledLogGate", "escape_log_text"]

--- a/perception/utils/model_downloader.py
+++ b/perception/utils/model_downloader.py
@@ -370,3 +370,69 @@ def _download_verified_bundle(
                 os.path.join(model_dir, filename),
             )
     log.info(f"[model_downloader] {name}: verified bundle ready at {model_dir}")
+
+
+# ── OCR (PP-OCRv6 small, TensorRT engines; one bundle per JetPack family) ──
+# The engines are built per TensorRT major and are not portable, so the
+# bundle is chosen from the TensorRT that is importable at runtime. Only the
+# base URL is provenance-specific: switching the distribution host (e.g. to
+# COS) means changing OCR_MODEL_BASE only.
+OCR_MODEL_BASE = os.environ.get(
+    "OCR_MODEL_BASE_URL",
+    "https://www.modelscope.cn/models/Flame4pd/"
+    "ppocrv6-small-edge-ocr/resolve/"
+    "0301e9299b3abe09c6a60796d7bed74c23fcc525",
+)
+_OCR_KEYS = {
+    "size": 74947,
+    "sha256": "b5f2bfe2bdd9448429e3e82b51c789775d9b42f2403d082b00662eb77e401c5d",
+}
+OCR_MODEL_BUNDLES = {
+    "jp61": {
+        "base_url": f"{OCR_MODEL_BASE}/tensorrt-jp6-trt10.4-orin-batch8-cls8",
+        "files": {
+            "det.engine": {
+                "size": 11194324,
+                "sha256": "3b36aae43b2cc4a1b1e2d74d846a1319b4b6f42fbc6d97747d8d72e12c74a1ef",
+            },
+            "rec.engine": {
+                "size": 23303292,
+                "sha256": "8149fa68d5418f2c0763b8c4e5088987cb679a407317c7510f88ab6de38dd641",
+            },
+            "cls.engine": {
+                "size": 1046484,
+                "sha256": "148a6895260d3b6b6f86e0c5787121fc1bba316f3427397f654421196c13cb77",
+            },
+            "keys.txt": _OCR_KEYS,
+        },
+    },
+    "jp511": {
+        "base_url": f"{OCR_MODEL_BASE}/tensorrt-jp511-trt8.5-orin-batch8-cls8",
+        "files": {
+            "det.engine": {
+                "size": 12334256,
+                "sha256": "1bb32a027e93b06d5319ac61e38bb3e447137b01465eacefa7a652f58130ebdf",
+            },
+            "rec.engine": {
+                "size": 19915466,
+                "sha256": "1e204f0469beba33d8590b29c06419cf1073d98d41243b5ee316d2f877340b61",
+            },
+            "cls.engine": {
+                "size": 1038858,
+                "sha256": "02c722e56e621b56a36678cc8aa124a31b41e9e3c9ca350b11e4de0d5bbd0a35",
+            },
+            "keys.txt": _OCR_KEYS,
+        },
+    },
+}
+
+
+def ensure_ocr_model(model_dir: str, family: str | None = None) -> dict[str, str]:
+    """Ensure the OCR TensorRT bundle matching the runtime TensorRT is present."""
+    model_dir = require_models_subpath(model_dir)
+    key = select_bundle_family(OCR_MODEL_BUNDLES, family)
+    entry = OCR_MODEL_BUNDLES[key]
+    log.info(f"[model_downloader] ocr: using {key} bundle")
+    return ensure_verified_bundle(
+        f"ocr/{key}", model_dir, entry["base_url"], entry["files"]
+    )

--- a/perception/utils/model_downloader.py
+++ b/perception/utils/model_downloader.py
@@ -4,12 +4,20 @@ utils/model_downloader.py — Auto-download sherpa-onnx models from COS if missi
 
 from __future__ import annotations
 
+import hashlib
 import logging
 import os
 import tarfile
 import tempfile
+import time
 import zipfile
-from urllib.request import urlretrieve
+from urllib.error import URLError
+from urllib.request import urlopen, urlretrieve
+
+try:  # Linux only; the perception images are Linux, dev hosts may not be.
+    import fcntl
+except ImportError:  # pragma: no cover - Windows/macOS dev hosts
+    fcntl = None
 
 log = logging.getLogger(__name__)
 
@@ -186,3 +194,179 @@ def _common_prefix_from_names(names: list[str]) -> str:
     if len(first_parts) == 1:
         return first_parts.pop() + "/"
     return ""
+
+
+# ── Verified bundles (OCR / obstacle TensorRT artefacts) ─────────────────────
+# Pure additions consumed by the vision plugins' thin wrappers. The legacy
+# ensure_model() above (sherpa-onnx archives, X-ASR) is intentionally left
+# untouched. Every file in a verified bundle carries a pinned size and SHA256:
+# existing files are re-verified before reuse, downloads are staged next to
+# the destination, verified, and only then moved into place. Concurrent
+# instances sharing /models serialize on a per-bundle file lock. Entries that
+# ship one bundle per JetPack family use {"jp511": {...}, "jp61": {...}} keys
+# selected by the TensorRT that is actually importable
+# (see utils.tensorrt_runtime).
+
+
+MODELS_ROOT = "/models"
+
+
+def require_models_subpath(path: str, root: str = MODELS_ROOT) -> str:
+    """Validate that a caller-supplied model_dir stays inside the models tree.
+
+    model_dir is accepted over MCP config, and the downloader runs as root in
+    the container — an unchecked value would let a caller create or overwrite
+    files at arbitrary container paths. Returns the normalized absolute path.
+    """
+    normalized = os.path.normpath(os.path.join("/", str(path)))
+    root_norm = os.path.normpath(root)
+    if normalized != root_norm and not normalized.startswith(root_norm + os.sep):
+        raise ValueError(
+            f"model_dir must be under {root_norm}/: got {path!r}"
+        )
+    return normalized
+
+
+def select_bundle_family(bundles: dict, family: str | None = None) -> str:
+    """Pick the bundle key ("jp511"/"jp61") for the runtime TensorRT.
+
+    An explicit ``family`` (or alias such as "61"/"511") wins; otherwise the
+    family is derived from the importable TensorRT major version. Never
+    depends on a Docker build argument or image ENV.
+    """
+    from utils.tensorrt_runtime import normalize_family, tensorrt_family
+
+    if family is not None:
+        key = normalize_family(family)
+        if key is None:
+            raise ValueError(f"Unknown model bundle family: {family!r}")
+    else:
+        key = tensorrt_family()
+    if key not in bundles:
+        raise RuntimeError(
+            f"No model bundle for TensorRT family {key}; available: {sorted(bundles)}"
+        )
+    return key
+
+
+def ensure_verified_bundle(
+    name: str, model_dir: str, base_url: str, files: dict
+) -> dict[str, str]:
+    """Ensure a size/SHA256-pinned bundle is present and valid in model_dir.
+
+    existing files → size check → SHA256 check → reuse
+    otherwise      → lock → re-check → download (retry) → verify → replace
+    Returns ``{filename: absolute path}``.
+    """
+    paths = {
+        filename: os.path.join(model_dir, filename) for filename in files
+    }
+    if _bundle_matches(model_dir, files):
+        log.info(f"[model_downloader] {name}: verified bundle already at {model_dir}")
+        return paths
+
+    os.makedirs(model_dir, exist_ok=True)
+    # Platform instances share /models. Serialize the download so a cold
+    # multi-instance launch fetches one copy instead of one per process; a
+    # waiter re-checks the bundle once it gets the lock.
+    lock_path = os.path.join(model_dir, f".{name.replace('/', '_')}.lock")
+    with open(lock_path, "a+b") as lock_file:
+        if fcntl is not None:
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+        try:
+            if _bundle_matches(model_dir, files):
+                log.info(f"[model_downloader] {name}: verified by another instance")
+                return paths
+            _download_verified_bundle(name, base_url, model_dir, files)
+        finally:
+            if fcntl is not None:
+                fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+    return paths
+
+
+def _file_matches(path: str, metadata: dict) -> bool:
+    """Return whether one file exists and matches its pinned size and SHA256."""
+    try:
+        if not os.path.isfile(path):
+            return False
+        _verify_pinned_file(path, metadata)
+    except (OSError, ValueError):
+        return False
+    return True
+
+
+def _bundle_matches(model_dir: str, files: dict) -> bool:
+    """Return whether every bundle file matches its pinned size and SHA256."""
+    return all(
+        _file_matches(os.path.join(model_dir, filename), metadata)
+        for filename, metadata in files.items()
+    )
+
+
+def _verify_pinned_file(path: str, metadata: dict) -> None:
+    actual_size = os.path.getsize(path)
+    if actual_size != metadata["size"]:
+        raise ValueError(
+            f"size mismatch for {os.path.basename(path)}: "
+            f"expected {metadata['size']}, got {actual_size}"
+        )
+
+    digest = hashlib.sha256()
+    with open(path, "rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    actual_sha256 = digest.hexdigest()
+    if actual_sha256 != metadata["sha256"]:
+        raise ValueError(
+            f"SHA256 mismatch for {os.path.basename(path)}: "
+            f"expected {metadata['sha256']}, got {actual_sha256}"
+        )
+
+
+def _download_verified_bundle(
+    name: str, base_url: str, model_dir: str, files: dict
+) -> None:
+    """Download and verify a multi-file model before replacing its destination."""
+    os.makedirs(model_dir, exist_ok=True)
+    staging_prefix = f".{name.replace('/', '_')}-"
+    with tempfile.TemporaryDirectory(prefix=staging_prefix, dir=model_dir) as staging:
+        for filename, metadata in files.items():
+            if os.path.basename(filename) != filename:
+                raise ValueError(f"Invalid model filename: {filename}")
+            url = f"{base_url.rstrip('/')}/{filename}"
+            destination = os.path.join(staging, filename)
+            last_error = None
+            for attempt in range(1, 4):
+                try:
+                    log.info(
+                        f"[model_downloader] {name}: downloading {filename} "
+                        f"(attempt {attempt}/3)"
+                    )
+                    with urlopen(url, timeout=120) as response, open(destination, "wb") as output:
+                        while True:
+                            chunk = response.read(1024 * 1024)
+                            if not chunk:
+                                break
+                            output.write(chunk)
+                        output.flush()
+                        os.fsync(output.fileno())
+                    _verify_pinned_file(destination, metadata)
+                    os.chmod(destination, 0o644)
+                    break
+                except (URLError, TimeoutError, OSError, ValueError) as error:
+                    last_error = error
+                    if os.path.exists(destination):
+                        os.unlink(destination)
+                    if attempt < 3:
+                        time.sleep(3)
+            else:
+                raise RuntimeError(
+                    f"[model_downloader] {name}: failed to download {filename}"
+                ) from last_error
+
+        for filename in files:
+            os.replace(
+                os.path.join(staging, filename),
+                os.path.join(model_dir, filename),
+            )
+    log.info(f"[model_downloader] {name}: verified bundle ready at {model_dir}")

--- a/perception/utils/model_downloader.py
+++ b/perception/utils/model_downloader.py
@@ -214,17 +214,36 @@ MODELS_ROOT = "/models"
 def require_models_subpath(path: str, root: str = MODELS_ROOT) -> str:
     """Validate that a caller-supplied model_dir stays inside the models tree.
 
-    model_dir is accepted over MCP config, and the downloader runs as root in
-    the container — an unchecked value would let a caller create or overwrite
-    files at arbitrary container paths. Returns the normalized absolute path.
+    model_dir is accepted over MCP config and the downloader runs as root in
+    the container, so an unchecked value would let a caller create or
+    overwrite files at arbitrary container paths.
+
+    A lexical check is not enough: ``/models/link`` passes it while ``link``
+    is a symlink pointing outside the tree, and every later makedirs/open/
+    os.replace would follow it. Resolve symlinks on both sides — for the
+    deepest component that exists, since the target directory is usually
+    created later — and compare the resolved paths. Returns the resolved
+    absolute path, which callers must use for all filesystem work.
     """
-    normalized = os.path.normpath(os.path.join("/", str(path)))
-    root_norm = os.path.normpath(root)
-    if normalized != root_norm and not normalized.startswith(root_norm + os.sep):
+    candidate = os.path.normpath(os.path.join("/", str(path)))
+    root_real = os.path.realpath(root)
+
+    # Resolve the longest existing prefix, then re-attach the missing tail:
+    # realpath() on a not-yet-created directory cannot detect a symlinked
+    # parent otherwise.
+    existing = candidate
+    tail: list[str] = []
+    while not os.path.exists(existing) and existing not in ("/", ""):
+        existing, name = os.path.split(existing)
+        tail.append(name)
+    resolved = os.path.join(os.path.realpath(existing), *reversed(tail))
+    resolved = os.path.normpath(resolved)
+
+    if resolved != root_real and not resolved.startswith(root_real + os.sep):
         raise ValueError(
-            f"model_dir must be under {root_norm}/: got {path!r}"
+            f"model_dir must resolve under {root_real}/: got {path!r}"
         )
-    return normalized
+    return resolved
 
 
 def select_bundle_family(bundles: dict, family: str | None = None) -> str:

--- a/perception/utils/qos.py
+++ b/perception/utils/qos.py
@@ -1,0 +1,29 @@
+"""
+utils/qos.py — Shared ROS2 QoS profiles for perception plugins.
+
+CAMERA_QOS is the platform convention for camera CompressedImage
+subscriptions. Robot camera publishers offer BEST_EFFORT; a RELIABLE reader
+does not match a BEST_EFFORT writer, so a plugin using RELIABLE would "start"
+successfully and never receive a frame (vop, OCR and obstacle all hit this).
+BEST_EFFORT readers match both offer kinds. depth=1 because vision plugins
+process the latest frame only (see utils.latest_frame) — the DDS history is
+not a work queue.
+"""
+
+from __future__ import annotations
+
+from rclpy.qos import (
+    DurabilityPolicy,
+    HistoryPolicy,
+    QoSProfile,
+    ReliabilityPolicy,
+)
+
+CAMERA_QOS = QoSProfile(
+    reliability=ReliabilityPolicy.BEST_EFFORT,
+    history=HistoryPolicy.KEEP_LAST,
+    depth=1,
+    durability=DurabilityPolicy.VOLATILE,
+)
+
+__all__ = ["CAMERA_QOS"]

--- a/perception/utils/ros_lifecycle.py
+++ b/perception/utils/ros_lifecycle.py
@@ -1,0 +1,37 @@
+"""
+utils/ros_lifecycle.py — Safe teardown of per-instance ROS2 nodes.
+
+Multi-instance plugins create one rclpy Node per input topic and register it
+with the bundle's MultiThreadedExecutor. When an instance is retired (topic
+change, stop-all, shutdown) the node must be removed from the executor *and*
+destroyed, otherwise its subscriptions keep matching camera publishers and
+its callbacks keep waking the executor for the rest of the process. The ASR
+plugin established this order; OCR and obstacle reuse it here.
+"""
+
+from __future__ import annotations
+
+import logging
+
+log = logging.getLogger(__name__)
+
+
+def dispose_node(executor, node, *, label: str = "") -> None:
+    """Remove `node` from `executor` and destroy it, logging (not raising) errors.
+
+    Callers stop the node's own workers/subscriptions first; this helper only
+    handles the executor + rclpy handle lifecycle. Every step is attempted
+    even if a previous one failed.
+    """
+    name = label or getattr(node, "get_name", lambda: type(node).__name__)()
+    try:
+        executor.remove_node(node)
+    except Exception as error:
+        log.warning("failed to remove ROS node %r from executor: %s", name, error)
+    try:
+        node.destroy_node()
+    except Exception as error:
+        log.warning("failed to destroy ROS node %r: %s", name, error)
+
+
+__all__ = ["dispose_node"]

--- a/perception/utils/tensorrt_runtime.py
+++ b/perception/utils/tensorrt_runtime.py
@@ -1,0 +1,495 @@
+"""
+utils/tensorrt_runtime.py — Shared TensorRT / CUDA runtime for Jetson plugins.
+
+Jetson + CUDA + TensorRT are platform capabilities of the perception base
+image. Vision plugins (OCR, obstacle, ...) only ship their own engines and
+pre/post-processing; everything below is the common part:
+
+    JetPack family selection   → tensorrt_family()
+    TensorRT ↔ numpy dtypes    → trt_dtype_to_numpy()
+    engine bytes (+ metadata)  → read_engine_file()
+    CUDA stream / buffers      → CudaRuntime
+    deserialize / execute      → TensorRTEngine
+
+Works with TensorRT 8.5 (JetPack 5.1.1) and TensorRT 10 (JetPack 6.x): both
+expose the tensor-name based API (num_io_tensors, set_tensor_address,
+execute_async_v3) that this module relies on. `tensorrt` itself is imported
+lazily so importing this module on a non-Jetson host is harmless.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import ctypes.util
+import json
+import logging
+import math
+import threading
+from pathlib import Path
+
+import numpy as np
+
+log = logging.getLogger(__name__)
+
+__all__ = [
+    "TensorRTError",
+    "TensorRTShapeError",
+    "tensorrt_family",
+    "tensorrt_version",
+    "normalize_family",
+    "trt_dtype_to_numpy",
+    "read_engine_file",
+    "CudaRuntime",
+    "TensorRTEngine",
+]
+
+
+class TensorRTError(RuntimeError):
+    """Raised for TensorRT / CUDA runtime failures."""
+
+
+class TensorRTShapeError(TensorRTError, ValueError):
+    """Raised when an input shape is not covered by any engine profile."""
+
+
+# ── JetPack family selection ─────────────────────────────────────────────────
+
+# TensorRT major → engine bundle family. Engines are not portable across
+# TensorRT majors, so the family is decided by the TensorRT that is actually
+# importable at runtime, never by a Docker build argument.
+_TRT_FAMILIES = {8: "jp511", 10: "jp61"}
+_FAMILY_ALIASES = {
+    "511": "jp511", "jp511": "jp511", "jp5": "jp511",
+    "61": "jp61", "jp61": "jp61", "jp6": "jp61",
+}
+
+
+def tensorrt_version() -> str:
+    """Return the importable TensorRT version string (raises TensorRTError)."""
+    try:
+        import tensorrt
+    except ImportError as error:
+        raise TensorRTError("TensorRT is not available in this runtime") from error
+    return str(getattr(tensorrt, "__version__", ""))
+
+
+def tensorrt_family(version: str | None = None) -> str:
+    """Map the runtime TensorRT version to an engine family ("jp511"/"jp61").
+
+    Passing an explicit `version` skips importing tensorrt (used by tests and
+    by manifests that want to describe both families).
+    """
+    text = tensorrt_version() if version is None else str(version)
+    try:
+        major = int(text.split(".", 1)[0])
+    except ValueError as error:
+        raise TensorRTError(f"Unsupported TensorRT version: {text or 'unknown'}") from error
+    if major >= 10:
+        return "jp61"
+    family = _TRT_FAMILIES.get(major)
+    if family is None:
+        raise TensorRTError(f"Unsupported TensorRT version: {text}")
+    return family
+
+
+def normalize_family(value: object) -> str | None:
+    """Normalize a user/env supplied family hint ("61", "jp511", ...) or None."""
+    if value is None:
+        return None
+    return _FAMILY_ALIASES.get(str(value).strip().lower())
+
+
+# ── dtype mapping ────────────────────────────────────────────────────────────
+
+def trt_dtype_to_numpy(trt_module, dtype) -> np.dtype:
+    """Map TensorRT dtypes to numpy without going through trt.nptype().
+
+    TensorRT 8.x's nptype() still references np.bool, which NumPy 1.24 removed,
+    so on the jp511 stack (TRT 8.5 + numpy 1.24.4) it raises AttributeError the
+    moment an engine is loaded. Resolve the common dtypes ourselves and only
+    fall back to nptype() for anything exotic.
+    """
+    mapping = {
+        trt_module.DataType.FLOAT: np.float32,
+        trt_module.DataType.HALF: np.float16,
+        trt_module.DataType.INT8: np.int8,
+        trt_module.DataType.INT32: np.int32,
+        trt_module.DataType.BOOL: np.bool_,
+    }
+    for name in ("UINT8", "INT64"):
+        member = getattr(trt_module.DataType, name, None)
+        if member is not None:
+            mapping[member] = getattr(np, name.lower())
+    try:
+        return np.dtype(mapping[dtype])
+    except KeyError:
+        return np.dtype(trt_module.nptype(dtype))
+
+
+# ── engine file ──────────────────────────────────────────────────────────────
+
+def read_engine_file(path: str | Path) -> tuple[dict, bytes]:
+    """Read a serialized engine, stripping an optional JSON metadata header.
+
+    Ultralytics-style exports prefix the engine with `<int32 size><json>`.
+    Plain TensorRT engines are returned unchanged with `{}` metadata.
+    """
+    try:
+        serialized = Path(path).read_bytes()
+    except OSError as error:
+        raise TensorRTError(f"TensorRT engine could not be read: {path}") from error
+    if len(serialized) < 8:
+        return {}, serialized
+    metadata_size = int.from_bytes(serialized[:4], "little", signed=True)
+    if metadata_size <= 0 or metadata_size > min(len(serialized) - 4, 1 << 20):
+        return {}, serialized
+    try:
+        metadata = json.loads(serialized[4 : 4 + metadata_size].decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return {}, serialized
+    if not isinstance(metadata, dict) or "task" not in metadata:
+        return {}, serialized
+    return metadata, serialized[4 + metadata_size :]
+
+
+# ── CUDA runtime ─────────────────────────────────────────────────────────────
+
+class CudaRuntime:
+    """Minimal checked wrapper around the CUDA Runtime C API (one stream)."""
+
+    _MEMCPY_HOST_TO_DEVICE = 1
+    _MEMCPY_DEVICE_TO_HOST = 2
+    _STREAM_NON_BLOCKING = 1
+
+    def __init__(self, device_id: int = 0):
+        self._device_id = int(device_id)
+        library = ctypes.util.find_library("cudart") or "libcudart.so"
+        try:
+            self._lib = ctypes.CDLL(library)
+        except OSError as error:
+            raise TensorRTError("CUDA Runtime library could not be loaded") from error
+        self._bind()
+        self._stream = ctypes.c_void_p()
+        self._set_device()
+        self._check(
+            self._lib.cudaStreamCreateWithFlags(
+                ctypes.byref(self._stream), self._STREAM_NON_BLOCKING
+            ),
+            "cudaStreamCreateWithFlags",
+        )
+
+    def _bind(self) -> None:
+        lib = self._lib
+        lib.cudaGetErrorString.argtypes = [ctypes.c_int]
+        lib.cudaGetErrorString.restype = ctypes.c_char_p
+        lib.cudaSetDevice.argtypes = [ctypes.c_int]
+        lib.cudaSetDevice.restype = ctypes.c_int
+        lib.cudaStreamCreateWithFlags.argtypes = [
+            ctypes.POINTER(ctypes.c_void_p),
+            ctypes.c_uint,
+        ]
+        lib.cudaStreamCreateWithFlags.restype = ctypes.c_int
+        lib.cudaStreamDestroy.argtypes = [ctypes.c_void_p]
+        lib.cudaStreamDestroy.restype = ctypes.c_int
+        lib.cudaStreamSynchronize.argtypes = [ctypes.c_void_p]
+        lib.cudaStreamSynchronize.restype = ctypes.c_int
+        lib.cudaMalloc.argtypes = [ctypes.POINTER(ctypes.c_void_p), ctypes.c_size_t]
+        lib.cudaMalloc.restype = ctypes.c_int
+        lib.cudaFree.argtypes = [ctypes.c_void_p]
+        lib.cudaFree.restype = ctypes.c_int
+        lib.cudaMemcpyAsync.argtypes = [
+            ctypes.c_void_p,
+            ctypes.c_void_p,
+            ctypes.c_size_t,
+            ctypes.c_int,
+            ctypes.c_void_p,
+        ]
+        lib.cudaMemcpyAsync.restype = ctypes.c_int
+
+    def _check(self, code: int, operation: str) -> None:
+        if code == 0:
+            return
+        message = self._lib.cudaGetErrorString(code)
+        detail = message.decode("utf-8", errors="replace") if message else str(code)
+        raise TensorRTError(f"{operation} failed with CUDA error {code}: {detail}")
+
+    def _set_device(self) -> None:
+        self._check(self._lib.cudaSetDevice(self._device_id), "cudaSetDevice")
+
+    @property
+    def stream_handle(self) -> int:
+        return int(self._stream.value or 0)
+
+    def malloc(self, size: int) -> int:
+        self._set_device()
+        pointer = ctypes.c_void_p()
+        self._check(
+            self._lib.cudaMalloc(ctypes.byref(pointer), ctypes.c_size_t(int(size))),
+            "cudaMalloc",
+        )
+        if not pointer.value:
+            raise TensorRTError("cudaMalloc returned a null device pointer")
+        return int(pointer.value)
+
+    def free(self, pointer: int) -> None:
+        if not pointer:
+            return
+        self._set_device()
+        self._check(self._lib.cudaFree(ctypes.c_void_p(pointer)), "cudaFree")
+
+    def copy_host_to_device(self, pointer: int, array: np.ndarray) -> None:
+        self._set_device()
+        self._check(
+            self._lib.cudaMemcpyAsync(
+                ctypes.c_void_p(pointer),
+                ctypes.c_void_p(array.ctypes.data),
+                ctypes.c_size_t(array.nbytes),
+                self._MEMCPY_HOST_TO_DEVICE,
+                self._stream,
+            ),
+            "cudaMemcpyAsync(H2D)",
+        )
+
+    def copy_device_to_host(self, array: np.ndarray, pointer: int) -> None:
+        self._set_device()
+        self._check(
+            self._lib.cudaMemcpyAsync(
+                ctypes.c_void_p(array.ctypes.data),
+                ctypes.c_void_p(pointer),
+                ctypes.c_size_t(array.nbytes),
+                self._MEMCPY_DEVICE_TO_HOST,
+                self._stream,
+            ),
+            "cudaMemcpyAsync(D2H)",
+        )
+
+    def synchronize(self) -> None:
+        self._set_device()
+        self._check(self._lib.cudaStreamSynchronize(self._stream), "cudaStreamSynchronize")
+
+    def close(self) -> None:
+        stream = getattr(self, "_stream", None)
+        if stream is None or not stream.value:
+            return
+        self._stream = ctypes.c_void_p()
+        self._set_device()
+        self._check(self._lib.cudaStreamDestroy(stream), "cudaStreamDestroy")
+
+
+# ── TensorRT engine ──────────────────────────────────────────────────────────
+
+class TensorRTEngine:
+    """One deserialized engine + execution context + reusable CUDA buffers.
+
+    Supports exactly one input tensor (any number of outputs). Static and
+    dynamic-shape engines are handled the same way: `infer()` selects the
+    optimization profile covering the input shape, sets it, resolves output
+    shapes, grows device buffers on demand and runs H2D → execute → D2H →
+    sync on the engine's own stream. Calls are serialized with a lock, so an
+    instance may be shared between threads.
+    """
+
+    def __init__(self, path: str | Path, *, device_id: int = 0):
+        import tensorrt as trt
+
+        self.path = str(path)
+        self._trt = trt
+        self._lock = threading.Lock()
+        self._cuda: CudaRuntime | None = None
+        self._runtime = None
+        self._engine = None
+        self._context = None
+        self._device_buffers: dict[str, int] = {}
+        self._device_capacity: dict[str, int] = {}
+        self._active_profile = 0
+        self._active_shape: tuple[int, ...] | None = None
+
+        self.metadata, serialized = read_engine_file(self.path)
+        try:
+            self._cuda = CudaRuntime(device_id)
+            self._runtime = trt.Runtime(trt.Logger(trt.Logger.WARNING))
+            self._engine = self._runtime.deserialize_cuda_engine(serialized)
+            del serialized
+            if self._engine is None:
+                raise TensorRTError(f"failed to deserialize TensorRT engine: {self.path}")
+            self._context = self._engine.create_execution_context()
+            if self._context is None:
+                raise TensorRTError(f"failed to create TensorRT context: {self.path}")
+
+            names = [
+                self._engine.get_tensor_name(index)
+                for index in range(self._engine.num_io_tensors)
+            ]
+            inputs = [
+                name for name in names
+                if self._engine.get_tensor_mode(name) == trt.TensorIOMode.INPUT
+            ]
+            if len(inputs) != 1:
+                raise TensorRTError(
+                    f"TensorRT engine must have exactly one input; got {inputs} ({self.path})"
+                )
+            self.input_name: str = inputs[0]
+            self.output_names: list[str] = [name for name in names if name not in inputs]
+            if not self.output_names:
+                raise TensorRTError(f"TensorRT engine has no outputs ({self.path})")
+            self.input_dtype: np.dtype = trt_dtype_to_numpy(
+                trt, self._engine.get_tensor_dtype(self.input_name)
+            )
+            self.output_dtypes: dict[str, np.dtype] = {
+                name: trt_dtype_to_numpy(trt, self._engine.get_tensor_dtype(name))
+                for name in self.output_names
+            }
+            self.profiles: list[tuple[tuple[int, ...], tuple[int, ...], tuple[int, ...]]] = (
+                self._read_profiles()
+            )
+        except Exception:
+            self.close()
+            raise
+
+    # ── shape / profile helpers ──────────────────────────────────────────
+
+    def _read_profiles(self):
+        static_shape = tuple(int(v) for v in self._engine.get_tensor_shape(self.input_name))
+        if static_shape and all(v > 0 for v in static_shape):
+            return [(static_shape, static_shape, static_shape)]
+        profiles = []
+        for index in range(self._engine.num_optimization_profiles):
+            minimum, optimum, maximum = self._engine.get_tensor_profile_shape(
+                self.input_name, index
+            )
+            profiles.append(
+                tuple(tuple(int(v) for v in shape) for shape in (minimum, optimum, maximum))
+            )
+        if not profiles:
+            raise TensorRTError(f"TensorRT engine has no optimization profile ({self.path})")
+        return profiles
+
+    @property
+    def is_static(self) -> bool:
+        return len(self.profiles) == 1 and self.profiles[0][0] == self.profiles[0][2]
+
+    @property
+    def input_shape(self) -> tuple[int, ...] | None:
+        """Static input shape, or None for dynamic engines."""
+        return self.profiles[0][0] if self.is_static else None
+
+    @property
+    def optimization_shape(self) -> tuple[int, ...]:
+        """Optimum shape of the first profile (useful for warm-up)."""
+        return self.profiles[0][1]
+
+    def select_profile(self, shape: tuple[int, ...]) -> int:
+        """Return the profile index best covering `shape` (TensorRTShapeError)."""
+        candidates = []
+        for index, (minimum, optimum, maximum) in enumerate(self.profiles):
+            if len(shape) != len(minimum):
+                continue
+            if all(lo <= v <= hi for v, lo, hi in zip(shape, minimum, maximum)):
+                distance = sum(
+                    abs(math.log(max(1, v) / max(1, o))) for v, o in zip(shape, optimum)
+                )
+                candidates.append((distance, index))
+        if candidates:
+            return min(candidates)[1]
+        ranges = [{"min": lo, "max": hi} for lo, _opt, hi in self.profiles]
+        raise TensorRTShapeError(
+            f"TensorRT input shape {tuple(shape)} is outside profiles {ranges} ({self.path})"
+        )
+
+    # ── execution ────────────────────────────────────────────────────────
+
+    def infer(self, array: np.ndarray) -> list[np.ndarray]:
+        """Run the engine on one input array; returns outputs in output_names order."""
+        array = np.ascontiguousarray(array, dtype=self.input_dtype)
+        shape = tuple(int(v) for v in array.shape)
+        with self._lock:
+            if self._context is None or self._cuda is None:
+                raise TensorRTError(f"TensorRT engine is closed ({self.path})")
+            cuda = self._cuda
+            context = self._context
+            if shape != self._active_shape:
+                profile = self.select_profile(shape)
+                if profile != self._active_profile:
+                    if not context.set_optimization_profile_async(profile, cuda.stream_handle):
+                        raise TensorRTError(f"failed to select TensorRT profile {profile}")
+                    self._active_profile = profile
+                if not context.set_input_shape(self.input_name, shape):
+                    raise TensorRTError(f"TensorRT rejected input shape {shape} ({self.path})")
+                self._active_shape = shape
+
+            outputs: list[np.ndarray] = []
+            for name in self.output_names:
+                output_shape = tuple(int(v) for v in context.get_tensor_shape(name))
+                if any(v < 0 for v in output_shape):
+                    raise TensorRTError(
+                        f"TensorRT produced unresolved output shape {output_shape} for {name}"
+                    )
+                outputs.append(np.empty(output_shape, dtype=self.output_dtypes[name]))
+
+            input_pointer = self._ensure_capacity(self.input_name, array.nbytes)
+            context.set_tensor_address(self.input_name, input_pointer)
+            for name, output in zip(self.output_names, outputs):
+                context.set_tensor_address(name, self._ensure_capacity(name, output.nbytes))
+
+            cuda.copy_host_to_device(input_pointer, array)
+            if not context.execute_async_v3(cuda.stream_handle):
+                raise TensorRTError(f"TensorRT execute_async_v3 failed ({self.path})")
+            for name, output in zip(self.output_names, outputs):
+                cuda.copy_device_to_host(output, self._device_buffers[name])
+            cuda.synchronize()
+            return outputs
+
+    def _ensure_capacity(self, name: str, required: int) -> int:
+        required = max(1, int(required))
+        pointer = self._device_buffers.get(name, 0)
+        if pointer and required <= self._device_capacity.get(name, 0):
+            return pointer
+        if pointer:
+            self._cuda.free(pointer)
+            self._device_buffers[name] = 0
+            self._device_capacity[name] = 0
+        pointer = self._cuda.malloc(required)
+        self._device_buffers[name] = pointer
+        self._device_capacity[name] = required
+        return pointer
+
+    # ── lifecycle ────────────────────────────────────────────────────────
+
+    def close(self) -> None:
+        # Taken under the same lock as infer(): a model-affecting config can
+        # close a stale adapter while a worker that missed its stop deadline
+        # is still inside infer(). Without the lock that frees CUDA buffers
+        # and destroys the stream under an in-flight execution — a
+        # use-after-free. With it, close() blocks until the in-flight infer()
+        # finishes, and any later infer() sees _context is None and raises.
+        lock = getattr(self, "_lock", None)
+        if lock is None:  # partially constructed instance (__del__ path)
+            return
+        with lock:
+            cuda = getattr(self, "_cuda", None)
+            buffers = getattr(self, "_device_buffers", {})
+            if cuda is not None:
+                for name, pointer in list(buffers.items()):
+                    try:
+                        cuda.free(pointer)
+                    except Exception:
+                        log.debug("cudaFree failed for %s", name, exc_info=True)
+            self._device_buffers = {}
+            self._device_capacity = {}
+            self._active_shape = None
+            self._context = None
+            self._engine = None
+            self._runtime = None
+            if cuda is not None:
+                self._cuda = None
+                try:
+                    cuda.close()
+                except Exception:
+                    log.debug("cudaStreamDestroy failed", exc_info=True)
+
+    def __del__(self):
+        try:
+            self.close()
+        except Exception:
+            # Interpreter shutdown can unload CUDA before Python finalizers run.
+            pass


### PR DESCRIPTION
> **更新 2026-08-22 15:30(北京时间)** — head `d528942`。修复 bot 本轮新增的 2 条节点级并发 P1(`d528942`):`_OCRNode.start()/stop()` 此前无锁,并发 start 可各建 worker 并互相覆盖 stop event/帧槽,极端时双 worker 同时发布且 stop 只能停掉一个;并发 stop 也可在注册与 start() 之间销毁节点,使 start 在已销毁句柄上建订阅。现 start/stop/retire 以 per-node RLock 序列化(与 obstacle 节点自始的模式一致),_dispose 改走 retire():同一次持锁内置死标志+停 worker,迟到的 start 见标志直接报 idle、零 rclpy 触碰。新增 2 测试:8 路并发 start 恰 1 订阅 1 worker;retired 节点上 start 惰性无副作用。
>
> **更新 2026-08-22 14:00(北京时间)** — head `eb0370f`,基于 main `4278296`。响应内部评审(陈雨强)反馈新增 3 个 commit,见下方"本轮更新(内部评审反馈)"一节。历史评论中引用旧 commit 的结果均已过时,以本 head 为准。
>
> **更新 2026-08-21 10:45(北京时间)** — head `80dd1eb`。新增:OCR 默认启用(与 asr/tts/htmsg/vop 一致);`model_dir` 限域改为解析符号链接后比较(修 bot 指出的 symlink 逃逸)。

## 本轮更新(内部评审反馈)

1. **结果 JSON 结构化,便于 LLM 消费**(`1cc203d`):此前 payload 只有碎片文本 + 裸 bbox,LLM 无法区分标题和小字。现在每个 item 附加 `height`(bbox 像素高,字号代理)、`prominence`(相对全帧最大文字的比例,1.0=最醒目)、`line`(按垂直重叠带分组的视觉行号);payload 附加 `image_size`([宽,高],bbox 的坐标参考系);`text` 改为按视觉行拼接(行内从左到右,行间换行)。全部为增量字段,既有字段语义不变。
2. **配置界面收敛**(`6b139eb` + `eb0370f`):configSchema 从 13 项砍到 1 项 —— 只保留 `min_interval_ms`(帧处理最小间隔,唯一真正的操作决策)。model_dir/device_id/DB 阈值/provider 等专家参数退回 config.yaml-only(dispatch 仍认,只是不再暴露给配置 UI);两个 object 类型项(crop_refinement/empty_result_retry)因前端渲染为 `[object Object]` 一并撤下,并加测试守住"schema 不得出现 object 类型属性";`language` 也撤出 UI —— 当前 TensorRT 管线是单一中英双语模型,该值只标注输出 payload、不改变识别行为,摆在界面上会误导。

## 概述

新增 PP-OCRv6 TensorRT 离线 OCR 插件(默认启用,注册廉价、引擎首次 start 才加载,见"默认启用"一节),同时引入 OCR 所需、供视觉插件复用的运行时公共组件。模型工件不进 Git,按 JetPack 家族在运行时下载并逐文件校验。

## Commit 结构(2 个,可分开审)

| commit | 内容 |
|---|---|
| `refactor(perception): shared vision runtime utils` | 纯新增:`tensorrt_runtime`(TRT8/TRT10 双 API engine 封装、profile 选择、buffer 增长、显式 close;`tensorrt_family()` 由**可 import 的 TensorRT** 推导家族,不依赖构建参数)、`qos.CAMERA_QOS`、`latest_frame`、`ros_lifecycle.dispose_node`、`model_downloader` 的 verified-bundle 路径(逐文件 size+SHA256、staged 下载+重试、跨实例文件锁)。**既有 `ensure_model()` 及其调用方(ASR/TTS/KWS/X-ASR)零改动。** |
| `feat(perception): add on-device OCR` | 插件本体 + 预处理 + TensorRT 编排、config 块、main.py 注册(+5 行)、Dockerfile OCR 依赖、单测。 |

## 生命周期与并发(对齐 #113)

```
idle → start → loading(立即返回)→ 后台 single-flight loader → running
                                              ↘ 失败 → error(下次 start 重试)
```

- `start` 不做慢操作:登记 pending、必要时启动唯一后台 loader、立即返回 `loading`(真机实测 6ms)。10 个并发 start = 1 次模型加载 + 10 个 pending。
- `info` 纯查询、锁内快照、loading 期间不被阻塞(实测 4ms);返回插件级 + 实例级状态,`desc` 在 loading/error 时给出原因(与 asr 同款),error 态另附结构化 `error` 字段。
- `stop`:loading 中撤销 pending(loader 复查,不复活已停实例);running 则停 worker 后完整销毁(`executor.remove_node + destroy_node`)。adapter 缓存保留,重启秒回 running。
- `config` 换代走 generation token,旧 loader 结果作废并释放。
- 快路径并发挡板:start 先在 pending 登记 claim,并发 stop 任意时刻可见可撤销(README "Plugin Concurrency" 描述的孤儿窗口不存在,含回归测试)。

## 与既有实现的关系

| | asr(#113) | 本 PR | 说明 |
|---|---|---|---|
| 模型后台加载 + `info` 的 loading/desc | ✅ | ✅ | 一致 |
| 加载期间收到 `start` | 自旋等待 + 超时 | 登记 pending,**立即返回 loading** | #113 批评过自旋占用 MCP worker;此处把该原则贯彻到 `start` 本身 |
| `starting` 中间态 | 有(需等首包音频) | 无 | `start` 立即返回,`loading` 已覆盖该语义 |
| 聚合 `state` | running 优先 | loading > running > error | 有实例在加载时报 loading 更贴近实情;如需完全一致可改,听 reviewer 的 |

`utils/ros_lifecycle.dispose_node()` 是 README 第 6 条(`destroy_node()`, not just `remove_node()`)的可复用函数版;`asr.py:_dispose_node()` 与 asr/htmsg/vop 各自的 QoS 定义**均未改动** —— 本 PR 不触碰既有插件。

## 相机 QoS

订阅用 BEST_EFFORT(`utils/qos.py`):相机发布端 offer BEST_EFFORT,RELIABLE reader 与其不匹配 —— start 成功但永远收不到帧。已在 Orin NX 复现(`requesting incompatible QoS ... RELIABILITY`,0 帧)并验证修复后识别结果与 GT 逐字一致。

## 模型分发

每个 JetPack 家族一套 engine(jp511/TRT8.5、jp61/TRT10.4),运行时按实际可 import 的 TensorRT 选择;逐文件 size+SHA256,已有文件复用前重验,staged 下载+重试+跨实例文件锁。当前托管 ModelScope 固定 revision,`OCR_MODEL_BASE_URL` 可整体切换。

## Dockerfile 依赖(最小化)

- `libvips42`:pyvips ABI 模式 dlopen 的运行库,不编译任何东西;**未新增编译工具链**(base 自带,main 现状即可编译 webrtcvad,已实测)。
- `rapidocr --no-deps` 仅用其纯 Python 后处理,自带 ONNX 模型已删除,onnxruntime 不装。
- numpy 钉到各 base 自带的同版本(jp511=1.24.4 / jp61=1.26.4,真机 base 镜像里核实),不升级镜像内任何既有包。
- **全部依赖钉版**;`six`/`Pillow` 不在列表中 —— 两个 base 已自带(jp511: 1.14.0/10.4.0,jp61: 1.16.0/9.0.1),重复列出且不钉版会使解析不可复现。
- **镜像增长实测**:apt 层(含 libvips42)17.2 MB + OCR pip 层 24.5 MB ≈ **42 MB**,占 ~14.6 GB 镜像 **<0.3%**(`docker history` 于 Orin NX 实测)。

## 边界

`main.py` 仅 +5 行条件注册;`asr / tts / vop / htmsg / x_asr / vad_preroll / ensure_model / service.yml / agent-core` 0 行差异;无 Fast DDS;默认 `enabled: true`(见"默认启用"一节)。

## 默认启用(本轮新增 commit)

`config.yaml` 里既有的 asr/tts/htmsg/vop 全部 `enabled: true`,OCR 原本是唯一的例外。改为一致,理由不只是风格:

- **默认关闭在实践中等于不可用**:`main.py` 只在 `enabled` 为真时 import 插件,关闭的插件不会注册 MCP 工具、不出现在控制台的 processor 列表里,因此**无法从控制台开启** —— 唯一入口是重建容器并挂载改过的 config.yaml。
- **开启不产生静态开销**:注册 MCP 工具是廉价的;TensorRT 引擎只在首次成功 `start` 时下载并初始化(loading → running 路径),未被使用的部署不付出显存/内存/启动时间。

真机验证(jetson-orin-02,JP6.1):插件随容器启动注册,控制台出现 processor 卡片,画布连线后 start → loading → running 正常;喂入一张实拍展板照片(283 KB,中英混排、反光、倾斜)识别出 **41 个文本框**,长句小字置信度 1.000,重复推理结果逐字一致。


## 验证

- **Orin NX(JP5.11)真机**:从零构建通过;容器 + MCP 全链路;1.42MB PNG 经 BEST_EFFORT 发布端喂入,识别与 GT 逐字一致;loading→running、stop 销毁均实测。
- **CI**:本 head(`29bbdb7`)双 target 构建成功;code review 仅剩 COS 一条 P1(见下)。本轮新增:MCP 传入的 `model_dir` 在下载器咽喉点强制限定于 `/models` 子树(路径归一化+越界拒绝,防 root 进程被指到任意容器路径写文件),含拒绝用例测试。另:与 #101 调整为平行结构(共享同一 utils commit,无合并顺序依赖)。
- **单测 49 个**(本轮 +6:节点并发 start 恰一 worker、retired 节点 start 惰性、payload 大小/主次/行分组/坐标系、行内左右排序、空结果与错误路径、schema 守卫):非阻塞 start(<100ms)、10 并发 single-flight(builder 恰 1 次)、loading 期 info/stop/config、完整销毁、start/stop×20 无增长、孤儿窗口回归、desc 状态迁移;macOS 与 .14 真机 Python 3.8.10 双环境通过。`python -m pytest perception/tests -q`(无需 Jetson)。

## 合并前待办(bot P1)

- **engine 迁 COS**:目前托管 ModelScope 固定 revision,团队规范要求走 COS。逐文件 SHA256 已钉死,**等 bucket 上传权限或有权限同学代传**;传完 manifest 只改 `OCR_MODEL_BASE` 一处,校验逻辑不变。

  **自助上传清单(8 文件,72.9 MB)**:

| COS 目标路径(public/ 下) | 字节 | SHA256 | 当前源 |
|---|---|---|---|
| `ocr-ppocrv6-small-trt/jp61/det.engine` | 11,194,324 | `3b36aae43b2cc4a1b1e2d74d846a1319b4b6f42fbc6d97747d8d72e12c74a1ef` | [源](https://www.modelscope.cn/models/Flame4pd/ppocrv6-small-edge-ocr/resolve/0301e9299b3abe09c6a60796d7bed74c23fcc525/tensorrt-jp6-trt10.4-orin-batch8-cls8/det.engine) |
| `ocr-ppocrv6-small-trt/jp61/rec.engine` | 23,303,292 | `8149fa68d5418f2c0763b8c4e5088987cb679a407317c7510f88ab6de38dd641` | [源](https://www.modelscope.cn/models/Flame4pd/ppocrv6-small-edge-ocr/resolve/0301e9299b3abe09c6a60796d7bed74c23fcc525/tensorrt-jp6-trt10.4-orin-batch8-cls8/rec.engine) |
| `ocr-ppocrv6-small-trt/jp61/cls.engine` | 1,046,484 | `148a6895260d3b6b6f86e0c5787121fc1bba316f3427397f654421196c13cb77` | [源](https://www.modelscope.cn/models/Flame4pd/ppocrv6-small-edge-ocr/resolve/0301e9299b3abe09c6a60796d7bed74c23fcc525/tensorrt-jp6-trt10.4-orin-batch8-cls8/cls.engine) |
| `ocr-ppocrv6-small-trt/jp61/keys.txt` | 74,947 | `b5f2bfe2bdd9448429e3e82b51c789775d9b42f2403d082b00662eb77e401c5d` | [源](https://www.modelscope.cn/models/Flame4pd/ppocrv6-small-edge-ocr/resolve/0301e9299b3abe09c6a60796d7bed74c23fcc525/tensorrt-jp6-trt10.4-orin-batch8-cls8/keys.txt) |
| `ocr-ppocrv6-small-trt/jp511/det.engine` | 12,334,256 | `1bb32a027e93b06d5319ac61e38bb3e447137b01465eacefa7a652f58130ebdf` | [源](https://www.modelscope.cn/models/Flame4pd/ppocrv6-small-edge-ocr/resolve/0301e9299b3abe09c6a60796d7bed74c23fcc525/tensorrt-jp511-trt8.5-orin-batch8-cls8/det.engine) |
| `ocr-ppocrv6-small-trt/jp511/rec.engine` | 19,915,466 | `1e204f0469beba33d8590b29c06419cf1073d98d41243b5ee316d2f877340b61` | [源](https://www.modelscope.cn/models/Flame4pd/ppocrv6-small-edge-ocr/resolve/0301e9299b3abe09c6a60796d7bed74c23fcc525/tensorrt-jp511-trt8.5-orin-batch8-cls8/rec.engine) |
| `ocr-ppocrv6-small-trt/jp511/cls.engine` | 1,038,858 | `02c722e56e621b56a36678cc8aa124a31b41e9e3c9ca350b11e4de0d5bbd0a35` | [源](https://www.modelscope.cn/models/Flame4pd/ppocrv6-small-edge-ocr/resolve/0301e9299b3abe09c6a60796d7bed74c23fcc525/tensorrt-jp511-trt8.5-orin-batch8-cls8/cls.engine) |
| `ocr-ppocrv6-small-trt/jp511/keys.txt` | 74,947 | `b5f2bfe2bdd9448429e3e82b51c789775d9b42f2403d082b00662eb77e401c5d` | [源](https://www.modelscope.cn/models/Flame4pd/ppocrv6-small-edge-ocr/resolve/0301e9299b3abe09c6a60796d7bed74c23fcc525/tensorrt-jp511-trt8.5-orin-batch8-cls8/keys.txt) |

  下载各"当前源"链接的文件,校验 SHA256 一致后按"COS 目标路径"上传;完成后告知,manifest 只需改一处 base URL 常量(校验逻辑零改动)。











