### PR TITLE
fix(perception): survive the qemu ldconfig segfault when cross-building jetson

### DIFF
--- a/perception/Dockerfile.jetson
+++ b/perception/Dockerfile.jetson
@@ -26,9 +26,33 @@ RUN if ls /etc/apt/sources.list.d/*.list 1>/dev/null 2>&1; then \
     fi
 
 # ── System deps ────────────────────────────────────────────────────
+# `ldconfig` is shimmed around every apt install in this file. The libc-bin
+# post-install trigger runs it, and it segfaults under qemu-user when the image
+# is cross-built from x86 (build_common.sh takes the `buildx --platform
+# linux/arm64` path there):
+#
+#   Processing triggers for libc-bin (2.35-0ubuntu3.8) ...
+#   qemu: uncaught target signal 11 (Segmentation fault) - core dumped
+#   dpkg: error processing package libc-bin (--configure): ... exit status 139
+#   E: Sub-process /usr/bin/dpkg returned an error code (1)
+#
+# The packages themselves unpack and configure fine — only the trigger dies, so
+# the layer contents are correct while apt still exits 100. jp6.1 hits it
+# (jammy, glibc 2.35); jp5.11 does not (focal, glibc 2.31); native arm64 builds
+# never do, because nothing is emulated.
+#
+# So: shim it for the duration of the install, then restore the real one and run
+# it best-effort. Native builds still get a correct /etc/ld.so.cache; emulated
+# builds fall back to ld.so's default search path, which already covers the
+# /usr/lib/aarch64-linux-gnu these packages install into.
 RUN rm -f /etc/apt/sources.list.d/* && rm -rf /var/cache/apt/archives/* /var/lib/apt/lists/* && \
+    mv /usr/sbin/ldconfig /usr/sbin/ldconfig.real && \
+    printf '#!/bin/sh\nexit 0\n' > /usr/sbin/ldconfig && \
+    chmod +x /usr/sbin/ldconfig && \
     apt-get -o Acquire::AllowInsecureRepositories=true update && \
     apt-get install -y --no-install-recommends --allow-unauthenticated ffmpeg && \
+    mv -f /usr/sbin/ldconfig.real /usr/sbin/ldconfig && \
+    { ldconfig || echo '[build] ldconfig skipped — emulated build, using default search path'; } && \
     apt-get clean && rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
 
 RUN pip3 install --no-cache-dir -i ${PYPI_MIRROR} colcon-common-extensions && \
@@ -80,7 +104,16 @@ ENV YOLO_CONFIG_DIR=/work
 RUN pip3 install --no-cache-dir -i ${PYPI_MIRROR} sherpa-onnx
 
 # ── phonemizer (multilingual IPA via espeak-ng for asr_kws mode) ──
-RUN apt-get update && apt-get install -y --no-install-recommends espeak-ng && \
+# ldconfig shimmed for the same reason as the ffmpeg step above — this is the
+# step that actually failed on `--jp-version 6.1`, because layers 1-11 were
+# cached and it was the first apt install to run.
+RUN mv /usr/sbin/ldconfig /usr/sbin/ldconfig.real && \
+    printf '#!/bin/sh\nexit 0\n' > /usr/sbin/ldconfig && \
+    chmod +x /usr/sbin/ldconfig && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends espeak-ng && \
+    mv -f /usr/sbin/ldconfig.real /usr/sbin/ldconfig && \
+    { ldconfig || echo '[build] ldconfig skipped — emulated build, using default search path'; } && \
     rm -rf /var/lib/apt/lists/*
 RUN pip3 install --no-cache-dir -i ${PYPI_MIRROR} phonemizer
 

--- a/perception/Dockerfile.jetson
+++ b/perception/Dockerfile.jetson
@@ -65,8 +65,24 @@ RUN cd /ros_ws && \
     colcon build --packages-select audio_msgs --cmake-args -DCMAKE_BUILD_TYPE=Release
 
 # ── Python deps ────────────────────────────────────────────────────
-RUN pip3 install --no-cache-dir -i ${PYPI_MIRROR} \
-    pyyaml requests websockets webrtcvad websocket-client dashscope && \
+# PyYAML goes first, on its own, with --ignore-installed. The jp5.11 base is
+# focal, whose apt `python3-yaml` (5.3.1) ships only egg-info, so pip cannot
+# work out which files belong to it and refuses to replace it the moment
+# something asks for a newer version:
+#
+#   ERROR: Cannot uninstall 'PyYAML'. It is a distutils installed project and
+#   thus we cannot accurately determine which files belong to it which would
+#   lead to only a partial uninstall.
+#
+# dashscope depends on PyYAML, so it triggers exactly that. Installing PyYAML
+# by itself with --ignore-installed leaves the apt egg-info in place and writes
+# a proper dist-info alongside it; the next pip invocation then sees a version
+# it can reason about and never attempts the uninstall. --ignore-installed is a
+# per-invocation flag, which is why this is a separate command rather than an
+# extra argument on the one below — we do not want it applied to everything.
+RUN pip3 install --no-cache-dir -i ${PYPI_MIRROR} --ignore-installed PyYAML && \
+    pip3 install --no-cache-dir -i ${PYPI_MIRROR} \
+    requests websockets webrtcvad websocket-client dashscope && \
     pip3 install --no-cache-dir --no-deps -i ${PYPI_MIRROR} silero-vad
 
 # ── HTMSG deps (KISS-ICP + future semantic) ──────────────────────


### PR DESCRIPTION
## 问题

`./build_perception.sh --jp-version 6.1` 在 espeak-ng 那步失败:

```
Processing triggers for libc-bin (2.35-0ubuntu3.8) ...
qemu: uncaught target signal 11 (Segmentation fault) - core dumped
dpkg: error processing package libc-bin (--configure): ... exit status 139
E: Sub-process /usr/bin/dpkg returned an error code (1)
```

**包本身没问题** —— espeak-ng / espeak-ng-data / libespeak-ng1 / libpcaudio0 / libsonic0 五个全部 `Setting up` 成功,挂掉的只有 `libc-bin` 的 post-install trigger,也就是 `ldconfig`,而它是**在 qemu 里**段错误的。那一层的内容是对的,只是 dpkg 拒绝报成功,apt 于是返回 100。

为什么只有 jp6.1:

- `build_common.sh` 在 arm64 主机走原生 `docker build`,在 x86 走 `buildx --platform linux/arm64` + binfmt。**只有后者有仿真**,所以只有它会撞上。
- 两个 JetPack 变体共用同一个 Dockerfile,只有 base image 不同:jp6.1 是 jammy(glibc **2.35**,报错里直接写着),jp5.11 是 focal(glibc 2.31)不复现。

## 改动一:ldconfig shim

两处 apt 安装都包起来:安装期间把 `ldconfig` shim 成 `exit 0`,装完还原真的那个并 best-effort 执行。原生构建照旧得到正确的 `/etc/ld.so.cache`;仿真构建跳过它,回退到 ld.so 的默认搜索路径 —— 而这些包装进的 `/usr/lib/aarch64-linux-gnu` 本来就在默认路径里。

**ffmpeg 那步也包了**,虽然它不是报错的那一步。它只是因为 1-11 层命中缓存才没跑(报告的日志从 `[12/22]` 开始),而 ffmpeg 拉进来的动态库比 espeak-ng 多得多,从零交叉构建时风险不小反大。

## 改动二:PyYAML 越过 focal 的 distutils python3-yaml

改动一把缓存打掉之后,**jp5.11 暴露了第二个失败**:

```
Attempting uninstall: pyyaml
  Found existing installation: PyYAML 5.3.1
ERROR: Cannot uninstall 'PyYAML'. It is a distutils installed project and thus we
cannot accurately determine which files belong to it which would lead to only a
partial uninstall.
```

focal 的 apt `python3-yaml` 5.3.1 只带 egg-info,pip 判定不出哪些文件属于它,拒绝替换。注意:裸写 `pyyaml` 会被 pip 当成"已满足"跳过 —— 真正逼它升级的是 **`dashscope`**,它对 PyYAML 有版本约束而 5.3.1 不满足。

把 PyYAML 单独拿出来用 `--ignore-installed` 先装:apt 的 egg-info 原样留着,旁边写入一份正常 dist-info;后面那条 pip 就能看懂版本,不再尝试卸载。`--ignore-installed` 是按次生效的,所以必须拆成独立命令 —— 加在原来那条上会把整串包强制重装,包括 base 镜像故意装好的那些。

**这行 pip 自 `e4d4a0d`(初始开源提交)就没改过**(`git log -S dashscope` 确认),缺陷本来就在。值得记录的推论:最近的 jp5.11 镜像(包括 `release.260819.f6d7596-jetson-jp5.11`)都是踩着一个早于这个冲突的缓存层构建出来的 —— **任何冷缓存的 jp5.11 构建都会在这里失败**,跟 ldconfig 那个改动有没有都一样。

## 验证

**jp5.11 冷缓存构建通过** —— `perception:release.260820.6994beb-jetson-jp5.11`(本 PR HEAD)已在 jetson-orin-02 上构建并部署运行。写 PR 时担心的 `kiss-icp scipy` 会撞同样的 distutils 问题**没有发生**:kiss-icp 对 scipy 没有强制升级的约束,裸 `scipy` 被当成已满足跳过了。

部署后在 orin-02 实测日志(顺带验证了 #115 的日志改动):

| 检查 | agent-core | perception |
|---|---|---|
| `docker logs` 完整读取 | rc=0 | rc=0 |
| NUL 字节 | 0 | 0 |
| ANSI 转义 | 0 | 0 |
| 其它 C0 控制符 | 0 | 0 |
| UTF-8 整体解码 | OK | OK |
| 撕裂/超长行 | 无(最长 275 字符) | 无(最长 341 字符) |

日志级别修复也确认生效:VAD 子进程现在是 `[asr.vad_worker] INFO`,一次说话 2 行,不再是 `basicConfig(DEBUG)` 的逐帧刷屏;整体 50 INFO + 1 WARNING、**0 条 DEBUG**。增长速率 agent-core ~4 KB/天、perception ~2 KB/天(90 秒实测外推,轻载)。ASR 端到端正常(`asr_kws TRIGGERED: '小范小范，你好。' → '你好。'`)。

**jp6.1 交叉构建也通过了**,而且能把功劳定位到具体改动 —— registry 里同时存在:

| tag | 内容 |
|---|---|
| `release.260820.5f9ab32-jetson-jp6.1` | **仅** ldconfig shim(改动一) |
| `release.260820.6994beb-jetson-jp6.1` | + PyYAML 修复(改动二),linux/arm64,45 层 |
| `release.260820.6994beb-jetson-jp5.11` | 同上,已部署运行 |

`5f9ab32` 能构建并推送成功,说明**改动一单独就修好了 jp6.1**。

反过来也说明 **jp6.1 从来没有 PyYAML 那个问题** —— 与最初的报错日志一致:jp6.1 跑到了 `[15/22]`,即 line 68 的 pip 步骤在 jammy 上本来就是过的。改动二只对 focal(jp5.11)必要。

另外补一条此前没说清的背景:jp6.1 在这之前也是能构建的,只要**在 arm64 上原生构建**。orin-02 上还留着 `local/phanthy-motus/perception:release.260814.0990014-jetson-jp6.1` —— `local/` 前缀正是 `PUSH_ENABLED=false` 时的产物,也就是在这台 Jetson 上原生构建出来的。所以这个缺陷的准确范围是"jp6.1 + 从 x86 交叉构建",不是"jp6.1"。

ldconfig 改动的两条分支另外还用 stub ldconfig 各跑过一遍(一条成功、一条 `exit 139`),确认真 binary 在两种情况下都被放回、且崩溃时 RUN 层仍退出 0;文件里 15 个 RUN 块全部过了 `bash -n`。

## 顺带记录:一个不属于本 PR 的遗留

orin-02 上 perception 的 log options 是空的(`local map[]` → 继承 20m×5 = 100 MB),agent-core 是正确的 `10m×3`。不是 #115 的修复失效 —— 是时间线:perception 创建于 `17:10:10`,agent-core 创建于 `17:11:34`,perception 是被**旧** agent-core 用 legacy `docker run` 路径创建的(它没有任何 `com.docker.compose.*` 标签)。新镜像里 `api/drivers.py:300 run_kwargs['log_config'] = _log_config()` 确实在。重新部署一次 perception 即可,log 配置改不了不重建容器。

## 零改动的替代方案

在 arm64 主机上构建 —— `build_common.sh` 会走原生 `docker build` 分支,完全没有仿真,也更快;这也是本 PR 之前 jp6.1 唯一能构建的方式。不过 PyYAML 那个缺陷跟架构无关,冷缓存的 jp5.11 无论哪条路都需要本 PR。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
