### PR TITLE
feat(pr-review): build perception for Jetson only, with a selectable JetPack version

### DIFF
--- a/PR_REVIEW_AGENT.md
+++ b/PR_REVIEW_AGENT.md
@@ -104,6 +104,35 @@ Supported versions are **5.11** (default) and **6.1** — the two
 with separate logs, rows and image tags, labelled `perception (jetson-jp5.11)`
 and `perception (jetson-jp6.1)` in the PR comment and on the dashboard.
 
+### Failure logs in the comment
+
+When a build fails, its log goes into the comment in full — collapsed under a
+`<details>` — rather than as a fixed number of trailing lines. A failure is
+diagnosed from the log, and a short tail routinely cut off above the actual
+error: a failing `pip install` or `apt-get` prints hundreds of lines after it.
+
+The one hard limit is GitHub's: a comment body over **65536 characters** is
+rejected with a 422, which would lose the entire failure report. So the logs are
+budgeted against it instead of trimmed to a line count:
+
+- Everything above the logs (result table, image refs, deploy help) is composed
+  first, and the failed builds split what is left equally — so the comment fits
+  by construction, roughly 600–900 lines for a single failure.
+- A log that fits goes in whole, and the summary says `complete log, N lines`.
+- One that does not keeps its **end**, where the error is, and says how many
+  earlier lines were dropped. A truncated log with no such note is worse than
+  none: it reads as though the build stopped where the text stops.
+- Many failures at once (a driver PR touching a dozen drivers) would each get a
+  few unreadable lines, so past that point the comment links to the dashboard
+  instead.
+- `github_client._clamp_body` is a last-resort backstop for every other comment
+  the agent posts, LLM review text included — nothing should reach it, but a 422
+  costs the whole comment.
+
+Log blocks use a four-backtick fence: build output can itself contain ```` ``` ````
+and would otherwise close the block early and spill the rest into the comment as
+markup. The complete, untrimmed log is always on the dashboard.
+
 ### How each target is deployed
 
 The build-result comment tailors its instructions per target, because the three

--- a/PR_REVIEW_AGENT.md
+++ b/PR_REVIEW_AGENT.md
@@ -41,8 +41,16 @@ logic, so they can run simultaneously without double-triggering.
 | `/request_bot_review build-only` | Build only |
 | `/request_bot_review force` | Re-review a commit that was already reviewed |
 | `/request_bot_review core` | Force the `core` target |
-| `/request_bot_review perception` | Force the `perception` target |
+| `/request_bot_review perception` | Force `perception` (JetPack 5.11, the default) |
+| `/request_bot_review perception jetson-6.1` | Force `perception` on JetPack 6.1 |
+| `/request_bot_review perception jetson-5.11 jetson-6.1` | Both JetPack versions — two builds, two images |
 | `/request_bot_review unitree/g1` | Force a specific driver |
+
+A JetPack token implies the `perception` target, so `/request_bot_review
+jetson-6.1` is enough. `jetson-6.1`, `jetson-jp6.1`, `jp6.1` and `6.1` are all
+accepted; an unsupported version is ignored with a warning rather than passed
+to the build script, which would exit 1 on it. The "Building..." comment lists
+the builds that will actually run, versions included.
 
 The trigger must start a line, and it must be in the PR's **main conversation**
 box. Line-level review comments are a different GitHub event and are not seen.
@@ -56,7 +64,7 @@ Determined from `git diff --name-only origin/main...HEAD`.
 | Changed path | Target |
 |--------------|--------|
 | `agent-core/**` | `deploy/build_core.sh` |
-| `perception/**` | `deploy/build_perception.sh` |
+| `perception/**` | `deploy/build_perception.sh --variant jetson` |
 | `README*`, `docs/**`, `CODEOWNERS` | none — review only |
 
 **phanthymotus-driver**
@@ -74,6 +82,27 @@ newly added vendor: that is exactly what happened to PR #166 adding
 
 The agent invokes the repos' existing build scripts rather than reimplementing
 the build. Image tags, mirrors, and registry handling stay in one place.
+
+### Perception: Jetson only
+
+`build_perception.sh` defaults to `--variant cpu`, but perception runs on Jetson
+hardware, so that image is not worth building — and its tag
+(`release.YYMMDD.<sha>`) does not even say which variant it is. The agent
+therefore always passes `--variant jetson`; the CPU variant is unreachable from
+a PR comment by design.
+
+What *is* selectable is the JetPack version, which picks the base image
+(`jetson-base:jp511-torch` / `jp61-torch`) and lands in the tag:
+
+| Requested | Built as | Tag |
+|-----------|----------|-----|
+| default | `--variant jetson --jp-version 5.11` | `release.YYMMDD.<sha>-jetson-jp5.11` |
+| `jetson-6.1` | `--variant jetson --jp-version 6.1` | `release.YYMMDD.<sha>-jetson-jp6.1` |
+
+Supported versions are **5.11** (default) and **6.1** — the two
+`build_perception.sh` accepts. Asking for both produces two sequential builds
+with separate logs, rows and image tags, labelled `perception (jetson-jp5.11)`
+and `perception (jetson-jp6.1)` in the PR comment and on the dashboard.
 
 ### How each target is deployed
 

--- a/agents/pr_review/builder.py
+++ b/agents/pr_review/builder.py
@@ -49,14 +49,20 @@ REF_SHAPE_PATTERN = re.compile(
     r"([\w.\-]+(?::\d+)?(?:/[\w.\-]+)+:release\.\d{6}\.[0-9a-f]{7,40})"
 )
 
-LOG_TAIL_LINES = 80
+# How much of a failed build's log to carry to the PR comment. Generous on
+# purpose: a build failure is diagnosed from the log, and 80 lines routinely cut
+# off above the actual error — a failing `pip install` or `apt-get` prints
+# hundreds of lines after it. `comments.format_build_result` trims to whatever
+# GitHub's comment limit leaves, so these bounds only need to be larger than
+# that limit can hold; reading further would always be discarded.
+LOG_TAIL_LINES = 4000
 READ_CHUNK = 8192
 # Bytes read from each end of a large log when scanning for the image tag.
 # Covers "Image :" at the head and "Done. ..." at the tail without loading a
 # multi-megabyte docker build log into memory.
 SCAN_WINDOW = 256 * 1024
 # Bytes read from the end when building the tail for the PR comment.
-TAIL_WINDOW = 64 * 1024
+TAIL_WINDOW = 512 * 1024
 
 
 def _build_env(config: Config) -> dict[str, str]:

--- a/agents/pr_review/builder.py
+++ b/agents/pr_review/builder.py
@@ -15,7 +15,7 @@ import signal
 from pathlib import Path
 
 from .config import Config
-from .models import BuildResult, BuildTarget
+from .models import DEFAULT_JP_VERSION, BuildResult, BuildTarget, build_label
 
 logger = logging.getLogger(__name__)
 
@@ -93,17 +93,30 @@ async def build_core(worktree: Path, config: Config, log_path: Path) -> BuildRes
 
 
 async def build_perception(
-    worktree: Path, config: Config, log_path: Path
+    worktree: Path,
+    config: Config,
+    log_path: Path,
+    jp_version: str = DEFAULT_JP_VERSION,
 ) -> BuildResult:
-    """Build the perception image via deploy/build_perception.sh."""
+    """Build the perception image via deploy/build_perception.sh.
+
+    Always `--variant jetson`: perception runs on Jetson hardware, so the
+    script's `cpu` default built an image nobody deploys. `--jp-version` picks
+    the base image and shows up in the tag as `-jetson-jp<ver>`.
+    """
     return await _build_with_script(
         target=BuildTarget.PERCEPTION,
         driver_path=None,
         script=worktree / "deploy" / "build_perception.sh",
-        args=["--mirror", config.mirror],
+        args=[
+            "--mirror", config.mirror,
+            "--variant", "jetson",
+            "--jp-version", jp_version,
+        ],
         cwd=worktree,
         config=config,
         log_path=log_path,
+        variant=jp_version,
     )
 
 
@@ -133,8 +146,9 @@ async def _build_with_script(
     config: Config,
     log_path: Path,
     env_overrides: dict[str, str] | None = None,
+    variant: str = "",
 ) -> BuildResult:
-    label = driver_path or target.value
+    label = build_label(target, driver_path, variant)
 
     if not script.exists():
         message = f"{script.name} not found in worktree"
@@ -146,6 +160,7 @@ async def _build_with_script(
             image_tag="",
             log_tail=message,
             log_path=str(log_path),
+            variant=variant,
         )
 
     env = _build_env(config)
@@ -168,6 +183,7 @@ async def _build_with_script(
         image_tag=_extract_image_tag(log_path),
         log_tail=_read_tail(log_path),
         log_path=str(log_path),
+        variant=variant,
     )
 
 
@@ -436,8 +452,16 @@ def read_service_yaml(worktree: Path, rel_path: str) -> str:
         return ""
 
 
-def log_filename(idx: int, target: BuildTarget, driver_path: str | None) -> str:
-    """Log filename for one build within a job: `{idx}-{safe-label}.log`."""
+def log_filename(
+    idx: int, target: BuildTarget, driver_path: str | None, variant: str = ""
+) -> str:
+    """Log filename for one build within a job: `{idx}-{safe-label}.log`.
+
+    The variant is part of the name so two perception builds in one job are
+    told apart by more than their index.
+    """
     label = driver_path or target.value
+    if variant:
+        label = f"{label}-jetson-jp{variant}"
     safe = re.sub(r"[^A-Za-z0-9._-]", "-", label)
     return f"{idx}-{safe}.log"

--- a/agents/pr_review/comments.py
+++ b/agents/pr_review/comments.py
@@ -11,6 +11,17 @@ from .reviewer import Finding
 # Marker prefixed to every bot comment, so bot comments are identifiable.
 BOT_MARKER = "<!-- pr-review-agent -->"
 
+# GitHub rejects an issue comment body over 65536 characters with a 422. That
+# would lose the entire failure report — the one comment the author most needs —
+# so failed build logs are budgeted against it rather than cut to a fixed line
+# count. The margin absorbs the surrounding table and the wrappers.
+GITHUB_COMMENT_LIMIT = 65536
+COMMENT_BUDGET = 60000
+# Below this a log fragment is too small to show the error with any context, so
+# many-failure jobs (a driver PR touching a dozen drivers) link to the dashboard
+# instead of padding the comment with a dozen unreadable snippets.
+MIN_USEFUL_LOG_CHARS = 1500
+
 MODE_LABELS = {
     (False, False): "Build + Review",
     (True, False): "Review only (build skipped)",
@@ -126,19 +137,24 @@ Commit: `{head_sha[:7]}`
             f"dashboard.\n"
         )
 
-    for r in results:
-        if not r.success and r.log_tail:
-            name = r.label()
-            line_count = len(r.log_tail.splitlines())
-            body += f"""
-<details><summary>{name} build log (last {line_count} lines)</summary>
-
-```
-{r.log_tail}
-```
-
-</details>
-"""
+    # Logs last, and sharing whatever the rest of the comment left over: the
+    # author reads the log to fix the build, so it gets the space, but the table
+    # and image refs above it must survive intact. Splitting the remainder
+    # equally keeps the total inside the limit by construction, rather than
+    # relying on the client's truncation backstop.
+    failed = [r for r in results if not r.success and r.log_tail]
+    if failed:
+        share = (COMMENT_BUDGET - len(body)) // len(failed)
+        if share >= MIN_USEFUL_LOG_CHARS:
+            for r in failed:
+                body += _log_details(r.label(), r.log_tail, share)
+        else:
+            names = ", ".join(f"`{r.label()}`" for r in failed)
+            body += (
+                f"\n> {len(failed)} builds failed — too many to include their "
+                f"logs here without cutting each to a few unreadable lines. "
+                f"Open the dashboard for the full log of each: {names}.\n"
+            )
 
     if not all_ok:
         body += (
@@ -146,6 +162,70 @@ Commit: `{head_sha[:7]}`
         )
 
     return body
+
+
+def _log_details(name: str, log_tail: str, budget: int) -> str:
+    """One collapsed build log, trimmed only if it cannot fit.
+
+    The whole tail goes in when there is room. Sending the author to the
+    dashboard for the actual error is friction at the moment they are most
+    blocked, and a truncated log is worse than none: it reads as though the
+    build stopped where the text stops.
+
+    When it does not fit, the *end* is kept — that is where the failure is — and
+    the omission is stated, with a pointer to the full log.
+    """
+    lines = log_tail.splitlines()
+    # `budget` also has to cover this wrapper and the summary line.
+    room = budget - 400
+    dropped = 0
+
+    if len(log_tail) > room:
+        kept: list[str] = []
+        total = 0
+        for line in reversed(lines):
+            total += len(line) + 1
+            if total > room and kept:
+                break
+            kept.append(line)
+        kept.reverse()
+        dropped = len(lines) - len(kept)
+        lines = kept
+
+    text = "\n".join(lines)
+    # A single line can be longer than the whole budget — a build step echoing a
+    # one-line JSON blob, or a progress bar written without newlines. Trimming by
+    # line cannot help there, so cut characters and keep the end.
+    cut_mid_line = len(text) > room
+    if cut_mid_line:
+        text = text[-room:]
+
+    where = "full log on the dashboard"
+    omitted = f"{dropped} earlier line{'' if dropped == 1 else 's'} omitted"
+    if dropped and cut_mid_line:
+        note = f"last {len(lines)} lines, cut mid-line — {omitted}; {where}"
+    elif dropped:
+        note = (
+            f"last {len(lines)} lines — {omitted} to stay under GitHub's "
+            f"comment limit; {where}"
+        )
+    elif cut_mid_line:
+        note = f"tail only — this log has no line breaks to cut on; {where}"
+    else:
+        note = f"complete log, {len(lines)} lines"
+
+    # A four-backtick fence, because build output can itself contain ``` — an
+    # npm or docker step echoing a README would otherwise close the block early
+    # and spill the rest of the log into the comment as markup.
+    return f"""
+<details><summary>{name} build log ({note})</summary>
+
+````
+{text}
+````
+
+</details>
+"""
 
 
 def _deploy_help(built: list[BuildResult]) -> str:

--- a/agents/pr_review/comments.py
+++ b/agents/pr_review/comments.py
@@ -5,7 +5,7 @@ Lives in its own module so both `trigger` (acknowledgment) and `worker`
 """
 
 from .builder import split_image_ref
-from .models import BuildResult, BuildTarget
+from .models import BuildResult
 from .reviewer import Finding
 
 # Marker prefixed to every bot comment, so bot comments are identifiable.
@@ -51,17 +51,22 @@ Request from @{requester} accepted — starting review.
 def format_building(
     requester: str,
     head_sha: str,
-    targets: list[BuildTarget],
-    driver_paths: list[str],
+    labels: list[str],
 ) -> str:
-    """Build-in-progress state."""
+    """Build-in-progress state.
+
+    Takes the resolved build plan rather than the targets, so a perception build
+    for two JetPack versions is announced as two builds — which is what will
+    happen, and how long it will take.
+    """
+    listed = ", ".join(f"`{n}`" for n in labels) if labels else "None"
     return f"""{BOT_MARKER}
 ## PR Review Agent
 
 | | |
 |---|---|
 | Commit | `{head_sha[:7]}` |
-| Build targets | {_target_list(targets, driver_paths)} |
+| Build targets | {listed} |
 | Status | Building... |
 
 Builds usually take 5–20 minutes. This comment will be updated when done.
@@ -72,7 +77,7 @@ def format_build_result(head_sha: str, results: list[BuildResult]) -> str:
     """Final build state — success or failure, with logs for failures."""
     rows = []
     for r in results:
-        name = r.driver_path or r.target.value
+        name = r.label()
         if r.success:
             _, tag = split_image_ref(r.image_tag)
             version = f"`{tag}`" if tag else "—"
@@ -108,13 +113,13 @@ Commit: `{head_sha[:7]}`
     if built:
         body += "\n### Images\n\n"
         for r in built:
-            name = r.driver_path or r.target.value
+            name = r.label()
             body += f"**{name}**\n```\n{r.image_tag}\n```\n"
         body += _deploy_help(built)
 
     missing_ref = [r for r in results if r.success and not r.image_tag]
     if missing_ref:
-        names = ", ".join(r.driver_path or r.target.value for r in missing_ref)
+        names = ", ".join(r.label() for r in missing_ref)
         body += (
             f"\n> Built successfully, but the image reference could not be read "
             f"from the build log for: {names}. Check the full log on the "
@@ -123,7 +128,7 @@ Commit: `{head_sha[:7]}`
 
     for r in results:
         if not r.success and r.log_tail:
-            name = r.driver_path or r.target.value
+            name = r.label()
             line_count = len(r.log_tail.splitlines())
             body += f"""
 <details><summary>{name} build log (last {line_count} lines)</summary>
@@ -158,7 +163,7 @@ def _deploy_help(built: list[BuildResult]) -> str:
 
     runnable = [r for r in built if r.container_name]
     for r in runnable:
-        name = r.driver_path or r.target.value
+        name = r.label()
         out += f"""
 **{name}**
 
@@ -174,7 +179,7 @@ Then `--logs`, `--shell`, `--down`. Starts container `{r.container_name}`, and
     # agent itself and updates in place rather than running as a second copy.
     web_only = [r for r in built if not r.container_name]
     if web_only:
-        names = ", ".join(r.driver_path or r.target.value for r in web_only)
+        names = ", ".join(r.label() for r in web_only)
         out += f"""
 **{names}** — deployed by updating through the web console, not by running a
 container: Agent Core pulls the image and hands over to a restart helper. Open
@@ -454,13 +459,3 @@ Commit: `{head_sha[:7]}`
 
 Push a fix and comment `/request_bot_review` again to retrigger.
 """
-
-
-def _target_list(targets: list[BuildTarget], driver_paths: list[str]) -> str:
-    names = []
-    for t in targets:
-        if t == BuildTarget.DRIVER:
-            names.extend(driver_paths)
-        else:
-            names.append(t.value)
-    return ", ".join(f"`{n}`" for n in names) if names else "None"

--- a/agents/pr_review/github_client.py
+++ b/agents/pr_review/github_client.py
@@ -6,6 +6,27 @@ import httpx
 
 logger = logging.getLogger(__name__)
 
+# GitHub rejects a comment body over 65536 characters with a 422. Anything the
+# agent posts is derived from build output or LLM text, so a length nobody
+# planned for is always possible — and losing the whole comment to it is much
+# worse than losing its tail. `comments.py` budgets logs well under this; the
+# clamp is the backstop for everything else.
+COMMENT_BODY_LIMIT = 65536
+
+
+def _clamp_body(body: str) -> str:
+    """Keep a comment postable, saying so if anything had to go."""
+    if len(body) <= COMMENT_BODY_LIMIT:
+        return body
+    note = (
+        "\n\n> :warning: This comment was truncated to fit GitHub's 65536-"
+        "character limit. See the dashboard for the full output.\n"
+    )
+    logger.warning(
+        f"Comment body {len(body)} chars exceeds GitHub's limit — truncating"
+    )
+    return body[: COMMENT_BODY_LIMIT - len(note)] + note
+
 
 class GitHubClient:
     """Thin async wrapper around GitHub REST API."""
@@ -124,7 +145,7 @@ class GitHubClient:
         """Post a comment on a PR. Returns the comment ID."""
         resp = await self._client.post(
             f"/repos/{repo}/issues/{pr_number}/comments",
-            json={"body": body},
+            json={"body": _clamp_body(body)},
         )
         resp.raise_for_status()
         return resp.json()["id"]
@@ -133,7 +154,7 @@ class GitHubClient:
         """Edit an existing comment."""
         resp = await self._client.patch(
             f"/repos/{repo}/issues/comments/{comment_id}",
-            json={"body": body},
+            json={"body": _clamp_body(body)},
         )
         resp.raise_for_status()
 

--- a/agents/pr_review/models.py
+++ b/agents/pr_review/models.py
@@ -2,10 +2,14 @@
 
 from __future__ import annotations
 
+import logging
+import re
 import uuid
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from enum import Enum
+
+logger = logging.getLogger(__name__)
 
 
 # ── Errors ────────────────────────────────────────────────────────────────────
@@ -54,6 +58,17 @@ class BuildTarget(str, Enum):
     CORE = "core"
     PERCEPTION = "perception"
     DRIVER = "driver"
+
+
+# Perception is built for Jetson only — that is where it runs, so the script's
+# `cpu` default produced an image nobody deploys. What is selectable is the
+# JetPack version, which picks the base image and lands in the tag as
+# `release.YYMMDD.<sha>-jetson-jp<ver>`.
+#
+# These are the versions `deploy/build_perception.sh` accepts; it exits 1 on
+# anything else, so an unrecognised one must never reach it.
+SUPPORTED_JP_VERSIONS = ("5.11", "6.1")
+DEFAULT_JP_VERSION = "5.11"
 
 
 # Statuses from which a job will never advance. Plain strings, because the
@@ -116,6 +131,27 @@ class BuildResult:
     # target ships a parseable fragment, so it doubles as the signal that
     # deploy/run-pr-image.sh will work for this image.
     container_name: str = ""
+    # JetPack version for a perception build, "" for core and drivers. Part of
+    # the build's identity, not a detail of it: one job can produce two
+    # perception images, and only this tells them apart.
+    variant: str = ""
+
+    def label(self) -> str:
+        return build_label(self.target, self.driver_path, self.variant)
+
+
+def build_label(
+    target: BuildTarget, driver_path: str | None, variant: str = ""
+) -> str:
+    """Human name for one build: what the comment and the dashboard both show.
+
+    In one place because a job can now contain two builds of the same target,
+    and a label that omits the variant would render them as duplicates.
+    """
+    name = driver_path or target.value
+    if variant:
+        return f"{name} (jetson-jp{variant})"
+    return name
 
 
 @dataclass
@@ -146,6 +182,9 @@ class ReviewJob:
     skip_build: bool = False
     build_only: bool = False
     force_targets: list[str] = field(default_factory=list)  # e.g. ["core"]
+    # JetPack versions to build perception for, in the order requested. Empty
+    # means the default; two entries mean two images from one job.
+    perception_variants: list[str] = field(default_factory=list)
 
     # Runtime state
     id: str = field(default_factory=lambda: uuid.uuid4().hex[:12])
@@ -218,12 +257,18 @@ class ReviewJob:
 
 TRIGGER = "/request_bot_review"
 
+# A JetPack version token: `jetson-5.11`, `jetson-jp6.1`, `jp5.11`, or the bare
+# version. Only perception has variants, so no target prefix is required — and a
+# version on its own is taken as a request to build perception.
+JP_TOKEN_PATTERN = re.compile(r"^(?:jetson-)?(?:jp)?(\d+\.\d+)$", re.IGNORECASE)
+
 
 def parse_trigger_command(comment_body: str) -> dict | None:
     """Parse a `/request_bot_review` command out of a comment body.
 
-    Returns {"skip_build", "build_only", "force_targets"}, or None when the
-    comment does not contain the trigger.
+    Returns {"skip_build", "build_only", "force", "force_targets",
+    "perception_variants"}, or None when the comment does not contain the
+    trigger.
     """
     if not comment_body:
         return None
@@ -241,6 +286,7 @@ def parse_trigger_command(comment_body: str) -> dict | None:
             "build_only": False,
             "force": False,
             "force_targets": [],
+            "perception_variants": [],
         }
         for arg in args:
             token = arg.strip().strip("`,")
@@ -254,6 +300,24 @@ def parse_trigger_command(comment_body: str) -> dict | None:
                 result["force"] = True
             elif lowered in ("core", "perception"):
                 result["force_targets"].append(lowered)
+            elif JP_TOKEN_PATTERN.match(lowered):
+                version = JP_TOKEN_PATTERN.match(lowered).group(1)
+                if version not in SUPPORTED_JP_VERSIONS:
+                    # Dropped rather than passed through: the build script exits
+                    # 1 on an unknown version, which would fail the whole job.
+                    # The build-in-progress comment lists what will actually be
+                    # built, so the drop is visible on the PR.
+                    logger.warning(
+                        f"Ignoring unsupported JetPack version {token!r} "
+                        f"(supported: {', '.join(SUPPORTED_JP_VERSIONS)})"
+                    )
+                    continue
+                if version not in result["perception_variants"]:
+                    result["perception_variants"].append(version)
+                # Asking for a version is asking for perception: the token means
+                # nothing for any other target.
+                if "perception" not in result["force_targets"]:
+                    result["force_targets"].append("perception")
             elif "/" in token:
                 # A driver path such as unitree/g1
                 result["force_targets"].append(token)

--- a/agents/pr_review/store.py
+++ b/agents/pr_review/store.py
@@ -101,6 +101,8 @@ class JobStore:
             ("merge_commit_sha",
              "ALTER TABLE jobs ADD COLUMN merge_commit_sha TEXT"),
             ("merged_at", "ALTER TABLE jobs ADD COLUMN merged_at TEXT"),
+            ("perception_variants",
+             "ALTER TABLE jobs ADD COLUMN perception_variants TEXT"),
         ):
             if column not in existing:
                 conn.execute(ddl)
@@ -118,6 +120,8 @@ class JobStore:
              "ALTER TABLE build_results ADD COLUMN run_command TEXT"),
             ("container_name",
              "ALTER TABLE build_results ADD COLUMN container_name TEXT"),
+            ("variant",
+             "ALTER TABLE build_results ADD COLUMN variant TEXT"),
         ):
             if column not in br_existing:
                 conn.execute(ddl)
@@ -157,9 +161,10 @@ class JobStore:
                   large_files, infra_files, shared_base_files,
                   review_rounds, review_stopped_reason, review_tool_calls,
                   pr_title, pr_body, pr_context,
-                  pr_author, build_ref_sha, merge_commit_sha, merged_at
+                  pr_author, build_ref_sha, merge_commit_sha, merged_at,
+                  perception_variants
                 ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,
-                          ?,?,?,?,?,?,?,?,?,?,?,?,?)
+                          ?,?,?,?,?,?,?,?,?,?,?,?,?,?)
                 """,
                 (
                     job.id,
@@ -198,6 +203,7 @@ class JobStore:
                     job.build_ref_sha,
                     job.merge_commit_sha,
                     job.merged_at,
+                    json.dumps(job.perception_variants),
                 ),
             )
             conn.commit()
@@ -280,8 +286,8 @@ class JobStore:
                 INSERT OR REPLACE INTO build_results (
                   job_id, idx, target, driver_path,
                   success, image_tag, log_path,
-                  container_name, created_at
-                ) VALUES (?,?,?,?,?,?,?,?,?)
+                  container_name, created_at, variant
+                ) VALUES (?,?,?,?,?,?,?,?,?,?)
                 """,
                 (
                     job_id,
@@ -295,6 +301,7 @@ class JobStore:
                     result.log_path,
                     result.container_name,
                     time.time(),
+                    result.variant,
                 ),
             )
             conn.commit()
@@ -346,7 +353,8 @@ class JobStore:
                 ids = [j["id"] for j in jobs]
                 marks = ",".join("?" * len(ids))
                 br = conn.execute(
-                    f"""SELECT job_id, idx, target, driver_path, success, image_tag
+                    f"""SELECT job_id, idx, target, driver_path, success,
+                               image_tag, variant
                         FROM build_results WHERE job_id IN ({marks})
                         ORDER BY job_id, idx""",
                     ids,
@@ -359,6 +367,7 @@ class JobStore:
                         "driver_path": row["driver_path"],
                         "success": _tri(row["success"]),
                         "image_tag": row["image_tag"],
+                        "variant": _col(row, "variant", ""),
                     })
                 for j in jobs:
                     j["build_results"] = by_job.get(j["id"], [])
@@ -420,6 +429,7 @@ class JobStore:
                     "image_tag": r["image_tag"],
                     "has_log": bool(r["log_path"]) and Path(r["log_path"]).exists(),
                     "container_name": _col(r, "container_name"),
+                    "variant": _col(r, "variant", ""),
                 }
                 for r in br
             ]
@@ -673,6 +683,9 @@ class JobStore:
                 "skip_build": bool(row["skip_build"]),
                 "build_only": bool(row["build_only"]),
                 "force_targets": _load_json(row["force_targets"], []),
+                "perception_variants": _load_json(
+                    _col(row, "perception_variants", ""), []
+                ),
             },
             "review_text": row["review_text"] or "",
             "findings": _load_json(row["findings"], []),
@@ -745,6 +758,7 @@ CREATE TABLE IF NOT EXISTS jobs (
   skip_build INTEGER DEFAULT 0,
   build_only INTEGER DEFAULT 0,
   force_targets TEXT,
+  perception_variants TEXT,
   review_text TEXT,
   findings TEXT,
   large_files TEXT,
@@ -781,6 +795,7 @@ CREATE TABLE IF NOT EXISTS build_results (
   log_path TEXT,
   run_command TEXT,        -- legacy, unused (see _migrate)
   container_name TEXT,
+  variant TEXT,            -- JetPack version for perception, "" otherwise
   created_at REAL NOT NULL,
   UNIQUE(job_id, idx)
 );

--- a/agents/pr_review/trigger.py
+++ b/agents/pr_review/trigger.py
@@ -108,6 +108,7 @@ async def create_job_from_comment(
         skip_build=trigger["skip_build"],
         build_only=trigger["build_only"],
         force_targets=trigger["force_targets"],
+        perception_variants=trigger["perception_variants"],
     )
 
     # Acknowledge with a comment immediately. With polling this matters — the

--- a/agents/pr_review/web/js/api.js
+++ b/agents/pr_review/web/js/api.js
@@ -167,7 +167,10 @@ export function shortSha(sha) {
 
 /** Human label for a build target row. */
 export function targetLabel(br) {
-  return br.driver_path || br.target || 'build';
+  const name = br.driver_path || br.target || 'build';
+  // A job can hold two perception builds — without the variant they render as
+  // duplicates of each other.
+  return br.variant ? `${name} (jetson-jp${br.variant})` : name;
 }
 
 /** "owner/repo" -> "repo", which is what disambiguates in this UI. */

--- a/agents/pr_review/web/js/views.js
+++ b/agents/pr_review/web/js/views.js
@@ -287,7 +287,9 @@ function _detailMeta(j) {
           <dt>Triggered via</dt><dd class="plain">${esc(j.source || '—')}</dd>
           <dt>Mode</dt><dd class="plain">${esc(mode)}${
             (o.force_targets || []).length
-              ? ` · forced: ${esc((o.force_targets || []).join(', '))}` : ''}</dd>
+              ? ` · forced: ${esc((o.force_targets || []).join(', '))}` : ''}${
+            (o.perception_variants || []).length
+              ? ` · JetPack: ${esc((o.perception_variants || []).join(', '))}` : ''}</dd>
           <dt>Attempt</dt><dd>${esc(j.attempt)}</dd>
           <dt>Created</dt><dd>${esc(fmtTime(j.created_at))}</dd>
           <dt>Started</dt><dd>${esc(fmtTime(j.started_at))}</dd>

--- a/agents/pr_review/worker.py
+++ b/agents/pr_review/worker.py
@@ -29,12 +29,14 @@ from .config import Config
 from .git_workspace import GitWorkspaceManager
 from .github_client import GitHubClient
 from .models import (
+    DEFAULT_JP_VERSION,
     BuildResult,
     BuildTarget,
     JobStatus,
     ReviewError,
     ReviewJob,
     Stage,
+    build_label,
 )
 from .components import build_context
 from .pr_context import PRContext, build_pr_context
@@ -217,16 +219,19 @@ async def _run_once(
 
     # 4. Build
     if not job.skip_build and targets:
+        # The plan is resolved before the comment goes out so the comment names
+        # the exact images that will be built — including one line per JetPack
+        # version when perception is built for more than one.
+        plan = _build_plan(job, targets, driver_paths)
         await _report(
             job, github_client,
             comments.format_building(
-                job.requester, job.pr_head_sha, targets, driver_paths
+                job.requester, job.pr_head_sha,
+                [build_label(t, dp, v) for t, dp, v in plan],
             ),
         )
 
-        results = await _execute_builds(
-            job, targets, driver_paths, worktree, config, store
-        )
+        results = await _execute_builds(job, plan, worktree, config, store)
         job.build_results = results
         await store.save_job(job)
 
@@ -381,15 +386,37 @@ def _round_reporter(job: ReviewJob, store: JobStore, model: str):
     return report
 
 
-async def _execute_builds(
+def _build_plan(
     job: ReviewJob,
     targets: list[BuildTarget],
     driver_paths: list[str],
+) -> list[tuple[BuildTarget, str | None, str]]:
+    """Expand targets into the individual builds to run, in order.
+
+    Perception expands over the requested JetPack versions — one job can produce
+    two images — and defaults to a single build at `DEFAULT_JP_VERSION`. Core and
+    drivers have no variant.
+    """
+    plan: list[tuple[BuildTarget, str | None, str]] = []
+    for target in targets:
+        if target == BuildTarget.DRIVER:
+            plan.extend((target, dp, "") for dp in driver_paths)
+        elif target == BuildTarget.PERCEPTION:
+            versions = job.perception_variants or [DEFAULT_JP_VERSION]
+            plan.extend((target, None, v) for v in versions)
+        else:
+            plan.append((target, None, ""))
+    return plan
+
+
+async def _execute_builds(
+    job: ReviewJob,
+    plan: list[tuple[BuildTarget, str | None, str]],
     worktree: Path,
     config: Config,
     store: JobStore,
 ) -> list[BuildResult]:
-    """Build each detected target in sequence, persisting each result.
+    """Build each planned target in sequence, persisting each result.
 
     Each build streams to its own log file under the job's log directory, so the
     dashboard can tail an in-progress build and the full output outlives the
@@ -398,17 +425,10 @@ async def _execute_builds(
     log_dir = store.log_dir_for(job.id)
     log_dir.mkdir(parents=True, exist_ok=True)
 
-    plan: list[tuple[BuildTarget, str | None]] = []
-    for target in targets:
-        if target == BuildTarget.DRIVER:
-            plan.extend((target, dp) for dp in driver_paths)
-        else:
-            plan.append((target, None))
-
     results = []
-    for idx, (target, driver_path) in enumerate(plan):
-        label = driver_path or target.value
-        log_path = log_dir / log_filename(idx, target, driver_path)
+    for idx, (target, driver_path, variant) in enumerate(plan):
+        label = build_label(target, driver_path, variant)
+        log_path = log_dir / log_filename(idx, target, driver_path, variant)
 
         job.set_stage(Stage.BUILDING, f"{idx + 1}/{len(plan)} {label}")
         await store.save_job(job)
@@ -429,13 +449,14 @@ async def _execute_builds(
                 image_tag="",
                 log_tail="",
                 log_path=str(log_path),
+                variant=variant,
             ),
         )
 
         if target == BuildTarget.CORE:
             result = await build_core(worktree, config, log_path)
         elif target == BuildTarget.PERCEPTION:
-            result = await build_perception(worktree, config, log_path)
+            result = await build_perception(worktree, config, log_path, variant)
         else:
             result = await build_driver(worktree, driver_path, config, log_path)
 


### PR DESCRIPTION
## Problem

The agent invoked `deploy/build_perception.sh` with no arguments, which means the script's default `--variant cpu`. Perception runs on Jetson hardware, so every perception PR has been publishing an image nobody deploys — and its tag (`release.YYMMDD.<sha>`) does not even say which variant it is.

## What changed

`--variant jetson` is now always passed; the CPU variant is unreachable from a PR comment by design. What *is* selectable is the JetPack version, which picks the base image and lands in the tag:

| Comment | Built as | Tag |
|---------|----------|-----|
| `/request_bot_review perception` | `--variant jetson --jp-version 5.11` | `release.YYMMDD.<sha>-jetson-jp5.11` |
| `/request_bot_review perception jetson-6.1` | `--variant jetson --jp-version 6.1` | `release.YYMMDD.<sha>-jetson-jp6.1` |
| `/request_bot_review perception jetson-5.11 jetson-6.1` | both, sequentially | both tags |

A version token implies the `perception` target, since it is meaningless for anything else — `/request_bot_review jetson-6.1` is enough. `jp6.1` and a bare `6.1` parse too. An unsupported version is **dropped with a warning** rather than passed to a script that would `exit 1` and fail the whole job; the "Building..." comment now lists the resolved plan, so the drop is visible on the PR.

## Design note

The JetPack version is modelled as a `variant` coordinate on the build rather than a perception special case, because one job can now produce two perception images and only the variant tells them apart — in log filenames, DB rows, comment labels and dashboard pills. One `build_label()` in `models.py` replaces the six places that computed `driver_path or target.value`, so the two builds never render as duplicates.

Two idempotent `ALTER TABLE`s follow the existing house pattern (`pr_author`, `build_ref_sha`). Pre-migration rows read back with an empty variant and render as plain `perception`.

## Verification

- **Parsing** — 9 cases: bare trigger, `perception`, each version, a bare version (implies perception), both versions (in order), `jp6.1`, `jetson-7.0` (dropped + warning), and `skip-build force perception jetson-6.1`. All correct.
- **Command** — exact argv is `--mirror tencent --variant jetson --jp-version 5.11|6.1`. `bash -n deploy/build_perception.sh` passes, and dry-running its own parser with those args yields `variant=jetson jp=6.1 tag_suffix=-jetson-jp6.1` (`--mirror` is stripped by `parse_mirror_arg` first, so order is safe).
- **Plan expansion** — default → one build at 5.11; two versions → two in order with distinct log filenames; `core` + `perception 6.1` + 2 drivers → 4 correctly labelled.
- **Migration** — against a DB with both columns dropped: added on next start, no-op on re-run, old jobs and build rows read back with empty variant.
- **Browser** — two pills `perception (jetson-jp5.11)` / `(jetson-jp6.1)`, two log panes, two distinct image tags, Mode line `build + review · JetPack: 5.11, 6.1`; a pre-migration row still reads plain `perception`. No console errors.

Note: the tag keeps the dotted version (`-jetson-jp6.1`). The `511`/`61` form is only the Docker build arg for the base image.

## Docs

`PR_REVIEW_AGENT.md` gains three command rows and a "Perception: Jetson only" subsection recording why, the supported versions, the default, and the tag shape. `README.md` needs no change — it only points here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)