### PR TITLE
fix(pr-review): retry transient LLM failures instead of ending the review

### DIFF
--- a/PR_REVIEW_AGENT.md
+++ b/PR_REVIEW_AGENT.md
@@ -223,6 +223,7 @@ failures another attempt could plausibly fix:
 | Network / git / registry error | yes | Usually transient |
 | Merge conflict | no | Only the author can resolve it |
 | Build failure (non-zero exit) | no | A real result — rebuilding says the same thing |
+| Reviewer produced nothing | no | Already re-tried in place, twice over (below) |
 
 > **Sizing note.** Builds run sequentially, so a PR touching N drivers needs
 > roughly N × `BUILD_TIMEOUT_SECONDS`. With the defaults, three drivers can
@@ -233,6 +234,46 @@ When a job is cancelled or times out, the build subprocess is killed by process
 group — `bash`, `docker`, and `buildx` all die together. Without that, an
 orphaned `docker build` would keep holding CPU and build cache while the retry
 competed with it.
+
+### A failing LLM gateway is not a failing PR
+
+The LLM call has its own retries, at two levels, because neither the round
+budget nor the job retry was the right tool for a gateway hiccup.
+
+**Per call.** A transient failure sleeps and tries the same call again —
+`LLM_RETRY_DELAYS`, currently 1s / 4s / 10s, so three retries and 15s of waiting
+worst case. Transient means the gateway or the network, not the request: any
+status ≥ 500, plus 408 / 425 / 429 / 529, plus a dropped connection or a read
+timeout. Note the ≥ 500 test is deliberately broad rather than a list of known
+codes — `router.phanthy.com` answers **666** with `bad_response_status_code`
+wrapping an upstream `openai_error`, which is an ordinary transient fault wearing
+a status no client would special-case.
+
+A retry does **not** consume a round. The round budget bounds how much the model
+explores; it is not there to absorb the gateway's bad minute. Nor does a retry
+sleep past `REVIEW_TIMEOUT_SECONDS` — the loop would then report a timeout and
+hide the fact that the gateway was the problem.
+
+A permanent failure (401, 403, 404, an unknown model) propagates on the first
+attempt. It will fail identically forever, and sleeping 15s first only delays the
+error comment.
+
+**Per review.** If the loop still ends with nothing the model wrote — an error
+and only the placeholder text — the whole review is started over, up to
+`REVIEW_ATTEMPTS` (2). In place, not by failing the job: the worktree is already
+there and the images are already built, so a second pass costs one review, while
+a job-level retry would rebuild and re-publish every image to ask the same
+question again. Both passes appear in the trace; the dashboard labels the second
+"Setup — review restarted (attempt 2)".
+
+A review that stopped early but *said* something is posted as-is — partial
+findings beat silence. Only a wholly empty one repeats, and if the second pass is
+empty too the PR gets an error comment rather than a review reading "the reviewer
+had no comments".
+
+Why this exists: one 666 on round 9 of a 20-round review used to end the whole
+thing, discarding 45 tool calls of accumulated context and posting the
+placeholder, with 11 rounds of budget left and nothing retried anywhere.
 
 ## PR comment lifecycle
 
@@ -492,16 +533,19 @@ Events are appended to `logs/<job_id>/review.jsonl` as they happen and tailed by
 the same cursor mechanism as a build log, so a review in progress can be watched
 live — the card appears before any review text exists. Rounds are found-or-created
 and rows appended rather than the timeline being re-rendered, so a result pane you
-have open stays open.
+have open stays open. "Found" means the *last* block with that number: one trace
+file can hold two reviews of the same job (a restarted review, or a job retry),
+and each starts counting rounds at 1 again.
 
 | Event | Carries |
 |---|---|
-| `setup` | component, rule files + size, docs, references, budget, model, and the deterministic size/infra results |
+| `setup` | component, rule files + size, docs, references, budget, model, and the deterministic size/infra results — plus `attempt` when this is a restarted review |
 | `round` | round, elapsed, prompt / cached / completion / reasoning tokens, narration, `finish_reason`, tools requested |
 | `tool` | round, name, args, summary, result bytes, duration, the result text, `error` / `refused` flags |
 | `tool` (`finish_review`) | the **written review itself**, flagged `markdown` so the timeline renders it as a *Review written* block rather than a `<pre>` |
 | `refusal` | a sandbox-blocked read — visible, not silently absent |
 | `nudge` | an empty completion and why, so a stalled review is legible |
+| `llm_retry` | round, attempt, the backoff, and the error — so "round 9 retried twice and then passed" is visible instead of reading as a slow model |
 | `finish` | stopped reason, rounds, tool calls, error |
 
 A trace runs ~100 KB for a 30-call review. It lives in the job's log directory, so

--- a/agents/pr_review/models.py
+++ b/agents/pr_review/models.py
@@ -39,6 +39,20 @@ class JobTimeoutError(ReviewError):
     retryable = True
 
 
+class EmptyReviewError(ReviewError):
+    """The reviewer failed and left nothing written behind.
+
+    Terminal on purpose. The review has already been re-tried in place — twice
+    over, once per model call and once over the whole loop — so a third pass
+    would only rebuild every image again to ask the same broken gateway the same
+    question. An error comment says what happened; the placeholder review this
+    replaces read as "the reviewer had no comments", which is worse than
+    silence.
+    """
+
+    retryable = False
+
+
 # ── Enums ─────────────────────────────────────────────────────────────────────
 
 

--- a/agents/pr_review/review_agent.py
+++ b/agents/pr_review/review_agent.py
@@ -32,7 +32,8 @@ from .config import Config
 from .pr_context import PRContext
 from .review_trace import ReviewTrace
 from .reviewer import (
-    chat_completions_url, describe_http_failure, explain_empty_completion,
+    TransientLLMError, chat_completions_url, describe_http_failure,
+    explain_empty_completion,
 )
 
 logger = logging.getLogger(__name__)
@@ -44,6 +45,16 @@ MAX_TOOL_RESULT = 4000
 # Consecutive rounds returning neither text nor tool calls before giving up. One
 # is a transient; three in a row is a misconfiguration worth reporting.
 MAX_EMPTY_ROUNDS = 3
+
+# Backoff before re-trying a transient LLM failure, in seconds — so up to three
+# retries per round, 15s of waiting worst case, against a 600s review budget.
+#
+# Without this, one gateway blip ended the whole review: a 666 from the router on
+# round 9 discarded 45 tool calls of accumulated context and posted a partial
+# review, with 11 rounds of budget left. The retry is per *call* and does not
+# consume a round, because the round budget exists to bound how much the model
+# explores, not to absorb the gateway's bad minute.
+LLM_RETRY_DELAYS = (1.0, 4.0, 10.0)
 
 # The written review is the point of the log, so it gets a larger cap than a
 # tool result. Still bounded: review_trace trims per field as a backstop.
@@ -57,6 +68,11 @@ class ReviewResult:
     stopped_reason: str = "finished"   # finished | max_rounds | timeout | error
     tool_calls: int = 0
     error: str = ""
+    # True when `markdown` is the placeholder rather than anything the model
+    # wrote. Lets the caller tell "the reviewer stopped early but had findings"
+    # from "the reviewer produced nothing at all" — the second is worth another
+    # attempt, the first is worth posting.
+    empty: bool = False
 
     @property
     def complete(self) -> bool:
@@ -277,6 +293,7 @@ class ReviewAgent:
         facts: PRFacts,
         trace: ReviewTrace | None = None,
         on_round=None,
+        attempt: int = 1,
     ):
         self._cfg = config
         self._ctx = ctx
@@ -289,6 +306,10 @@ class ReviewAgent:
         # Called with (round, max_rounds) so the caller can surface progress;
         # a minute of "generating review" with no movement reads as a hang.
         self._on_round = on_round
+        # Which pass over the loop this is. Only traced — one trace file can
+        # hold two reviews of the same job, and without this the second one's
+        # rounds read as a continuation of the first.
+        self._attempt = attempt
 
     async def run(self) -> ReviewResult:
         if not self._cfg.llm_base_url or not self._cfg.llm_api_key:
@@ -331,7 +352,9 @@ class ReviewAgent:
 
                 started = time.monotonic()
                 try:
-                    assistant, usage = await self._call(client, messages)
+                    assistant, usage = await self._call_with_retry(
+                        client, messages, rnd
+                    )
                 except Exception as e:
                     # A failure mid-loop still yields whatever was learned; the
                     # partial review is more useful than nothing.
@@ -414,6 +437,9 @@ class ReviewAgent:
         pr = self._facts.context
         self._trace.event(
             "setup",
+            # None on the first pass, so nothing changes for the common case
+            # (the trace drops None fields).
+            attempt=self._attempt if self._attempt > 1 else None,
             component=self._ctx.name,
             rules=self._ctx.rule_files,
             rules_chars=len(self._ctx.rules),
@@ -458,6 +484,48 @@ class ReviewAgent:
             finish_reason=assistant.get("_finish_reason") or None,
             tools=[c["function"]["name"] for c in calls] or None,
         )
+
+    async def _call_with_retry(
+        self, client: httpx.AsyncClient, messages: list[dict], rnd: int
+    ) -> tuple[dict, dict]:
+        """One model call, re-trying the failures that a second try can fix.
+
+        Transient means the gateway or the network, not the request: a 5xx (or
+        the router's synthetic 666), a 429, a dropped connection, a read
+        timeout. A bad key or an unknown model fails identically forever, so
+        those propagate on the first attempt rather than sleeping 15s first.
+
+        Each retry is traced. A silent one would make a slow round look like a
+        slow model, which is the wrong thing to go debugging.
+        """
+        last: Exception | None = None
+        for i, delay in enumerate((*LLM_RETRY_DELAYS, None)):
+            try:
+                return await self._call(client, messages)
+            except (TransientLLMError, httpx.TransportError) as e:
+                last = e
+                if delay is None:
+                    break
+                # Never sleep past the review budget: the round loop's own
+                # deadline check would then report a timeout, hiding the fact
+                # that the gateway was the problem.
+                if time.monotonic() + delay > self._deadline:
+                    logger.warning(
+                        f"round {rnd}: no budget left to retry after {e}"
+                    )
+                    break
+                logger.warning(
+                    f"round {rnd}: transient LLM failure "
+                    f"({i + 1}/{len(LLM_RETRY_DELAYS)}), retrying in {delay}s: {e}"
+                )
+                self._trace.event(
+                    "llm_retry", round=rnd, attempt=i + 1,
+                    limit=len(LLM_RETRY_DELAYS), delay=delay,
+                    error=f"{type(e).__name__}: {e}",
+                )
+                await asyncio.sleep(delay)
+        assert last is not None
+        raise last
 
     async def _call(
         self, client: httpx.AsyncClient, messages: list[dict]
@@ -613,6 +681,7 @@ class ReviewAgent:
         ]
         if prose:
             return prose[-1]
+        result.empty = True
         return (
             "_The reviewer explored the change but did not produce a written "
             "review before its budget ran out._"

--- a/agents/pr_review/reviewer.py
+++ b/agents/pr_review/reviewer.py
@@ -274,6 +274,30 @@ def _check_sensitive_files(changed_files: list[str]) -> list[Finding]:
 
 # ── LLM Review ─────────────────────────────────────────────────────────────────
 
+class TransientLLMError(RuntimeError):
+    """An LLM call that failed for a reason that may not recur.
+
+    Separated from a permanent failure because the two want opposite handling:
+    a bad key or a wrong model name will fail identically forever and should
+    surface immediately, while a gateway hiccup on round 9 of a review throws
+    away everything the reviewer had learned. Callers that can retry catch this;
+    callers that cannot still see a RuntimeError with the same message.
+    """
+
+
+# Statuses worth retrying. 5xx and above is the broad case, and it deliberately
+# covers non-standard codes: `router.phanthy.com` answers 666 with
+# `bad_response_status_code` wrapping an upstream `openai_error`, which is a
+# transient upstream fault wearing a status code no client would special-case.
+# 408/429 are the sub-500 ones that mean "try again", and 529 is Anthropic's
+# overloaded signal.
+RETRYABLE_STATUSES = frozenset({408, 425, 429, 529})
+
+
+def is_retryable_status(status: int) -> bool:
+    return status >= 500 or status in RETRYABLE_STATUSES
+
+
 def describe_http_failure(resp: "httpx.Response", endpoint: str) -> dict:
     """Parse a completion response, raising errors that say what happened.
 
@@ -292,9 +316,10 @@ def describe_http_failure(resp: "httpx.Response", endpoint: str) -> dict:
     snippet = resp.text[:200].replace("\n", " ").strip()
 
     if resp.status_code >= 400:
-        raise RuntimeError(
-            f"HTTP {resp.status_code} ({ctype}) from {endpoint}: {snippet}"
-        )
+        message = f"HTTP {resp.status_code} ({ctype}) from {endpoint}: {snippet}"
+        if is_retryable_status(resp.status_code):
+            raise TransientLLMError(message)
+        raise RuntimeError(message)
 
     try:
         data = json.loads(resp.text)

--- a/agents/pr_review/web/js/views.js
+++ b/agents/pr_review/web/js/views.js
@@ -498,6 +498,13 @@ export function appendTraceEvents(container, events) {
       case 'nudge':   _traceRoundBody(container, ev.round)
                         .appendChild(_traceNote('warning',
                           `Returned nothing (${ev.attempt}/${ev.limit}) — ${ev.reason || 'retrying'}`)); break;
+      // A retried round is otherwise indistinguishable from a slow model, which
+      // sends you debugging the wrong thing.
+      case 'llm_retry':
+                      _traceRoundBody(container, ev.round)
+                        .appendChild(_traceNote('warning',
+                          `LLM call failed (retry ${ev.attempt}/${ev.limit}, ` +
+                          `waiting ${ev.delay}s) — ${ev.error || 'transient error'}`)); break;
       case 'finish':  container.appendChild(_traceFinish(ev)); break;
       // 'refusal' duplicates what the tool row already shows as [refused].
       default: break;
@@ -546,7 +553,9 @@ function _kv(body, label, value) {
 function _traceSetup(ev) {
   // Open by default: what the reviewer was told is the context for everything
   // below it, and it is short.
-  const block = _traceBlock('Setup', ev.model || '', true);
+  const block = _traceBlock(
+    ev.attempt > 1 ? `Setup — review restarted (attempt ${ev.attempt})` : 'Setup',
+    ev.model || '', true);
   const body = block.querySelector('.trace-body');
   _kv(body, 'component', ev.component);
   _kv(body, 'rules', `${(ev.rules || []).join(' + ')}  (${ev.rules_chars || 0} chars)`);
@@ -601,7 +610,12 @@ function _traceRound(ev) {
 /** The body of round N, creating a placeholder block if it is not there yet. */
 function _traceRoundBody(container, round) {
   const key = String(round ?? 0);
-  let block = container.querySelector(`[data-trace-round="${CSS.escape(key)}"]`);
+  // The *last* block with this number, not the first: one trace file can hold
+  // more than one review of the same job — a restarted review, or a job-level
+  // retry — and each starts counting rounds at 1 again. Matching the first
+  // block would file the second review's round 1 under the first review's.
+  const all = container.querySelectorAll(`[data-trace-round="${CSS.escape(key)}"]`);
+  let block = all[all.length - 1];
   if (!block) {
     block = _traceBlock(`Round ${key}`, '', true);
     block.dataset.traceRound = key;

--- a/agents/pr_review/worker.py
+++ b/agents/pr_review/worker.py
@@ -32,6 +32,7 @@ from .models import (
     DEFAULT_JP_VERSION,
     BuildResult,
     BuildTarget,
+    EmptyReviewError,
     JobStatus,
     ReviewError,
     ReviewJob,
@@ -50,6 +51,12 @@ logger = logging.getLogger(__name__)
 # Marks a timeout reason string, so the final status can distinguish a lost
 # job from a hard error without threading an extra flag through the loop.
 TIMEOUT_PREFIX = "Job timed out"
+
+# How many times the review loop is started over when it comes back with
+# nothing written. Two, because the interesting failure is a gateway blip that
+# survived the per-call retries — an outage long enough to eat two whole loops
+# is not going to be fixed by a third.
+REVIEW_ATTEMPTS = 2
 
 
 # ── Entry point: retry wrapper ─────────────────────────────────────────────────
@@ -297,33 +304,58 @@ async def _run_once(
             "comments_dropped": pr_ctx.comments_dropped,
         }
 
-        agent = ReviewAgent(
-            config,
-            worktree,
-            build_context(
-                job.repo_full_name, targets, driver_paths, changed_files
-            ),
-            PRFacts(
-                repo=job.repo_full_name,
-                pr_number=job.pr_number,
-                base_ref=base_ref,
-                changed_files=changed_files,
-                diff_stat=diff_stat,
-                large_files=big,
-                infra_files=infra,
-                shared_base_files=shared,
-                context=pr_ctx,
-            ),
-            # Records what the loop did, streamed to disk so the dashboard can
-            # follow a review in progress rather than only see the verdict.
-            trace=ReviewTrace(store.review_trace_path(job.id)),
-            on_round=_round_reporter(job, store, config.llm_model),
-        )
-        result = await agent.run()
+        # Retried in place rather than by failing the job: the worktree is
+        # already here and the images are already built, so a second pass costs
+        # one review while a job-level retry would rebuild and re-publish every
+        # image to ask the same question again.
+        for review_attempt in range(1, REVIEW_ATTEMPTS + 1):
+            agent = ReviewAgent(
+                config,
+                worktree,
+                build_context(
+                    job.repo_full_name, targets, driver_paths, changed_files
+                ),
+                PRFacts(
+                    repo=job.repo_full_name,
+                    pr_number=job.pr_number,
+                    base_ref=base_ref,
+                    changed_files=changed_files,
+                    diff_stat=diff_stat,
+                    large_files=big,
+                    infra_files=infra,
+                    shared_base_files=shared,
+                    context=pr_ctx,
+                ),
+                # Records what the loop did, streamed to disk so the dashboard
+                # can follow a review in progress rather than only see the
+                # verdict.
+                trace=ReviewTrace(store.review_trace_path(job.id)),
+                on_round=_round_reporter(job, store, config.llm_model),
+                attempt=review_attempt,
+            )
+            result = await agent.run()
+            # Anything the model actually wrote is worth posting, even from a
+            # loop that ended badly — so only a wholly empty failure repeats.
+            if not (result.stopped_reason == "error" and result.empty):
+                break
+            if review_attempt < REVIEW_ATTEMPTS:
+                logger.warning(
+                    f"Job {job.id}: review produced nothing "
+                    f"({result.error or 'unknown error'}) — starting over "
+                    f"({review_attempt + 1}/{REVIEW_ATTEMPTS})"
+                )
+
         job.review_text = result.markdown
         job.review_rounds = result.rounds
         job.review_stopped_reason = result.stopped_reason
         job.review_tool_calls = result.tool_calls
+
+        if result.stopped_reason == "error" and result.empty:
+            await store.save_job(job)
+            raise EmptyReviewError(
+                f"the reviewer produced nothing after {REVIEW_ATTEMPTS} "
+                f"attempts: {result.error or 'unknown error'}"
+            )
 
         job.set_stage(Stage.POSTING)
         await store.save_job(job)


### PR DESCRIPTION
## The problem

Round 9 of a 20-round review, from a real run:

```
RuntimeError: HTTP 666 (application/json) from https://router.phanthy.com/v1/chat/completions:
{"error":{"message":"openai_error","type":"bad_response_status_code",...}}
```

One blip ended the review. 45 tool calls of context discarded, the placeholder
_"The reviewer explored the change but did not produce a written review"_ posted
to the PR, 11 rounds of budget unused.

Nothing retried, at any of the three layers that could have:

1. No transport retries on the httpx client, and any status `>= 400` raised immediately.
2. The round loop's `except Exception` broke out on the first failure.
3. Job-level `MAX_ATTEMPTS` was never consulted — the agent *returned* normally, so the job counted as complete.

## The fix

**Per call** — a transient failure sleeps and re-tries the same call: 1s / 4s / 10s.

- Transient = status `>= 500`, plus 408 / 425 / 429 / 529, plus httpx transport errors. The `>= 500` test is deliberately broad rather than a list: **666** is the router's synthetic code wrapping an upstream `openai_error`, an ordinary transient fault wearing a status no client special-cases.
- Permanent (401, 403, unknown model) propagates on the first attempt — it will fail identically forever, and sleeping 15s first only delays the error comment.
- A retry does not consume a round: the round budget bounds how much the model *explores*.
- The backoff never sleeps past `REVIEW_TIMEOUT_SECONDS` — the loop would otherwise report a timeout and hide the gateway as the cause.

**Per review** — a loop ending with nothing the model wrote starts over, in place, up to `REVIEW_ATTEMPTS` (2). In place rather than by failing the job because the worktree is already there and the images are already built: a second pass costs one review, a job retry would rebuild and re-publish every image to ask the same question again. If the second pass is empty too, `EmptyReviewError` (terminal) posts an error comment instead of a review that reads "the reviewer had no comments". A review that stopped early but *said* something is still posted as-is.

**Visible, not silent** — an `llm_retry` trace event per retry, and a restarted review's `setup` carries its attempt number, so "round 9 retried twice and then passed" is legible instead of reading as a slow model.

## Dashboard bug found on the way

`_traceRoundBody` matched the **first** block with a given round number. One trace file can hold two reviews of the same job — this restart, or the job-level retry that already existed — and each counts rounds from 1, so the second review's round 1 filed its tool calls under the first review's. Now matches the last.

## Verification

- Classification: 500 / 502 / 503 / 666 / 429 / 408 / 425 / 529 retry; 400 / 401 / 403 / 404 / 422 do not.
- `describe_http_failure` raises `TransientLLMError` for 666 and plain `RuntimeError` for 401; a 200 still parses.
- Retry loop: transient-then-success returns the completion after 3 calls with 2 traced retries; permanent errors make exactly 1 call; always-transient makes 4 calls and re-raises the last error; with the deadline 1ms away it makes 1 call and does **not** sleep the 5s backoff.
- `_salvage` sets `empty` only when the model wrote no prose (so a partial review is never mistaken for an empty one); the "LLM not configured" path is untouched.
- Browser: a seeded two-attempt trace renders both retries as warnings under round 1, labels the second setup _"Setup — review restarted (attempt 2)"_, and files attempt 2's round 1 tool call under the second round-1 block.

Not exercised against the live router — the incident is not reproducible on demand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)