### PR TITLE
fix(core): preserve map robot yaw sign

### DIFF
--- a/agent-core/web/js/renderers/mapping.js
+++ b/agent-core/web/js/renderers/mapping.js
@@ -244,11 +244,12 @@ export const MappingRenderer = {
 
     // Update robot position and orientation
     // Coordinate mapping: robot at (robotX, 0.2, -robotY)
-    // Yaw: in original frame yaw=0 is +X, yaw=pi/2 is +Y
-    // In Three.js: +X stays +X, +Y maps to -Z → rotation around Y axis = -yaw
+    // Yaw: in the ROS map frame yaw=0 is +X and yaw=pi/2 is +Y.
+    // The display maps ROS +Y to Three.js -Z. A positive Three.js rotation
+    // around +Y already turns +X toward -Z, so preserve the ROS yaw sign.
     if (this._robotMesh) {
       this._robotMesh.position.set(robotX, 0.2, -robotY);
-      this._robotMesh.rotation.set(0, -robotYaw, 0);
+      this._robotMesh.rotation.set(0, robotYaw, 0);
       this._robotPos.set(robotX, 0.2, -robotY);
     }
   },


### PR DESCRIPTION
## Visible result
地图渲染器将 ROS map→base_link 的 yaw 直接传给 Three.js，机器人箭头不再被镜像。

## Root cause
`mapping.js` 使用 `rotation.set(0, -robotYaw, 0)`，导致真机 yaw=-1.847 rad 被显示为 +1.847 rad。在 Canvas 上位姿朝向显示反了。

## Scope
- 仅修改 `agent-core/web/js/renderers/mapping.js`
- 保留位置坐标映射 `position.set(robotX, 0.2, -robotY)`

## Tests and evidence
- `node --check agent-core/web/js/renderers/mapping.js`
- 静态符号不变量检查：存在 `rotation.set(0, robotYaw, 0)`，不存在负号版本
- 北京 G1 真机 overlay：Core 容器运行、WebUI HTTP 200、MCP HTTP 200、地图 topic `/ubuntu/navigation/fast_livo2/map_view` 持续约 1 Hz
- 容器内实际文件确认使用正号版本

## Demo in 5 minutes
1. 部署 PR 镜像或本地构建 Core。
2. 打开北京 G1 WebUI 地图视图。
3. 对照导航输出点云检查机器人箭头朝向；负 yaw 不应显示成相反方向。

## Rollback
恢复原 Core 镜像并执行 `docker compose up -d agent-core`。

## Safety
本 PR 只改 WebUI 绘制，不发送任何机器人运动指令。