### PR TITLE
feat(agent-core): add remote_image sensor card

### DIFF
--- a/agent-core/src/api/mcp_manage.py
+++ b/agent-core/src/api/mcp_manage.py
@@ -811,6 +811,21 @@ async def mcp_call_tool(mcp_id: str, req: MCPCallRequest):
             elif action == 'info':
                 return {'code': 200, 'data': {'state': 'running', 'topic_out': [{'topic': '/remote_control/audio', 'format': 'audio/pcm-16k'}]}}
             return {'code': 200, 'data': None}
+        if req.tool == 'remote_image':
+            action = req.arguments.get('action', 'start')
+            if action == 'start':
+                return {'code': 200, 'data': {'state': 'running'}}
+            elif action == 'stop':
+                return {'code': 200, 'data': {'state': 'idle'}}
+            elif action == 'send_image':
+                image_file = req.arguments.get('image_file', '')
+                if not image_file:
+                    return {'code': 400, 'message': '缺少 image_file 参数', 'data': None}
+                from start import publish_image_file
+                return await publish_image_file(image_file)
+            elif action == 'info':
+                return {'code': 200, 'data': {'state': 'running', 'topic_out': [{'topic': '/remote_control/image', 'format': 'image/jpeg'}]}}
+            return {'code': 200, 'data': None}
         return await _handle_agentcore_call(req)
 
     # ── Handle internal channel MCP ──

--- a/agent-core/src/start.py
+++ b/agent-core/src/start.py
@@ -178,9 +178,19 @@ def _register_core_mcp(silent=False):
                     'audio_file': {'type': 'string', 'format': 'file', 'accept': 'audio/*', 'description': '音频文件'},
                 }, 'required': ['action', 'audio_file']},
                 'topic_out': [{'topic': '/remote_control/audio', 'format': 'audio/pcm-16k'}],
+            },
+            {
+                'name': 'remote_image',
+                'type': 'sensor',
+                'description': '远程图片 — 从浏览器上传图片文件，转换为 JPEG 发布到 DDS',
+                'inputSchema': {'type': 'object', 'properties': {
+                    'action': {'type': 'string', 'enum': ['send_image'], 'description': 'Action to perform'},
+                    'image_file': {'type': 'string', 'format': 'file', 'accept': 'image/*', 'description': '图片文件'},
+                }, 'required': ['action', 'image_file']},
+                'topic_out': [{'topic': '/remote_control/image', 'format': 'image/jpeg'}],
             }
         ],
-        'topic_out': [{'topic': '/decision_core', 'format': 'data/json'}, {'topic': '/remote_control/mic', 'format': 'audio/pcm-16k'}, {'topic': '/remote_control/message', 'format': 'data/json'}, {'topic': '/remote_control/audio', 'format': 'audio/pcm-16k'}],
+        'topic_out': [{'topic': '/decision_core', 'format': 'data/json'}, {'topic': '/remote_control/mic', 'format': 'audio/pcm-16k'}, {'topic': '/remote_control/message', 'format': 'data/json'}, {'topic': '/remote_control/audio', 'format': 'audio/pcm-16k'}, {'topic': '/remote_control/image', 'format': 'image/jpeg'}],
         'topic_in': [{'format': 'data/json'}],
     })
 
@@ -601,6 +611,69 @@ async def _remote_audio_upload(file: fastapi.UploadFile = fastapi.File()):
         return await publish_audio_file(tmp_path)
     finally:
         os.unlink(tmp_path)
+
+# ── Remote Image: convert file to JPEG and publish to ROS2 ─────────────────────
+_image_pub = None
+
+def _ensure_image_pub():
+    """Lazily create the ROS2 publisher for /remote_control/image."""
+    global _image_pub
+    if _image_pub is not None:
+        return _image_pub
+    try:
+        from sensor_msgs.msg import CompressedImage
+        import ros2_bridge
+        node = ros2_bridge._node_main
+        if node:
+            from rclpy.qos import QoSProfile, ReliabilityPolicy, HistoryPolicy, DurabilityPolicy
+            qos = QoSProfile(reliability=ReliabilityPolicy.BEST_EFFORT,
+                             history=HistoryPolicy.KEEP_LAST, depth=1,
+                             durability=DurabilityPolicy.VOLATILE)
+            _image_pub = node.create_publisher(CompressedImage, "/remote_control/image", qos)
+    except Exception:
+        pass
+    return _image_pub
+
+async def publish_image_file(file_path: str) -> dict:
+    """Re-encode arbitrary uploaded image to JPEG (if needed) and publish once to DDS."""
+    import os
+    import subprocess
+    pub = _ensure_image_pub()
+    if not pub:
+        return {'code': 500, 'message': 'ROS2 not available'}
+    if not os.path.isfile(file_path):
+        return {'code': 400, 'message': f'文件不存在: {file_path}'}
+
+    proc = subprocess.run(
+        ['ffmpeg', '-y', '-i', file_path, '-frames:v', '1', '-f', 'mjpeg', 'pipe:1'],
+        capture_output=True, timeout=30,
+    )
+    if proc.returncode != 0:
+        return {'code': 400, 'message': f'图片解码失败: {proc.stderr.decode(errors="replace")[:200]}'}
+    jpeg_bytes = proc.stdout
+    if not jpeg_bytes:
+        return {'code': 400, 'message': 'No image data after conversion'}
+
+    width = height = 0
+    try:
+        probe = subprocess.run(
+            ['ffprobe', '-v', 'error', '-select_streams', 'v:0',
+             '-show_entries', 'stream=width,height', '-of', 'csv=p=0', file_path],
+            capture_output=True, timeout=10,
+        )
+        if probe.returncode == 0:
+            w, h = probe.stdout.decode().strip().split(',')
+            width, height = int(w), int(h)
+    except Exception:
+        pass
+
+    from sensor_msgs.msg import CompressedImage
+    msg = CompressedImage()
+    msg.format = "jpeg"
+    msg.data = list(jpeg_bytes)
+    pub.publish(msg)
+
+    return {'code': 200, 'data': {'width': width, 'height': height, 'bytes': len(jpeg_bytes)}}
 
 # ── Mic WebSocket endpoint (receive browser PCM and publish to ROS2) ──────────
 _mic_pub = None

--- a/agent-core/web/js/dashboard.js
+++ b/agent-core/web/js/dashboard.js
@@ -8,10 +8,11 @@ import { ActivityRenderer } from './renderers/activity.js';
 import { TextRenderer }     from './renderers/text.js';
 import { VideoRenderer }    from './renderers/video.js';
 import { ImageRenderer }    from './renderers/image.js';
+import { CameraRenderer }   from './renderers/camera.js';
 import { AudioRenderer }    from './renderers/audio.js';
 import { LidarRenderer }    from './renderers/lidar.js';
 
-const RENDERERS = [VideoRenderer, ImageRenderer, AudioRenderer, LidarRenderer, TextRenderer, ActivityRenderer];
+const RENDERERS = [VideoRenderer, ImageRenderer, CameraRenderer, AudioRenderer, LidarRenderer, TextRenderer, ActivityRenderer];
 
 const PREVIEW_CAPACITY = 100;  // sliding window frame count per topic
 


### PR DESCRIPTION
## Summary
- Add a `remote_image` virtual sensor tool to the internal `agentcore` MCP (mirrors `remote_audio`): lets the user upload a local image from the browser, converts it to JPEG via `ffmpeg` (handles arbitrary input formats, avoiding a hard Pillow dependency not present in the image), and publishes once to `/remote_control/image` as `sensor_msgs/CompressedImage`.
- Add matching dispatch branch in `mcp_manage.py` (`start`/`stop`/`send_image`/`info`).
- Register `CameraRenderer` in `dashboard.js`'s `RENDERERS` list so `image/jpeg` topics preview live in the main dashboard (previously only wired up in `monitor-dashboard.js`).
- No frontend changes needed for the upload widget itself — reuses the existing generic `inputSchema.properties.<field>.format === 'file'` convention in `canvas.js`.

## Test plan
- [x] Deployed to a live agent-core container (10.100.121.16) and verified via direct API calls: `remote_image` `start`/`send_image` actions return 200 with `{width, height, bytes}`.
- [x] Confirmed `/remote_control/image` topic registers with format `image/jpeg` in inspection logs.
- [ ] Manual UI check: drag `remote_image` card onto canvas, upload a JPEG/PNG, execute, confirm live preview via `CameraRenderer`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)