### PR TITLE
fix(deploy-panel): make the marketplace version list respect the selected update channel

### DIFF
--- a/agent-core/src/api/drivers.py
+++ b/agent-core/src/api/drivers.py
@@ -442,16 +442,16 @@ async def drivers_list():
 @router.post('/sync')
 async def drivers_sync():
     """Fetch registry catalog and upsert drivers in DB."""
-    from api.registry import _build_catalog_sync, _cache as _registry_cache
+    from api.registry import _build_catalog_sync, _current_channel, _cache as _registry_cache
+    channel = _current_channel()
     loop = asyncio.get_event_loop()
     try:
-        catalog = await loop.run_in_executor(None, _build_catalog_sync)
+        catalog = await loop.run_in_executor(None, _build_catalog_sync, channel)
     except Exception as e:
         return {'code': 500, 'message': str(e)}
 
     # Update registry cache with fresh data so next GET /registry/catalog is immediate
-    _registry_cache['data'] = catalog
-    _registry_cache['ts']   = __import__('time').time()
+    _registry_cache[channel] = {'data': catalog, 'ts': __import__('time').time()}
 
     manifest = _load_manifest()
     added, updated = _upsert_from_catalog(manifest, catalog)

--- a/agent-core/src/api/registry.py
+++ b/agent-core/src/api/registry.py
@@ -16,23 +16,25 @@ router = fastapi.APIRouter(prefix='/registry', tags=['registry'])
 RESOURCE_CENTER_URL = os.environ.get('RESOURCE_CENTER_URL', 'https://motus.phanthy.com')
 
 # ── Simple in-memory cache ──────────────────────────────────────────────────
-
-_cache: dict = {'data': None, 'ts': 0.0}
+# Keyed by channel: without this, switching channels while a stale cache entry
+# from the previous channel is still within TTL would serve mismatched data to
+# any caller that doesn't pass refresh=true.
+_cache: dict[str, dict] = {}
 _CACHE_TTL = 300  # 5 minutes
+
+
+def _current_channel() -> str:
+    try:
+        import config as _cfg
+        return _cfg.main.get('core', {}).get('update_channel', 'ga')
+    except Exception:
+        return 'ga'
 
 
 # ── Catalog fetch ─────────────────────────────────────────────────────────
 
-def _build_catalog_sync() -> dict:
-    url = f'{RESOURCE_CENTER_URL}/api/images'
-
-    # Append channel parameter from config
-    try:
-        import config as _cfg
-        channel = _cfg.main.get('core', {}).get('update_channel', 'ga')
-    except Exception:
-        channel = 'ga'
-    url = f'{url}?channel={channel}'
+def _build_catalog_sync(channel: str) -> dict:
+    url = f'{RESOURCE_CENTER_URL}/api/images?channel={channel}'
 
     print(f'[registry] fetching catalog from resource-center: {url}')
 
@@ -119,17 +121,18 @@ def _build_catalog_sync() -> dict:
 
 @router.get('/catalog')
 async def registry_catalog(refresh: bool = False):
+    channel = _current_channel()
     now = time.time()
-    if not refresh and _cache['data'] and (now - _cache['ts']) < _CACHE_TTL:
-        return {'code': 200, 'data': _cache['data'], 'cached': True}
+    cached = _cache.get(channel)
+    if not refresh and cached and (now - cached['ts']) < _CACHE_TTL:
+        return {'code': 200, 'data': cached['data'], 'cached': True}
 
     import asyncio
     loop = asyncio.get_event_loop()
     try:
-        data = await loop.run_in_executor(None, _build_catalog_sync)
+        data = await loop.run_in_executor(None, _build_catalog_sync, channel)
     except Exception as e:
         return {'code': 500, 'message': str(e), 'data': {'core': [], 'hardware': [], 'perception': [], 'inspection': []}}
 
-    _cache['data'] = data
-    _cache['ts'] = now
+    _cache[channel] = {'data': data, 'ts': now}
     return {'code': 200, 'data': data, 'cached': False}

--- a/agent-core/src/api/system.py
+++ b/agent-core/src/api/system.py
@@ -74,11 +74,11 @@ def _tag_from_image(image: str) -> str:
 
 
 def _check_update_sync() -> dict:
-    from api.registry import _build_catalog_sync
+    from api.registry import _build_catalog_sync, _current_channel
 
     current_tag = _get_current_tag()
 
-    catalog = _build_catalog_sync()
+    catalog = _build_catalog_sync(_current_channel())
     core_items = catalog.get('core', [])
 
     if not core_items:

--- a/agent-core/web/js/deploy-panel.js
+++ b/agent-core/web/js/deploy-panel.js
@@ -12,6 +12,7 @@ let _polling  = null;
 let _catalog  = { core: [], driver: [], perception: [], inspection: [] };
 let _statuses = {};   // driver_id → { running, status, running_image, image, last_deploy }
 let _logPolls = {};   // driver_id → intervalId
+let _currentChannel = 'ga'; // mirrors config.core.update_channel; kept in sync by _loadChannel/_onChannelChange
 
 // { driverId → { image } }
 let _pending = {};
@@ -48,6 +49,7 @@ async function _loadChannel() {
     const json = await res.json();
     const channel = json.data?.channel || 'ga';
     document.getElementById('deploy-channel-select').value = channel;
+    _currentChannel = channel;
   } catch { /* keep default */ }
 }
 
@@ -67,9 +69,28 @@ async function _onChannelChange(e) {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ channel }),
     });
+    _currentChannel = channel;
     await _loadCatalog(true);
     _render();
   } catch { /* ignore */ }
+}
+
+// Versions visible per channel. Release also shows ga (a stable fallback);
+// preview is deliberately NOT inclusive of release/ga — mixing in the far
+// more sparsely-published stable tags just buries the preview builds you're
+// there to see. Anything not in this map's active list is hidden, not merely
+// re-labelled — resource-center's own channel param already narrows what it
+// returns, this is the client's independent guarantee that the version list
+// never shows a build outside the selected channel.
+const _CHANNEL_TAGS = {
+  ga:      ['ga'],
+  release: ['release', 'ga'],
+  preview: ['preview'],
+};
+
+function _channelTags(item) {
+  const allowed = _CHANNEL_TAGS[_currentChannel] || _CHANNEL_TAGS.ga;
+  return (item.tags || []).filter(t => allowed.includes(t.channel));
 }
 
 // ── Tab switching ─────────────────────────────────────────────────────────
@@ -190,7 +211,7 @@ function _renderMyServices() {
   for (const item of deployed) {
     const id = _driverIdForItem(item, item._cat);
     const s  = _statuses[id] || {};
-    const tags = item.tags || [];
+    const tags = _channelTags(item);
     const latestTag = tags.length > 0 ? tags[0].tag : null;
     const currentTag = s.running_image?.includes(':') ? s.running_image.split(':').pop() : null;
     const hasUpdate = latestTag && currentTag && latestTag !== currentTag;
@@ -299,7 +320,7 @@ function _svcRowHTML({ item, id, s, latestTag, currentTag, hasUpdate }) {
   const isRunning = s.running || item._cat === 'core';
   const statusDot = isRunning ? 'running' : s.status === 'error' ? 'error' : 'stopped';
   const imageBase = item.full_repo || item.image;
-  const tags = item.tags || [];
+  const tags = _channelTags(item);
 
   let actions = '';
   // Version switcher (dropdown)
@@ -453,7 +474,7 @@ function _mpCardHTML(item) {
   const driverId = _driverIdForItem(item, cat);
   const s = _statuses[driverId];
   const isInstalled = s && (s.running || s.last_deploy);
-  const tags = item.tags || [];
+  const tags = _channelTags(item);
   const imageBase = item.full_repo || item.image;
   const desc = item.description || (cat === 'perception' ? '语音感知套件 — ASR 语音识别 + TTS 语音合成 + VAD 静音检测 + 唤醒词检测' : '');
   const fullName = item.name || label;


### PR DESCRIPTION
## What

驱动市场卡片和详情页的版本下拉框会列出 resource-center 按通道层级返回的**所有** tag——层级是向上包含的（preview 能看到 preview+release+ga）。由于预览版发布频率远高于晋级到 release/ga 的频率，即使从没碰过预览通道，列表也会被 Preview 标签淹没；而且如果上游任何环节（不感知通道的缓存、一次过期的 fetch）碰巧返回了错误通道的数据，前端也没有任何兜底。

按部署 modal 里实际选中的通道加了一层客户端过滤：

```
ga      → 只列 ga
release → release + ga（ga 作为稳定版兜底）
preview → 只列 preview（不再被更稀疏的 release/ga 晋级稀释）
```

这不是简单的相等匹配——release 保留 ga 作为兜底，preview 不包含 release/ga——每个通道按各自的场景取舍，而不是套用统一规则。

## 改动

**`deploy-panel.js`**：加 `_currentChannel`（由 `_loadChannel`/`_onChannelChange` 保持同步）和 `_channelTags(item)`。三处读 `item.tags` 做版本展示的地方（我的服务行、驱动市场卡片自己的下拉、升级检测）全部改用它。详情页不需要改——它是从卡片自己渲染出的 `.mp-version-opt` 元素里重新取数据的，天然继承了这层过滤。

**`registry.py`**：5 分钟的目录缓存原来不按任何 key 区分，切换通道后，只要缓存还没过期，任何没传 `refresh=true` 的调用方都会拿到上一个通道的数据。改成按通道分 key 缓存。`_build_catalog_sync` 现在把 channel 作为显式参数传入，而不是内部再读一次 config，保证缓存 key 和实际请求的通道永远一致。

**`drivers.py`、`system.py`**：跟着上面两个函数的新签名 / 缓存结构改了调用方。

## 验证

- `py_compile` 过 4 个改动的 Python 文件，`node --check` 过 `deploy-panel.js`
- 在隔离环境里跑了 `registry.py` 的 `_current_channel()` / 按 channel 分 key 的缓存逻辑——确认切换通道后两个 key 各自独立存取，互不覆盖
- 把 `_CHANNEL_TAGS` + `_channelTags` 抽出来单独跑了一遍：三个通道各自返回预期的 tag 子集，且顺序保持后端原有的按发布时间倒序（filter 不改变相对顺序）；对完全没有匹配通道 tag 的镜像（比如只发布过 preview 的），`ga`/`release` 下正确返回空数组（对应「暂无版本」）

未在真实 ROS2/机器人环境里跑通——本机没有 ROS2/Docker，只能做静态检查 + 隔离行为测试。

🤖 Generated with [Claude Code](https://claude.com/claude-code)