### PR TITLE
fix(pr-review): show the published version's commit, attribute jobs to the PR author

### DIFF
--- a/PR_REVIEW_AGENT.md
+++ b/PR_REVIEW_AGENT.md
@@ -494,6 +494,37 @@ byte offset it last received. The pane only autoscrolls if you are already at th
 bottom, so tailing does not yank the view away while you read an error further
 up.
 
+### Three commits per job
+
+The dashboard's `Commit` column is deliberately **not** the PR head sha, because
+that sha never names an image. A job carries three ids:
+
+| Id | What it is | Where it comes from |
+|---|---|---|
+| `head_sha` | what the author pushed | the PR, at trigger time |
+| `build_ref_sha` | worktree HEAD after the PR is merged onto base | `git rev-parse HEAD` in the worktree |
+| `merge_commit_sha` | the commit on the base branch once merged | backfilled from the GitHub API |
+
+`build_ref_sha` is the one that matters for finding an image: reviews build a
+worktree that is *base + PR merged*, and `build.sh` / `build_core.sh` /
+`build_perception.sh` all tag from that worktree's HEAD —
+`TAG="release.${DATE}.${COMMIT}"` where `COMMIT` is its short sha. It is a local
+merge commit in a worktree that is deleted when the job ends, so it exists nowhere
+but the job record. (When the PR has not diverged from its base the merge
+fast-forwards and it equals `head_sha`.)
+
+`merge_commit_sha` is what you search for when tracing a release back to a
+change. The poller fills it in roughly every 5 minutes from
+`GET /repos/{repo}/pulls?state=closed` — one request per repo, since that endpoint
+carries `merge_commit_sha` and `merged_at` for every PR it lists. It is only
+recorded when `merged_at` is set: on an open PR that field holds a throwaway
+test-merge sha that changes whenever the base moves.
+
+Jobs are attributed to the **PR author**, not to whoever typed
+`/request_bot_review` — the trigger is often used by a reviewer or by whoever is
+operating the agent. The requester is still recorded, and is who the
+acknowledgment comment on the PR thanks.
+
 ### Persistence
 
 State lives on the host at `DATA_HOST_DIR` (default

--- a/agents/pr_review/git_workspace.py
+++ b/agents/pr_review/git_workspace.py
@@ -214,12 +214,20 @@ class GitWorkspaceManager:
         pr_number: int,
         head_sha: str,
         base_ref: str,
-    ) -> Path:
+    ) -> tuple[Path, str]:
         """Create an isolated worktree at `base_ref` with the PR merged in.
 
         `base_ref` is a plain branch name (e.g. "main"), not `origin/main`: this
         is a bare clone, where branches live at `refs/heads/*` and there are no
         remote-tracking refs for `origin/main` to resolve against.
+
+        Returns (worktree_path, build_ref_sha). The second value is the worktree
+        HEAD after the merge — the commit the build scripts turn into the image
+        tag (`release.YYMMDD.<7hex>`), which is what makes a published image
+        traceable back to a review. It is a *local* merge commit: this worktree
+        is thrown away, so it exists nowhere else and cannot be recovered later.
+        (When the PR has not diverged from base the merge fast-forwards and this
+        equals `head_sha`.)
 
         Raises MergeConflictError when the PR cannot be merged.
         """
@@ -268,7 +276,23 @@ class GitWorkspaceManager:
             )
 
         logger.info(f"Worktree ready: {wt_path} ({base_ref} + PR #{pr_number})")
-        return wt_path
+        return wt_path, await self._head_sha(wt_path)
+
+    async def _head_sha(self, worktree_path: Path) -> str:
+        """Worktree HEAD, or "" if it cannot be read.
+
+        Never fatal: this is recorded for traceability, and losing the id is not
+        a reason to fail a review that would otherwise have run.
+        """
+        rc, out = await self._run_git_status(
+            ["git", "rev-parse", "HEAD"],
+            cwd=str(worktree_path),
+            timeout=GIT_LOCAL_TIMEOUT,
+        )
+        if rc != 0:
+            logger.warning(f"Could not read build ref in {worktree_path}: {out.strip()}")
+            return ""
+        return out.strip()
 
     async def remove_worktree(self, repo_full_name: str, worktree_path: Path):
         """Remove a worktree after use."""

--- a/agents/pr_review/github_client.py
+++ b/agents/pr_review/github_client.py
@@ -90,6 +90,36 @@ class GitHubClient:
         resp.raise_for_status()
         return resp.json()
 
+    async def list_pulls(
+        self,
+        repo: str,
+        state: str = "closed",
+        sort: str = "updated",
+        direction: str = "desc",
+        per_page: int = 100,
+    ) -> list[dict]:
+        """List a repo's PRs — one call, not one per PR.
+
+        Used to backfill merge commits: this endpoint carries `merge_commit_sha`
+        and `merged_at` for every entry, so the whole backlog is covered by a
+        single request per repo.
+
+        Caller beware: on an *open* PR, `merge_commit_sha` is GitHub's throwaway
+        test-merge sha and changes whenever the base moves. It is only the real
+        merge commit when `merged_at` is non-null.
+        """
+        resp = await self._client.get(
+            f"/repos/{repo}/pulls",
+            params={
+                "state": state,
+                "sort": sort,
+                "direction": direction,
+                "per_page": per_page,
+            },
+        )
+        resp.raise_for_status()
+        return resp.json()
+
     async def post_comment(self, repo: str, pr_number: int, body: str) -> int:
         """Post a comment on a PR. Returns the comment ID."""
         resp = await self._client.post(

--- a/agents/pr_review/models.py
+++ b/agents/pr_review/models.py
@@ -128,6 +128,10 @@ class ReviewJob:
     comment_id: int  # triggering comment
     requester: str  # GitHub username
     source: str = "webhook"  # "webhook" | "poll"
+    # Who opened the PR. Distinct from `requester`, who merely typed the trigger
+    # and is often a reviewer or the bot operator; the dashboard attributes work
+    # to the author, while the acknowledgment comment still thanks the requester.
+    pr_author: str = ""
     # The PR's own account of itself. Captured at trigger time off the get_pr
     # response already being fetched, so it costs no extra API call and survives
     # a retry without one.
@@ -173,6 +177,17 @@ class ReviewJob:
     started_at: datetime | None = None
     finished_at: datetime | None = None
     worktree_path: str = ""
+    # The three ids a released image has to be traceable through:
+    #
+    #   pr_head_sha     what the author pushed
+    #   build_ref_sha   worktree HEAD after the PR is merged onto base — the one
+    #                   the build scripts shorten into release.YYMMDD.<7hex>, so
+    #                   the only id that finds the published image
+    #   merge_commit_sha  the commit on the base branch once the PR is merged;
+    #                   backfilled by the poller, empty until then
+    build_ref_sha: str = ""
+    merge_commit_sha: str = ""
+    merged_at: str = ""  # ISO8601 from GitHub, alongside merge_commit_sha
     # Acknowledgment comment, edited in place through the job's lifetime.
     progress_comment_id: int | None = None
 

--- a/agents/pr_review/poller.py
+++ b/agents/pr_review/poller.py
@@ -15,6 +15,7 @@ import asyncio
 import json
 import logging
 import re
+import time
 from collections import deque
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -38,6 +39,18 @@ PROCESSED_IDS_MAX = 1000
 
 # Pages of 100 comments to walk per repo per cycle.
 MAX_PAGES_PER_POLL = 5
+
+# How often to look for merge commits of PRs already reviewed. Much slower than
+# the trigger poll: nothing waits on a merge id.
+#
+# The pass is skipped when no reviewed PR is missing one. A PR that is still open
+# — or was closed without merging — never gets one, so it keeps the pass alive at
+# one request per repo per interval. That is the intended cost: it is also what
+# picks up a merge that happens weeks after the review.
+MERGE_BACKFILL_INTERVAL_SECONDS = 300
+
+# PRs per repo examined in one backfill pass (one request, newest-updated first).
+MERGE_BACKFILL_PER_PAGE = 100
 
 
 class Poller:
@@ -68,6 +81,11 @@ class Poller:
         self.last_poll_at: str | None = None
         self.last_error: str | None = None
         self.triggers_found = 0
+        # Merge-commit backfill. Monotonic, so a clock change cannot stall it;
+        # 0.0 means the first cycle runs one, which catches PRs merged while the
+        # agent was down.
+        self._last_backfill = 0.0
+        self.merge_commits_found = 0
 
     # ── Lifecycle ─────────────────────────────────────────────────────────────
 
@@ -121,6 +139,47 @@ class Poller:
         self.poll_count += 1
         self.last_poll_at = _now_iso()
         self._save_state()
+
+        # Piggybacks on the same loop rather than owning a task: it shares the
+        # repo list and the client, and runs far less often than it.
+        if time.monotonic() - self._last_backfill >= MERGE_BACKFILL_INTERVAL_SECONDS:
+            self._last_backfill = time.monotonic()
+            for repo in self._config.repos:
+                try:
+                    await self._backfill_merge_commits(repo)
+                except Exception as e:
+                    logger.warning(f"Merge backfill failed for {repo}: {e}")
+
+    async def _backfill_merge_commits(self, repo: str):
+        """Record the merge commit of PRs that have been reviewed and merged.
+
+        The reviewed commit and the commit that names the built image are both
+        local to a throwaway worktree; this is the id that survives on the base
+        branch, and the one to search for when tracing a release to a change.
+        """
+        pending = await self._store.prs_missing_merge_commit(repo)
+        if not pending:
+            return
+
+        pulls = await self._github.list_pulls(
+            repo, state="closed", per_page=MERGE_BACKFILL_PER_PAGE
+        )
+        found = 0
+        for pr in pulls:
+            number = pr.get("number")
+            if number not in pending:
+                continue
+            # Only a merged PR has a real merge commit. On an open one the field
+            # holds a throwaway test-merge sha that would be wrong to record.
+            merged_at = pr.get("merged_at")
+            sha = pr.get("merge_commit_sha") or ""
+            if not merged_at or not sha:
+                continue
+            if await self._store.set_merge_commit(repo, number, sha, merged_at):
+                found += 1
+                logger.info(
+                    f"Recorded merge commit for {repo}#{number}: {sha[:7]}")
+        self.merge_commits_found += found
 
     async def _poll_repo(self, repo: str):
         """Poll a single repo for new trigger comments."""
@@ -260,6 +319,7 @@ class Poller:
             "last_poll_at": self.last_poll_at,
             "last_error": self.last_error,
             "triggers_found": self.triggers_found,
+            "merge_commits_found": self.merge_commits_found,
             "watermarks": dict(self._last_checked),
         }
 

--- a/agents/pr_review/router_api.py
+++ b/agents/pr_review/router_api.py
@@ -127,6 +127,11 @@ def _summarize_active(job) -> dict:
         "repo": job.repo_full_name,
         "pr_number": job.pr_number,
         "head_sha": job.pr_head_sha,
+        "build_ref_sha": job.build_ref_sha,
+        # An in-flight PR is by definition not merged yet; sent so the shape
+        # matches a history row and the table needs no special case.
+        "merge_commit_sha": "",
+        "pr_author": job.pr_author,
         "requester": job.requester,
         "status": job.status.value,
         "stage": job.stage,

--- a/agents/pr_review/store.py
+++ b/agents/pr_review/store.py
@@ -96,6 +96,11 @@ class JobStore:
             ("pr_title", "ALTER TABLE jobs ADD COLUMN pr_title TEXT"),
             ("pr_body", "ALTER TABLE jobs ADD COLUMN pr_body TEXT"),
             ("pr_context", "ALTER TABLE jobs ADD COLUMN pr_context TEXT"),
+            ("pr_author", "ALTER TABLE jobs ADD COLUMN pr_author TEXT"),
+            ("build_ref_sha", "ALTER TABLE jobs ADD COLUMN build_ref_sha TEXT"),
+            ("merge_commit_sha",
+             "ALTER TABLE jobs ADD COLUMN merge_commit_sha TEXT"),
+            ("merged_at", "ALTER TABLE jobs ADD COLUMN merged_at TEXT"),
         ):
             if column not in existing:
                 conn.execute(ddl)
@@ -151,9 +156,10 @@ class JobStore:
                   created_at, started_at, finished_at,
                   large_files, infra_files, shared_base_files,
                   review_rounds, review_stopped_reason, review_tool_calls,
-                  pr_title, pr_body, pr_context
+                  pr_title, pr_body, pr_context,
+                  pr_author, build_ref_sha, merge_commit_sha, merged_at
                 ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,
-                          ?,?,?,?,?,?,?,?,?)
+                          ?,?,?,?,?,?,?,?,?,?,?,?,?)
                 """,
                 (
                     job.id,
@@ -188,9 +194,72 @@ class JobStore:
                     job.pr_title,
                     job.pr_body,
                     json.dumps(job.pr_context),
+                    job.pr_author,
+                    job.build_ref_sha,
+                    job.merge_commit_sha,
+                    job.merged_at,
                 ),
             )
             conn.commit()
+        finally:
+            conn.close()
+
+    async def set_merge_commit(
+        self, repo: str, pr_number: int, sha: str, merged_at: str
+    ) -> int:
+        """Record a PR's merge commit on every job row for that PR.
+
+        Every row, because a PR can be reviewed several times and each run wants
+        the same id. Only rows where it is still empty, so this is idempotent and
+        a repeat pass costs one no-op UPDATE.
+        """
+        try:
+            return await asyncio.to_thread(
+                self._set_merge_commit_sync, repo, pr_number, sha, merged_at
+            )
+        except Exception as e:
+            logger.warning(
+                f"Failed to record merge commit for {repo}#{pr_number}: {e}")
+            return 0
+
+    def _set_merge_commit_sync(
+        self, repo: str, pr_number: int, sha: str, merged_at: str
+    ) -> int:
+        conn = self._connect()
+        try:
+            cursor = conn.execute(
+                """UPDATE jobs SET merge_commit_sha = ?, merged_at = ?
+                   WHERE repo = ? AND pr_number = ?
+                     AND (merge_commit_sha IS NULL OR merge_commit_sha = '')""",
+                (sha, merged_at, repo, pr_number),
+            )
+            conn.commit()
+            return cursor.rowcount or 0
+        finally:
+            conn.close()
+
+    async def prs_missing_merge_commit(self, repo: str) -> set[int]:
+        """PR numbers in this repo whose rows still have no merge commit.
+
+        The backfill asks first and skips the API call entirely when this is
+        empty, so a quiet agent makes no extra requests.
+        """
+        try:
+            return await asyncio.to_thread(self._prs_missing_merge_commit_sync, repo)
+        except Exception as e:
+            logger.warning(f"Failed to list PRs missing a merge commit: {e}")
+            return set()
+
+    def _prs_missing_merge_commit_sync(self, repo: str) -> set[int]:
+        conn = self._connect()
+        try:
+            rows = conn.execute(
+                """SELECT DISTINCT pr_number FROM jobs
+                   WHERE repo = ?
+                     AND (merge_commit_sha IS NULL OR merge_commit_sha = '')""",
+                (repo,),
+            ).fetchall()
+            return {r[0] for r in rows}
         finally:
             conn.close()
 
@@ -575,6 +644,12 @@ class JobStore:
             "pr_number": row["pr_number"],
             "head_sha": row["head_sha"],
             "head_ref": row["head_ref"],
+            # The commit that names the published image, and the one on the base
+            # branch after merge. _col: both are post-migration columns.
+            "build_ref_sha": _col(row, "build_ref_sha", ""),
+            "merge_commit_sha": _col(row, "merge_commit_sha", ""),
+            "merged_at": _col(row, "merged_at", ""),
+            "pr_author": _col(row, "pr_author", ""),
             "requester": row["requester"],
             "source": row["source"],
             "status": row["status"],
@@ -681,6 +756,10 @@ CREATE TABLE IF NOT EXISTS jobs (
   pr_title TEXT,
   pr_body TEXT,
   pr_context TEXT,
+  pr_author TEXT,
+  build_ref_sha TEXT,
+  merge_commit_sha TEXT,
+  merged_at TEXT,
   error TEXT,
   attempt_errors TEXT,
   created_at REAL NOT NULL,

--- a/agents/pr_review/trigger.py
+++ b/agents/pr_review/trigger.py
@@ -101,6 +101,7 @@ async def create_job_from_comment(
         pr_base_ref=pr_info["base"]["ref"],
         pr_title=pr_info.get("title") or "",
         pr_body=pr_info.get("body") or "",
+        pr_author=(pr_info.get("user") or {}).get("login", ""),
         comment_id=comment_id,
         requester=requester,
         source=source,

--- a/agents/pr_review/web/js/views.js
+++ b/agents/pr_review/web/js/views.js
@@ -10,6 +10,37 @@ const TERMINAL = new Set([
   'review_done', 'build_success', 'build_failed', 'timeout', 'error', 'cancelled',
 ]);
 
+// ── Shared cells ─────────────────────────────────────────────────────────────
+
+/**
+ * The commit cell.
+ *
+ * Shows the *build ref* — the worktree HEAD after the PR was merged onto base,
+ * which is the sha the build scripts shorten into `release.YYMMDD.<7hex>`. That
+ * makes the column the thing you can actually search a registry for. The PR head
+ * sha is not: it never names an image. Falls back to it for jobs recorded before
+ * the build ref was captured, and the tooltip carries all three ids in full.
+ */
+function commitCell(j) {
+  const shown = j.build_ref_sha || j.head_sha;
+  const lines = [
+    `PR head:      ${j.head_sha || '—'}`,
+    `build ref:    ${j.build_ref_sha || '—'}   (names the image tag)`,
+    `merge commit: ${j.merge_commit_sha || 'not merged yet'}`,
+  ].join('\n');
+  return `<td class="mono" title="${esc(lines)}">${esc(shortSha(shown))}</td>`;
+}
+
+/**
+ * Who the work belongs to: the PR's author, not whoever typed the trigger.
+ *
+ * Falls back to `requester` for rows written before the author was recorded —
+ * usually the same person, and better than a blank column.
+ */
+function byCell(j) {
+  return `<td>${esc(j.pr_author || j.requester || '—')}</td>`;
+}
+
 // ── Overview ─────────────────────────────────────────────────────────────────
 
 export function renderStats(el, s) {
@@ -54,10 +85,10 @@ export function renderActive(bodyEl, metaEl, s) {
           <tr class="clickable" data-job="${esc(j.id)}">
             <td class="mono">#${esc(j.pr_number)}</td>
             <td>${esc(shortRepo(j.repo))}</td>
-            <td class="mono">${esc(shortSha(j.head_sha))}</td>
+            ${commitCell(j)}
             <td>${stageCell(j)}</td>
             <td class="mono">${esc(j.attempt)}</td>
-            <td>${esc(j.requester)}</td>
+            ${byCell(j)}
             <td class="num">${esc(fmtDuration(j.elapsed))}</td>
           </tr>
         `).join('')}
@@ -154,7 +185,7 @@ export function renderHistory(el, jobs) {
           <tr class="clickable" data-job="${esc(j.id)}">
             <td class="mono">#${esc(j.pr_number)}</td>
             <td>${esc(shortRepo(j.repo))}</td>
-            <td class="mono">${esc(shortSha(j.head_sha))}</td>
+            ${commitCell(j)}
             <td>
               ${TERMINAL.has(j.status)
                 ? `<span class="pill ${esc(j.status)}">${esc(j.status)}</span>`
@@ -162,7 +193,7 @@ export function renderHistory(el, jobs) {
               ${j.attempt > 1 ? `<span class="pill">try ${esc(j.attempt)}</span>` : ''}
             </td>
             <td>${_buildSummary(j.build_results)}</td>
-            <td>${esc(j.requester)}</td>
+            ${byCell(j)}
             <td>${esc(j.source)}</td>
             <td class="num">${esc(fmtDuration(j.elapsed))}</td>
             <td class="num" title="${esc(fmtTime(j.created_at))}">${esc(fmtRelative(j.created_at))}</td>
@@ -242,9 +273,18 @@ function _detailMeta(j) {
         ${running ? `<div class="stage-banner">${stageCell(j)}</div>` : ''}
         <dl class="kv">
           ${j.pr_title ? `<dt>Title</dt><dd class="plain">${esc(j.pr_title)}</dd>` : ''}
-          <dt>Commit</dt><dd>${esc(j.head_sha || '—')}</dd>
+          <dt>PR head</dt><dd>${esc(j.head_sha || '—')}</dd>
+          <dt title="The sha the build scripts turn into release.YYMMDD.&lt;7hex&gt;">Build ref</dt>
+          <dd>${j.build_ref_sha
+            ? `${esc(j.build_ref_sha)} <span class="stage-detail">names the image tag</span>`
+            : '—'}</dd>
+          <dt>Merge commit</dt>
+          <dd>${j.merge_commit_sha
+            ? esc(j.merge_commit_sha)
+            : '<span style="color:var(--text-dim)">not merged yet</span>'}</dd>
           <dt>Branch</dt><dd>${esc(j.head_ref || '—')} → ${esc(j.base_ref || '—')}</dd>
-          <dt>Requested by</dt><dd class="plain">${esc(j.requester)} (via ${esc(j.source)})</dd>
+          <dt>PR author</dt><dd class="plain">${esc(j.pr_author || j.requester || '—')}</dd>
+          <dt>Triggered via</dt><dd class="plain">${esc(j.source || '—')}</dd>
           <dt>Mode</dt><dd class="plain">${esc(mode)}${
             (o.force_targets || []).length
               ? ` · forced: ${esc((o.force_targets || []).join(', '))}` : ''}</dd>

--- a/agents/pr_review/worker.py
+++ b/agents/pr_review/worker.py
@@ -186,10 +186,13 @@ async def _run_once(
     # 2. Create an isolated worktree with the PR merged onto the base
     job.set_stage(Stage.WORKTREE, f"{base_ref} + PR #{job.pr_number}")
     await store.save_job(job)
-    worktree = await workspace_mgr.create_worktree(
+    worktree, build_ref_sha = await workspace_mgr.create_worktree(
         job.repo_full_name, job.pr_number, job.pr_head_sha, base_ref
     )
     job.worktree_path = str(worktree)
+    # Recorded now because the worktree — and with it this commit — is removed
+    # when the job ends.
+    job.build_ref_sha = build_ref_sha
 
     # 3. Determine what changed
     job.set_stage(Stage.DETECTING)


### PR DESCRIPTION
## 问题

1. **`COMMIT` 列找不到发布的镜像。** dashboard 显示的是 PR head sha，但 `create_worktree` 把 `refs/pull/N/head` merge 到 base 上，build 脚本再用那个 worktree HEAD 算 `TAG="release.${DATE}.${COMMIT}"`（`build.sh` / `build_core.sh` / `build_perception.sh`）。那个 commit 是本地的、worktree 一删就不可达，之前谁都没记。分支没 diverge 时 merge 会 fast-forward、两者相等，但那是运气不是规则。
2. **`BY` 是发 comment 的人**，常常是 reviewer 或机器人操作者，不是 PR 作者。

## 改动

每个 job 记三个 id：

| 字段 | 含义 | 来源 |
|---|---|---|
| `pr_head_sha` | 作者 push 的 commit | trigger（原有） |
| `build_ref_sha` | merge 后的 worktree HEAD — **镜像 tag 就是它** | `create_worktree` |
| `merge_commit_sha` | merge 后落在 base 分支上的 commit | poller 回填 |

- **回填**在 poller 现有循环里，最多 5 分钟一次，没有待补的行时完全跳过，每个 repo 一个 `pulls?state=closed` 请求。`merged_at` 为空的条目直接忽略 —— 开着的 PR 上 `merge_commit_sha` 是 GitHub 的临时 test-merge sha，记进去是错的。
- **`By`** 改成 `pr_author`，取自 trigger 已经拿到的 `get_pr` 响应，不多发请求。`requester` 保留在 DB 和日志里，ack 评论照旧感谢发起人。
- **迁移**是四条幂等 `ALTER TABLE`，读取走已有的 `_col()`，迁移前的旧行照样渲染（显示 `—`）。

## 验证

- **build ref 正确性**：构造了 diverge 和 fast-forward 两个 PR ref。diverge 时 `build_ref=58627d6` vs `head=2509203`，而 `58627d6` 正是 build 脚本执行 `git rev-parse --short=7 HEAD` 得到的值；fast-forward 时两者相等。这也直接说明旧的 `Commit` 列为什么找不到镜像。
- **回填（连真实 API）**：用生产 `jobs.db` 的副本跑，`phanthymotus-driver#166 → b1d0648`，与 `gh pr view 166 --json mergeCommit` 一致，并写入该 PR 的全部 19 行 job。开着的 PR（35/168/169/171/173/174）和 closed-unmerged 的 #170 正确保持为空。第二遍写 0 行。
- **迁移**：生产 `jobs.db` 副本（34 行）加列成功，第二次 `init()` 静默，旧行读回 `''`。
- **浏览器**（Playwright，跑在迁移后的 DB 上）：overview / history / detail 全部正常，tooltip 三个 id 齐全，旧行回退到 head sha + requester，没有 `undefined`；作者名写成 `<script>` 形状时渲染为文本。

仓库内没有 `pr_review` 的测试文件（CLAUDE.md: "No dedicated test suite exists"），所以回归部分是 9 个被改模块的 import 扫描 + 本地起服务 + dashboard 渲染。

🤖 Generated with [Claude Code](https://claude.com/claude-code)