### PR TITLE
feat(canvas): auto-claim edit lock on demand, fix lock gaps

### DIFF
--- a/agent-core/src/api/canvas.py
+++ b/agent-core/src/api/canvas.py
@@ -101,17 +101,12 @@ async def save_layout(layout: CanvasLayout):
     _check_editor_expired()
 
     session_id = layout.session_id
-    if _editor_session and session_id != _editor_session:
+    if session_id != _editor_session:
         return fastapi.responses.JSONResponse(
             status_code=403, content={'code': 403, 'message': 'Not the current editor',
                                       'editor': _editor_session})
 
-    # Auto-claim if no editor (backward compat: first save becomes editor)
-    if not _editor_session and session_id:
-        _editor_session = session_id
-
-    if session_id == _editor_session:
-        _editor_last_seen = time.monotonic()
+    _editor_last_seen = time.monotonic()
 
     save_data = layout.dict()
     save_data.pop('session_id', None)

--- a/agent-core/web/css/style.css
+++ b/agent-core/web/css/style.css
@@ -876,8 +876,13 @@ html, body {
 .canvas-editor-bar .editor-label--active {
   color: var(--green);
 }
+.canvas-editor-bar.canvas-editor-bar--locked {
+  background: var(--red-bg);
+  border-color: var(--red);
+}
 .canvas-editor-bar .editor-label--locked {
-  color: var(--text-dim);
+  color: var(--red);
+  font-weight: 600;
 }
 .canvas-editor-bar .editor-btn {
   background: none;

--- a/agent-core/web/js/canvas.js
+++ b/agent-core/web/js/canvas.js
@@ -49,6 +49,7 @@ async function _ensureEdit() {
       _isEditor = true;
       _currentEditor = _sessionId;
       _updateEditorUI();
+      _showToast('已自动获取编辑权限');
       return true;
     }
     _currentEditor = data.editor || null;

--- a/agent-core/web/js/canvas.js
+++ b/agent-core/web/js/canvas.js
@@ -32,14 +32,33 @@ if (!_sessionId) {
 let _isEditor = false;
 let _currentEditor = null;  // session_id of current editor (null = no one)
 
-/** Check if current session can modify. If not, show warning and return false. */
-function _canEdit() {
-  if (!_isEditor) {
-    const msg = _currentEditor ? '画布已被其他用户锁定，无法编辑' : '请先点击「编辑」进入编辑状态';
-    _showToast(msg);
+/**
+ * Ensure current session holds the edit lock, auto-claiming it if free.
+ * Returns true if editing may proceed, false if the canvas is occupied by
+ * another session (in which case a toast + locked UI state is shown).
+ */
+async function _ensureEdit() {
+  if (_isEditor) return true;
+  try {
+    const resp = await fetch('/api/canvas/claim-edit', {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ session_id: _sessionId }),
+    });
+    const data = await resp.json();
+    if (resp.ok) {
+      _isEditor = true;
+      _currentEditor = _sessionId;
+      _updateEditorUI();
+      return true;
+    }
+    _currentEditor = data.editor || null;
+    _updateEditorUI();
+    _showToast('画布正被其他用户编辑，请稍后重试');
+    return false;
+  } catch {
+    _showToast('无法获取编辑权限，请检查网络');
     return false;
   }
-  return true;
 }
 
 function _showToast(msg) {
@@ -63,14 +82,16 @@ let _projectRunning = false;
 
 export function isProjectRunning() { return _projectRunning; }
 export function redrawCanvas() { _redrawConnections(); }
-export function canEdit() { return _canEdit(); }
+export function ensureEdit() { return _ensureEdit(); }
+export function isEditor() { return _isEditor; }
 
 /**
  * Programmatically add a card to the canvas (used by mobile tap-to-add).
  * Returns true if added, false if rejected.
  */
-export function addCardFromSidebar({ mcpId, toolName, driverName, hasConfig, multiInstance }) {
+export async function addCardFromSidebar({ mcpId, toolName, driverName, hasConfig, multiInstance }) {
   if (_projectRunning) return false;
+  if (!(await _ensureEdit())) return false;
   if (hasConfig && !isToolConfigured(mcpId, toolName)) return false;
   if (!multiInstance) {
     const existing = _cards.find(c => c.mcpId === mcpId && c.toolName === toolName);
@@ -596,12 +617,12 @@ function _addCard(data, save = true) {
   if (save) _saveLayout();
 }
 
-function _removeCard(id) {
+async function _removeCard(id) {
   if (_projectRunning) {
     _logActivity('warn', '请停止智能控制后修改');
     return;
   }
-  if (!_canEdit()) return;
+  if (!(await _ensureEdit())) return;
   const idx = _cards.findIndex(c => c.id === id);
   if (idx === -1) return;
   _cards[idx].el.remove();
@@ -818,7 +839,7 @@ function _buildCardEl({ id, mcpId, toolName, driverName, x, y, topicIn: savedTop
     if (sensorExecBtn) {
       sensorExecBtn.addEventListener('click', async (e) => {
         e.stopPropagation();
-        if (!_canEdit()) return;
+        if (!(await _ensureEdit())) return;
         await _executeCard(el, mcpId, toolName, id);
       });
     }
@@ -953,8 +974,8 @@ function _buildCardEl({ id, mcpId, toolName, driverName, x, y, topicIn: savedTop
             field.style.display = paramKeys.includes(key) ? '' : 'none';
           });
         };
-        actionSelect.addEventListener('change', () => {
-          if (!_canEdit()) {
+        actionSelect.addEventListener('change', async () => {
+          if (!(await _ensureEdit())) {
             _applyActionParams();  // revert visual to match current state
             return;
           }
@@ -993,7 +1014,7 @@ function _buildCardEl({ id, mcpId, toolName, driverName, x, y, topicIn: savedTop
     if (execBtn) {
       execBtn.addEventListener('click', async (e) => {
         e.stopPropagation();
-        if (!_canEdit()) return;
+        if (!(await _ensureEdit())) return;
         await _executeCard(el, mcpId, toolName);
       });
     }
@@ -1205,7 +1226,7 @@ function _setupPortDrag() {
   });
 
   // Delegate pointerdown on out ports and executor ports
-  _viewport.addEventListener('pointerdown', (e) => {
+  _viewport.addEventListener('pointerdown', async (e) => {
     const outPort = e.target.closest('.canvas-port.out');
     const execPort = !outPort ? e.target.closest('.canvas-port.executor') : null;
     if (!outPort && !execPort) return;
@@ -1213,7 +1234,7 @@ function _setupPortDrag() {
       _logActivity('warn', '请停止智能控制后修改');
       return;
     }
-    if (!_canEdit()) return;
+    if (!(await _ensureEdit())) return;
     e.preventDefault();
     e.stopPropagation();
 
@@ -1324,13 +1345,13 @@ function _redrawConnections() {
     line.addEventListener('mouseenter', showBtn);
     line.addEventListener('mouseleave', hideBtn);
     delBtn.addEventListener('mouseleave', () => delBtn.classList.remove('visible'));
-    delBtn.addEventListener('click', (e) => {
+    delBtn.addEventListener('click', async (e) => {
       e.stopPropagation();
       if (_projectRunning) {
         _logActivity('warn', '请停止智能控制后修改');
         return;
       }
-      if (!_canEdit()) return;
+      if (!(await _ensureEdit())) return;
       _connections = _connections.filter(c => c.id !== conn.id);
       _resolveAllTopics();
       _autoStopOnDisconnect(conn.toCardId, conn.toPortIdx, conn.fromTopic);
@@ -1405,8 +1426,8 @@ function _redrawConnections() {
     line.addEventListener('mouseleave', hideBtn);
     delBtn.addEventListener('mouseleave', () => delBtn.classList.remove('visible'));
 
-    const removeExec = () => {
-      if (!_canEdit()) return;
+    const removeExec = async () => {
+      if (!(await _ensureEdit())) return;
       _execConnections = _execConnections.filter(c => c.id !== conn.id);
       _logActivity('executor', `解绑执行器: ${conn.toToolName || conn.toCardId}`);
       _redrawConnections();
@@ -1947,12 +1968,12 @@ function _makeDraggable(el, cardData) {
 
   let startClientX, startClientY, startWorldX, startWorldY, isDragging = false;
 
-  header.addEventListener('pointerdown', (e) => {
+  header.addEventListener('pointerdown', async (e) => {
     if (e.target.closest('.canvas-card-close')) return;
     if (e.target.closest('.canvas-card-info-btn')) return;
     if (e.target.closest('.canvas-card-instance-cfg-btn')) return;
     if (_projectRunning) return;
-    if (!_canEdit()) return;
+    if (!(await _ensureEdit())) return;
     e.preventDefault();
     e.stopPropagation();
 
@@ -1998,7 +2019,7 @@ function _debouncedSave() {
 }
 
 async function _saveLayout() {
-  if (!_isEditor) return;  // Only editor can save
+  if (!(await _ensureEdit())) return;  // auto-reclaim if lock was lost, bail if occupied
   const cards = _cards.map(c => ({
     id:         c.id,
     mcpId:      c.mcpId,
@@ -2051,44 +2072,28 @@ function _createEditorBar() {
 function _updateEditorUI() {
   let bar = document.getElementById('canvas-editor-bar');
   if (!bar) bar = _createEditorBar();
+  bar.classList.toggle('canvas-editor-bar--locked', !_isEditor && !!_currentEditor);
 
   if (_isEditor) {
     bar.innerHTML = `${_SVG_PEN}<span class="editor-label editor-label--active">编辑中</span><button class="editor-btn" id="canvas-release-btn">释放</button>`;
     bar.querySelector('#canvas-release-btn').onclick = _releaseEdit;
     _setCanvasReadonly(false);
   } else if (_currentEditor) {
-    bar.innerHTML = `${_SVG_LOCK}<span class="editor-label editor-label--locked">已锁定</span>`;
+    bar.innerHTML = `${_SVG_LOCK}<span class="editor-label editor-label--locked">画布被占用，无法编辑</span>`;
     _setCanvasReadonly(true);
   } else {
     bar.innerHTML = `${_SVG_PEN}<button class="editor-btn editor-btn--claim" id="canvas-claim-btn">编辑</button>`;
-    bar.querySelector('#canvas-claim-btn').onclick = _claimEdit;
+    bar.querySelector('#canvas-claim-btn').onclick = _ensureEdit;
     _setCanvasReadonly(true);
   }
 }
 
 function _setCanvasReadonly(readonly) {
   // Don't use pointer-events: none — it blocks all interaction including toast triggers.
-  // Instead, each action handler checks _canEdit() individually.
+  // Instead, each action handler calls _ensureEdit() individually.
   document.querySelectorAll('.sidebar-tool-item').forEach(el => {
     el.draggable = !readonly;
   });
-}
-
-async function _claimEdit() {
-  try {
-    const resp = await fetch('/api/canvas/claim-edit', {
-      method: 'POST', headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ session_id: _sessionId }),
-    });
-    const data = await resp.json();
-    if (resp.ok) {
-      _isEditor = true;
-      _currentEditor = _sessionId;
-    } else {
-      _currentEditor = data.editor || null;
-    }
-  } catch { /* silent */ }
-  _updateEditorUI();
 }
 
 async function _releaseEdit() {
@@ -2115,6 +2120,7 @@ async function _checkEditStatus() {
       // We lost editor status (timeout)
       _isEditor = false;
       _logActivity('warn', '编辑权已超时释放（60秒无操作）');
+      _showToast('编辑权已超时释放，请重新操作');
     }
     _updateEditorUI();
   } catch { /* silent */ }

--- a/agent-core/web/js/canvas.js
+++ b/agent-core/web/js/canvas.js
@@ -24,10 +24,13 @@ let _cards      = [];   // [{ id, mcpId, toolName, driverName, x, y, el }]
 let _allMcps    = [];
 
 // ── Editor Lock ──────────────────────────────────────────────────────────────
-let _sessionId = localStorage.getItem('canvas_session_id');
+// sessionStorage (not localStorage) so each tab/window gets its own session_id —
+// otherwise all tabs of the same browser would share one id and be treated as
+// the same editor, letting them edit concurrently and silently clobber each other's autosave.
+let _sessionId = sessionStorage.getItem('canvas_session_id');
 if (!_sessionId) {
   _sessionId = 'sess-' + Date.now().toString(36) + Math.random().toString(36).slice(2, 6);
-  localStorage.setItem('canvas_session_id', _sessionId);
+  sessionStorage.setItem('canvas_session_id', _sessionId);
 }
 let _isEditor = false;
 let _currentEditor = null;  // session_id of current editor (null = no one)
@@ -2020,7 +2023,7 @@ function _debouncedSave() {
 }
 
 async function _saveLayout() {
-  if (!(await _ensureEdit())) return;  // auto-reclaim if lock was lost, bail if occupied
+  if (!_isEditor) return;  // only the current editor may persist; system-triggered saves must not auto-claim
   const cards = _cards.map(c => ({
     id:         c.id,
     mcpId:      c.mcpId,

--- a/agent-core/web/js/sidebar.js
+++ b/agent-core/web/js/sidebar.js
@@ -4,7 +4,7 @@
  * Tools with configSchema show config status and config button.
  */
 
-import { isProjectRunning, addCardFromSidebar, canEdit } from './canvas.js';
+import { isProjectRunning, addCardFromSidebar, ensureEdit, isEditor } from './canvas.js';
 import { isMobile, closeSidebarMobile } from './mobile.js';
 
 let _scroll = null;
@@ -267,10 +267,10 @@ function _buildChip(mcp, tool) {
   chip.innerHTML = `<span class="chip-name">${_esc(tool.name)}</span><button class="mobile-add-btn" title="添加到画布">+</button>${configBtnHtml}`;
 
   // Mobile add-to-canvas button
-  chip.querySelector('.mobile-add-btn').addEventListener('click', (e) => {
+  chip.querySelector('.mobile-add-btn').addEventListener('click', async (e) => {
     e.stopPropagation();
     e.preventDefault();
-    const added = addCardFromSidebar({
+    const added = await addCardFromSidebar({
       mcpId: mcp.id, toolName: tool.name,
       driverName: mcp.server_name || mcp.name || mcp.id,
       hasConfig: !!hasSharedFields,
@@ -294,8 +294,9 @@ function _buildChip(mcp, tool) {
     _showDetail(mcp, tool);
   });
 
+  chip.addEventListener('pointerdown', () => { ensureEdit(); });
   chip.addEventListener('dragstart', (e) => {
-    if (!canEdit()) { e.preventDefault(); return; }
+    if (!isEditor()) { e.preventDefault(); ensureEdit(); return; }
     chip.classList.add('dragging-source');
     e.dataTransfer.effectAllowed = 'copy';
     e.dataTransfer.setData('application/x-cap-card', JSON.stringify({
@@ -402,10 +403,10 @@ function _buildToolCard(mcp, tool) {
   });
 
   // Mobile add-to-canvas button
-  card.querySelector('.mobile-add-btn').addEventListener('click', (e) => {
+  card.querySelector('.mobile-add-btn').addEventListener('click', async (e) => {
     e.stopPropagation();
     e.preventDefault();
-    const added = addCardFromSidebar({
+    const added = await addCardFromSidebar({
       mcpId: mcp.id, toolName: tool.name,
       driverName: mcp.server_name || mcp.name || mcp.id,
       hasConfig: !!hasSharedFields,
@@ -423,8 +424,9 @@ function _buildToolCard(mcp, tool) {
   }
 
   // Drag (for canvas drop)
+  card.addEventListener('pointerdown', () => { ensureEdit(); });
   card.addEventListener('dragstart', (e) => {
-    if (!canEdit()) { e.preventDefault(); return; }
+    if (!isEditor()) { e.preventDefault(); ensureEdit(); return; }
     card.classList.add('dragging-source');
     e.dataTransfer.effectAllowed = 'copy';
     e.dataTransfer.setData('application/x-cap-card', JSON.stringify({
@@ -457,12 +459,12 @@ export function hasSharedRequired(configSchema) {
 
 // ── Tool config modal (shared fields only) ────────────────────────────────────
 
-function _openToolConfigModal(mcpId, toolName, configSchema) {
+async function _openToolConfigModal(mcpId, toolName, configSchema) {
   if (isProjectRunning()) {
     alert('Stop agent before modifying');
     return;
   }
-  if (!canEdit()) return;
+  if (!(await ensureEdit())) return;
   const overlay = document.getElementById('tool-config-overlay');
   const titleEl = document.getElementById('tool-config-title');
   const bodyEl  = document.getElementById('tool-config-body');
@@ -668,7 +670,7 @@ function _openToolConfigModal(mcpId, toolName, configSchema) {
   // Handlers
   const close = () => { overlay.classList.add('hidden'); };
   const save = async () => {
-    if (!canEdit()) return;
+    if (!(await ensureEdit())) return;
     const values = {};
     bodyEl.querySelectorAll('[data-key]').forEach(input => {
       const v = input.value.trim();
@@ -784,12 +786,12 @@ function _hideDetail() {
  * Open a config modal for a specific canvas card instance.
  * Only shows fields with scope === "instance".
  */
-export function openInstanceConfigModal(mcpId, toolName, instanceId, configSchema) {
+export async function openInstanceConfigModal(mcpId, toolName, instanceId, configSchema) {
   if (isProjectRunning()) {
     alert('Stop agent before modifying');
     return;
   }
-  if (!canEdit()) return;
+  if (!(await ensureEdit())) return;
   const overlay = document.getElementById('tool-config-overlay');
   const titleEl = document.getElementById('tool-config-title');
   const bodyEl  = document.getElementById('tool-config-body');
@@ -955,7 +957,7 @@ export function openInstanceConfigModal(mcpId, toolName, instanceId, configSchem
 
   const close = () => { overlay.classList.add('hidden'); };
   const save = async () => {
-    if (!canEdit()) return;
+    if (!(await ensureEdit())) return;
     const values = {};
     bodyEl.querySelectorAll('[data-key]').forEach(input => {
       const v = input.value.trim();


### PR DESCRIPTION
## Summary
- Edit lock is now auto-claimed on demand: any editing action (drag, connect, delete, config save, mobile add-to-canvas) automatically requests the lock instead of requiring a manual "编辑" click first. If occupied by another session, the canvas switches to a clearly-marked locked state with a toast.
- Fixed the mobile "add to canvas" button, which previously bypassed the lock check entirely.
- Removed the backend `save_layout` auto-claim backdoor that silently granted the lock to whoever saved first without going through `claim-edit`.
- Lock timeout is now surfaced as a toast, not just an activity log entry.
- "Occupied" state gets a distinct red-tinted styling instead of blending in with the default bar.

## Test plan
- [x] `node --check` on modified JS files
- [x] Backend lock flow (claim/423/save/403/release/status) verified via FastAPI TestClient
- [ ] Manual two-tab browser verification (blocked locally — this machine lacks ROS2/rclpy which agent-core requires to boot; needs to be run on a robot debug environment or a host with ROS2 installed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)