### PR TITLE
feat(asr): add X-ASR bilingual model (minimal, replaces #102)

### DIFF
--- a/perception/README.md
+++ b/perception/README.md
@@ -71,6 +71,123 @@ The VAD parameters can be adjusted per ASR canvas card via the instance config (
 |-----------|---------|-------|
 | `vad_threshold` | `0.5` | Speech probability threshold (0–1). Raise to `0.7`–`0.85` in noisy environments (e.g. robot motor noise). |
 | `vad_silence_ms` | `400` | Silence duration (ms) required before an utterance is considered complete. |
+| `vad_pre_roll_ms` | `500` | Audio retained from *before* the VAD tripped. Recovers clipped word onsets — without it the first syllable is often missing, which costs wake-word recall. |
+
+---
+
+## Plugin Concurrency
+
+**`dispatch()` is not single-threaded.** `main.py` serves MCP over
+`ThreadingHTTPServer`, so every `tools/call` runs on its own thread. `start`,
+`stop`, `config`, and `speak` on the *same* plugin can genuinely run at once —
+the canvas does exactly this (config → start, then stop, then config → start).
+
+This has already caused a production incident, so the rules below are not
+theoretical.
+
+### The failure mode
+
+Any plugin that keeps per-instance state in a dict is exposed to this shape:
+
+```python
+# ❌ WRONG — check-then-act with no lock
+node_key = instance_id or input_topic
+if node_key not in self._nodes:          # ← two threads both pass here
+    node = _ASRNode(...)
+    self._executor.add_node(node)
+    self._nodes[node_key] = node         # ← only the last one survives
+return self._nodes[node_key].start()
+```
+
+Both threads build a node with the *same* ROS node name, both add it to the
+executor, and the dict keeps only the second. The first is now an **orphan**: its
+subscription, its VAD subprocess, and its transcription thread are all still
+running and still publishing to the same output topic, but it is not in
+`self._nodes`, so `stop` can never reach it. It survives until the process exits.
+
+Observable symptoms: every utterance recognised and published twice, duplicate
+files in `/models/vad_segments` with byte-identical content, an extra
+`vad_worker` child process that `stop` does not reap, and this from rclpy:
+
+```
+Publisher already registered for provided node name. If this is due to multiple
+nodes with the same name then all logs for that logger name will go out over the
+existing publisher.
+```
+
+### The rules
+
+**1. Make the dict access atomic.** One `threading.RLock` per plugin, guarding
+every read-modify-write of the state dict:
+
+```python
+# ✅ CORRECT — atomic get-or-create
+with self._nodes_lock:
+    node = self._nodes.get(node_key)
+    if node is None:
+        node = _ASRNode(...)
+        try:
+            self._executor.add_node(node)
+        except Exception:
+            node.destroy_node()          # don't leak a half-registered node
+            raise
+        self._nodes[node_key] = node
+    else:
+        self._sync_cfg(node)
+```
+
+**2. Never hold that lock across `node.start()`, `node.stop()`, or a model
+load.** `_ASRNode.start()` blocks for up to 15 s waiting for the first audio
+chunk. If `stop` is queued behind the lock for those 15 s, it cannot set the
+cancellation flag in time, `start` sails through to `running`, and you are left
+with a pipeline nobody asked for. Register the node inside the lock, then release
+it and call `start()` outside.
+
+**3. Register the node *before* starting it.** That is what lets a concurrent
+`stop` find it and cancel the in-flight start. Loading a model or otherwise
+blocking *before* the node is in the dict means `stop` finds nothing, returns
+`{"state": "idle"}`, and silently no-ops — while the start it was meant to cancel
+completes anyway.
+
+**4. `stop` signals first, locks second.** Give the node a non-blocking
+`request_stop()` that sets its cancellation events, call that before taking any
+lock, and only then tear down:
+
+```python
+def stop(self) -> dict:
+    self.request_stop()                  # non-blocking; unblocks an in-flight start
+    with self._lifecycle_lock:
+        self._teardown()
+        self.state = "idle"
+        return {"state": "idle"}
+```
+
+**5. Guard the node object too, and treat "starting" as taken.** A per-node
+`RLock` plus `if self.state in ("running", "starting")` — otherwise two threads
+that resolve to the *same* node object can both enter `_start_inner()` and build
+two subscriptions and two subprocesses on one node.
+
+**6. `destroy_node()`, not just `remove_node()`.** `remove_node` detaches the
+node from the executor; it does not release the rclpy node, its publishers, or
+its node name. Skip it and every start/stop cycle leaks a topic endpoint, and a
+later start on the same key collides with the still-registered ghost:
+
+```python
+def _dispose_node(self, node, key=""):
+    node.stop()
+    self._executor.remove_node(node)
+    node.destroy_node()                  # ← required
+```
+
+**7. Snapshot before iterating.** `info` is a heartbeat probe called constantly.
+Iterating the live dict can raise `RuntimeError: dictionary changed size during
+iteration` in the middle of a start. Copy under the lock, then iterate the copy.
+
+### Where this applies
+
+Every MCP server in the project uses `ThreadingHTTPServer` — `perception/main.py`
+and each robot driver's `main.py`. Any plugin holding a `self._nodes` /
+`self._instances` / `self._streams` dict needs the treatment above.
 
 ---
 

--- a/perception/config.yaml
+++ b/perception/config.yaml
@@ -12,6 +12,7 @@ plugins:
       model: sherpa_onnx    # sherpa_onnx (ONNX, lightweight) | silero (PyTorch) | webrtc
       threshold: 0.5
       silence_ms: 400
+      pre_roll_ms: 500
     kws:
       enabled: true
       model_dir: /models/sherpa-onnx/kws

--- a/perception/plugins/asr.py
+++ b/perception/plugins/asr.py
@@ -301,7 +301,7 @@ TOOLS = [
                 "vad_threshold": {"type": "number", "description": "VAD speech threshold (0-1, higher = stricter)", "default": 0.5, "scope": "shared"},
                 "vad_silence_ms":{"type": "integer", "description": "Silence duration (ms) before sentence end", "default": 400, "scope": "shared"},
                 "vad_pre_roll_ms":{"type": "integer", "description": "Audio retained before detected speech (ms)", "default": 500, "scope": "shared"},
-                "save_vad_segments": {"type": "boolean", "description": "Save VAD segments as WAV to /opt/embodied/models/vad_segments/", "default": False, "scope": "shared"},
+                "save_vad_segments": {"type": "boolean", "description": "Save VAD segments as WAV to /opt/embodied/models/vad_segments/", "default": True, "scope": "shared"},
                 "max_saved_segments": {"type": "integer", "description": "Max saved VAD segments (oldest deleted when exceeded)", "default": 1000, "scope": "shared"},
             },
             "required": []
@@ -1299,8 +1299,12 @@ class ASRPlugin:
         self._vad_threshold = float(vad_cfg.get('threshold', SPEECH_THRESH))
         self._vad_silence_ms = int(vad_cfg.get('silence_ms', 400))
         self._kws_cfg      = plugin_cfg.get('kws', {})
-        self._save_vad_segments = False
-        self._max_saved_segments = 1000
+        # On by default: the saved segments are the only way to audit what the VAD
+        # actually handed the recogniser when a transcription looks wrong. Bounded
+        # by _max_saved_segments — see _enforce_retention(), which unlike the
+        # previous per-process counter actually prunes.
+        self._save_vad_segments = bool(plugin_cfg.get('save_vad_segments', True))
+        self._max_saved_segments = int(plugin_cfg.get('max_saved_segments', 1000))
         self._vad_pre_roll_ms = int(vad_cfg.get('pre_roll_ms', 500))
         self._nodes: dict[str, _ASRNode] = {}           # key = instance_id
         # main.py serves MCP over ThreadingHTTPServer, so start/stop/config can

--- a/perception/plugins/asr.py
+++ b/perception/plugins/asr.py
@@ -23,12 +23,26 @@ from rclpy.node import Node
 from rclpy.qos import QoSProfile, ReliabilityPolicy, HistoryPolicy, DurabilityPolicy
 from std_msgs.msg import String
 
+from plugins.vad_preroll import PcmHistory
+
 log = logging.getLogger(__name__)
 
 SAMPLE_RATE    = 16000
 SPEECH_THRESH  = 0.5
 SILENCE_THRESH = 0.35
 SILENCE_FRAMES = 16
+
+# Documented AudioChunk contract — see perception/README.md ("Audio Requirements
+# for ASR"): 16 kHz mono PCM_S16_LE, at least 512 samples per chunk.
+AUDIO_FORMAT       = "audio/pcm-16k"
+# agent-core's remote-control mic bridge publishes this spelling instead; accept
+# it rather than warning on every chunk of a path that already works.
+_AUDIO_FORMAT_ALIASES = frozenset({AUDIO_FORMAT, "pcm_16k_16bit_mono"})
+MIN_CHUNK_BYTES    = 1024  # 512 samples — one Silero VAD window
+
+# Upper bound on how long `start` waits for a background model load. Prevents a
+# stalled download from pinning an MCP worker thread indefinitely.
+MODEL_LOAD_TIMEOUT_S = 300
 
 _LOW_LAT_QOS = QoSProfile(
     reliability=ReliabilityPolicy.BEST_EFFORT,
@@ -278,7 +292,7 @@ TOOLS = [
         "configSchema": {
             "type": "object",
             "properties": {
-                "asr_model":     {"type": "string", "enum": ["paraformer-zh-en", "paraformer-offline", "zipformer-en", "sensevoice-small"], "description": "ASR model (paraformer-zh-en = bilingual streaming, paraformer-offline = bilingual offline, zipformer-en = English streaming, sensevoice-small = multilingual offline)", "default": "sensevoice-small", "scope": "shared"},
+                "asr_model":     {"type": "string", "enum": ["x-asr-zh-en", "paraformer-zh-en", "paraformer-offline", "zipformer-en", "sensevoice-small"], "description": "ASR model (x-asr-zh-en = bilingual offline transducer with hotwords, paraformer-zh-en = bilingual streaming, paraformer-offline = bilingual offline, zipformer-en = English streaming, sensevoice-small = multilingual offline)", "default": "sensevoice-small", "scope": "shared"},
                 "trigger_mode":  {"type": "string", "enum": ["vad", "kws", "asr_kws"], "description": "Trigger mode (vad = always listen, kws = KWS model, asr_kws = ASR + phoneme matching)", "default": "kws", "scope": "shared"},
                 "kws_model":     {"type": "string", "enum": ["zh", "en", "zh-en"], "description": "KWS 模型 (zh=纯中文, en=纯英文, zh-en=双语)", "default": "zh", "scope": "shared", "x-show-when": {"trigger_mode": "kws"}},
                 "kws_keywords":  {"type": "string", "description": "Wake word (zh: 'f àn sh ì x iǎo g ǒu @范式小狗', en: '▁FA N C Y ▁RO B O T @FANCY_ROBOT')", "scope": "shared", "x-show-when": {"trigger_mode": "kws"}},
@@ -286,6 +300,7 @@ TOOLS = [
                 "asr_kws_threshold": {"type": "number", "description": "音素匹配阈值（0-1，越小越严格，推荐0.3）", "default": 0.3, "scope": "shared", "x-show-when": {"trigger_mode": "asr_kws"}},
                 "vad_threshold": {"type": "number", "description": "VAD speech threshold (0-1, higher = stricter)", "default": 0.5, "scope": "shared"},
                 "vad_silence_ms":{"type": "integer", "description": "Silence duration (ms) before sentence end", "default": 400, "scope": "shared"},
+                "vad_pre_roll_ms":{"type": "integer", "description": "Audio retained before detected speech (ms)", "default": 500, "scope": "shared"},
                 "save_vad_segments": {"type": "boolean", "description": "Save VAD segments as WAV to /opt/embodied/models/vad_segments/", "default": False, "scope": "shared"},
                 "max_saved_segments": {"type": "integer", "description": "Max saved VAD segments (oldest deleted when exceeded)", "default": 1000, "scope": "shared"},
             },
@@ -517,8 +532,27 @@ class SherpaOnnxOfflineParaformerAdapter(ASRAdapter):
         return text.strip()
 
 
+class SherpaOnnxXASRAdapter(ASRAdapter):
+    """Offline X-ASR transducer with general robot-domain hotword biasing."""
+
+    def __init__(self, model_dir: str, hw_provider: str = "cpu", num_threads: int = 2):
+        from utils.model_downloader import ensure_model
+        from plugins.x_asr import XASRAdapter
+
+        ensure_model("asr_x_asr", model_dir)
+        self._delegate = XASRAdapter(model_dir, hw_provider, num_threads)
+
+    def transcribe(self, wav_bytes: bytes, language: str) -> str:
+        return self._delegate.transcribe(wav_bytes, language)
+
+
 # ASR model registry
 ASR_MODELS = {
+    "x-asr-zh-en": {
+        "label": "X-ASR Bilingual (zh+en, offline transducer)",
+        "adapter": SherpaOnnxXASRAdapter,
+        "default_model_dir": "/models/sherpa-onnx/x-asr-zh-en",
+    },
     "paraformer-zh-en": {
         "label": "Paraformer Bilingual (zh+en, streaming)",
         "adapter": SherpaOnnxASRAdapter,
@@ -567,7 +601,8 @@ def _vad_worker(pcm_q: multiprocessing.Queue, result_q: multiprocessing.Queue,
                 stop_evt: multiprocessing.Event,
                 backend: str, threshold: float, silence_ms: int,
                 kws_cfg: dict = None,
-                save_vad_segments: bool = False, max_saved_segments: int = 1000):
+                save_vad_segments: bool = False, max_saved_segments: int = 1000,
+                pre_roll_ms: int = 500):
     """Runs in a child process — sherpa-onnx ONNX VAD + optional KWS gate.
 
     Pipeline: Audio → VAD → (KWS gate) → utterance output
@@ -600,7 +635,13 @@ def _vad_worker(pcm_q: multiprocessing.Queue, result_q: multiprocessing.Queue,
         provider="cpu",
     )
     vad = sherpa_onnx.VoiceActivityDetector(vad_config, buffer_size_in_seconds=30)
-    _log.info(f"[vad-worker] sherpa-onnx VAD initialized (threshold={threshold}, silence_ms={silence_ms})")
+    pre_roll_samples = max(0, int(SAMPLE_RATE * pre_roll_ms / 1000))
+    silence_samples = max(0, int(SAMPLE_RATE * silence_ms / 1000))
+    pcm_history = PcmHistory(SAMPLE_RATE * 31)
+    _log.info(
+        f"[vad-worker] sherpa-onnx VAD initialized (threshold={threshold}, "
+        f"silence_ms={silence_ms}, pre_roll_ms={pre_roll_ms})"
+    )
 
     # ── Initialize KWS (optional) ──
     kws_spotter = None
@@ -684,46 +725,76 @@ def _vad_worker(pcm_q: multiprocessing.Queue, result_q: multiprocessing.Queue,
 
     # VAD segment saving
     _VAD_SEG_DIR = '/models/vad_segments'
-    _seg_count = [0]
 
-    def _save_segment(float_samples_list, count_ref):
+    def _save_segment(float_samples_list):
         """Save float samples as WAV."""
         try:
-            import wave as _wave, time as _time2
-            os.makedirs(_VAD_SEG_DIR, exist_ok=True)
-            seg_pcm = _struct.pack(f'<{len(float_samples_list)}h',
-                                   *[int(max(-32768, min(32767, s * 32768))) for s in float_samples_list])
-            fname = os.path.join(_VAD_SEG_DIR, f"seg_{int(_time2.time()*1000)}.wav")
-            with _wave.open(fname, 'wb') as wf:
-                wf.setnchannels(1)
-                wf.setsampwidth(2)
-                wf.setframerate(SAMPLE_RATE)
-                wf.writeframes(seg_pcm)
-            # Enforce max segments limit
-            if count_ref[0] >= max_saved_segments:
-                files = sorted(os.listdir(_VAD_SEG_DIR))
-                for old in files[:len(files) - max_saved_segments + 1]:
-                    os.remove(os.path.join(_VAD_SEG_DIR, old))
+            seg_pcm = struct.pack(f'<{len(float_samples_list)}h',
+                                  *[int(max(-32768, min(32767, s * 32768))) for s in float_samples_list])
+            _write_segment(seg_pcm)
         except Exception:
             pass
 
-    def _save_segment_pcm(pcm_bytes, count_ref):
+    def _save_segment_pcm(pcm_bytes):
         """Save raw PCM bytes as WAV."""
         try:
-            import wave as _wave, time as _time2
-            os.makedirs(_VAD_SEG_DIR, exist_ok=True)
-            fname = os.path.join(_VAD_SEG_DIR, f"seg_{int(_time2.time()*1000)}.wav")
-            with _wave.open(fname, 'wb') as wf:
-                wf.setnchannels(1)
-                wf.setsampwidth(2)
-                wf.setframerate(SAMPLE_RATE)
-                wf.writeframes(pcm_bytes)
-            if count_ref[0] >= max_saved_segments:
-                files = sorted(os.listdir(_VAD_SEG_DIR))
-                for old in files[:len(files) - max_saved_segments + 1]:
-                    os.remove(os.path.join(_VAD_SEG_DIR, old))
+            _write_segment(pcm_bytes)
         except Exception:
             pass
+
+    def _segment_path():
+        """A path no existing segment occupies.
+
+        The name carries wall-clock milliseconds, and _save_segment is called
+        from inside the wake-wait drain loop — several segments get written
+        back-to-back well within one millisecond, and wave.open(..., 'wb')
+        truncates, so without a suffix the earlier audio is silently lost.
+        """
+        stamp = int(time.time() * 1000)
+        path = os.path.join(_VAD_SEG_DIR, f"seg_{stamp}.wav")
+        if not os.path.exists(path):
+            return path
+        for n in range(1, 1000):
+            alt = os.path.join(_VAD_SEG_DIR, f"seg_{stamp}_{n}.wav")
+            if not os.path.exists(alt):
+                return alt
+        return path
+
+    def _enforce_retention():
+        """Prune to max_saved_segments, counting what is on disk.
+
+        The old gate was an in-process counter `>= max_saved_segments`, but it was
+        initialised per VAD worker *process* — every ASR restart reset it to 0,
+        so a robot that restarts ASR regularly never pruned at all (observed:
+        5590 files with max_saved_segments=1000). Also filter the listing: it
+        used to feed raw os.listdir() to os.remove(), which would delete any
+        unrelated file that happened to live in this directory.
+        """
+        try:
+            names = [f for f in os.listdir(_VAD_SEG_DIR)
+                     if f.startswith('seg_') and f.endswith('.wav')]
+        except OSError:
+            return
+        if len(names) <= max_saved_segments:
+            return
+        # Fixed-width 13-digit epoch-ms keeps ASCII order == chronological order
+        # until year 2286, so a plain sort is correct here.
+        names.sort()
+        for old in names[:len(names) - max_saved_segments]:
+            try:
+                os.remove(os.path.join(_VAD_SEG_DIR, old))
+            except OSError:
+                pass
+
+    def _write_segment(pcm_bytes):
+        import wave as _wave
+        os.makedirs(_VAD_SEG_DIR, exist_ok=True)
+        with _wave.open(_segment_path(), 'wb') as wf:
+            wf.setnchannels(1)
+            wf.setsampwidth(2)
+            wf.setframerate(SAMPLE_RATE)
+            wf.writeframes(pcm_bytes)
+        _enforce_retention()
 
     while not stop_evt.is_set():
         try:
@@ -744,6 +815,7 @@ def _vad_worker(pcm_q: multiprocessing.Queue, result_q: multiprocessing.Queue,
         float_samples = [s / 32768.0 for s in samples]
 
         # Feed VAD
+        pcm_history.append(pcm[:n * 2])
         vad.accept_waveform(float_samples)
 
         if state == 'waiting_wake':
@@ -771,8 +843,7 @@ def _vad_worker(pcm_q: multiprocessing.Queue, result_q: multiprocessing.Queue,
             while not vad.empty():
                 seg = vad.front
                 if save_vad_segments:
-                    _save_segment(seg.samples, _seg_count)
-                    _seg_count[0] += 1
+                    _save_segment(seg.samples)
                 vad.pop()
 
         elif state == 'listening':
@@ -782,24 +853,47 @@ def _vad_worker(pcm_q: multiprocessing.Queue, result_q: multiprocessing.Queue,
                 result_q.put(("speech_start", ts, ts, False))
             _was_speaking = _is_speaking
 
-            # Collect completed VAD segments
+            # Collect completed VAD segments.
+            # The VAD only reports a segment after min_silence_duration of
+            # trailing silence has elapsed, and that silence is not part of
+            # seg.samples — so the current chunk timestamp sits one silence
+            # window past the real end of speech. Rewind it, the same way
+            # PcmHistory.pre_roll() rewinds by silence_samples to locate the
+            # segment start in the sample domain.
+            seg_end_ts = ts - silence_samples / SAMPLE_RATE
             while not vad.empty():
                 seg = vad.front
                 seg_pcm = _struct.pack(f'<{len(seg.samples)}h',
                                        *[int(max(-32768, min(32767, s * 32768))) for s in seg.samples])
-                if not start_ts:
-                    start_ts = ts
-                speech_buf += seg_pcm
-                end_ts = ts
+                # `is None`, not falsy: a legitimate start_ts of 0.0 would
+                # otherwise be re-stamped.
+                if start_ts is None:
+                    pre_pcm = pcm_history.pre_roll(
+                        getattr(seg, 'start', None),
+                        len(seg.samples),
+                        pre_roll_samples,
+                        silence_samples,
+                    )
+                    start_ts = seg_end_ts - (len(pre_pcm) + len(seg_pcm)) / 2 / SAMPLE_RATE
+                    speech_buf = pre_pcm + seg_pcm
+                else:
+                    pre_pcm = b''
+                    speech_buf += seg_pcm
+                end_ts = seg_end_ts
                 vad.pop()
 
                 # Output the segment as an utterance
                 if len(speech_buf) > SAMPLE_RATE:  # >500ms
-                    _log.info(f"[vad-worker] utterance complete, len={len(speech_buf)} bytes")
+                    _log.info(
+                        f"[vad-worker] utterance complete, len={len(speech_buf)} bytes, "
+                        f"pre_roll_bytes={len(pre_pcm)}"
+                    )
                     if save_vad_segments:
-                        _save_segment_pcm(speech_buf, _seg_count)
-                        _seg_count[0] += 1
-                    result_q.put((speech_buf, start_ts or ts, end_ts or ts, _kws_triggered))
+                        _save_segment_pcm(speech_buf)
+                    result_q.put((speech_buf,
+                                  seg_end_ts if start_ts is None else start_ts,
+                                  seg_end_ts if end_ts is None else end_ts,
+                                  _kws_triggered))
                     _kws_triggered = False
                     speech_buf = b''
                     start_ts = None
@@ -807,6 +901,15 @@ def _vad_worker(pcm_q: multiprocessing.Queue, result_q: multiprocessing.Queue,
                     # Return to waiting for wake word (if KWS enabled)
                     if kws_enabled:
                         state = 'waiting_wake'
+                        # Stop draining here. Without the break, segments still
+                        # queued in the VAD keep being treated as an active
+                        # listening session and can emit a second utterance in
+                        # this same pass, after the wake gate has already closed.
+                        # `state` is only re-read on the next outer iteration, so
+                        # the gate would be bypassed for however many segments
+                        # the VAD had queued. The remainder belongs to
+                        # waiting_wake, which drains it next round.
+                        break
 
     _log.info("[vad-worker] process exiting")
 
@@ -817,7 +920,8 @@ class _ASRNode(Node):
     def __init__(self, input_topic: str, adapter: Optional[ASRAdapter], language: str,
                  vad_backend: str = 'sherpa_onnx', vad_threshold: float = SPEECH_THRESH, vad_silence_ms: int = 400,
                  kws_cfg: dict = None, node_suffix: str = '',
-                 save_vad_segments: bool = False, max_saved_segments: int = 1000):
+                 save_vad_segments: bool = False, max_saved_segments: int = 1000,
+                 vad_pre_roll_ms: int = 500):
         node_name = f"asr_{node_suffix}" if node_suffix else "asr"
         super().__init__(node_name)
         self._input_topic  = input_topic
@@ -831,6 +935,7 @@ class _ASRNode(Node):
         self._vad_backend = vad_backend
         self._vad_threshold = vad_threshold
         self._vad_silence_ms = vad_silence_ms
+        self._vad_pre_roll_ms = vad_pre_roll_ms
         self._kws_cfg = kws_cfg or {}
         self._save_vad_segments = save_vad_segments
         self._max_saved_segments = max_saved_segments
@@ -841,25 +946,51 @@ class _ASRNode(Node):
         self._worker_thread: Optional[threading.Thread] = None
         self._stop_event = threading.Event()
         self._first_chunk_event = threading.Event()
+        # Created here rather than in _start_inner so request_stop() can always
+        # set it, and so the worker thread cannot reach it before it exists.
+        self._worker_ready = threading.Event()
+        # Serialises start/stop on this node. RLock because _start_inner calls
+        # _teardown() while already holding it.
+        self._lifecycle_lock = threading.RLock()
+        self._audio_contract_warns: dict = {}
 
     def start(self) -> dict:
-        if self.state == "running":
-            return self._status_dict()
-        if not self._adapter:
-            return {"state": "error", "message": "ASR adapter not configured"}
-        try:
-            return self._start_inner()
-        except Exception as e:
-            log.error(f"[asr] start failed: {e}", exc_info=True)
-            self.state = "error"
-            return {"state": "error", "message": str(e)}
+        with self._lifecycle_lock:
+            # "starting" counts as taken: _start_inner blocks up to 15s waiting
+            # for the first audio chunk, and a second start slipping in during
+            # that window would build a second subscription and a second VAD
+            # process on this same node.
+            if self.state in ("running", "starting"):
+                return self._status_dict()
+            if not self._adapter:
+                return {"state": "error", "message": "ASR adapter not configured"}
+            try:
+                return self._start_inner()
+            except Exception as e:
+                log.error(f"[asr] start failed: {e}", exc_info=True)
+                self.state = "error"
+                return {"state": "error", "message": str(e)}
 
     def _start_inner(self) -> dict:
         from audio_msgs.msg import AudioChunk
+        # Belt and braces: never let a second subscription or VAD process exist
+        # on one node. If the plugin-level guard ever regresses, this turns a
+        # silent duplicate-pipeline leak into a logged restart.
+        if (self._vad_proc is not None or self._sub is not None
+                or (self._worker_thread is not None and self._worker_thread.is_alive())):
+            log.warning(
+                f"[asr] stale pipeline on {self._input_topic} "
+                f"(vad_pid={getattr(self._vad_proc, 'pid', None)}, sub={self._sub is not None}) "
+                f"— tearing down before restart"
+            )
+            self._teardown()
         log.info(f"[asr] subscribing to topic={self._input_topic}, publishing to={self._output_topic}")
         self._first_chunk_event = threading.Event()
+        self._worker_ready = threading.Event()
         self._sub = self.create_subscription(AudioChunk, self._input_topic, self._audio_cb, _LOW_LAT_QOS)
-        self._stop_event.clear()
+        # A fresh event, not .clear(): the previous worker thread and _audio_cb
+        # closures still hold a reference to the old one.
+        self._stop_event = threading.Event()
         # Start VAD in a child process
         self._pcm_queue = multiprocessing.Queue(maxsize=1000)
         self._utterance_queue = multiprocessing.Queue(maxsize=100)
@@ -868,7 +999,8 @@ class _ASRNode(Node):
             target=_vad_worker,
             args=(self._pcm_queue, self._utterance_queue, self._vad_stop,
                   self._vad_backend, self._vad_threshold, self._vad_silence_ms,
-                  self._kws_cfg, self._save_vad_segments, self._max_saved_segments),
+                  self._kws_cfg, self._save_vad_segments, self._max_saved_segments,
+                  self._vad_pre_roll_ms),
             daemon=True, name="vad_worker",
         )
         self._vad_proc.start()
@@ -877,7 +1009,6 @@ class _ASRNode(Node):
         self._worker_thread = threading.Thread(target=self._worker, daemon=True)
         self._worker_thread.start()
         self.state = "starting"
-        self._worker_ready = threading.Event()
         log.info("[asr] waiting for first audio chunk...")
         # Block until first audio chunk arrives or stop() cancels (timeout to avoid infinite hang)
         got_chunk = self._first_chunk_event.wait(timeout=10)
@@ -894,7 +1025,35 @@ class _ASRNode(Node):
         log.info("[asr] started, receiving audio data")
         return self._status_dict()
 
+    def request_stop(self) -> None:
+        """Signal cancellation without blocking. Safe from any thread, idempotent.
+
+        stop() must call this *before* taking _lifecycle_lock: _start_inner holds
+        that lock for up to 15s waiting on the first audio chunk, and it can only
+        honour a cancellation if _stop_event is already set by the time its wait
+        returns. Blocking on the lock first would let start() sail through to
+        "running" and leave a pipeline nobody asked for.
+        """
+        for event in (self._stop_event, self._first_chunk_event, self._worker_ready):
+            try:
+                event.set()
+            except Exception:
+                pass
+        if self._vad_stop is not None:
+            try:
+                self._vad_stop.set()
+            except Exception:
+                pass
+
     def stop(self) -> dict:
+        self.request_stop()
+        with self._lifecycle_lock:
+            self._teardown()
+            self.state = "idle"
+            return {"state": "idle"}
+
+    def _teardown(self) -> None:
+        """Release every handle this node owns. Idempotent."""
         # Stop subscription first to prevent new audio_cb calls
         if self._sub:
             try:
@@ -902,14 +1061,7 @@ class _ASRNode(Node):
             except Exception:
                 pass  # may already be invalid
             self._sub = None
-        self._stop_event.set()
-        # Unblock start() if it's waiting
-        if hasattr(self, '_first_chunk_event'):
-            self._first_chunk_event.set()
-        if hasattr(self, '_worker_ready'):
-            self._worker_ready.set()
-        if self._vad_stop:
-            self._vad_stop.set()
+        self.request_stop()
         # Cancel feeder threads immediately — avoids BrokenPipeError spam
         for q in (self._pcm_queue, self._utterance_queue):
             if q:
@@ -918,14 +1070,32 @@ class _ASRNode(Node):
                     q.close()
                 except Exception:
                     pass
-        if self._vad_proc and self._vad_proc.is_alive():
-            self._vad_proc.join(timeout=5)
+        if self._vad_proc is not None:
             if self._vad_proc.is_alive():
-                self._vad_proc.terminate()
-        if self._worker_thread and self._worker_thread.is_alive():
-            self._worker_thread.join(timeout=3)
-        self.state = "idle"
-        return {"state": "idle"}
+                self._vad_proc.join(timeout=5)
+                if self._vad_proc.is_alive():
+                    log.warning(f"[asr] VAD worker pid={self._vad_proc.pid} ignored stop, terminating")
+                    self._vad_proc.terminate()
+                    self._vad_proc.join(timeout=2)
+                    if self._vad_proc.is_alive():
+                        # A worker wedged inside sherpa-onnx survives SIGTERM.
+                        # main only sent terminate() and never joined, so such a
+                        # worker leaked for the life of the container.
+                        log.warning(f"[asr] VAD worker pid={self._vad_proc.pid} ignored SIGTERM, killing")
+                        self._vad_proc.kill()
+                        self._vad_proc.join(timeout=2)
+            try:
+                self._vad_proc.close()
+            except Exception:
+                pass
+            self._vad_proc = None
+        if self._worker_thread is not None:
+            if self._worker_thread.is_alive():
+                self._worker_thread.join(timeout=3)
+            self._worker_thread = None
+        self._pcm_queue = None
+        self._utterance_queue = None
+        self._vad_stop = None
 
     def _audio_cb(self, msg):
         if self._stop_event.is_set():
@@ -947,7 +1117,9 @@ class _ASRNode(Node):
                         pass
             self.state = "error"
             return
-        pcm = bytes(msg.data)
+        pcm = self._check_audio_contract(getattr(msg, 'format', '') or '', bytes(msg.data))
+        if not pcm:
+            return
         ts  = msg.header.stamp.sec + msg.header.stamp.nanosec * 1e-9
         if ts < 1e9:  # header.stamp not set by publisher
             ts = time.time()
@@ -956,14 +1128,51 @@ class _ASRNode(Node):
         except Exception:
             pass  # drop if severely behind
 
+    def _warn_audio_contract(self, key: str, detail: str) -> None:
+        """Warn on the first violation of a kind, then every 500th one.
+
+        A misbehaving mic driver publishes ~30 chunks/s, so an unthrottled
+        warning would bury the log.
+        """
+        n = self._audio_contract_warns.get(key, 0) + 1
+        self._audio_contract_warns[key] = n
+        if n == 1 or n % 500 == 0:
+            log.warning(f"[asr] audio contract violated on {self._input_topic}: {detail} "
+                        f"(occurrence {n}) — see perception/README.md")
+
+    def _check_audio_contract(self, fmt: str, pcm: bytes) -> bytes:
+        """Validate the documented AudioChunk contract, return usable PCM.
+
+        Only the 16-bit alignment is corrected: a chunk with an odd byte count
+        makes the VAD worker's struct.unpack() raise, killing the subprocess and
+        taking ASR to the error state. Format and chunk size are reported but
+        left alone — undersized chunks are the most common cause of "ASR hears
+        audio but never emits text", and dropping them here would change the
+        behaviour of producers that work today.
+        """
+        if fmt not in _AUDIO_FORMAT_ALIASES:
+            self._warn_audio_contract(
+                'format', f"format={fmt!r}, expected {AUDIO_FORMAT!r}")
+
+        if len(pcm) % 2:
+            self._warn_audio_contract(
+                'align', f"{len(pcm)} bytes is not 16-bit aligned, truncating")
+            pcm = pcm[:len(pcm) // 2 * 2]
+
+        if len(pcm) and len(pcm) < MIN_CHUNK_BYTES:
+            self._warn_audio_contract(
+                'size', f"{len(pcm)}-byte chunk is below the {MIN_CHUNK_BYTES}-byte "
+                        f"minimum, VAD may never emit a segment")
+
+        return pcm
+
     def _worker(self):
         try:
             self._worker_inner()
         except Exception as e:
             log.error(f"[asr] worker fatal error: {e}", exc_info=True)
             self.state = "error"
-            if hasattr(self, '_worker_ready'):
-                self._worker_ready.set()
+            self._worker_ready.set()
 
     def _worker_inner(self):
         # Pre-compute keyword IPA if in asr_kws mode
@@ -981,8 +1190,7 @@ class _ASRNode(Node):
                 trigger_mode = 'vad'
 
         # Signal that worker init is complete
-        if hasattr(self, '_worker_ready'):
-            self._worker_ready.set()
+        self._worker_ready.set()
 
         while not self._stop_event.is_set():
             try:
@@ -1093,13 +1301,57 @@ class ASRPlugin:
         self._kws_cfg      = plugin_cfg.get('kws', {})
         self._save_vad_segments = False
         self._max_saved_segments = 1000
+        self._vad_pre_roll_ms = int(vad_cfg.get('pre_roll_ms', 500))
         self._nodes: dict[str, _ASRNode] = {}           # key = instance_id
+        # main.py serves MCP over ThreadingHTTPServer, so start/stop/config can
+        # run concurrently on this plugin. Guards read-modify-write of _nodes
+        # only — never held across node.start()/stop() or a model load, because
+        # start() blocks up to 15s and a stop queued behind it could no longer
+        # cancel it. See perception/README.md § Plugin Concurrency.
+        self._nodes_lock = threading.RLock()
         self._executor = executor
         log.info(f"[asr] plugin init: model={self._asr_model}, vad={self._vad_backend}, threshold={self._vad_threshold}, "
-                 f"silence_ms={self._vad_silence_ms}, kws_enabled={self._kws_cfg.get('enabled', False)}")
+                 f"silence_ms={self._vad_silence_ms}, pre_roll_ms={self._vad_pre_roll_ms}, "
+                 f"kws_enabled={self._kws_cfg.get('enabled', False)}")
 
     def get_tools(self) -> list:
         return TOOLS
+
+    def _dispose_node(self, node: _ASRNode, key: str = "") -> dict:
+        """Stop a node and release its ROS endpoints.
+
+        Takes the node itself rather than a key: the caller unlinks it from
+        _nodes first, and an already-orphaned node is by definition not in there.
+        destroy_node() matters — without it the publisher and the ROS node name
+        outlive the node object, so a later start on the same key collides with
+        a still-registered ghost.
+        """
+        result = {"state": "idle"}
+        try:
+            result = node.stop()
+        except Exception:
+            log.error(f"[asr] node.stop() failed while disposing '{key}'", exc_info=True)
+        try:
+            self._executor.remove_node(node)
+        except Exception as error:
+            log.warning(f"[asr] failed to remove ROS node '{key}': {error}")
+        try:
+            node.destroy_node()
+        except Exception as error:
+            log.warning(f"[asr] failed to destroy ROS node '{key}': {error}")
+        return result
+
+    def _sync_cfg(self, node: _ASRNode) -> None:
+        """Push current shared plugin config into an existing node."""
+        node._adapter = self._adapter
+        node._language = self._language
+        node._vad_backend = self._vad_backend
+        node._vad_threshold = self._vad_threshold
+        node._vad_silence_ms = self._vad_silence_ms
+        node._vad_pre_roll_ms = self._vad_pre_roll_ms
+        node._kws_cfg = self._kws_cfg
+        node._save_vad_segments = self._save_vad_segments
+        node._max_saved_segments = self._max_saved_segments
 
     def _load_model_async(self, model_name: str):
         """Download and load ASR model in a background thread."""
@@ -1118,8 +1370,12 @@ class ASRPlugin:
                 self._loading = False
                 self._load_error = str(e)
 
-        self._loading = True
-        self._load_error = None
+        with self._nodes_lock:
+            if self._loading:
+                log.warning(f"[asr] a model load is already in flight, ignoring '{model_name}'")
+                return
+            self._loading = True
+            self._load_error = None
         threading.Thread(target=_do_load, daemon=True, name="asr_model_loader").start()
 
     def dispatch(self, name: str, args: dict) -> dict | None:
@@ -1141,8 +1397,12 @@ class ASRPlugin:
                     "desc": f"Model load failed: {self._load_error}",
                 }
             input_topic = args.get("input_topic", "")
-            if instance_id and instance_id in self._nodes:
-                node = self._nodes[instance_id]
+            # Snapshot under the lock: info is a heartbeat probe and iterating
+            # the live dict can raise "dictionary changed size" mid-start.
+            with self._nodes_lock:
+                node = self._nodes.get(instance_id) if instance_id else None
+                nodes_snapshot = list(self._nodes.values())
+            if instance_id and node is not None:
                 return {
                     "name": "ASR", "manufacture": "Embodied", "model": "asr",
                     "state": node.state,
@@ -1162,10 +1422,10 @@ class ASRPlugin:
                     "desc": "ASR service — converts audio/pcm-16k to text",
                 }
             # Aggregate info for all instances (no instance_id = ping/overview only)
-            if self._nodes:
-                topics_in = [{"topic": n._input_topic, "format": "audio/pcm-16k", "desc": ""} for n in self._nodes.values()]
-                topics_out = [{"topic": n._output_topic, "format": "data/json", "desc": ""} for n in self._nodes.values()]
-                states = list(set(n.state for n in self._nodes.values()))
+            if nodes_snapshot:
+                topics_in = [{"topic": n._input_topic, "format": "audio/pcm-16k", "desc": ""} for n in nodes_snapshot]
+                topics_out = [{"topic": n._output_topic, "format": "data/json", "desc": ""} for n in nodes_snapshot]
+                states = list(set(n.state for n in nodes_snapshot))
                 state = "running" if "running" in states else states[0] if states else "idle"
             else:
                 inferred_out = f"{input_topic}/asr" if input_topic else ""
@@ -1182,10 +1442,17 @@ class ASRPlugin:
 
         elif action == "start":
             if self._loading:
-                # Wait for model to finish loading
-                import time as _time
+                # Bounded wait. The unbounded `while self._loading: sleep(0.5)`
+                # this replaces pinned an MCP worker thread for as long as the
+                # download took — and forever if the loader thread died without
+                # raising Exception, since nothing else clears _loading.
+                deadline = time.monotonic() + MODEL_LOAD_TIMEOUT_S
                 while self._loading:
-                    _time.sleep(0.5)
+                    if time.monotonic() > deadline:
+                        return {"state": "loading", "asr_model": self._asr_model,
+                                "message": f"model '{self._asr_model}' still loading after "
+                                           f"{MODEL_LOAD_TIMEOUT_S}s, retry later"}
+                    time.sleep(0.5)
             if self._load_error:
                 return {"state": "error", "message": f"Model failed to load: {self._load_error}"}
             if not self._adapter:
@@ -1199,45 +1466,59 @@ class ASRPlugin:
             if not input_topic:
                 raise ValueError("input_topic is required")
             node_key = instance_id or input_topic
-            if node_key not in self._nodes:
-                node = _ASRNode(input_topic, self._adapter, self._language,
-                                self._vad_backend, self._vad_threshold, self._vad_silence_ms,
-                                kws_cfg=self._kws_cfg,
-                                node_suffix=node_key.replace('/', '_').replace('-', '_'),
-                                save_vad_segments=self._save_vad_segments,
-                                max_saved_segments=self._max_saved_segments)
-                self._executor.add_node(node)
-                self._nodes[node_key] = node
-            else:
-                # Sync latest config into existing node before restart
-                node = self._nodes[node_key]
-                node._adapter = self._adapter
-                node._language = self._language
-                node._vad_backend = self._vad_backend
-                node._vad_threshold = self._vad_threshold
-                node._vad_silence_ms = self._vad_silence_ms
-                node._kws_cfg = self._kws_cfg
-                node._save_vad_segments = self._save_vad_segments
-                node._max_saved_segments = self._max_saved_segments
-            return self._nodes[node_key].start()
+            # Atomic get-or-create. Two concurrent starts used to both pass a
+            # bare `not in` check and each build an _ASRNode with the same ROS
+            # node name; the dict kept only the last, orphaning a live node whose
+            # subscription and VAD subprocess nothing could ever stop.
+            with self._nodes_lock:
+                node = self._nodes.get(node_key)
+                if node is None:
+                    node = _ASRNode(input_topic, self._adapter, self._language,
+                                    self._vad_backend, self._vad_threshold, self._vad_silence_ms,
+                                    kws_cfg=self._kws_cfg,
+                                    node_suffix=node_key.replace('/', '_').replace('-', '_'),
+                                    save_vad_segments=self._save_vad_segments,
+                                    max_saved_segments=self._max_saved_segments,
+                                    vad_pre_roll_ms=self._vad_pre_roll_ms)
+                    try:
+                        self._executor.add_node(node)
+                    except Exception:
+                        node.destroy_node()
+                        raise
+                    self._nodes[node_key] = node
+                else:
+                    # Sync latest config into existing node before restart
+                    self._sync_cfg(node)
+            # Outside the lock on purpose: node.start() blocks up to 15s, and the
+            # node is already registered, so a concurrent stop can find it, set
+            # its _stop_event, and have start() roll itself back to idle.
+            result = node.start()
+            if result.get("state") == "error":
+                with self._nodes_lock:
+                    if self._nodes.get(node_key) is node:
+                        del self._nodes[node_key]
+                self._dispose_node(node, node_key)
+            return result
 
         elif action == "stop":
-            if instance_id and instance_id in self._nodes:
-                node = self._nodes[instance_id]
-                result = node.stop()
-                self._executor.remove_node(node)
-                del self._nodes[instance_id]
+            with self._nodes_lock:
+                if instance_id:
+                    keys = [instance_id] if instance_id in self._nodes else []
+                else:
+                    # Stop all instances (backward compat / project stop)
+                    keys = list(self._nodes.keys())
+                nodes = [(k, self._nodes.pop(k)) for k in keys]
+            # request_stop() before disposing: it is non-blocking and unblocks an
+            # in-flight start() so _dispose_node does not sit behind it.
+            for _, node in nodes:
+                node.request_stop()
+            result = {"state": "idle"}
+            for key, node in nodes:
+                result = self._dispose_node(node, key)
+            if instance_id:
                 return result
-            elif not instance_id and self._nodes:
-                # Stop all instances (backward compat / project stop)
-                results = []
-                for key in list(self._nodes.keys()):
-                    node = self._nodes[key]
-                    node.stop()
-                    self._executor.remove_node(node)
-                    del self._nodes[key]
-                    results.append(key)
-                return {"state": "idle", "stopped_instances": results}
+            if keys:
+                return {"state": "idle", "stopped_instances": keys}
             return {"state": "idle"}
 
         elif action == "config":
@@ -1262,32 +1543,30 @@ class ASRPlugin:
                 self._save_vad_segments = bool(cfg['save_vad_segments'])
             if 'max_saved_segments' in cfg:
                 self._max_saved_segments = int(cfg['max_saved_segments'])
+            if 'vad_pre_roll_ms' in cfg:
+                self._vad_pre_roll_ms = int(cfg['vad_pre_roll_ms'])
             # ASR model switch — load in background if changed
             if 'asr_model' in cfg and cfg['asr_model'] != self._asr_model:
                 # Stop all running nodes first
-                for key in list(self._nodes.keys()):
-                    node = self._nodes.pop(key, None)
-                    if node:
-                        node.stop()
-                        self._executor.remove_node(node)
+                with self._nodes_lock:
+                    nodes = [(k, self._nodes.pop(k)) for k in list(self._nodes.keys())]
+                for _, node in nodes:
+                    node.request_stop()
+                for key, node in nodes:
+                    self._dispose_node(node, key)
                 self._asr_model = cfg['asr_model']
                 self._load_model_async(self._asr_model)
                 return {"status": "loading", "asr_model": self._asr_model,
                         "message": f"Switching to model '{self._asr_model}', downloading..."}
             # Hot-reload: stop running nodes, apply new config, restart automatically
-            was_running = [(key, node) for key, node in self._nodes.items() if node.state == "running"]
-            for key, node in was_running:
+            with self._nodes_lock:
+                was_running = [(key, node) for key, node in self._nodes.items()
+                               if node.state == "running"]
+            for _, node in was_running:
                 node.stop()
             # Sync updated config into nodes and restart
             for key, node in was_running:
-                node._adapter = self._adapter
-                node._language = self._language
-                node._vad_backend = self._vad_backend
-                node._vad_threshold = self._vad_threshold
-                node._vad_silence_ms = self._vad_silence_ms
-                node._kws_cfg = self._kws_cfg
-                node._save_vad_segments = self._save_vad_segments
-                node._max_saved_segments = self._max_saved_segments
+                self._sync_cfg(node)
                 node.start()
             return {"status": "configured", "asr_model": self._asr_model}
 

--- a/perception/plugins/tts.py
+++ b/perception/plugins/tts.py
@@ -499,9 +499,39 @@ class TTSPlugin:
             self._adapter = None
             self._load_error = str(e)
         self._nodes: dict[str, _TTSNode] = {}
+        # main.py serves MCP over ThreadingHTTPServer, so start/stop/speak/config
+        # can run concurrently. Every read-modify-write of _nodes must hold this:
+        # otherwise two threads both pass a "key not in _nodes" check, both build
+        # a node, and the dict keeps only the last — leaving the other running but
+        # unreachable, with a duplicate publisher on the same topic that nothing
+        # can stop. See perception/README.md § Plugin Concurrency.
+        # RLock: dispatch paths nest (start → _dispose_node).
+        self._nodes_lock = threading.RLock()
         self._executor = executor
         log.info(f"[tts] plugin init: sherpa-onnx VITS, "
                  f"speaker_id={plugin_cfg.get('speaker_id', 0)}, speed={plugin_cfg.get('speed', 1.0)}")
+
+    def _dispose_node(self, node: _TTSNode, key: str = "") -> dict:
+        """Stop a node and release its ROS endpoints. Caller holds _nodes_lock.
+
+        destroy_node() matters: without it the publisher and the ROS node name
+        outlive the node object, so a later start on the same key collides with a
+        still-registered ghost.
+        """
+        result = {"state": "idle"}
+        try:
+            result = node.stop()
+        except Exception:
+            log.error(f"[tts] node.stop() failed while disposing '{key}'", exc_info=True)
+        try:
+            self._executor.remove_node(node)
+        except Exception as error:
+            log.warning(f"[tts] failed to remove ROS node '{key}': {error}")
+        try:
+            node.destroy_node()
+        except Exception as error:
+            log.warning(f"[tts] failed to destroy ROS node '{key}': {error}")
+        return result
 
     def get_tools(self) -> list:
         return TOOLS
@@ -524,8 +554,12 @@ class TTSPlugin:
                     "desc": f"Model load failed: {self._load_error}",
                 }
             input_topic = args.get("input_topic", "")
-            if instance_id and instance_id in self._nodes:
-                node = self._nodes[instance_id]
+            # Snapshot under the lock: info is a heartbeat probe and iterating the
+            # live dict can raise "dictionary changed size" mid-start.
+            with self._nodes_lock:
+                node = self._nodes.get(instance_id) if instance_id else None
+                nodes_snapshot = list(self._nodes.values())
+            if instance_id and node is not None:
                 return {
                     "name": "TTS", "manufacture": "Embodied", "model": "tts",
                     "state": node.state,
@@ -544,10 +578,10 @@ class TTSPlugin:
                     "desc": "TTS service — converts text to audio/pcm-16k",
                 }
             # Aggregate info (no instance_id = ping/overview only)
-            if self._nodes:
-                topics_in = [{"topic": n._input_topic, "format": "data/json", "desc": ""} for n in self._nodes.values()]
-                topics_out = [{"topic": n._output_topic, "format": "audio/pcm-16k", "desc": ""} for n in self._nodes.values()]
-                states = list(set(n.state for n in self._nodes.values()))
+            if nodes_snapshot:
+                topics_in = [{"topic": n._input_topic, "format": "data/json", "desc": ""} for n in nodes_snapshot]
+                topics_out = [{"topic": n._output_topic, "format": "audio/pcm-16k", "desc": ""} for n in nodes_snapshot]
+                states = list(set(n.state for n in nodes_snapshot))
                 state = "running" if "running" in states else states[0] if states else "idle"
             else:
                 inferred_out = f"{input_topic}/tts" if input_topic else "/perception/tts"
@@ -571,43 +605,39 @@ class TTSPlugin:
                 return {"state": "error", "message": "TTS model not loaded"}
             input_topic = args.get("input_topic") or ''
             node_key = instance_id or input_topic or '_default'
-            # Clean up _default node if it would conflict with this instance
-            if '_default' in self._nodes and node_key != '_default':
-                default_node = self._nodes['_default']
-                if default_node._input_topic == input_topic or default_node._output_topic == (f"{input_topic}/tts" if input_topic else '/perception/tts'):
-                    default_node.stop()
-                    self._executor.remove_node(default_node)
-                    del self._nodes['_default']
-            if node_key not in self._nodes:
-                node = _TTSNode(input_topic or None, self._adapter,
-                                node_suffix=node_key.replace('/', '_').replace('-', '_'))
-                self._executor.add_node(node)
-                self._nodes[node_key] = node
-            elif input_topic and self._nodes[node_key]._input_topic != input_topic:
-                # Input topic changed for existing instance — recreate
-                old_node = self._nodes[node_key]
-                old_node.stop()
-                self._executor.remove_node(old_node)
-                node = _TTSNode(input_topic, self._adapter,
-                                node_suffix=node_key.replace('/', '_').replace('-', '_'))
-                self._executor.add_node(node)
-                self._nodes[node_key] = node
-            return self._nodes[node_key].start()
+            with self._nodes_lock:
+                # Clean up _default node if it would conflict with this instance
+                if '_default' in self._nodes and node_key != '_default':
+                    default_node = self._nodes['_default']
+                    if default_node._input_topic == input_topic or default_node._output_topic == (f"{input_topic}/tts" if input_topic else '/perception/tts'):
+                        del self._nodes['_default']
+                        self._dispose_node(default_node, '_default')
+                node = self._nodes.get(node_key)
+                if node is None:
+                    node = _TTSNode(input_topic or None, self._adapter,
+                                    node_suffix=node_key.replace('/', '_').replace('-', '_'))
+                    self._executor.add_node(node)
+                    self._nodes[node_key] = node
+                elif input_topic and node._input_topic != input_topic:
+                    # Input topic changed for existing instance — recreate
+                    del self._nodes[node_key]
+                    self._dispose_node(node, node_key)
+                    node = _TTSNode(input_topic, self._adapter,
+                                    node_suffix=node_key.replace('/', '_').replace('-', '_'))
+                    self._executor.add_node(node)
+                    self._nodes[node_key] = node
+                return node.start()
 
         elif action == "stop":
-            if instance_id and instance_id in self._nodes:
-                node = self._nodes[instance_id]
-                result = node.stop()
-                self._executor.remove_node(node)
-                del self._nodes[instance_id]
-                return result
-            elif not instance_id and self._nodes:
+            with self._nodes_lock:
+                if instance_id:
+                    node = self._nodes.pop(instance_id, None)
+                    if node is None:
+                        return {"state": "idle"}
+                    return self._dispose_node(node, instance_id)
                 for key in list(self._nodes.keys()):
-                    self._nodes[key].stop()
-                    self._executor.remove_node(self._nodes[key])
-                    del self._nodes[key]
+                    self._dispose_node(self._nodes.pop(key), key)
                 return {"state": "idle"}
-            return {"state": "idle"}
 
         elif action == "speak":
             if self._loading:
@@ -618,29 +648,29 @@ class TTSPlugin:
             if not text:
                 raise ValueError("text is required")
             # Find any existing running node to reuse
-            node = None
-            for n in self._nodes.values():
-                if n.state == "running":
-                    node = n
-                    break
-            if node is None:
-                # No running node — use instance key or fallback
-                node_key = instance_id or '_default'
-                if node_key not in self._nodes:
-                    input_topic = args.get("input_topic") or None
-                    adapter = self._adapter
-                    if instance_id and instance_id in self._instance_configs:
-                        inst_adapter = _build_tts_adapter(self._instance_configs[instance_id])
-                        if inst_adapter:
-                            adapter = inst_adapter
-                    node = _TTSNode(input_topic, adapter,
-                                    node_suffix=node_key.replace('/', '_').replace('-', '_'))
-                    self._executor.add_node(node)
-                    self._nodes[node_key] = node
-                else:
-                    node = self._nodes[node_key]
-                if node.state != "running":
-                    node.start()
+            with self._nodes_lock:
+                node = None
+                for n in self._nodes.values():
+                    if n.state == "running":
+                        node = n
+                        break
+                if node is None:
+                    # No running node — use instance key or fallback
+                    node_key = instance_id or '_default'
+                    node = self._nodes.get(node_key)
+                    if node is None:
+                        input_topic = args.get("input_topic") or None
+                        adapter = self._adapter
+                        if instance_id and instance_id in self._instance_configs:
+                            inst_adapter = _build_tts_adapter(self._instance_configs[instance_id])
+                            if inst_adapter:
+                                adapter = inst_adapter
+                        node = _TTSNode(input_topic, adapter,
+                                        node_suffix=node_key.replace('/', '_').replace('-', '_'))
+                        self._executor.add_node(node)
+                        self._nodes[node_key] = node
+                    if node.state != "running":
+                        node.start()
             # ACP: 生成 action_id
             import uuid as _uuid
             action_id = f"speak-{_uuid.uuid4().hex[:8]}"
@@ -656,26 +686,24 @@ class TTSPlugin:
                 self._cfg['speed'] = float(cfg['speed'])
             self._adapter = _build_tts_adapter(self._cfg)
             # Stop all nodes (they'll use new adapter on next start)
-            for key in list(self._nodes.keys()):
-                self._nodes[key].stop()
-                self._executor.remove_node(self._nodes[key])
-                del self._nodes[key]
+            with self._nodes_lock:
+                for key in list(self._nodes.keys()):
+                    self._dispose_node(self._nodes.pop(key), key)
             return {"status": "configured"}
 
         elif action == "interrupt":
             # 立即中止所有 TTS 播放（清空队列 + 停止当前 utterance）
             total_cleared = 0
             interrupted_count = 0
-            if instance_id and instance_id in self._nodes:
-                result = self._nodes[instance_id].interrupt()
+            with self._nodes_lock:
+                if instance_id:
+                    targets = [self._nodes[instance_id]] if instance_id in self._nodes else []
+                else:
+                    targets = [n for n in self._nodes.values() if n.state == "running"]
+            for node in targets:
+                result = node.interrupt()
                 total_cleared += result.get('cleared', 0)
                 interrupted_count += 1
-            elif not instance_id:
-                for node in self._nodes.values():
-                    if node.state == "running":
-                        result = node.interrupt()
-                        total_cleared += result.get('cleared', 0)
-                        interrupted_count += 1
             return {"status": "interrupted", "nodes": interrupted_count, "cleared": total_cleared}
 
         return None

--- a/perception/plugins/vad_preroll.py
+++ b/perception/plugins/vad_preroll.py
@@ -1,0 +1,70 @@
+"""Bounded PCM history used to restore audio before a VAD segment."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+
+class PcmHistory:
+    """PCM16 history addressable by the VAD's absolute sample offsets."""
+
+    def __init__(self, max_samples: int):
+        if max_samples <= 0:
+            raise ValueError("max_samples must be positive")
+        self._max_samples = int(max_samples)
+        self._pcm = bytearray()
+        self.start_sample = 0
+        self.total_samples = 0
+
+    def clear(self) -> None:
+        self._pcm.clear()
+        self.start_sample = 0
+        self.total_samples = 0
+
+    def append(self, pcm: bytes) -> None:
+        """Append aligned PCM16 bytes and evict history older than the limit."""
+        pcm = pcm[: len(pcm) // 2 * 2]
+        if not pcm:
+            return
+        sample_count = len(pcm) // 2
+        self._pcm.extend(pcm)
+        self.total_samples += sample_count
+
+        excess_samples = len(self._pcm) // 2 - self._max_samples
+        if excess_samples > 0:
+            del self._pcm[: excess_samples * 2]
+            self.start_sample += excess_samples
+
+    def slice(self, start_sample: int, end_sample: int) -> bytes:
+        """Return an absolute half-open sample range still present in history."""
+        start = max(int(start_sample), self.start_sample)
+        end = min(int(end_sample), self.total_samples)
+        if start >= end:
+            return b""
+        local_start = start - self.start_sample
+        local_end = end - self.start_sample
+        return bytes(self._pcm[local_start * 2 : local_end * 2])
+
+    def pre_roll(
+        self,
+        segment_start: Optional[int],
+        segment_samples: int,
+        pre_roll_samples: int,
+        silence_samples: int,
+    ) -> bytes:
+        """Return PCM immediately before a completed sherpa VAD segment.
+
+        Recent sherpa-onnx releases expose ``segment.start`` as an absolute
+        sample offset. The fallback matches the upstream buffering contract
+        when that attribute is unavailable.
+        """
+        if segment_start is None:
+            segment_start = max(
+                0,
+                self.total_samples - int(segment_samples) - int(silence_samples),
+            )
+        segment_start = int(segment_start)
+        return self.slice(
+            segment_start - max(0, int(pre_roll_samples)),
+            segment_start,
+        )

--- a/perception/plugins/x_asr.py
+++ b/perception/plugins/x_asr.py
@@ -1,0 +1,155 @@
+"""Offline X-ASR transducer adapter for the product ASR plugin."""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import logging
+import os
+import struct
+import tempfile
+import threading
+import wave
+from pathlib import Path
+
+
+SAMPLE_RATE = 16000
+TAIL_PADDING_SECONDS = 0.5
+MAX_ACTIVE_PATHS = 10
+HOTWORDS_SCORE = 2.5
+
+log = logging.getLogger(__name__)
+
+
+def _prepare_hotwords_file(
+    source: Path,
+    score: float = HOTWORDS_SCORE,
+    output_dir: Path = Path("/tmp/asr_x_asr_hotwords"),
+) -> Path:
+    """Convert one phrase per line to sherpa's character-separated BPE form."""
+    source_bytes = source.read_bytes()
+    digest = hashlib.sha256(
+        source_bytes + b"\0" + str(float(score)).encode("ascii")
+    ).hexdigest()[:16]
+    output_dir.mkdir(parents=True, exist_ok=True)
+    output = output_dir / f"hotwords-char-bpe-{digest}.txt"
+    if output.is_file():
+        return output
+
+    seen: set[str] = set()
+    lines: list[str] = []
+    for raw_line in source_bytes.decode("utf-8").splitlines():
+        phrase = raw_line.strip()
+        if not phrase or phrase.startswith("#"):
+            continue
+        compact = "".join(phrase.split())
+        if not compact or compact in seen:
+            continue
+        seen.add(compact)
+        lines.append(f"{' '.join(compact)} :{float(score)}\n")
+
+    if not lines:
+        raise ValueError(f"No usable hotwords in {source}")
+
+    temporary = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=output_dir,
+            prefix=f".{output.name}.",
+            delete=False,
+        ) as stream:
+            temporary = Path(stream.name)
+            stream.writelines(lines)
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary, output)
+    finally:
+        if temporary is not None:
+            temporary.unlink(missing_ok=True)
+    return output
+
+
+class XASRAdapter:
+    """Decode complete utterances with X-ASR and the packaged hotword list."""
+
+    def __init__(
+        self,
+        model_dir: str,
+        hw_provider: str = "cpu",
+        num_threads: int = 2,
+    ):
+        root = Path(model_dir)
+        encoder = root / "encoder-epoch-99-avg-1.int8.onnx"
+        decoder = root / "decoder-epoch-99-avg-1.onnx"
+        joiner = root / "joiner-epoch-99-avg-1.int8.onnx"
+        tokens = root / "tokens.txt"
+        bpe_model = root / "bpe.model"
+        bpe_vocab = root / "bpe.vocab"
+        hotwords = root / "hotwords.txt"
+        required = (
+            encoder,
+            decoder,
+            joiner,
+            tokens,
+            bpe_model,
+            bpe_vocab,
+            hotwords,
+        )
+        missing = [path.name for path in required if not path.is_file()]
+        if missing:
+            raise FileNotFoundError(
+                f"X-ASR model bundle is incomplete at {root}: {', '.join(missing)}"
+            )
+
+        import sherpa_onnx
+
+        encoded_hotwords = _prepare_hotwords_file(hotwords)
+        self._recognizer = sherpa_onnx.OfflineRecognizer.from_transducer(
+            encoder=str(encoder),
+            decoder=str(decoder),
+            joiner=str(joiner),
+            tokens=str(tokens),
+            num_threads=int(num_threads),
+            provider=hw_provider,
+            sample_rate=SAMPLE_RATE,
+            feature_dim=80,
+            decoding_method="modified_beam_search",
+            max_active_paths=MAX_ACTIVE_PATHS,
+            hotwords_file=str(encoded_hotwords),
+            hotwords_score=HOTWORDS_SCORE,
+            modeling_unit="bpe",
+            bpe_vocab=str(bpe_vocab),
+        )
+        self._decode_lock = threading.Lock()
+        log.info(
+            "[asr] X-ASR adapter loaded: encoder=%s, provider=%s, "
+            "max_active_paths=%d, hotwords_score=%.1f",
+            encoder,
+            hw_provider,
+            MAX_ACTIVE_PATHS,
+            HOTWORDS_SCORE,
+        )
+
+    def transcribe(self, wav_bytes: bytes, language: str) -> str:
+        del language
+        with wave.open(io.BytesIO(wav_bytes), "rb") as wav_file:
+            if wav_file.getnchannels() != 1 or wav_file.getsampwidth() != 2:
+                raise ValueError("X-ASR expects mono 16-bit PCM WAV")
+            sample_rate = wav_file.getframerate()
+            pcm = wav_file.readframes(wav_file.getnframes())
+
+        sample_count = len(pcm) // 2
+        samples = [
+            sample / 32768.0
+            for sample in struct.unpack(f"<{sample_count}h", pcm)
+        ]
+        samples.extend([0.0] * int(sample_rate * TAIL_PADDING_SECONDS))
+
+        with self._decode_lock:
+            stream = self._recognizer.create_stream()
+            stream.accept_waveform(sample_rate, samples)
+            self._recognizer.decode_streams([stream])
+            result = stream.result
+        return str(getattr(result, "text", result or "")).strip()

--- a/perception/utils/model_downloader.py
+++ b/perception/utils/model_downloader.py
@@ -46,6 +46,10 @@ MODELS = {
         "url": f"{COS_BASE}/sherpa-onnx-paraformer-zh-small-2024-03-09.tar.bz2",
         "check_file": "tokens.txt",
     },
+    "asr_x_asr": {
+        "url": f"{COS_BASE}/x-asr-zh-en-punct-int8-robot.zip",
+        "check_file": "tokens.txt",
+    },
     "tts": {
         "url": f"{COS_BASE}/matcha-icefall-zh-en.tar.bz2",
         "check_file": "model-steps-3.onnx",


### PR DESCRIPTION
## 概述

新增 X-ASR 中英双语离线 transducer 作为一个**可选**模型,并顺手修掉 `main` 里几个既有缺陷。

**这个 PR 用来替代 #102。** #102 的题目也是"新增一个模型",但它顺带重写了插件生命周期(`asr.py` 311 行变更),并因此引入了一个 P0 缺陷。本 PR 从 `main` 重新做,保留 `main` 的生命周期设计不动。是否关闭 #102 请 @zhitao-zeng 和 reviewer 定 —— 本 PR 没有动 #102 的分支。

## 为什么重做而不是在 #102 上打补丁

在 R1(`10.100.130.6`)和 jetson-orin-02(`10.100.121.16`)上实测:每段语音存两份、每句话识别并发布两次,并且**永久泄漏一个不可见、不可停止的 ASR 节点**(ROS 订阅 + VAD 子进程 + 转写线程),直到容器重启。指令场景下即同一条指令派发两次。

两份 wav 的 `md5sum` 完全一致(`seg_1787053034227` / `seg_1787053034229` → `ff483be5…`),日志里 `[vad-worker] utterance complete` 每句打两遍,启动时两条 `subscribing to topic=` 和两个 VAD 子进程(pid 1616160/1616161),`stop` 后 `ps` 显示 pid 1616160 仍然活着。

根因不是 #102 写的那行竞态(`if node_key not in self._nodes:` 在 `main` 里就有),而是 #102 把窗口从微秒撑到了 36 秒:

| | main | #102 |
|---|---|---|
| `start` 阻塞多久 | ≤15s(等首包 + 等 worker) | **36s**(模型下载 + 加载) |
| 阻塞期间能否被 `stop` 取消 | **能**(`if self._stop_event.is_set()`) | **不能**(该检查被删) |
| 阻塞发生在节点注册之前还是之后 | **之后**(`stop` 找得到节点) | **之前**(`pop(key)` 返回 None → 静默 no-op) |

第三行最致命:窗口不只变长,还挪到了节点注册**之前**。#102 还删掉了 `info` 的 `"loading"` 状态,所以冷启动 36 秒内 dashboard 显示 `idle`,用户分不清"正在下模型"和"没启动"。

本 PR 因此**保留** `main` 的 `_load_model_async` 后台加载、`_first_chunk_event`/`_worker_ready` 握手、`state="starting"` 中间态和 `info` 的 `loading` 状态,只从 #102 挑出真正做对的部分(`_dispose_node`、`add_node` 失败回滚)。

## 改动内容

### 新增模型(题目本身)

`plugins/x_asr.py`(自包含,只用标准库 + 延迟 `import sherpa_onnx`)、`asr.py` 的 adapter wrapper + registry 条目 + configSchema enum、`model_downloader.py` **一个 4 行条目**指向 COS zip。

**下载逻辑零改动** —— 现有 `_extract_zip` 的剥顶层目录逻辑刚好适用,7 个运行文件会平铺到 `model_dir`。(#102 为了从 ModelScope 下 9 个散文件新增了 ~91 行下载基础设施;改用 COS zip 后不需要。)

默认模型**不变**,只是让 x-asr 可选。

### VAD pre-roll

`plugins/vad_preroll.py` 的 `PcmHistory` 保留 VAD 判定前的音频,修的是句首音节被吃掉、影响唤醒词召回。连带修正了 utterance 时间戳(VAD 要等 `min_silence_duration` 才报 segment,chunk 时间戳落在真实语音结束之后一个静音窗)以及 `if not start_ts:` → `is None`(`start_ts == 0.0` 会被重新盖掉)。

### 音频契约校验

奇数字节 chunk 会让 VAD worker 的 `struct.unpack()` 抛异常、搞挂子进程。现在修正 16-bit 对齐并节流告警(第一次 + 每 500 次)。

### 修 main 的既有缺陷

所有 MCP server 都跑在 `ThreadingHTTPServer` 上,每个 `tools/call` 一个线程,而插件里**一把锁都没有**:

- **孤儿节点(P0)** —— 无锁 check-then-act。加每插件 `RLock` 做原子 get-or-create,加每节点 `_lifecycle_lock` 和 `state in ("running","starting")` 幂等闸。锁**刻意不跨** `node.start()`/`stop()` 持有(start 会阻塞 15 秒,stop 排在后面就取消不了);节点在 `start()` 之前注册好,`stop` 先调非阻塞 `request_stop()` 再拿锁。
- **ROS endpoint 泄漏** —— 全代码 `grep destroy_node` 零命中。加 `_dispose_node()`,入口取 node 对象而非 key,这样已成孤儿的节点也能处理。
- **无界自旋** —— `while self._loading: sleep(0.5)` 会占住 MCP worker 线程,loader 线程若以非 `Exception` 方式死掉则永久自旋。加 `MODEL_LOAD_TIMEOUT_S`,并禁止并发起第二个 loader。
- **唤醒门被绕过** —— `state = 'waiting_wake'` 在排空循环内赋值且无 `break`,已排队的 segment 仍被当作 listening 会话,可能在门关闭后再发一次。加 `break`。
- **保留策略从不生效** —— 删除条件依赖每进程重置的计数器,重启 ASR 就归零(实测 `max_saved_segments=1000` 的机器上有 5590 个文件)。改为按磁盘实际文件数判断。段文件名加唯一后缀(`_save_segment` 在排空循环内调用,一毫秒内连写多段会静默互相覆盖),列目录过滤 `seg_*.wav` 以免删掉无关文件。
- **`info` 可能在 start 中途抛异常** —— 它是心跳探针却迭代活字典,改为在锁内取快照。
- `plugins/tts.py` 有完全同构的无锁 check-then-act 和同样缺失的 `destroy_node()`,一并修掉。

### 文档

`perception/README.md` 新增 "Plugin Concurrency" 一节:线程前提、孤儿失效模式及其可观测症状、七条规矩配正误对照代码。**这不是 ASR 独有的坑** —— 项目里每个 MCP server 都是 `ThreadingHTTPServer`,任何持有 per-instance 状态字典的插件都适用。

## 待办 / 已知阻塞

- [ ] **需要先把模型打包上传 COS**:7 个运行文件(`encoder`/`decoder`/`joiner` + `tokens.txt` + `bpe.model` + `bpe.vocab` + `hotwords.txt`)打成 `x-asr-zh-en-punct-int8-robot.zip`。在此之前无法端到端验证。
- **未在真机验证**(等上述 zip + 重新 build 镜像)。已完成:`python3 -m compileall -q perception`,以及复核 `main` 的生命周期符号(`_load_model_async` / `_first_chunk_event` / `_worker_ready` / `"starting"` / `"loading"`)全部保留、`main.py` 零改动。
- 建议另开的两个 PR:
  1. `phanthymotus-driver`:`unitree/g1/ext_devices.py` 和 `unitree/r1/ext_devices.py` 里 4 处同构的无锁 check-then-act(`_ExtMicNode` / `_ExtCameraNode`,`grep Lock` 均为 0),外加 `README_dev.md` 的并发章节。
  2. `main.py` 的 `MCP_PORT`/`WS_PORT` 环境变量覆盖(#102 有,本 PR 拆走了)。**优先级不低** —— #102 描述里说 Darvin/Judge 多实例评估失败正是因为旧镜像忽略这两个变量,拆走后平台评测仍会跑不起来。

## Reviewer 需要签字的行为变更

1. `stop` 不带 `instance_id` 时仍停全部,但现在返回的 `stopped_instances` 顺序来自 `list(self._nodes.keys())` 快照。
2. `_dispose_node` 会调 `destroy_node()`,所以 ROS graph 观察者现在会看到 `asr_*` / `tts_*` 节点在 stop 时**消失**(此前会残留到进程退出)。
3. `start` 等模型加载有了 300s 上限,超时返回 `{"state":"loading"}` 而非无限等待。
4. 模型切换时若已有加载在飞,`_load_model_async` 会拒绝并打 WARN,不再起第二个 loader 线程。

## 模型来源

- [公开部署 bundle](https://www.modelscope.cn/models/Flame4pd/x-asr-zh-en-punct-int8-robot)
- [X-ASR upstream](https://github.com/Gilgamesh-J/X-ASR)
- [sherpa-onnx ASR model release](https://github.com/k2-fsa/sherpa-onnx/releases/tag/asr-models)

ONNX 权重与上游 `epoch-99-avg-1` 制品一致,产品侧只增加通用机器人热词表。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
