### PR TITLE
feat(registry): only offer images that can run on this host

### DIFF
--- a/agent-core/src/api/drivers.py
+++ b/agent-core/src/api/drivers.py
@@ -256,6 +256,12 @@ def _deploy_sync_legacy(driver: dict) -> dict:
         restart_policy={'Name': 'unless-stopped'},
     )
 
+    # Second consumer of the `-jetson` tag suffix, alongside hostarch.py /
+    # resource-center's lib/arch.ts — but a different question: does this image want
+    # the nvidia runtime? Keep it even though the catalog is now arch-filtered:
+    # POST /api/drivers/{id}/deploy still accepts an arbitrary image, so the UI being
+    # unable to pick a mismatched one is not a guarantee. If tags ever stop carrying
+    # `-jetson`, this silently falls back to privileged without the nvidia runtime.
     if '-jetson' in target_image:
         # Only use nvidia runtime if available on host
         try:
@@ -463,7 +469,9 @@ async def drivers_list():
 @router.post('/sync')
 async def drivers_sync():
     """Fetch registry catalog and upsert drivers in DB."""
-    from api.registry import _build_catalog_sync, _current_channel, _cache as _registry_cache
+    from api.registry import (
+        _build_catalog_sync, _current_channel, cache_key, _cache as _registry_cache,
+    )
     channel = _current_channel()
     loop = asyncio.get_event_loop()
     try:
@@ -471,8 +479,9 @@ async def drivers_sync():
     except Exception as e:
         return {'code': 500, 'message': str(e)}
 
-    # Update registry cache with fresh data so next GET /registry/catalog is immediate
-    _registry_cache[channel] = {'data': catalog, 'ts': __import__('time').time()}
+    # Update registry cache with fresh data so next GET /registry/catalog is immediate.
+    # Must use cache_key(): the key includes the host arch facets, not just the channel.
+    _registry_cache[cache_key(channel)] = {'data': catalog, 'ts': __import__('time').time()}
 
     manifest = _load_manifest()
     added, updated = _upsert_from_catalog(manifest, catalog)

--- a/agent-core/src/api/registry.py
+++ b/agent-core/src/api/registry.py
@@ -7,6 +7,7 @@ GET /registry/catalog  → 返回按 category 分组的镜像列表及 release.*
 import json
 import os
 import time
+import urllib.parse
 import urllib.request
 
 import fastapi
@@ -25,11 +26,20 @@ def empty_catalog() -> dict:
 
 
 # ── Simple in-memory cache ──────────────────────────────────────────────────
-# Keyed by channel: without this, switching channels while a stale cache entry
-# from the previous channel is still within TTL would serve mismatched data to
-# any caller that doesn't pass refresh=true.
+# Keyed by channel + host arch facets: without this, switching channels while a
+# stale cache entry from the previous channel is still within TTL would serve
+# mismatched data to any caller that doesn't pass refresh=true. The facets are in
+# the key for the same reason — they're constant per process today, but the
+# ACC_ARCH / CPU_ARCH overrides make that a convention rather than a fact.
 _cache: dict[str, dict] = {}
 _CACHE_TTL = 300  # 5 minutes
+
+# What the last successful fetch reported about arch filtering. `applied` is False when
+# resource-center is an older build that ignored the params and returned everything —
+# the dashboard must not then claim the list was filtered for this host. The hidden_*
+# counts let it tell the user exactly how many variants the website has that this
+# machine can't run.
+_last_filter = {'applied': False, 'hidden_tags': 0, 'hidden_images': 0}
 
 
 def _current_channel() -> str:
@@ -40,10 +50,26 @@ def _current_channel() -> str:
         return 'ga'
 
 
+def cache_key(channel: str) -> str:
+    """Cache key for a catalog fetch. Callers that write into `_cache` must use this."""
+    import hostarch
+    return f'{channel}|{hostarch.acc_arch()}|{hostarch.cpu_arch()}'
+
+
 # ── Catalog fetch ─────────────────────────────────────────────────────────
 
 def _build_catalog_sync(channel: str) -> dict:
-    url = f'{RESOURCE_CENTER_URL}/api/images?channel={channel}'
+    # Host arch facets are a property of this process, not of the call site, so they
+    # are resolved here rather than threaded through all three callers. resource-center
+    # drops images that can't run on this host (e.g. a jp5.11 perception on a JetPack 6
+    # robot); images with no arch marker are arch-agnostic and always returned.
+    import hostarch
+    query = {
+        'channel': channel,
+        'acc_arch': hostarch.acc_arch(),
+        'cpu_arch': hostarch.cpu_arch(),
+    }
+    url = f'{RESOURCE_CENTER_URL}/api/images?' + urllib.parse.urlencode(query)
 
     print(f'[registry] fetching catalog from resource-center: {url}')
 
@@ -58,6 +84,21 @@ def _build_catalog_sync(channel: str) -> dict:
     if not payload.get('ok') or not isinstance(payload.get('data'), list):
         print(f'[registry] unexpected response: {str(payload)[:200]}')
         return empty_catalog()
+
+    # An arch-aware resource-center echoes the filter it applied.
+    flt = payload.get('filter')
+    if isinstance(flt, dict):
+        _last_filter.update(
+            applied=True,
+            hidden_tags=flt.get('hidden_tags', 0) or 0,
+            hidden_images=flt.get('hidden_images', 0) or 0,
+        )
+        print(f'[registry] arch filter applied: {flt.get("acc_arch")}/{flt.get("cpu_arch")} '
+              f'— hid {_last_filter["hidden_tags"]} versions, '
+              f'{_last_filter["hidden_images"]} components')
+    else:
+        _last_filter.update(applied=False, hidden_tags=0, hidden_images=0)
+        print('[registry] resource-center did not echo a filter — catalog is unfiltered')
 
     result: dict = empty_catalog()
 
@@ -91,6 +132,9 @@ def _build_catalog_sync(channel: str) -> dict:
                 'size': '',
                 'imageRef': t.get('imageRef', ''),
                 'channel': t.get('channel', ''),
+                # Which host this version needs. Absent from older resource-centers.
+                'acc_arch': t.get('accArch'),
+                'cpu_arch': t.get('cpuArch'),
             })
 
         entry = {
@@ -120,11 +164,14 @@ def _build_catalog_sync(channel: str) -> dict:
 
 @router.get('/catalog')
 async def registry_catalog(refresh: bool = False):
+    import hostarch
     channel = _current_channel()
+    key = cache_key(channel)
     now = time.time()
-    cached = _cache.get(channel)
+    cached = _cache.get(key)
     if not refresh and cached and (now - cached['ts']) < _CACHE_TTL:
-        return {'code': 200, 'data': cached['data'], 'cached': True}
+        return {'code': 200, 'data': cached['data'], 'cached': True,
+                'facets': hostarch.facets(), 'filter': dict(_last_filter)}
 
     import asyncio
     loop = asyncio.get_event_loop()
@@ -133,5 +180,6 @@ async def registry_catalog(refresh: bool = False):
     except Exception as e:
         return {'code': 500, 'message': str(e), 'data': empty_catalog()}
 
-    _cache[channel] = {'data': data, 'ts': now}
-    return {'code': 200, 'data': data, 'cached': False}
+    _cache[key] = {'data': data, 'ts': now}
+    return {'code': 200, 'data': data, 'cached': False,
+            'facets': hostarch.facets(), 'filter': dict(_last_filter)}

--- a/agent-core/src/hostarch.py
+++ b/agent-core/src/hostarch.py
@@ -1,0 +1,88 @@
+"""hostarch.py — 在容器内探测宿主的加速器 / CPU 架构。
+
+用途：向 resource-center 请求镜像目录时带上本机架构，让它只返回能在本机运行的镜像
+（perception / actucore 是 Jetson 专用镜像，按 JetPack 大版本分别构建，不能混装）。
+
+为什么读 /proc/version：已在 JetPack 6 真机（L4T 36.4）验证，agent-core 容器内
+/proc/device-tree 和 /etc/nv_tegra_release **都不存在**，但 /proc/version 仍显示
+宿主内核（"Linux version 5.15.148-tegra …"）—— 内核不受 namespace 隔离。NVIDIA BSP
+内核永远带 `-tegra` 后缀，所以从内核版本即可反推 L4T 大版本、进而推出 JetPack 线。
+挂载宿主路径能拿到更精确的小版本，但那要改 install.sh 生成的 compose 并让所有机器
+重装 core，不值得。
+
+刻意不落库：这是宿主属性而非用户配置，持久化后在克隆 SD 卡、原地升级 JetPack 之后
+就是过期值。模块级 memo 足够 —— 升级必然重启容器，进程寿命 == 部署寿命。
+
+取值必须与 resource-center/lib/arch.ts 保持一致。
+"""
+
+import functools
+import os
+import platform
+import re
+
+# 本机无 NVIDIA 加速器。也兼任「无法识别的 tegra 内核」——失败方向安全：
+# 只会看到 agnostic 镜像，而不是装上跑不了的镜像。
+ACC_NONE = 'none'
+
+# tegra 内核 major.minor -> JetPack 线
+_TEGRA_KERNEL_TO_ACC = {
+    '4.9': 'jetson-jp4',    # L4T 32.x（未实测，暂无 jp4 镜像）
+    '5.10': 'jetson-jp5',   # L4T 35.x
+    '5.15': 'jetson-jp6',   # L4T 36.x
+}
+
+_TEGRA_RE = re.compile(r'(\d+)\.(\d+)\.\d+\S*-tegra')
+
+
+def _kernel_string() -> str:
+    try:
+        with open('/proc/version') as f:
+            return f.read()
+    except OSError:
+        return platform.release()  # 容器内同样是宿主内核
+
+
+@functools.cache
+def acc_arch() -> str:
+    """加速器架构：jetson-jp5 / jetson-jp6 / none。
+
+    ACC_ARCH 环境变量可覆盖（误判时不必重新构建镜像；install.sh 生成的 compose
+    已带 env_file: .env）。
+    """
+    override = os.environ.get('ACC_ARCH', '').strip()
+    if override:
+        print(f'[hostarch] acc_arch overridden by env: {override}')
+        return override
+
+    m = _TEGRA_RE.search(_kernel_string())
+    if not m:
+        return ACC_NONE  # 不是 Jetson BSP 内核
+
+    line = f'{m.group(1)}.{m.group(2)}'
+    acc = _TEGRA_KERNEL_TO_ACC.get(line)
+    if not acc:
+        print(f'[hostarch] unknown tegra kernel {line}; treating host as {ACC_NONE}')
+        return ACC_NONE
+    return acc
+
+
+@functools.cache
+def cpu_arch() -> str:
+    """CPU 架构：arm64 / amd64。CPU_ARCH 环境变量可覆盖。"""
+    override = os.environ.get('CPU_ARCH', '').strip()
+    if override:
+        print(f'[hostarch] cpu_arch overridden by env: {override}')
+        return override
+
+    m = platform.machine().lower()
+    if m in ('aarch64', 'arm64'):
+        return 'arm64'
+    if m in ('x86_64', 'amd64'):
+        return 'amd64'
+    print(f'[hostarch] unrecognized machine {m!r}; passing through')
+    return m
+
+
+def facets() -> dict:
+    return {'acc_arch': acc_arch(), 'cpu_arch': cpu_arch()}

--- a/agent-core/src/start.py
+++ b/agent-core/src/start.py
@@ -302,6 +302,11 @@ async def lifespan(app):
     loop = asyncio.get_event_loop()
     await loop.run_in_executor(None, _check_dds)
 
+    # 探测宿主架构（用于向 resource-center 过滤镜像目录）。只是预热 memo 并把值写进
+    # 日志 —— 「为什么这个组件不显示在驱动市场」全靠这一行排查。
+    import hostarch
+    print(f'[startup] host facets: acc_arch={hostarch.acc_arch()} cpu_arch={hostarch.cpu_arch()}')
+
     # 启动 ROS2 bridge（用于 DDS topic 订阅）
     import ros2_bridge
     _ros2_loop = asyncio.get_running_loop()

--- a/agent-core/web/css/style.css
+++ b/agent-core/web/css/style.css
@@ -2361,6 +2361,61 @@ html, body {
   font-size: 10px;
   color: var(--text-dim);
 }
+/* 版本所需的加速器架构（JetPack 5 / 6）；agnostic 的版本不挂徽标 */
+.mp-version-arch {
+  font-size: 10px;
+  font-weight: 500;
+  color: var(--accent);
+  background: var(--accent-dim);
+  border-radius: 3px;
+  padding: 2px 6px;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+/* ── 本机架构提示 ─────────────────────────────────────────────────────────
+   驱动市场的列表按本机架构过滤过，跟官网看到的不一样。不解释的话用户只会以为
+   某个组件消失了，所以把本机架构和被隐藏的数量摊开讲清楚。 */
+.mp-host-hint {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 16px;
+  padding: 8px 12px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg-secondary);
+  font-size: 11px;
+}
+.mp-host-hint-label {
+  color: var(--text-dim);
+  flex-shrink: 0;
+}
+.mp-host-hint-arch {
+  font-weight: 600;
+  color: var(--accent);
+  background: var(--accent-dim);
+  border-radius: 3px;
+  padding: 2px 8px;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+.mp-host-hint-note {
+  color: var(--text-muted);
+  line-height: 1.5;
+}
+.mp-host-hint-warn {
+  border-color: var(--yellow);
+  background: var(--yellow-bg);
+}
+.mp-host-hint-warn .mp-host-hint-label,
+.mp-host-hint-warn .mp-host-hint-note { color: var(--yellow); }
+.mp-host-hint-warn .mp-host-hint-arch {
+  color: var(--yellow);
+  background: transparent;
+  border: 1px solid var(--yellow);
+}
 
 /* ── Driver detail (in-pane view) ────────────────────────────────────────── */
 .mp-detail {

--- a/agent-core/web/index.html
+++ b/agent-core/web/index.html
@@ -354,6 +354,7 @@
         <input id="marketplace-search" type="search" placeholder="搜索驱动…" autocomplete="off" spellcheck="false">
       </div>
       <div class="marketplace-filters" id="marketplace-filters"></div>
+      <div id="marketplace-host-hint"></div>
       <div class="marketplace-grid" id="marketplace-grid"></div>
     </div>
     <div class="modal-footer" id="deploy-modal-footer" style="display:none">

--- a/agent-core/web/js/deploy-panel.js
+++ b/agent-core/web/js/deploy-panel.js
@@ -17,6 +17,12 @@ const _CAT_DESC = {
   actucore:   '执行模型层 — VLA 策略 / 导航 / 抓取 / locomotion / 全身控制',
 };
 let _statuses = {};   // driver_id → { running, status, running_image, image, last_deploy }
+
+// 本机架构 facet，由 /api/registry/catalog 返回；resource-center 据此过滤掉跑不了的镜像。
+// _filter.applied 为 false 说明服务端不认识这两个参数（老版本），此时目录未经过滤。
+let _facets = null;   // { acc_arch, cpu_arch }
+let _filter = { applied: false, hidden_tags: 0, hidden_images: 0 };
+
 let _logPolls = {};   // driver_id → intervalId
 let _currentChannel = 'ga'; // mirrors config.core.update_channel; kept in sync by _loadChannel/_onChannelChange
 
@@ -143,6 +149,10 @@ async function _loadCatalog(refresh = false) {
     const res  = await fetch(url);
     const json = await res.json();
     if (json.data) _catalog = json.data;
+    if (json.facets) _facets = json.facets;
+    // Only applied=true when resource-center actually understands the arch params — an
+    // older one returns everything, and we must not claim the list was filtered.
+    if (json.filter) _filter = json.filter;
   } catch { /* keep existing */ }
 }
 
@@ -201,6 +211,30 @@ function _renderMyServices() {
     if (!s) return false;
     return s.running || s.last_deploy || item._cat === 'core';
   });
+
+  // Orphan guard: the catalog is arch-filtered by resource-center, so a service that
+  // was installed with a wrong-arch image (e.g. a jp5 perception on a JetPack 6 robot,
+  // installed before that filtering existed) has no catalog entry any more. Without
+  // this it would vanish from 我的服务 entirely — no way to stop, uninstall, or read
+  // its logs. The manifest and GET /api/drivers still know about it, so rebuild a
+  // minimal item from the status. tags: [] makes _svcRowHTML drop the version switcher
+  // while keeping 启动 / 停止 / 卸载 / 日志.
+  const seenIds = new Set(deployed.map(it => _driverIdForItem(it, it._cat)));
+  for (const [id, s] of Object.entries(_statuses)) {
+    if (seenIds.has(id) || !(s.running || s.last_deploy)) continue;
+    const friendly = s.name || id;
+    deployed.push({
+      _cat:      s.category || 'driver',
+      _id:       id,
+      _orphan:   true,
+      // _svcRowHTML 取 model（driver）或 name（其余），两个都给，否则会退化成裸镜像地址
+      name:      friendly,
+      model:     friendly,
+      image:     id,
+      full_repo: (s.image || s.running_image || '').split(':')[0],
+      tags:      [],
+    });
+  }
 
   if (deployed.length === 0) {
     container.innerHTML = `<div class="svc-empty">
@@ -367,7 +401,12 @@ function _svcRowHTML({ item, id, s, latestTag, currentTag, hasUpdate }) {
   // Log button (always available)
   actions += `<button class="svc-btn svc-btn-log" data-action="log" data-driver-id="${id}">日志</button>`;
 
-  const versionText = currentTag || (s.running_image?.split(':').pop()) || '—';
+  // 孤儿服务没有 catalog 条目，停止时 running_image 也是空的 —— 退回到 manifest 里记录的
+  // 镜像，否则用户看到的只有一个「—」，没法知道自己装的到底是哪个版本。
+  const versionText = currentTag
+    || (s.running_image?.split(':').pop())
+    || (item._orphan ? (s.image || s.last_deploy?.image || '').split(':').pop() : '')
+    || '—';
 
   return `
     <div class="svc-row" id="card-${id}">
@@ -376,6 +415,7 @@ function _svcRowHTML({ item, id, s, latestTag, currentTag, hasUpdate }) {
         <span class="svc-row-name">${label}</span>
         <div class="svc-row-version-line">
           <span class="svc-row-version">${versionText}</span>
+          ${item._orphan ? '<span class="svc-ver-channel" title="该镜像与本机架构不匹配，或已从资源中心下架">架构不匹配</span>' : ''}
           ${hasUpdate ? `<span class="svc-row-arrow">→</span><span class="svc-row-new-version">${latestTag}</span>` : ''}
         </div>
       </div>
@@ -430,6 +470,8 @@ function _renderMarketplace() {
 
   // Render grid
   const gridEl = document.getElementById('marketplace-grid');
+  const hintEl = document.getElementById('marketplace-host-hint');
+  if (hintEl) hintEl.innerHTML = _hostHintHTML();
   if (filtered.length === 0) {
     gridEl.innerHTML = `<div class="svc-empty">
       <div class="svc-empty-title">未找到驱动</div>
@@ -493,6 +535,7 @@ function _mpCardHTML(item) {
     return `<div class="mp-version-opt" data-driver-id="${driverId}" data-full-image="${fullImg}" data-tag="${t.tag}" data-label="${label}" data-channel="${t.channel || ''}">
       <span class="mp-version-tag">${t.tag}</span>
       ${ch ? `<span class="svc-ver-channel">${ch}</span>` : ''}
+      ${_archBadgeHTML(t)}
       ${t.created ? `<span class="mp-version-date">${t.created.replace(/\s+\d{2}:\d{2}$/, '')}</span>` : ''}
     </div>`;
   }).join('');
@@ -729,6 +772,8 @@ function _showVersionSheet(optionsHTML) {
 }
 
 function _driverIdForItem(item, category) {
+  // Orphan items (rebuilt from _statuses, not from the catalog) carry their id directly
+  if (item._id) return item._id;
   if (category === 'driver') return `${item.provider}-${item.model}`;
   return item.image;
 }
@@ -738,6 +783,61 @@ function _channelLabel(channel) {
   if (channel === 'release') return 'Release';
   if (channel === 'preview') return 'Preview';
   return '';
+}
+
+// ── 架构展示 ──────────────────────────────────────────────────────────────
+
+const _ACC_LABEL = {
+  'jetson-jp4': 'JetPack 4',
+  'jetson-jp5': 'JetPack 5',
+  'jetson-jp6': 'JetPack 6',
+  'agnostic':   '通用',
+  'none':       '无 NVIDIA 加速器',
+};
+
+function _accLabel(v) {
+  return _ACC_LABEL[v] || v || '未知';
+}
+
+/**
+ * 单个版本的架构徽标。只在版本确实绑定了某种加速器时显示 —— agnostic / 未知不显示，
+ * 免得给每个 driver 都挂一个没信息量的「通用」。
+ */
+function _archBadgeHTML(t) {
+  const acc = t.acc_arch;
+  if (!acc || acc === 'agnostic') return '';
+  return `<span class="mp-version-arch">${_accLabel(acc)}</span>`;
+}
+
+/**
+ * 本机架构提示条。
+ *
+ * 存在的理由：市场里的列表是按本机架构过滤过的，跟官网 motus.phanthy.com 看到的**不一样**。
+ * 用户如果不知道这件事，只会以为某个组件消失了。所以把本机架构和被隐藏的数量都摊开讲清楚。
+ */
+function _hostHintHTML() {
+  if (!_facets) return '';
+
+  const arch = `${_accLabel(_facets.acc_arch)} · ${_facets.cpu_arch || '未知'}`;
+
+  if (!_filter.applied) {
+    // 老 resource-center 忽略了架构参数 —— 不能谎称已过滤，但要提醒用户自己看清版本后缀
+    return `<div class="mp-host-hint mp-host-hint-warn">
+      <span class="mp-host-hint-label">本机架构</span>
+      <span class="mp-host-hint-arch">${arch}</span>
+      <span class="mp-host-hint-note">资源中心版本较旧，未按架构过滤 —— 安装前请自行核对版本后缀</span>
+    </div>`;
+  }
+
+  const hidden = _filter.hidden_tags > 0
+    ? `已为你隐藏 ${_filter.hidden_tags} 个跑不了的版本${_filter.hidden_images > 0 ? `（含 ${_filter.hidden_images} 个组件）` : ''}，因此这里比官网少`
+    : '当前所有版本都能在本机运行';
+
+  return `<div class="mp-host-hint">
+    <span class="mp-host-hint-label">本机架构</span>
+    <span class="mp-host-hint-arch">${arch}</span>
+    <span class="mp-host-hint-note">${hidden}</span>
+  </div>`;
 }
 
 function _updateStatusDots() {

--- a/deploy/build_actucore.sh
+++ b/deploy/build_actucore.sh
@@ -52,18 +52,25 @@ TAG="release.${DATE}.${COMMIT}-jetson-jp${JP_VERSION}"
 
 BUILD_ARGS=""
 # ── 根据 jp_version 选择 base image  ────────────────────────
+# ACC_ARCH 是 resource-center 的过滤依据（大版本粒度，见 resource-center/lib/arch.ts）：
+# 机器上报自己的 JetPack 线，跑不了的镜像就不会出现在驱动市场里。
 case "${JP_VERSION}" in
     5.11)
         BUILD_ARGS="${BUILD_ARGS} JP_VERSION=511"
+        ACC_ARCH="jetson-jp5"
         ;;
     6.1)
         BUILD_ARGS="${BUILD_ARGS} JP_VERSION=61"
+        ACC_ARCH="jetson-jp6"
         ;;
     *)
         echo "Unknown JetPack version: ${JP_VERSION} (support: 5.11, 6.1)"
         exit 1
         ;;
 esac
+
+# Dockerfile.jetson 基于 L4T base image —— 只有 arm64
+CPU_ARCH="arm64"
 
 FULL_IMAGE="${REGISTRY}/${IMAGE_NAMESPACE}/actucore:${TAG}"
 
@@ -72,6 +79,7 @@ echo "Building actucore image (Jetson only)"
 echo "PyTorch for JetPack: JP${JP_VERSION}"
 echo "Image  : ${FULL_IMAGE}"
 echo "Arch   : ${ARCH} (native=${IS_ARM64})"
+echo "Runs on: ${ACC_ARCH} / ${CPU_ARCH}"
 echo "Push   : ${PUSH_ENABLED}"
 echo "============================================"
 
@@ -119,6 +127,8 @@ if ${PUSH_ENABLED} && [ -n "${RESOURCE_CENTER_API_KEY:-}" ]; then
                 \"registryImage\": \"actucore\",
                 \"tag\": \"${TAG}\",
                 \"category\": \"actucore\",
+                \"acc_arch\": \"${ACC_ARCH}\",
+                \"cpu_arch\": \"${CPU_ARCH}\",
                 \"name\": \"ActuCore\",
                 \"port\": 15730,
                 \"description\": \"执行模型层 — VLA 策略 / 导航 / 抓取 / locomotion / 全身控制，以 processor 卡片接入\"

--- a/deploy/build_core.sh
+++ b/deploy/build_core.sh
@@ -72,6 +72,8 @@ if ${PUSH_ENABLED} && [ -n "${RESOURCE_CENTER_API_KEY:-}" ]; then
     fi
     if [[ ! "${SYNC_CONFIRM}" =~ ^[Nn] ]]; then
         echo "Registering image to resource-center (${RESOURCE_CENTER_URL})..."
+        # acc_arch=agnostic 是硬要求：core 不依赖 CUDA，且必须在所有主机可见 —— 一旦被架构
+        # 过滤掉，agent-core 的 api/system.py:_check_update_sync 会默默报「已是最新」。
         HTTP_STATUS=$(curl -s -o /tmp/rc_register_resp.json -w "%{http_code}" \
             -X POST "${RESOURCE_CENTER_URL}/api/admin/register" \
             -H "Content-Type: application/json" \
@@ -81,6 +83,8 @@ if ${PUSH_ENABLED} && [ -n "${RESOURCE_CENTER_API_KEY:-}" ]; then
                 \"registryImage\": \"core\",
                 \"tag\": \"${TAG}\",
                 \"category\": \"core\",
+                \"acc_arch\": \"agnostic\",
+                \"cpu_arch\": \"arm64\",
                 \"name\": \"Agent Core\"
             }")
 

--- a/deploy/build_perception.sh
+++ b/deploy/build_perception.sh
@@ -52,18 +52,25 @@ TAG="release.${DATE}.${COMMIT}-jetson-jp${JP_VERSION}"
 
 BUILD_ARGS=""
 # ── 根据 jp_version 选择 base image  ────────────────────────
+# ACC_ARCH 是 resource-center 的过滤依据（大版本粒度，见 resource-center/lib/arch.ts）：
+# 机器上报自己的 JetPack 线，跑不了的镜像就不会出现在驱动市场里。
 case "${JP_VERSION}" in
     5.11)
         BUILD_ARGS="${BUILD_ARGS} JP_VERSION=511"
+        ACC_ARCH="jetson-jp5"
         ;;
     6.1)
         BUILD_ARGS="${BUILD_ARGS} JP_VERSION=61"
+        ACC_ARCH="jetson-jp6"
         ;;
     *)
         echo "Unknown JetPack version: ${JP_VERSION} (support: 5.11, 6.1)"
         exit 1
         ;;
 esac
+
+# Dockerfile.jetson 基于 L4T base image —— 只有 arm64
+CPU_ARCH="arm64"
 
 FULL_IMAGE="${REGISTRY}/${IMAGE_NAMESPACE}/perception:${TAG}"
 
@@ -73,6 +80,7 @@ echo "Variant: jetson"
 echo "PyTorch for JetPack: JP${JP_VERSION}"
 echo "Image  : ${FULL_IMAGE}"
 echo "Arch   : ${ARCH} (native=${IS_ARM64})"
+echo "Runs on: ${ACC_ARCH} / ${CPU_ARCH}"
 echo "Push   : ${PUSH_ENABLED}"
 echo "============================================"
 
@@ -120,6 +128,8 @@ if ${PUSH_ENABLED} && [ -n "${RESOURCE_CENTER_API_KEY:-}" ]; then
                 \"registryImage\": \"perception\",
                 \"tag\": \"${TAG}\",
                 \"category\": \"perception\",
+                \"acc_arch\": \"${ACC_ARCH}\",
+                \"cpu_arch\": \"${CPU_ARCH}\",
                 \"name\": \"Perception Stack\",
                 \"description\": \"语音感知套件 — ASR 语音识别 + TTS 语音合成 + VAD 静音检测 + 唤醒词检测\"
             }")


### PR DESCRIPTION
## 背景

`perception` / `actucore` 按 JetPack 大版本分别构建，不能跨版本混装。但驱动市场把 resource-center 返回的镜像原样列出，用户可以把 jp5.11 的 perception 装到 JetPack 6 的机器上，装完才发现跑不起来。

本 PR 让 agent-core 上报本机架构，由 resource-center 过滤目录（配套 PR：resource-center MR `feat/arch-facet-filtering`）。

## 改动

| 文件 | 说明 |
|---|---|
| `src/hostarch.py`（新） | 从 `/proc/version` + `platform.machine()` 探测 `acc_arch` / `cpu_arch` |
| `src/api/registry.py` | 请求带上两个 facet；缓存 key 加入 facet；`/catalog` 回传 `facets` 与 `filter` |
| `src/api/drivers.py` | `/sync` 写缓存改用 `cache_key()`；`-jetson` runtime 判断加注释说明为何保留 |
| `src/start.py` | 启动日志打印本机 facet |
| `web/js/deploy-panel.js` | 孤儿服务兜底 + 本机架构提示 + 版本架构徽标 |
| `deploy/build_*.sh` | 注册镜像时打上 `acc_arch` / `cpu_arch` |

## 关键设计

**探测方式**：已在 JetPack 6 真机（`nvidia@10.100.129.72`，L4T 36.4）验证，agent-core 容器内 `/proc/device-tree` 和 `/etc/nv_tegra_release` **都不存在**，但 `/proc/version` 仍显示宿主内核 `5.15.148-tegra`（内核不受 namespace 隔离）。因此从 tegra 内核版本反推 JetPack 大版本，**无需改 compose、无需重装 core**。

**不落库**：宿主属性而非用户配置，持久化后在克隆卡 / 原地升级 JetPack 之后就是过期值。惰性 + `functools.cache`，另提供 `ACC_ARCH` / `CPU_ARCH` 环境变量兜底。

**`core` 标 agnostic**：否则 jp6 主机上 core 被过滤掉，`api/system.py:_check_update_sync` 会默默返回「已是最新」+ 空 `latest_tag`。

## 必须注意的回归点

目录一旦按架构过滤，**此前用错架构镜像装过的服务会从「我的服务」里消失**（该列表是 `_catalog ∩ _statuses`），用户再也无法停止 / 卸载 / 看日志。因此 `_renderMyServices` 增加孤儿兜底：从 manifest 状态重建条目，标注「架构不匹配」，保留 启动 / 停止 / 卸载 / 日志，不显示版本切换。

## 兼容性

| 场景 | 行为 |
|---|---|
| 老 agent-core → 新 API | 不带参数 = 不过滤，与今天完全一致 |
| 新 agent-core → 老 API | 参数被忽略，响应无 `filter` → 前端不显示「已过滤」，改为提示自行核对版本后缀（已实测） |
| 新 API + 未回填的行 | resolver 回落到 tag 后缀解析，回填前即可正确过滤 |

## 验证

- `hostarch` 探测：6 组内核字符串全部符合预期，含「5.15 但非 tegra 的 x86 Ubuntu → none」这个陷阱用例
- 前后兼容：本机实跑 `_build_catalog_sync` 打到线上（尚未升级的）resource-center，返回 `filter_applied: False`、目录未过滤、无报错
- 前端：用 stub API 在浏览器里验证了孤儿兜底（下架的 driver 仍显示 Lynx M20 / 版本号 / 架构不匹配 / 启动·卸载·日志）与两种提示文案
- `bash -n` 四个构建脚本 + 注册 payload 展开后 JSON 合法

真机端到端（部署新 core 后）待验证，步骤见 plan。