### PR TITLE
fix(pr-review): bound builds by silence, not by total time

### DIFF
--- a/PR_REVIEW_AGENT.md
+++ b/PR_REVIEW_AGENT.md
@@ -205,14 +205,51 @@ makes the poller replay up to `POLL_INITIAL_LOOKBACK_MINUTES` of comments.
 
 ## Timeouts and retries
 
-Two independent timeouts:
+Three bounds, only one of which normally fires:
 
-- `BUILD_TIMEOUT_SECONDS` (default 1800) — one `docker build` invocation
-- `JOB_TIMEOUT_SECONDS` (default 3600) — the whole pipeline for one attempt
+| Var | Default | Bounds |
+|---|---|---|
+| `BUILD_IDLE_TIMEOUT_SECONDS` | 600 | time since one build's **last line of output** |
+| `BUILD_TIMEOUT_SECONDS` | 7200 | one `docker build` invocation, absolute |
+| `JOB_TIMEOUT_SECONDS` | 14400 | the whole pipeline for one attempt, absolute |
 
 A job exceeding the job timeout is presumed lost and retried, up to
 `MAX_ATTEMPTS` (default 3) with `RETRY_BACKOFF_SECONDS` between attempts. When
 attempts run out, the PR gets a failure comment listing each attempt's reason.
+
+### Silence, not slowness
+
+A build is bounded by how long it has been **quiet**, because that is what
+separates a wedged build from a slow one. A live `docker build` prints
+constantly — buildx progress lines, compiler output, layer exports — while one
+stuck on a network read or a lock prints nothing at all. Every chunk of output
+resets the clock, so a slow-but-progressing build keeps extending its own lease.
+
+This replaced a plain wall-clock bound of 1800s, which could not tell the two
+apart. It killed a build that was compiling openfst's `src/script/` one file at
+a time — output flowing the whole way, longest gap between lines about 100s —
+and then reported a **build failure** on the PR. Wrong verdict, and half an hour
+of build cache discarded. Compiling openfst, torch extensions or ROS packages
+from source on ARM routinely runs past an hour; none of it is ever silent for ten
+minutes.
+
+`BUILD_TIMEOUT_SECONDS` remains only as a backstop for what the idle bound
+cannot see: a build that prints forever without finishing.
+
+`JOB_TIMEOUT_SECONDS` is loose for the same reason — every stage under it is
+already bounded on its own: git by `FETCH_TIMEOUT` / `GIT_LOCAL_TIMEOUT`, the
+review loop by `REVIEW_TIMEOUT_SECONDS` and `LLM_TIMEOUT_SECONDS`, builds by
+silence. It no longer means "how long may a job take" but "the agent itself is
+stuck".
+
+A killed build is reported as *killed*, not failed: the comment says which bound
+fired and which knob to raise, the result table shows how long it ran, and the
+dashboard's pill reads `stalled` or `timed out` rather than `failed`. Without
+that, the log tail alone reads as though the last compiler line was the error.
+
+Every build's wall clock is recorded (`duration_seconds`) and shown in the
+result table's **Took** column, so "was it slow or was it stuck?" does not need
+log timestamps to answer.
 
 Not everything is retried. Retrying costs an hour, so it is reserved for
 failures another attempt could plausibly fix:
@@ -223,12 +260,8 @@ failures another attempt could plausibly fix:
 | Network / git / registry error | yes | Usually transient |
 | Merge conflict | no | Only the author can resolve it |
 | Build failure (non-zero exit) | no | A real result — rebuilding says the same thing |
+| Build killed for going quiet | no | A build that wedges usually wedges again, and the author needs to see where |
 | Reviewer produced nothing | no | Already re-tried in place, twice over (below) |
-
-> **Sizing note.** Builds run sequentially, so a PR touching N drivers needs
-> roughly N × `BUILD_TIMEOUT_SECONDS`. With the defaults, three drivers can
-> exceed the 1h job timeout and be retried as "lost" even though the build was
-> progressing. Raise `JOB_TIMEOUT_SECONDS` if that is common.
 
 When a job is cancelled or times out, the build subprocess is killed by process
 group — `bash`, `docker`, and `buildx` all die together. Without that, an

--- a/agents/pr_review/.env.example
+++ b/agents/pr_review/.env.example
@@ -75,13 +75,22 @@ LLM_TIMEOUT_SECONDS=180
 # interfere; raise this if the host has spare CPU and disk.
 MAX_CONCURRENT_JOBS=2
 
-# Timeout for a single `docker build` invocation.
-BUILD_TIMEOUT_SECONDS=1800
+# What actually bounds a build: seconds since its last line of output. A live
+# docker build prints constantly (buildx progress, compiler lines, layer
+# exports), so silence for this long means it is wedged — not merely slow.
+# Raise it only if a build here legitimately goes quiet for longer than 10 min.
+BUILD_IDLE_TIMEOUT_SECONDS=600
 
-# Whole-job timeout. A job exceeding this is presumed lost and retried.
-# NOTE: builds run sequentially, so a PR touching N drivers needs roughly
-# N * BUILD_TIMEOUT_SECONDS. Raise this if PRs routinely touch several drivers.
-JOB_TIMEOUT_SECONDS=3600
+# Absolute backstop for one `docker build`, for what the idle bound cannot see:
+# a build that prints forever without ever finishing. Not the usual limit —
+# a slow-but-progressing build is expected to run for an hour or more (compiling
+# openfst or torch extensions on ARM does).
+BUILD_TIMEOUT_SECONDS=7200
+
+# Whole-job backstop. A job exceeding this is presumed lost and retried.
+# Loose on purpose: git, the review loop and each build are all bounded on their
+# own, so this only catches the agent itself being stuck.
+JOB_TIMEOUT_SECONDS=14400
 
 # Total attempts per job including the first (3 = two retries). Only timeouts
 # and infrastructure failures are retried; merge conflicts and genuine build

--- a/agents/pr_review/builder.py
+++ b/agents/pr_review/builder.py
@@ -12,6 +12,7 @@ import logging
 import os
 import re
 import signal
+import time
 from pathlib import Path
 
 from .config import Config
@@ -199,14 +200,17 @@ async def _build_with_script(
     if env_overrides:
         env.update(env_overrides)
 
-    success = await _run_build(
+    started = time.monotonic()
+    success, timeout_kind = await _run_build(
         ["bash", str(script), *args],
         cwd=str(cwd),
         env=env,
         timeout=config.build_timeout_seconds,
+        idle_timeout=config.build_idle_timeout_seconds,
         log_path=log_path,
         label=label,
     )
+    duration = time.monotonic() - started
 
     return BuildResult(
         target=target,
@@ -216,6 +220,8 @@ async def _build_with_script(
         log_tail=_read_tail(log_path),
         log_path=str(log_path),
         variant=variant,
+        duration_seconds=duration,
+        timeout_kind=timeout_kind,
     )
 
 
@@ -227,10 +233,28 @@ async def _run_build(
     cwd: str,
     env: dict[str, str],
     timeout: int,
+    idle_timeout: int,
     log_path: Path,
     label: str,
-) -> bool:
-    """Run a build, streaming its output to `log_path`. Returns success.
+) -> tuple[bool, str]:
+    """Run a build, streaming its output to `log_path`.
+
+    Returns `(success, timeout_kind)`, where `timeout_kind` is `""` for a build
+    that ended on its own, `"idle"` for one killed for going quiet, and `"cap"`
+    for one killed by the absolute bound.
+
+    Two bounds, because "too slow" and "stuck" are different failures:
+
+    - `idle_timeout` — time since the last byte of output. This is the one that
+      catches a real hang, and the one that should normally fire: a live docker
+      build prints buildx progress, compiler lines, layer exports. A wedged one
+      (network read, lock) prints nothing at all.
+    - `timeout` — total wall clock, as a backstop for a build that prints
+      forever without finishing.
+
+    The wall clock alone used to be the only bound, and it killed a build that
+    was compiling openfst one file at a time, output flowing the whole way —
+    then reported it on the PR as a build failure. Slowness is not a hang.
 
     The subprocess is killed on both timeout and cancellation. Cancellation
     matters because the whole-job timeout cancels this coroutine from the
@@ -260,6 +284,9 @@ async def _run_build(
     # rather than one block per flush.
     log_file = open(log_path, "wb", buffering=0)
 
+    started = time.monotonic()
+    last_output = started
+
     async def pump_and_wait() -> int:
         """Copy the child's output to disk until EOF, then reap it.
 
@@ -267,28 +294,63 @@ async def _run_build(
         raises ValueError once a line exceeds the stream limit (64 KiB by
         default), and docker build output can contain very long single lines.
 
+        Every chunk stamps `last_output` — that timestamp is the liveness
+        signal the idle bound below is built on.
+
         The reap is inside the timed region deliberately — a process that
         closes stdout without exiting would otherwise hang past the timeout.
         """
+        nonlocal last_output
         while True:
             chunk = await proc.stdout.read(READ_CHUNK)
             if not chunk:
                 break
+            last_output = time.monotonic()
             log_file.write(chunk)
         return await proc.wait()
 
     task = asyncio.create_task(pump_and_wait())
 
     try:
-        # Shielded so a timeout or outer cancellation does not kill the task
-        # mid-write; it is drained explicitly below so the partial log survives.
-        returncode = await asyncio.wait_for(asyncio.shield(task), timeout=timeout)
-    except asyncio.TimeoutError:
-        await _terminate(proc)
-        await _drain(task)
-        log_file.write(f"\n[agent] Build timed out after {timeout}s\n".encode())
-        logger.error(f"Build timed out after {timeout}s: {label}")
-        return False
+        # Waits for whichever bound expires first, then re-checks: output that
+        # arrives while waiting moves the idle deadline, so a slow-but-alive
+        # build keeps extending its own lease.
+        while True:
+            now = time.monotonic()
+            idle_left = idle_timeout - (now - last_output)
+            cap_left = timeout - (now - started)
+            if idle_left <= 0 or cap_left <= 0:
+                quiet_for = int(now - last_output)
+                elapsed = int(now - started)
+                await _terminate(proc)
+                await _drain(task)
+                if idle_left <= 0:
+                    kind = "idle"
+                    note = (
+                        f"no output for {idle_timeout}s "
+                        f"({elapsed:,}s into the build)"
+                    )
+                else:
+                    kind = "cap"
+                    note = (
+                        f"absolute cap of {timeout}s reached; "
+                        f"last output {quiet_for}s ago"
+                    )
+                log_file.write(f"\n[agent] Build killed: {note}\n".encode())
+                logger.error(f"Build killed ({kind}): {label} — {note}")
+                return False, kind
+            try:
+                # Shielded so a timeout or outer cancellation does not kill the
+                # task mid-write; it is drained explicitly below so the partial
+                # log survives.
+                returncode = await asyncio.wait_for(
+                    asyncio.shield(task), timeout=min(idle_left, cap_left)
+                )
+                break
+            except asyncio.TimeoutError:
+                # A bound elapsed — the loop decides which, since output may
+                # have arrived in the meantime.
+                continue
     except asyncio.CancelledError:
         await _terminate(proc)
         await _drain(task)
@@ -301,11 +363,12 @@ async def _run_build(
         log_file.close()
 
     success = returncode == 0
+    took = time.monotonic() - started
     if success:
-        logger.info(f"Build succeeded: {label}")
+        logger.info(f"Build succeeded in {took:.0f}s: {label}")
     else:
-        logger.error(f"Build failed (rc={returncode}): {label}")
-    return success
+        logger.error(f"Build failed (rc={returncode}) after {took:.0f}s: {label}")
+    return success, ""
 
 
 async def _drain(task: asyncio.Task):

--- a/agents/pr_review/comments.py
+++ b/agents/pr_review/comments.py
@@ -80,7 +80,8 @@ def format_building(
 | Build targets | {listed} |
 | Status | Building... |
 
-Builds usually take 5–20 minutes. This comment will be updated when done.
+Builds usually take 5–20 minutes, and longer when something compiles from source.
+This comment will be updated when done.
 """
 
 
@@ -89,24 +90,31 @@ def format_build_result(head_sha: str, results: list[BuildResult]) -> str:
     rows = []
     for r in results:
         name = r.label()
+        took = _fmt_took(r.duration_seconds)
         if r.success:
             _, tag = split_image_ref(r.image_tag)
             version = f"`{tag}`" if tag else "—"
-            rows.append(f"| {name} | :white_check_mark: Success | {version} |")
+            rows.append(
+                f"| {name} | :white_check_mark: Success | {version} | {took} |"
+            )
+        elif r.timeout_kind:
+            rows.append(f"| {name} | :hourglass: Killed | — | {took} |")
         else:
-            rows.append(f"| {name} | :x: Failed | — |")
+            rows.append(f"| {name} | :x: Failed | — | {took} |")
 
     table = (
-        "| Target | Status | Version |\n"
-        "|--------|--------|---------|\n" + "\n".join(rows)
+        "| Target | Status | Version | Took |\n"
+        "|--------|--------|---------|------|\n" + "\n".join(rows)
     )
 
     all_ok = all(r.success for r in results)
-    headline = (
-        "All builds succeeded."
-        if all_ok
-        else "Build failed. See the collapsed logs below."
-    )
+    killed = [r for r in results if r.timeout_kind]
+    if all_ok:
+        headline = "All builds succeeded."
+    elif killed and not [r for r in results if not r.success and not r.timeout_kind]:
+        headline = "A build did not finish — the agent stopped it. See below."
+    else:
+        headline = "Build failed. See the collapsed logs below."
 
     body = f"""{BOT_MARKER}
 ## PR Review Agent — Build Result
@@ -117,6 +125,27 @@ Commit: `{head_sha[:7]}`
 
 {table}
 """
+
+    # A killed build is not a failed build, and reading the log tail alone would
+    # suggest the last compiler line was the error. Said before the logs so it is
+    # visible without expanding them.
+    for r in killed:
+        took = _fmt_took(r.duration_seconds)
+        if r.timeout_kind == "idle":
+            body += (
+                f"\n> :hourglass: `{r.label()}` was killed for going quiet, not "
+                f"for failing to build: it ran for {took} and then produced no "
+                f"output for long enough to be presumed stuck. The log below "
+                f"ends where it went silent. If this build legitimately goes "
+                f"quiet for that long, raise `BUILD_IDLE_TIMEOUT_SECONDS`.\n"
+            )
+        else:
+            body += (
+                f"\n> :hourglass: `{r.label()}` hit the absolute build time "
+                f"limit after {took} and was killed while still producing "
+                f"output. Raise `BUILD_TIMEOUT_SECONDS` if this build is meant "
+                f"to take that long.\n"
+            )
 
     # Full refs, so the image can be pulled or deployed without hunting through
     # the log for it.
@@ -162,6 +191,25 @@ Commit: `{head_sha[:7]}`
         )
 
     return body
+
+
+def _fmt_took(seconds: float | None) -> str:
+    """A build's wall clock, for the result table. "—" while still building.
+
+    Minutes are the unit that matters here: a build is either a few minutes or
+    the better part of an hour, and seconds-only would read as a raw number for
+    every real build.
+    """
+    if seconds is None:
+        return "—"
+    s = max(0, int(seconds))
+    if s < 60:
+        return f"{s}s"
+    m, s = divmod(s, 60)
+    if m < 60:
+        return f"{m}m {s:02d}s"
+    h, m = divmod(m, 60)
+    return f"{h}h {m:02d}m"
 
 
 def _log_details(name: str, log_tail: str, budget: int) -> str:
@@ -212,7 +260,7 @@ def _log_details(name: str, log_tail: str, budget: int) -> str:
     elif cut_mid_line:
         note = f"tail only — this log has no line breaks to cut on; {where}"
     else:
-        note = f"complete log, {len(lines)} lines"
+        note = f"complete log, {len(lines)} line{'' if len(lines) == 1 else 's'}"
 
     # A four-backtick fence, because build output can itself contain ``` — an
     # npm or docker step echoing a README would otherwise close the block early

--- a/agents/pr_review/config.py
+++ b/agents/pr_review/config.py
@@ -66,10 +66,21 @@ class Config:
 
     # Worker
     max_concurrent_jobs: int = 2
-    # Timeout for a single docker build invocation.
-    build_timeout_seconds: int = 1800
-    # Whole-job timeout. A job exceeding this is treated as lost and retried.
-    job_timeout_seconds: int = 3600
+    # What actually bounds a build: time since its last line of output. A live
+    # docker build prints constantly (buildx progress, compiler lines, layer
+    # exports); a wedged one prints nothing. Slowness is not a hang — bounding
+    # by total wall clock killed a build that was compiling openfst one file at
+    # a time, output flowing the whole way, and reported it as a build failure.
+    build_idle_timeout_seconds: int = 600
+    # Absolute backstop for one build, for the case the idle bound cannot see:
+    # a build that prints forever without finishing.
+    build_timeout_seconds: int = 7200
+    # Whole-job backstop. A job exceeding this is treated as lost and retried.
+    # Loose on purpose: every stage below it is already bounded on its own —
+    # git by FETCH_TIMEOUT/GIT_LOCAL_TIMEOUT, the review loop by
+    # review_timeout_seconds, builds by silence — so this is no longer "how long
+    # may a job take" but "the agent itself is stuck".
+    job_timeout_seconds: int = 14400
     # Total attempts per job including the first (3 = two retries).
     max_attempts: int = 3
     retry_backoff_seconds: int = 60
@@ -172,8 +183,9 @@ def load_config() -> Config:
         pr_context_max_chars=_env_int("PR_CONTEXT_MAX_CHARS", 4000),
         pr_context_max_comments=_env_int("PR_CONTEXT_MAX_COMMENTS", 20),
         max_concurrent_jobs=_env_int("MAX_CONCURRENT_JOBS", 2),
-        build_timeout_seconds=_env_int("BUILD_TIMEOUT_SECONDS", 1800),
-        job_timeout_seconds=_env_int("JOB_TIMEOUT_SECONDS", 3600),
+        build_idle_timeout_seconds=_env_int("BUILD_IDLE_TIMEOUT_SECONDS", 600),
+        build_timeout_seconds=_env_int("BUILD_TIMEOUT_SECONDS", 7200),
+        job_timeout_seconds=_env_int("JOB_TIMEOUT_SECONDS", 14400),
         max_attempts=_env_int("MAX_ATTEMPTS", 3),
         retry_backoff_seconds=_env_int("RETRY_BACKOFF_SECONDS", 60),
         job_history_days=_env_int("JOB_HISTORY_DAYS", 30),

--- a/agents/pr_review/models.py
+++ b/agents/pr_review/models.py
@@ -151,6 +151,14 @@ class BuildResult:
     # the build's identity, not a detail of it: one job can produce two
     # perception images, and only this tells them apart.
     variant: str = ""
+    # Wall clock for the whole script invocation, None while still building.
+    # Recorded because "was it slow or was it stuck?" is the first question
+    # asked of a long build, and reading it off log timestamps is tedious.
+    duration_seconds: float | None = None
+    # Why the agent killed this build, if it did: "idle" (went quiet) or "cap"
+    # (hit the absolute wall clock). "" for a build that ended on its own,
+    # including one that failed to compile — that distinction is the point.
+    timeout_kind: str = ""
 
     def label(self) -> str:
         return build_label(self.target, self.driver_path, self.variant)

--- a/agents/pr_review/router_api.py
+++ b/agents/pr_review/router_api.py
@@ -36,6 +36,7 @@ async def status(request: Request):
             "max_concurrent_jobs": config.max_concurrent_jobs,
             "job_timeout_seconds": config.job_timeout_seconds,
             "build_timeout_seconds": config.build_timeout_seconds,
+            "build_idle_timeout_seconds": config.build_idle_timeout_seconds,
             "max_attempts": config.max_attempts,
             "job_history_days": config.job_history_days,
             "mirror": config.mirror,

--- a/agents/pr_review/store.py
+++ b/agents/pr_review/store.py
@@ -122,6 +122,10 @@ class JobStore:
              "ALTER TABLE build_results ADD COLUMN container_name TEXT"),
             ("variant",
              "ALTER TABLE build_results ADD COLUMN variant TEXT"),
+            ("duration_seconds",
+             "ALTER TABLE build_results ADD COLUMN duration_seconds REAL"),
+            ("timeout_kind",
+             "ALTER TABLE build_results ADD COLUMN timeout_kind TEXT"),
         ):
             if column not in br_existing:
                 conn.execute(ddl)
@@ -286,8 +290,9 @@ class JobStore:
                 INSERT OR REPLACE INTO build_results (
                   job_id, idx, target, driver_path,
                   success, image_tag, log_path,
-                  container_name, created_at, variant
-                ) VALUES (?,?,?,?,?,?,?,?,?,?)
+                  container_name, created_at, variant,
+                  duration_seconds, timeout_kind
+                ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?)
                 """,
                 (
                     job_id,
@@ -302,6 +307,8 @@ class JobStore:
                     result.container_name,
                     time.time(),
                     result.variant,
+                    result.duration_seconds,
+                    result.timeout_kind,
                 ),
             )
             conn.commit()
@@ -430,6 +437,13 @@ class JobStore:
                     "has_log": bool(r["log_path"]) and Path(r["log_path"]).exists(),
                     "container_name": _col(r, "container_name"),
                     "variant": _col(r, "variant", ""),
+                    # Not _col(): it collapses a falsy value to the default, and
+                    # a duration is a number where 0 is a legitimate reading.
+                    "duration_seconds": (
+                        r["duration_seconds"]
+                        if "duration_seconds" in r.keys() else None
+                    ),
+                    "timeout_kind": _col(r, "timeout_kind", ""),
                 }
                 for r in br
             ]

--- a/agents/pr_review/web/js/views.js
+++ b/agents/pr_review/web/js/views.js
@@ -141,7 +141,10 @@ export function renderConfig(el, c) {
     <dl class="kv">
       <dt>Repos</dt><dd>${(c.repos || []).map((r) => esc(r)).join('<br>') || '—'}</dd>
       <dt>Concurrency</dt><dd>${esc(c.max_concurrent_jobs)}</dd>
-      <dt>Build timeout</dt><dd>${esc(fmtDuration(c.build_timeout_seconds))}</dd>
+      <dt title="No output for this long means a build is stuck, and it is killed. This is the bound that normally fires.">Build idle timeout</dt>
+      <dd>${esc(fmtDuration(c.build_idle_timeout_seconds))}</dd>
+      <dt title="Absolute backstop for one build, for a build that prints forever without finishing.">Build timeout</dt>
+      <dd>${esc(fmtDuration(c.build_timeout_seconds))}</dd>
       <dt>Job timeout</dt><dd>${esc(fmtDuration(c.job_timeout_seconds))}</dd>
       <dt>Max attempts</dt><dd>${esc(c.max_attempts)}</dd>
       <dt>Mirror</dt><dd>${esc(c.mirror)}</dd>
@@ -217,7 +220,12 @@ function buildPill(b) {
 
 function buildLabel(b) {
   if (b.success === null || b.success === undefined) return 'building';
-  return b.success ? 'success' : 'failed';
+  if (b.success) return 'success';
+  // A build the agent killed is a different fact from one that failed to
+  // compile, and the fix is different too — so it does not read as "failed".
+  if (b.timeout_kind === 'idle') return 'stalled';
+  if (b.timeout_kind === 'cap') return 'timed out';
+  return 'failed';
 }
 
 function _buildSummary(results) {
@@ -319,6 +327,7 @@ function _detailBuilds(j) {
           <span class="mono">${esc(b.image_tag)}</span>
           <button class="btn-copy" data-copy="${esc(b.image_tag)}">copy</button>
         </div>` : '<span style="color:var(--text-dim)">—</span>'}</td>
+      <td>${esc(fmtDuration(b.duration_seconds))}</td>
     </tr>`).join('');
 
   // Each build gets its own log pane; app.js attaches the tailing loop by
@@ -339,7 +348,7 @@ function _detailBuilds(j) {
       <div class="card-header"><h2 class="card-title">Builds</h2></div>
       <div class="card-body no-pad">
         <table class="tbl">
-          <thead><tr><th>Target</th><th>Status</th><th>Image</th></tr></thead>
+          <thead><tr><th>Target</th><th>Status</th><th>Image</th><th>Took</th></tr></thead>
           <tbody>${rows}</tbody>
         </table>
       </div>

--- a/deploy/pr-review/.env.example
+++ b/deploy/pr-review/.env.example
@@ -95,13 +95,22 @@ PR_CONTEXT_MAX_COMMENTS=20
 # interfere; raise this if the host has spare CPU and disk.
 MAX_CONCURRENT_JOBS=2
 
-# Timeout for a single `docker build` invocation.
-BUILD_TIMEOUT_SECONDS=1800
+# What actually bounds a build: seconds since its last line of output. A live
+# docker build prints constantly (buildx progress, compiler lines, layer
+# exports), so silence for this long means it is wedged — not merely slow.
+# Raise it only if a build here legitimately goes quiet for longer than 10 min.
+BUILD_IDLE_TIMEOUT_SECONDS=600
 
-# Whole-job timeout. A job exceeding this is presumed lost and retried.
-# NOTE: builds run sequentially, so a PR touching N drivers needs roughly
-# N * BUILD_TIMEOUT_SECONDS. Raise this if PRs routinely touch several drivers.
-JOB_TIMEOUT_SECONDS=3600
+# Absolute backstop for one `docker build`, for what the idle bound cannot see:
+# a build that prints forever without ever finishing. Not the usual limit —
+# a slow-but-progressing build is expected to run for an hour or more (compiling
+# openfst or torch extensions on ARM does).
+BUILD_TIMEOUT_SECONDS=7200
+
+# Whole-job backstop. A job exceeding this is presumed lost and retried.
+# Loose on purpose: git, the review loop and each build are all bounded on their
+# own, so this only catches the agent itself being stuck.
+JOB_TIMEOUT_SECONDS=14400
 
 # Total attempts per job including the first (3 = two retries). Only timeouts
 # and infrastructure failures are retried; merge conflicts and genuine build


### PR DESCRIPTION
## The problem

```
#7 1657.9  ... -c -o intersect.lo intersect.cc
#7 1764.0  ... -c -o invert.lo invert.cc
#7 1794.4  ... -c -o map.lo map.cc
[agent] Build timed out after 1800s
```

**Not hung — slow.** That is openfst's `src/script/` compiling one `.cc` at a time (serially, so no `-j`), with output flowing the entire time and the longest gap between lines around 100s. A wall-clock bound cannot tell "slow" from "stuck", so it killed a healthy build, threw away half an hour of build cache, and posted a **build failure** on the PR.

## The fix

What separates a wedged build from a slow one is **silence**. A live `docker build` prints constantly — buildx progress, compiler lines, layer exports; one stuck on a network read or a lock prints nothing at all.

`_run_build` now waits on whichever of two bounds expires first and re-checks, so every chunk of output resets the idle clock and a slow-but-progressing build keeps extending its own lease:

| Var | Was | Now | Bounds |
|---|---|---|---|
| `BUILD_IDLE_TIMEOUT_SECONDS` | — | **600** | time since the last line of output — the bound that normally fires |
| `BUILD_TIMEOUT_SECONDS` | 1800 | **7200** | absolute backstop for a build that prints forever without finishing |
| `JOB_TIMEOUT_SECONDS` | 3600 | **14400** | absolute backstop for one attempt |

The job timeout had to move too: left at 3600 it would preempt the relaxed build and mark the job "presumed lost", which is worse — that path *retries*. It can afford to be loose because every stage under it is already bounded on its own (git by `FETCH_TIMEOUT` / `GIT_LOCAL_TIMEOUT`, the review loop by `REVIEW_TIMEOUT_SECONDS`, builds by silence). It stops meaning "how long may a job take" and starts meaning "the agent itself is stuck".

## A killed build is not a failed build

`BuildResult` gains `timeout_kind` (`"idle"` / `"cap"`) and `duration_seconds`, so the difference is visible everywhere instead of being buried in the log tail — which on its own reads as though the last compiler line was the error:

```
| Target                    | Status        | Version   | Took    |
|---------------------------|---------------|-----------|---------|
| perception (jetson-jp6.1) | ✅ Success     | release…  | 41m 12s |
| actucore (jetson-jp5.11)  | ⌛ Killed      | —         | 36m 54s |
| core                      | ❌ Failed      | —         | 1m 01s  |

> ⌛ `actucore (jetson-jp5.11)` was killed for going quiet, not for failing to
> build: it ran for 36m 54s and then produced no output for long enough to be
> presumed stuck. The log below ends where it went silent. If this build
> legitimately goes quiet for that long, raise `BUILD_IDLE_TIMEOUT_SECONDS`.
```

The dashboard's pill reads `stalled` / `timed out` rather than `failed`, the Builds table gains a **Took** column, and the Configuration card shows the new idle bound. The retry table gains a row: a build killed for silence is still terminal — one that wedges usually wedges again, and the author needs to see where.

## Verification

`_run_build` driven directly with synthetic commands:

| Case | Bounds | Result |
|---|---|---|
| `echo tick; sleep 1` × 6 | idle=2, cap=120 | survives 6.1s, `(True, "")` — the case this exists for |
| `echo starting; sleep 60` | idle=2 | killed at 2.0s, `(False, "idle")` |
| `while true; echo spam; sleep .2` | idle=30, cap=3 | killed at 3.0s, `(False, "cap")` |
| `echo boom; exit 7` | — | `(False, "")` — a real failure keeps no `timeout_kind` |
| `sleep`-forever child, cancelled | — | still raises `CancelledError`, cancel line in the log, canary file stops growing (no orphaned process group) |

Also: store round-trip for all three states (`None` duration on the in-progress placeholder row); migration run against a database created by the *pre-change* `store.py` — both columns added, second start a no-op, old rows read back `None` / `""`; comment body stays inside GitHub's 65536-char limit at 1/3/12/20/40 failures (40 falls back to the existing "too many logs" branch); Playwright check of the Builds table, the `stalled` pill and the Configuration card.

Not exercised: a real >1800s build on the build host. Re-triggering the openfst PR is the end-to-end test and takes about an hour.

## Aside, not in this PR

Whatever pulls openfst in is compiling it serially. A prebuilt wheel, or `MAKEFLAGS=-j$(nproc)`, would cut that build several-fold. That Dockerfile is not on `main` — it belongs to the PR under review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)