### PR TITLE
feat(channel): 飞书卡片附件收发 + 连接状态与启动自检加固

### DIFF
--- a/agent-core/resource/memory/defaults/prompt_system.md
+++ b/agent-core/resource/memory/defaults/prompt_system.md
@@ -46,6 +46,12 @@ IMU 姿态变化：pitch +5°
 
 具体使用哪个工具回复，参考各工具的 description 中的使用场景说明。不同渠道的回复方式绝不混用——不要把一个渠道的消息发到另一个渠道。
 
+**消息平台的附件：** 来自消息平台的事件可能带 `files` 字段，每项形如
+`{"kind":"image|video|audio|file","path":"/work/resource/channel_files/...","name":...}`。
+`path` 是容器内的真实路径：图片用 `Read(path)` 可以直接看到内容，其它类型可用 Bash/PythonExec 处理。
+需要回传文件时，用 `channel_reply(action="send", files=[{"path":"/work/...","caption":"..."}])`，
+路径必须在 `/work` 或 `/tmp` 内。
+
 **ASR 分句注意：** 同一批次中来自 ASR 的连续多条事件，可能实际上是同一句话被错误切分。判断依据：时间戳相近（audio_start/end 有重叠或间隔极短）且语义上可拼接。遇到这种情况，应将它们合并理解为一句完整的话再做响应，而不是逐条分别回应。
 
 ---

--- a/agent-core/resource/memory/prompt_system.md
+++ b/agent-core/resource/memory/prompt_system.md
@@ -46,6 +46,12 @@ IMU 姿态变化：pitch +5°
 
 具体使用哪个工具回复，参考各工具的 description 中的使用场景说明。不同渠道的回复方式绝不混用——不要把一个渠道的消息发到另一个渠道。
 
+**消息平台的附件：** 来自消息平台的事件可能带 `files` 字段，每项形如
+`{"kind":"image|video|audio|file","path":"/work/resource/channel_files/...","name":...}`。
+`path` 是容器内的真实路径：图片用 `Read(path)` 可以直接看到内容，其它类型可用 Bash/PythonExec 处理。
+需要回传文件时，用 `channel_reply(action="send", files=[{"path":"/work/...","caption":"..."}])`，
+路径必须在 `/work` 或 `/tmp` 内。
+
 **ASR 分句注意：** 同一批次中来自 ASR 的连续多条事件，可能实际上是同一句话被错误切分。判断依据：时间戳相近（audio_start/end 有重叠或间隔极短）且语义上可拼接。遇到这种情况，应将它们合并理解为一句完整的话再做响应，而不是逐条分别回应。
 
 ---

--- a/agent-core/src/api/channel.py
+++ b/agent-core/src/api/channel.py
@@ -89,6 +89,10 @@ async def restart_channel(channel_id: str):
     ch = get_channel_config(channel_id)
     if ch is None:
         raise fastapi.HTTPException(404, f'Channel not found: {channel_id}')
+    # Restart implies "I want this running" — otherwise restart_adapter is a no-op
+    # for a previously stopped (disabled) channel.
+    if not ch.get('enabled'):
+        update_channel_config(channel_id, enabled=True)
     await manager.restart_adapter(channel_id)
     return {'status': 'ok'}
 
@@ -98,6 +102,9 @@ async def stop_channel(channel_id: str):
     ch = get_channel_config(channel_id)
     if ch is None:
         raise fastapi.HTTPException(404, f'Channel not found: {channel_id}')
+    # Persist the intent: the manager watchdog reconnects any *enabled* channel,
+    # so without this a stopped channel would come back within 30s.
+    update_channel_config(channel_id, enabled=False)
     if channel_id in manager._adapters:
         await manager._adapters[channel_id].stop()
         del manager._adapters[channel_id]

--- a/agent-core/src/api/config.py
+++ b/agent-core/src/api/config.py
@@ -281,6 +281,19 @@ async def _do_start_project():
             return topics[0], []
         return '', []
 
+    # 先确保 channel adapters 已连接（被 Stop 过 / 上次启动失败的在此拉起）。
+    # 必须在卡片启动之前：channel 卡片的自检要求 adapter 真的连通，
+    # 放在最后会让自检先失败触发整体回滚，永远走不到这里。
+    from channel.manager import manager as channel_mgr, _get_channel_configs
+    channel_mgr.sync_from_canvas()
+    for ch_cfg in _get_channel_configs():
+        ch_id = ch_cfg.get('id', '')
+        if ch_cfg.get('enabled') and ch_id not in channel_mgr._adapters:
+            try:
+                await channel_mgr.restart_adapter(ch_id, retries=1)
+            except Exception as e:
+                print(f'[start-project] channel {ch_id} restart failed: {e}')
+
     # Phase 1: start sources (no input_topic needed) and collect their topic_out
     for card in sources:
         await _start_and_resolve(card)
@@ -301,17 +314,6 @@ async def _do_start_project():
     core = config.main.get('core', {})
     core['project_running'] = True
     config.main['core'] = core
-
-    # 确保 channel adapters 已连接（restart 断开的 adapter）
-    from channel.manager import manager as channel_mgr, _get_channel_configs
-    channel_mgr.sync_from_canvas()
-    for ch_cfg in _get_channel_configs():
-        ch_id = ch_cfg.get('id', '')
-        if ch_cfg.get('enabled') and ch_id not in channel_mgr._adapters:
-            try:
-                await channel_mgr.restart_adapter(ch_id)
-            except Exception as e:
-                print(f'[start-project] channel {ch_id} restart failed: {e}')
 
     # 广播启动完成
     await push_event({'type': 'project_start_done', 'payload': {'has_error': False}})

--- a/agent-core/src/api/inspection.py
+++ b/agent-core/src/api/inspection.py
@@ -94,8 +94,6 @@ def _push_factory(topic: str):
                         conn.close()
                         if row:
                             perf_log.commit_spans(row[0], [span_data], source='perception')
-                    if row:
-                        perf_log.commit_spans(row[0], [span_data], source='perception')
             except Exception:
                 pass
     return _push

--- a/agent-core/src/api/mcp_manage.py
+++ b/agent-core/src/api/mcp_manage.py
@@ -830,64 +830,56 @@ async def mcp_call_tool(mcp_id: str, req: MCPCallRequest):
 
     # ── Handle internal channel MCP ──
     if mcp_id == 'channel':
+        from channel.manager import manager as channel_mgr
+
+        def _card_channel(tool: str, instance_id: str) -> str:
+            if not instance_id:
+                return ''
+            cfg = config.main.get(f'tool_config:channel:{tool}:{instance_id}', None)
+            return (cfg or {}).get('channel_id', '')
+
         if req.tool == 'channel_request':
             action = req.arguments.get('action', 'start')
+            instance_id = req.arguments.get('instance_id', '')
             if action == 'start':
-                # Self-check: verify channel adapter is connected (with retry wait)
-                from channel.manager import manager as channel_mgr
-                import asyncio
-                instance_id = req.arguments.get('instance_id', '')
-                channel_id = ''
-                if instance_id:
-                    cfg = config.main.get(f'tool_config:channel:channel_request:{instance_id}', None)
-                    if cfg:
-                        channel_id = cfg.get('channel_id', '')
-                if channel_id:
-                    # Wait up to 10s for adapter to connect
-                    for _ in range(20):  # 20 × 0.5s = 10s
-                        if channel_id in channel_mgr._adapters:
-                            adapter = channel_mgr._adapters[channel_id]
-                            if adapter.status() == 'connected':
-                                return {'code': 200, 'data': {'state': 'running', 'channel': channel_id}}
-                        await asyncio.sleep(0.5)
-                    return {'code': 200, 'data': {'state': 'error', 'message': f'channel {channel_id} adapter not connected (10s timeout)'}}
-                return {'code': 200, 'data': {'state': 'running'}}
+                # 自检：卡片必须选了一个存在且启用的 channel，且 adapter 真的连通。
+                # ensure_connected 会顺手把被 Stop 过的 adapter 拉起来（自愈）。
+                channel_id = _card_channel('channel_request', instance_id)
+                ok, reason = await channel_mgr.ensure_connected(channel_id)
+                if not ok:
+                    print(f'[channel_request] self-check failed: {reason}')
+                    return {'code': 200, 'data': {'state': 'error', 'message': reason}}
+                return {'code': 200, 'data': {'state': 'running', 'channel': channel_id}}
             elif action == 'stop':
                 return {'code': 200, 'data': {'state': 'idle'}}
             elif action == 'info':
-                channel_id = req.arguments.get('channel_id', '')
-                if not channel_id:
-                    instance_id = req.arguments.get('instance_id', '')
-                    if instance_id:
-                        cfg = config.main.get(f'tool_config:channel:channel_request:{instance_id}', None)
-                        if cfg:
-                            channel_id = cfg.get('channel_id', '')
+                channel_id = req.arguments.get('channel_id', '') or _card_channel(
+                    'channel_request', instance_id)
                 topic_id = channel_id.replace(' ', '_') if channel_id else ''
                 topic = f'/channel/request/{topic_id}' if topic_id else '/channel/request'
                 return {'code': 200, 'data': {'topic_out': [{'topic': topic, 'format': 'data/json'}]}}
             return {'code': 200, 'data': None}
         if req.tool == 'channel_reply':
             action = req.arguments.get('action', 'send')
+            instance_id = req.arguments.get('instance_id', '')
             if action == 'start':
-                # Self-check: send a greeting to verify channel is working
-                from channel.manager import manager as channel_mgr
-                try:
-                    import asyncio
-                    result = await channel_mgr.send_to_channel_any("我上线啦！我可以通过飞书与您交流。")
-                    if result:
-                        return {'code': 200, 'data': {'state': 'running', 'self_check': 'greeting sent'}}
-                    else:
-                        return {'code': 200, 'data': {'state': 'error', 'message': 'failed to send greeting — channel not connected'}}
-                except Exception as e:
-                    return {'code': 200, 'data': {'state': 'error', 'message': f'channel send failed: {e}'}}
+                # 自检：静默探测（校验配置 + adapter 健康），不给用户发问候消息。
+                # 旧实现发「我上线啦！」并用 `if result:` 判断，而返回值恒为非空字符串 —— 永远「通过」。
+                channel_id = _card_channel('channel_reply', instance_id)
+                ok, reason = await channel_mgr.ensure_connected(channel_id)
+                if not ok:
+                    print(f'[channel_reply] self-check failed: {reason}')
+                    return {'code': 200, 'data': {'state': 'error', 'message': reason}}
+                return {'code': 200, 'data': {'state': 'running', 'channel': channel_id}}
             elif action == 'stop':
                 return {'code': 200, 'data': {'state': 'idle'}}
             elif action == 'send':
                 text = req.arguments.get('text', '')
-                if not text:
-                    return {'code': 200, 'data': {'error': 'text is required'}}
-                from channel.manager import manager as channel_mgr
-                result = await channel_mgr.send_to_channel_any(text)
+                files = req.arguments.get('files', []) or []
+                if not text and not files:
+                    return {'code': 200, 'data': {'error': 'text or files is required'}}
+                result = await channel_mgr.send_reply(instance_id=instance_id,
+                                                     text=text, files=files)
                 return {'code': 200, 'data': {'result': result}}
             return {'code': 200, 'data': None}
         return {'code': 200, 'data': None}

--- a/agent-core/src/channel/adapter.py
+++ b/agent-core/src/channel/adapter.py
@@ -1,7 +1,19 @@
 """
 channel/adapter.py — Channel Adapter ABC。
 
-每个消息平台（Telegram、Slack 等）实现此接口。
+每个消息平台（Telegram、Slack、飞书 等）实现此接口。
+
+## 附件（Attachment）
+
+入站与出站共用 `Attachment` 描述媒体：入站由平台下载后落盘（见 channel/store.py），
+`path` 指向容器内持久化目录；出站由 LLM 给出容器内路径（见 channel/media.py 做白名单校验），
+adapter 负责上传到平台。
+
+## 健康状态
+
+`status()` 不能只看「start() 有没有抛异常」——WS 长连接可能静默断开、凭据可能被吊销。
+每个 adapter 应重写 `health_check()` 返回真实可观测的连通性；`ChannelManager` 的 watchdog
+和「启动控制」时的卡片自检都依赖它。
 """
 
 from abc import ABC, abstractmethod
@@ -9,16 +21,44 @@ from dataclasses import dataclass, field
 from typing import Callable, Awaitable
 
 
+# 附件类别 → 各平台据此选择上传/发送接口
+KIND_IMAGE = 'image'
+KIND_VIDEO = 'video'
+KIND_AUDIO = 'audio'
+KIND_FILE  = 'file'
+
+
+@dataclass
+class Attachment:
+    """一个媒体文件（入站已落盘 / 出站待上传）。"""
+    kind: str = KIND_FILE       # image | video | audio | file
+    path: str = ''              # 容器内绝对路径
+    name: str = ''              # 展示用文件名
+    mime: str = ''              # MIME 类型（可空）
+    size: int = 0               # 字节数
+    caption: str = ''           # 出站时的附带说明（部分平台支持）
+
+    def to_dict(self) -> dict:
+        return {
+            'kind': self.kind,
+            'path': self.path,
+            'name': self.name,
+            'mime': self.mime,
+            'size': self.size,
+        }
+
+
 @dataclass
 class InboundMessage:
     """适配器解析后的统一入站消息格式。"""
-    platform: str           # 'telegram', 'slack', ...
+    platform: str           # 'telegram', 'slack', 'feishu', ...
     channel_id: str         # 配置 ID（channel_configs.id）
     user_id: str            # 平台用户 ID
     chat_id: str            # 会话/频道 ID（用于回复路由）
     display_name: str       # 用户显示名
-    text: str               # 消息文本
-    attachments: list = field(default_factory=list)  # 附件列表（future）
+    text: str               # 消息文本（无文本时为附件占位描述，如 "[图片]"）
+    message_id: str = ''    # 平台消息 ID（用于去重）
+    attachments: list[Attachment] = field(default_factory=list)
 
 
 @dataclass
@@ -26,7 +66,9 @@ class OutboundMessage:
     """发送给平台的统一出站消息格式。"""
     chat_id: str            # 目标会话 ID
     text: str = ''          # 文本内容
-    image_bytes: bytes | None = None  # 图片（可选）
+    files: list[Attachment] = field(default_factory=list)  # 附件（图片/视频/文件）
+    # 兼容旧调用方：直接给字节的图片
+    image_bytes: bytes | None = None
     image_caption: str = ''
 
 
@@ -36,6 +78,9 @@ OnMessageCallback = Callable[[InboundMessage], Awaitable[None]]
 
 class ChannelAdapter(ABC):
     """消息平台适配器基类。"""
+
+    # 该平台支持发送的附件类别；send_message 遇到不支持的类别应抛异常而非静默丢弃
+    SUPPORTED_FILE_KINDS: tuple[str, ...] = ()
 
     def __init__(self, channel_id: str, platform: str, config: dict,
                  on_message: OnMessageCallback):
@@ -51,7 +96,11 @@ class ChannelAdapter(ABC):
 
     @abstractmethod
     async def start(self) -> None:
-        """启动适配器（开始接收消息）。"""
+        """启动适配器（开始接收消息）。
+
+        实现约定：凭据无效 / 无法连接时必须抛异常，不要「起个线程就返回」——
+        上层据此决定是否重试、是否把状态标成 error。
+        """
         ...
 
     @abstractmethod
@@ -61,9 +110,16 @@ class ChannelAdapter(ABC):
 
     @abstractmethod
     async def send_message(self, msg: OutboundMessage) -> None:
-        """发送消息到平台。"""
+        """发送消息到平台。失败必须抛异常（上层据此回报给 LLM/用户）。"""
         ...
 
+    async def health_check(self) -> tuple[bool, str]:
+        """返回 (是否连通, 失败原因)。默认只看 _running，子类应重写为真实探测。"""
+        return (self._running, '' if self._running else 'adapter not running')
+
     def status(self) -> str:
-        """返回当前状态。"""
+        """返回当前状态：connected / degraded / disconnected。
+
+        默认实现无法区分 degraded；重写 health_check() 的子类应同时重写本方法。
+        """
         return 'connected' if self._running else 'disconnected'

--- a/agent-core/src/channel/adapter.py
+++ b/agent-core/src/channel/adapter.py
@@ -76,6 +76,25 @@ class OutboundMessage:
 OnMessageCallback = Callable[[InboundMessage], Awaitable[None]]
 
 
+class PartialSendError(RuntimeError):
+    """一条出站消息里，部分内容发出去了、部分失败了。
+
+    文本与每个附件在平台侧是**独立的**几次调用（飞书要先上传再发一条 image/file 消息）。
+    如果附件失败就整体抛异常，上层只看到「失败」，LLM 会把已经送达的文本重发一遍
+    —— 用户那边收到两条一样的话。带上 sent 让上层能如实回报「文本已达、文件没成功」。
+    """
+
+    def __init__(self, sent: list[str], failures: list[str]):
+        self.sent = sent
+        self.failures = failures
+        parts = []
+        if sent:
+            parts.append('已发送：' + '、'.join(sent) + '（不要重发这部分）')
+        if failures:
+            parts.append('失败：\n' + '\n'.join(failures))
+        super().__init__('\n'.join(parts))
+
+
 class ChannelAdapter(ABC):
     """消息平台适配器基类。"""
 

--- a/agent-core/src/channel/adapters/feishu.py
+++ b/agent-core/src/channel/adapters/feishu.py
@@ -10,8 +10,9 @@ Config: {app_id, app_secret, domain?}
 
 Required Feishu permissions:
 - im:message                — 接收消息
-- im:message:send_as_bot    — 以机器人身份发消息
-- im:resource               — 上传/下载图片与文件（收发附件必需）
+- im:message:send_as_bot    — 以机器人身份发消息（只发文本时够了）
+- im:resource               — 上传/下载图片与文件（收发附件必需；仅发送也可用
+                              im:resource:upload。缺它时文本能发出去、附件一律 99991672）
 - im:chat:readonly          — 列出会话（可选）
 
 Event subscription:
@@ -29,7 +30,7 @@ import aiohttp
 
 from channel.adapter import (
     Attachment, ChannelAdapter, InboundMessage, OnMessageCallback, OutboundMessage,
-    KIND_AUDIO, KIND_FILE, KIND_IMAGE, KIND_VIDEO,
+    PartialSendError, KIND_AUDIO, KIND_FILE, KIND_IMAGE, KIND_VIDEO,
 )
 
 # Common Feishu error codes and actionable messages
@@ -323,8 +324,21 @@ class FeishuAdapter(ChannelAdapter):
             for chunk in _chunks(msg.text, _TEXT_CHUNK):
                 await self._send_raw(msg.chat_id, 'text', {'text': chunk})
 
+        if not files:
+            return
+
+        # 逐个附件独立汇报成败：一个文件失败不该让上层以为整条消息（含已送达的文本）失败
+        sent = ['文本'] if msg.text else []
+        failures = []
         for att in files:
-            await self._send_attachment(msg.chat_id, att)
+            try:
+                await self._send_attachment(msg.chat_id, att)
+                sent.append(att.name or att.path)
+            except Exception as e:
+                print(f'[feishu] send attachment failed ({att.name or att.path}): {e}')
+                failures.append(f'- {att.name or att.path}: {e}')
+        if failures:
+            raise PartialSendError(sent, failures)
 
     async def _send_raw(self, chat_id: str, msg_type: str, content: dict) -> None:
         await self._request(
@@ -360,7 +374,7 @@ class FeishuAdapter(ChannelAdapter):
         form.add_field('image_type', 'message')
         form.add_field('image', payload, filename=os.path.basename(path),
                        content_type='application/octet-stream')
-        data = await self._request('POST', '/open-apis/im/v1/images', data=form)
+        data = await self._upload('/open-apis/im/v1/images', form)
         return data.get('image_key', '')
 
     async def _upload_file(self, path: str, name: str = '') -> str:
@@ -374,8 +388,24 @@ class FeishuAdapter(ChannelAdapter):
         form.add_field('file_name', fname)
         form.add_field('file', payload, filename=fname,
                        content_type='application/octet-stream')
-        data = await self._request('POST', '/open-apis/im/v1/files', data=form)
+        data = await self._upload('/open-apis/im/v1/files', form)
         return data.get('file_key', '')
+
+    async def _upload(self, path: str, form: 'aiohttp.FormData') -> dict:
+        """上传资源。缺权限是这里最常见的失败，且与「发消息」的权限是两码事 ——
+        只有 im:message:send_as_bot 时文本照发、附件全 99991672，所以要说清是上传权限。"""
+        try:
+            return await self._request('POST', path, data=form)
+        except FeishuError as e:
+            if e.code == 99991672:
+                raise FeishuError(
+                    e.code, e.msg,
+                    '上传资源需要 im:resource（或 im:resource:upload）权限，与发送文本的 '
+                    'im:message:send_as_bot 是两个权限。在飞书开发者后台开通后**发布新版本**：'
+                    f'https://open.feishu.cn/app/{self.config.get("app_id", "")}/auth'
+                    '?q=im:resource:upload,im:resource'
+                ) from None
+            raise
 
     # ── 接收 ─────────────────────────────────────────────────────────────────
 

--- a/agent-core/src/channel/adapters/feishu.py
+++ b/agent-core/src/channel/adapters/feishu.py
@@ -1,16 +1,18 @@
 """
-channel/adapters/feishu.py — Feishu (Lark) adapter using WebSocket long connection.
+channel/adapters/feishu.py — Feishu (Lark) adapter。
 
-Uses lark-oapi SDK's built-in WebSocket mode — outbound connection to Feishu servers,
-no public IP or webhook needed. Same pattern as Telegram long-polling and Slack Socket Mode.
+**接收**用 lark-oapi SDK 的 WebSocket 长连接（出网连接，无需公网 IP / webhook），
+**所有 REST 调用**（发消息、上传/下载资源、健康探测）走 aiohttp 直连开放平台，
+不经过 SDK 的同步客户端——这样错误码可以统一处理，也不用为每个调用开线程池。
 
 Requires: pip install lark-oapi
-Config: {app_id, app_secret}
+Config: {app_id, app_secret, domain?}
 
 Required Feishu permissions:
-- im:message — receive messages
-- im:message:send_as_bot — send messages as bot
-- im:chat:readonly — list chats (optional)
+- im:message                — 接收消息
+- im:message:send_as_bot    — 以机器人身份发消息
+- im:resource               — 上传/下载图片与文件（收发附件必需）
+- im:chat:readonly          — 列出会话（可选）
 
 Event subscription:
 - Event: im.message.receive_v1
@@ -19,16 +21,23 @@ Event subscription:
 
 import asyncio
 import json
+import os
 import threading
+import time
 
-from channel.adapter import ChannelAdapter, InboundMessage, OutboundMessage, OnMessageCallback
+import aiohttp
+
+from channel.adapter import (
+    Attachment, ChannelAdapter, InboundMessage, OnMessageCallback, OutboundMessage,
+    KIND_AUDIO, KIND_FILE, KIND_IMAGE, KIND_VIDEO,
+)
 
 # Common Feishu error codes and actionable messages
 _FEISHU_ERROR_HINTS = {
     10003: 'Invalid app_id. Check your Feishu app credentials in Channel settings.',
     10014: 'Invalid app_secret. Check your Feishu app credentials in Channel settings.',
     99991663: 'Tenant token invalid. The adapter will attempt to reconnect automatically. If this persists, restart the channel.',
-    99991668: 'Tenant token expired. The SDK auto-refreshes tokens; if this persists, check app_id/app_secret in Channel settings.',
+    99991668: 'Tenant token expired. Tokens auto-refresh; if this persists, check app_id/app_secret in Channel settings.',
     99991672: 'Permission denied. Grant the required permission in Feishu Developer Console: https://open.feishu.cn/app/{app_id}/auth',
     230001: 'Bot not in this chat. Add the bot to the chat first, or the user needs to message the bot directly.',
     230002: 'Bot has been removed from chat. Re-add the bot.',
@@ -36,17 +45,130 @@ _FEISHU_ERROR_HINTS = {
     230014: 'Message too long. Maximum 4096 characters.',
 }
 
+_DEFAULT_DOMAIN = 'https://open.feishu.cn'
+
+# 单条文本上限 4096 字符，留些余量分片
+_TEXT_CHUNK = 3500
+
+# 探测结果缓存时长（秒）——status() 可能被前端高频轮询
+_PROBE_TTL = 15
+
+# 去重窗口：飞书可能重投递同一事件
+_DEDUP_MAX = 512
+
+# 上传时的 file_type（飞书只认这几种，其余用 stream）
+_FILE_TYPE_BY_EXT = {
+    '.opus': 'opus', '.mp4': 'mp4', '.pdf': 'pdf',
+    '.doc': 'doc', '.docx': 'doc', '.xls': 'xls', '.xlsx': 'xls',
+    '.ppt': 'ppt', '.pptx': 'ppt',
+}
+
+# SDK 把事件循环存在模块级变量里，多个飞书 channel 同时启动会互相覆盖
+_ws_loop_lock = threading.Lock()
+
+
+class FeishuError(RuntimeError):
+    """飞书 API 返回了非 0 的 code。"""
+
+    def __init__(self, code: int, msg: str, hint: str = ''):
+        self.code = code
+        self.msg = msg
+        text = f'[feishu] API error (code={code}): {msg}'
+        if hint:
+            text += f'\n  → {hint}'
+        super().__init__(text)
+
 
 class FeishuAdapter(ChannelAdapter):
     """Feishu/Lark adapter using SDK WebSocket long connection."""
 
+    SUPPORTED_FILE_KINDS = (KIND_IMAGE, KIND_VIDEO, KIND_AUDIO, KIND_FILE)
+
     def __init__(self, channel_id: str, platform: str, config: dict,
                  on_message: OnMessageCallback):
         super().__init__(channel_id, platform, config, on_message)
-        self._client = None
-        self._task: asyncio.Task | None = None
-        self._api_client = None
+        self._client = None                       # lark ws client
         self._thread: threading.Thread | None = None
+        self._sdk_loop: asyncio.AbstractEventLoop | None = None
+        self._loop: asyncio.AbstractEventLoop | None = None   # main app loop
+        self._token = ''
+        self._token_expire = 0.0
+        self._token_lock = asyncio.Lock()
+        self._probe_ok = False
+        self._probe_err = ''
+        self._probe_ts = 0.0
+        self._last_event_ts = 0.0
+        self._seen_ids: list[str] = []
+        self._seen_set: set[str] = set()
+
+    # ── 基础设施：token / REST ────────────────────────────────────────────────
+
+    @property
+    def _domain(self) -> str:
+        return (self.config.get('domain') or _DEFAULT_DOMAIN).rstrip('/')
+
+    async def _tenant_token(self, force: bool = False) -> str:
+        async with self._token_lock:
+            if not force and self._token and time.time() < self._token_expire:
+                return self._token
+            payload = {
+                'app_id': self.config.get('app_id', ''),
+                'app_secret': self.config.get('app_secret', ''),
+            }
+            url = f'{self._domain}/open-apis/auth/v3/tenant_access_token/internal'
+            timeout = aiohttp.ClientTimeout(total=10)
+            async with aiohttp.ClientSession(timeout=timeout) as s:
+                async with s.post(url, json=payload) as resp:
+                    data = await resp.json(content_type=None)
+            code = data.get('code', -1)
+            if code != 0:
+                raise FeishuError(code, data.get('msg', 'token request failed'),
+                                  self._hint(code))
+            self._token = data.get('tenant_access_token', '')
+            # 官方 expire 单位为秒，提前 60s 过期
+            self._token_expire = time.time() + max(60, int(data.get('expire', 7200))) - 60
+            return self._token
+
+    def _hint(self, code: int) -> str:
+        hint = _FEISHU_ERROR_HINTS.get(code, '')
+        return hint.format(app_id=self.config.get('app_id', '')) if hint else ''
+
+    async def _request(self, method: str, path: str, *, json_body: dict | None = None,
+                       params: dict | None = None, data=None,
+                       raw: bool = False, retry_auth: bool = True):
+        """调用开放平台 REST。raw=True 时返回 (bytes, headers)，否则返回 data 字段。"""
+        token = await self._tenant_token()
+        url = f'{self._domain}{path}'
+        headers = {'Authorization': f'Bearer {token}'}
+        timeout = aiohttp.ClientTimeout(total=120 if (data is not None or raw) else 20)
+        try:
+            async with aiohttp.ClientSession(timeout=timeout) as s:
+                async with s.request(method, url, headers=headers, json=json_body,
+                                     params=params, data=data) as resp:
+                    ctype = resp.headers.get('Content-Type', '')
+                    if raw and 'application/json' not in ctype:
+                        return await resp.read(), resp.headers
+                    body = await resp.json(content_type=None)
+        except FeishuError:
+            raise
+        except (asyncio.TimeoutError, aiohttp.ClientError) as e:
+            raise RuntimeError(
+                f'[feishu] network error calling {path}: {e}\n'
+                f'  → Cause: Feishu API unreachable or rate-limited.\n'
+                f'  → Solution: check connectivity, then retry.'
+            )
+
+        code = body.get('code', -1)
+        if code != 0:
+            # token 失效 → 强制刷新后重试一次
+            if retry_auth and code in (99991663, 99991668, 99991661):
+                await self._tenant_token(force=True)
+                return await self._request(method, path, json_body=json_body, params=params,
+                                          data=data, raw=raw, retry_auth=False)
+            raise FeishuError(code, body.get('msg', ''), self._hint(code))
+        return body.get('data', {})
+
+    # ── 生命周期 ─────────────────────────────────────────────────────────────
 
     async def start(self) -> None:
         app_id = self.config.get('app_id', '')
@@ -59,21 +181,19 @@ class FeishuAdapter(ChannelAdapter):
 
         import lark_oapi as lark
 
-        # Store the main event loop for cross-thread scheduling
-        self._loop = asyncio.get_event_loop()
+        self._loop = asyncio.get_running_loop()
 
-        # Create API client for sending messages
-        self._api_client = lark.Client.builder() \
-            .app_id(app_id) \
-            .app_secret(app_secret) \
-            .build()
+        # 凭据前置校验：起线程前先确认 app_id/app_secret 与网络可用。
+        # 否则「起个线程就返回成功」，凭据错了状态依然显示 connected。
+        await self._tenant_token(force=True)
+        ok, err = await self._probe(force=True)
+        if not ok:
+            raise RuntimeError(f'Feishu credential check failed: {err}')
 
-        # Create event handler
         event_handler = lark.EventDispatcherHandler.builder("", "") \
             .register_p2_im_message_receive_v1(self._handle_message_event) \
             .build()
 
-        # Create WebSocket long connection client
         self._client = lark.ws.Client(
             app_id=app_id,
             app_secret=app_secret,
@@ -82,13 +202,9 @@ class FeishuAdapter(ChannelAdapter):
             auto_reconnect=True,
         )
 
-        # Hook into SDK reconnect lifecycle for status tracking
-        self._client.on_reconnecting = self._on_reconnecting
-        self._client.on_reconnected = self._on_reconnected
-
-        # Start in background thread — SDK's start() blocks (contains _select())
         self._running = True
-        self._thread = threading.Thread(target=self._thread_target, daemon=True, name='feishu-ws')
+        self._thread = threading.Thread(target=self._thread_target, daemon=True,
+                                        name=f'feishu-ws-{self.channel_id}')
         self._thread.start()
         print(f'[feishu] adapter started (WebSocket mode): {self.channel_id}')
 
@@ -101,138 +217,333 @@ class FeishuAdapter(ChannelAdapter):
         3. _select() — keeps event loop alive forever
 
         _receive_message_loop has built-in auto_reconnect on disconnect.
+
+        SDK 把事件循环放在模块级 `lark_oapi.ws.client.loop`（import 时捕获主 uvloop）。
+        每个 adapter 换成自己的 loop，并只停自己的那个——共用模块变量时，
+        第二个 channel 启动会覆盖它，停第一个就会停错 loop。
         """
-        # Lark SDK stores the event loop in a module-level variable (lark_oapi.ws.client.loop)
-        # which captures the main uvloop at import time. Replace it with a fresh loop
-        # so SDK operations run independently of the main event loop.
         import lark_oapi.ws.client as ws_mod
         new_loop = asyncio.new_event_loop()
+        self._sdk_loop = new_loop
         asyncio.set_event_loop(new_loop)
-        ws_mod.loop = new_loop
+        with _ws_loop_lock:
+            ws_mod.loop = new_loop
         try:
             self._client.start()
         except Exception as e:
             err_msg = str(e)
             if 'invalid' in err_msg.lower() and ('app_id' in err_msg.lower() or 'secret' in err_msg.lower()):
-                print(f'[feishu] Connection failed: invalid app credentials. '
-                      f'Check app_id and app_secret in Channel settings.')
+                print('[feishu] Connection failed: invalid app credentials. '
+                      'Check app_id and app_secret in Channel settings.')
             else:
                 print(f'[feishu] WebSocket connection error: {e}')
+        finally:
             self._running = False
-
-    def _on_reconnecting(self):
-        print(f'[feishu] connection lost, reconnecting... ({self.channel_id})')
-
-    def _on_reconnected(self):
-        print(f'[feishu] reconnected successfully ({self.channel_id})')
+            print(f'[feishu] ws thread exited: {self.channel_id}')
 
     async def stop(self) -> None:
         self._running = False
 
-        # Stop the SDK's event loop to break out of _select()
-        import lark_oapi.ws.client as ws_mod
-        if ws_mod.loop and ws_mod.loop.is_running():
-            ws_mod.loop.call_soon_threadsafe(ws_mod.loop.stop)
+        # 停自己的 SDK loop 以打断 _select()
+        if self._sdk_loop and self._sdk_loop.is_running():
+            try:
+                self._sdk_loop.call_soon_threadsafe(self._sdk_loop.stop)
+            except RuntimeError:
+                pass
 
-        # Wait for thread to exit
         if self._thread and self._thread.is_alive():
             self._thread.join(timeout=5)
 
         self._client = None
         self._thread = None
+        self._sdk_loop = None
         print(f'[feishu] adapter stopped: {self.channel_id}')
 
-    async def send_message(self, msg: OutboundMessage) -> None:
-        """Send message via Feishu Open API."""
-        if not self._api_client:
-            raise RuntimeError(
-                '[feishu] Cannot send: adapter not initialized. '
-                'Cause: The adapter failed to start or has been stopped. '
-                'Solution: Check app_id/app_secret in Channel settings and restart the channel.'
-            )
+    # ── 健康状态 ─────────────────────────────────────────────────────────────
 
-        import lark_oapi as lark
-        from lark_oapi.api.im.v1 import CreateMessageRequest, CreateMessageRequestBody
+    async def _probe(self, force: bool = False) -> tuple[bool, str]:
+        """轻量 API 探测（bot info），结果缓存 _PROBE_TTL 秒。
 
-        body = CreateMessageRequestBody.builder() \
-            .receive_id(msg.chat_id) \
-            .msg_type('text') \
-            .content(json.dumps({'text': msg.text})) \
-            .build()
-
-        request = CreateMessageRequest.builder() \
-            .receive_id_type('chat_id') \
-            .request_body(body) \
-            .build()
-
-        loop = asyncio.get_event_loop()
+        探测同时覆盖：凭据是否有效（换 token）+ 网络是否通 + 应用是否已发布。
+        应用没开 bot info 权限时不算故障——token 换到了就说明凭据没问题。
+        """
+        if not force and time.time() - self._probe_ts < _PROBE_TTL:
+            return self._probe_ok, self._probe_err
         try:
-            response = await loop.run_in_executor(
-                None, self._api_client.im.v1.message.create, request
-            )
-            if not response.success():
-                hint = _FEISHU_ERROR_HINTS.get(response.code, '')
-                app_id = self.config.get('app_id', '')
-                if hint:
-                    hint = hint.format(app_id=app_id)
-                error_detail = f'[feishu] send_message failed (code={response.code}): {response.msg}'
-                if hint:
-                    error_detail += f'\n  → {hint}'
-                print(error_detail)
-                raise RuntimeError(error_detail)
-        except RuntimeError:
-            raise
+            await self._request('GET', '/open-apis/bot/v3/info')
+            self._probe_ok, self._probe_err = True, ''
+        except FeishuError as e:
+            if e.code == 99991672:
+                self._probe_ok, self._probe_err = True, ''
+            else:
+                self._probe_ok, self._probe_err = False, str(e)
         except Exception as e:
-            error_str = str(e)
-            if 'timeout' in error_str.lower() or 'connect' in error_str.lower():
-                raise RuntimeError(
-                    f'[feishu] send_message network error: {e}\n'
-                    f'  → Cause: Network unreachable or Feishu API rate-limited.\n'
-                    f'  → Solution: Check network connectivity. Retry in a few seconds.'
-                )
-            raise RuntimeError(f'[feishu] send_message exception: {e}')
+            self._probe_ok, self._probe_err = False, str(e)
+        self._probe_ts = time.time()
+        return self._probe_ok, self._probe_err
+
+    async def health_check(self) -> tuple[bool, str]:
+        if not self._running:
+            return False, 'adapter not running'
+        if self._thread is None or not self._thread.is_alive():
+            return False, 'WebSocket thread is dead — restart the channel'
+        return await self._probe()
+
+    def status(self) -> str:
+        """同步状态：线程死了就是 disconnected；线程活着但最近探测失败为 degraded。
+
+        探测本身是异步的（health_check），这里只读缓存结果，避免前端轮询打 API。
+        """
+        if not self._running or self._thread is None or not self._thread.is_alive():
+            return 'disconnected'
+        if self._probe_ts and not self._probe_ok:
+            return 'degraded'
+        return 'connected'
+
+    # ── 发送 ─────────────────────────────────────────────────────────────────
+
+    async def send_message(self, msg: OutboundMessage) -> None:
+        """Send text and/or attachments via Feishu Open API."""
+        if not self._running:
+            raise RuntimeError(
+                '[feishu] Cannot send: adapter not running. '
+                'Cause: the adapter failed to start or has been stopped. '
+                'Solution: check app_id/app_secret in Channel settings and restart the channel.'
+            )
+
+        files = list(msg.files)
+        if msg.image_bytes:
+            # 兼容旧调用方：字节图片先落盘再走统一路径
+            from channel import store
+            files.append(store.save_bytes(self.channel_id, msg.image_bytes,
+                                          kind=KIND_IMAGE, name='image.jpg',
+                                          mime='image/jpeg', fallback_ext='.jpg'))
+
+        if msg.text:
+            for chunk in _chunks(msg.text, _TEXT_CHUNK):
+                await self._send_raw(msg.chat_id, 'text', {'text': chunk})
+
+        for att in files:
+            await self._send_attachment(msg.chat_id, att)
+
+    async def _send_raw(self, chat_id: str, msg_type: str, content: dict) -> None:
+        await self._request(
+            'POST', '/open-apis/im/v1/messages',
+            params={'receive_id_type': 'chat_id'},
+            json_body={
+                'receive_id': chat_id,
+                'msg_type': msg_type,
+                'content': json.dumps(content, ensure_ascii=False),
+            },
+        )
+
+    async def _send_attachment(self, chat_id: str, att: Attachment) -> None:
+        if att.kind == KIND_IMAGE:
+            image_key = await self._upload_image(att.path)
+            await self._send_raw(chat_id, 'image', {'image_key': image_key})
+        elif att.kind == KIND_VIDEO:
+            file_key = await self._upload_file(att.path, att.name)
+            await self._send_raw(chat_id, 'media', {'file_key': file_key})
+        elif att.kind == KIND_AUDIO and att.path.lower().endswith('.opus'):
+            file_key = await self._upload_file(att.path, att.name)
+            await self._send_raw(chat_id, 'audio', {'file_key': file_key})
+        else:
+            file_key = await self._upload_file(att.path, att.name)
+            await self._send_raw(chat_id, 'file', {'file_key': file_key})
+        if att.caption:
+            await self._send_raw(chat_id, 'text', {'text': att.caption})
+
+    async def _upload_image(self, path: str) -> str:
+        with open(path, 'rb') as f:
+            payload = f.read()
+        form = aiohttp.FormData()
+        form.add_field('image_type', 'message')
+        form.add_field('image', payload, filename=os.path.basename(path),
+                       content_type='application/octet-stream')
+        data = await self._request('POST', '/open-apis/im/v1/images', data=form)
+        return data.get('image_key', '')
+
+    async def _upload_file(self, path: str, name: str = '') -> str:
+        ext = os.path.splitext(path)[1].lower()
+        file_type = _FILE_TYPE_BY_EXT.get(ext, 'stream')
+        fname = name or os.path.basename(path)
+        with open(path, 'rb') as f:
+            payload = f.read()
+        form = aiohttp.FormData()
+        form.add_field('file_type', file_type)
+        form.add_field('file_name', fname)
+        form.add_field('file', payload, filename=fname,
+                       content_type='application/octet-stream')
+        data = await self._request('POST', '/open-apis/im/v1/files', data=form)
+        return data.get('file_key', '')
+
+    # ── 接收 ─────────────────────────────────────────────────────────────────
 
     def _handle_message_event(self, data):
-        """Handle im.message.receive_v1 event from SDK callback (runs in SDK thread)."""
+        """Handle im.message.receive_v1 (runs in the SDK thread).
+
+        SDK 线程里只做纯数据提取，下载/落盘/回调都丢到主 loop 的协程里完成。
+        """
         try:
             event = data.event
             message = event.message
             sender = event.sender
 
-            # Skip bot messages
             if sender.sender_type == 'app':
+                return  # 跳过机器人自己的消息
+
+            raw = {
+                'message_id': getattr(message, 'message_id', '') or '',
+                'message_type': getattr(message, 'message_type', '') or '',
+                'content': getattr(message, 'content', '') or '',
+                'chat_id': getattr(message, 'chat_id', '') or '',
+                'sender_id': (sender.sender_id.open_id or sender.sender_id.user_id or ''),
+            }
+
+            self._last_event_ts = time.time()
+
+            if self._loop is None:
+                print('[feishu] event dropped: adapter loop not ready')
+                return
+            asyncio.run_coroutine_threadsafe(self._process_event(raw), self._loop)
+
+        except Exception as e:
+            print(f'[feishu] handle message error: {e}')
+            print('  If messages are not being received, ensure:')
+            print('  1. Event "im.message.receive_v1" is subscribed in Feishu Developer Console')
+            print('  2. Subscription mode is set to "长连接" (WebSocket long connection)')
+            print('  3. App has "im:message" permission and is published')
+
+    def _is_duplicate(self, message_id: str) -> bool:
+        """飞书可能重投递同一事件；用有界 LRU 去重。"""
+        if not message_id:
+            return False
+        if message_id in self._seen_set:
+            return True
+        self._seen_set.add(message_id)
+        self._seen_ids.append(message_id)
+        if len(self._seen_ids) > _DEDUP_MAX:
+            self._seen_set.discard(self._seen_ids.pop(0))
+        return False
+
+    async def _process_event(self, raw: dict) -> None:
+        """在主 loop 上解析消息、下载附件、回调 manager。"""
+        try:
+            if self._is_duplicate(raw['message_id']):
+                print(f'[feishu] duplicate message dropped: {raw["message_id"]}')
                 return
 
-            # Extract text
-            msg_type = message.message_type
-            text = ''
-            if msg_type == 'text':
-                content = json.loads(message.content)
-                text = content.get('text', '')
-            else:
-                text = f'[{msg_type}]'
-
-            if not text:
+            text, attachments = await self._parse_content(raw)
+            if not text and not attachments:
                 return
-
-            sender_id = sender.sender_id.open_id or sender.sender_id.user_id or ''
-            chat_id = message.chat_id
 
             msg = InboundMessage(
                 platform='feishu',
                 channel_id=self.channel_id,
-                user_id=sender_id,
-                chat_id=chat_id,
-                display_name=sender_id,
+                user_id=raw['sender_id'],
+                chat_id=raw['chat_id'],
+                display_name=raw['sender_id'],
                 text=text,
+                message_id=raw['message_id'],
+                attachments=attachments,
             )
-
-            # Schedule coroutine from SDK thread to main event loop
-            asyncio.run_coroutine_threadsafe(self._on_message(msg), self._loop)
-
+            await self._on_message(msg)
         except Exception as e:
-            print(f'[feishu] handle message error: {e}')
-            print(f'  If messages are not being received, ensure:')
-            print(f'  1. Event "im.message.receive_v1" is subscribed in Feishu Developer Console')
-            print(f'  2. Subscription mode is set to "长连接" (WebSocket long connection)')
-            print(f'  3. App has "im:message" permission and is published')
+            print(f'[feishu] process event failed: {e}')
+
+    async def _parse_content(self, raw: dict) -> tuple[str, list[Attachment]]:
+        msg_type = raw['message_type']
+        try:
+            content = json.loads(raw['content'] or '{}')
+        except json.JSONDecodeError:
+            content = {}
+
+        message_id = raw['message_id']
+        attachments: list[Attachment] = []
+
+        if msg_type == 'text':
+            return content.get('text', ''), []
+
+        if msg_type in ('image', 'sticker'):
+            key = content.get('image_key', '')
+            att = await self._download(message_id, key, 'image', KIND_IMAGE,
+                                       name='image.jpg', fallback_ext='.jpg')
+            if att:
+                attachments.append(att)
+            return ('[表情]' if msg_type == 'sticker' else '[图片]'), attachments
+
+        if msg_type in ('file', 'media', 'audio'):
+            key = content.get('file_key', '')
+            name = content.get('file_name', '') or ''
+            kind = {'media': KIND_VIDEO, 'audio': KIND_AUDIO}.get(msg_type, KIND_FILE)
+            ext = {'media': '.mp4', 'audio': '.opus'}.get(msg_type, '')
+            att = await self._download(message_id, key, 'file', kind,
+                                       name=name or f'{msg_type}{ext}', fallback_ext=ext)
+            if att:
+                attachments.append(att)
+            label = {'media': '[视频]', 'audio': '[语音]'}.get(msg_type, '[文件]')
+            return f'{label} {att.name}' if att else label, attachments
+
+        if msg_type == 'post':
+            # 富文本：content = {"title":..,"content":[[{tag:text|img|a,...}]]}
+            parts = []
+            for block in content.get('content', []) or []:
+                for el in block or []:
+                    tag = el.get('tag', '')
+                    if tag == 'text':
+                        parts.append(el.get('text', ''))
+                    elif tag == 'a':
+                        parts.append(f'{el.get("text", "")}({el.get("href", "")})')
+                    elif tag == 'img':
+                        att = await self._download(message_id, el.get('image_key', ''),
+                                                   'image', KIND_IMAGE,
+                                                   name='image.jpg', fallback_ext='.jpg')
+                        if att:
+                            attachments.append(att)
+                            parts.append('[图片]')
+                parts.append('\n')
+            title = content.get('title', '')
+            text = (f'{title}\n' if title else '') + ''.join(parts).strip()
+            return text, attachments
+
+        # 其它类型（分享、位置…）：给出可读占位，不静默丢弃
+        return f'[{msg_type}]', []
+
+    async def _download(self, message_id: str, key: str, res_type: str,
+                        kind: str, *, name: str = '', fallback_ext: str = '') -> Attachment | None:
+        """下载消息资源并落盘。res_type: 'image' 用于图片，'file' 用于文件/视频/语音。"""
+        if not message_id or not key:
+            return None
+        try:
+            result = await self._request(
+                'GET', f'/open-apis/im/v1/messages/{message_id}/resources/{key}',
+                params={'type': res_type}, raw=True,
+            )
+        except Exception as e:
+            print(f'[feishu] resource download failed ({key}): {e}\n'
+                  f'  → 确认应用已获得 "im:resource" 权限并发布新版本')
+            return None
+
+        # raw=True 时返回 (bytes, headers)；若平台回了 JSON（code==0 但无二进制体）则放弃
+        if not (isinstance(result, tuple) and isinstance(result[0], (bytes, bytearray))):
+            print(f'[feishu] resource download returned no binary data ({key}): {result!r:.200}')
+            return None
+        payload, headers = result
+
+        from channel import store
+        mime = headers.get('Content-Type', '').split(';')[0] if headers else ''
+        return store.save_bytes(self.channel_id, bytes(payload), kind=kind,
+                                name=name, mime=mime, fallback_ext=fallback_ext)
+
+
+def _chunks(text: str, size: int):
+    """按 size 切分长文本（尽量在换行处断开）。"""
+    while text:
+        if len(text) <= size:
+            yield text
+            return
+        cut = text.rfind('\n', 0, size)
+        if cut < size // 2:
+            cut = size
+        yield text[:cut]
+        text = text[cut:].lstrip('\n')

--- a/agent-core/src/channel/adapters/slack.py
+++ b/agent-core/src/channel/adapters/slack.py
@@ -15,7 +15,7 @@ import os
 
 from channel.adapter import (
     Attachment, ChannelAdapter, InboundMessage, OnMessageCallback, OutboundMessage,
-    KIND_AUDIO, KIND_FILE, KIND_IMAGE, KIND_VIDEO,
+    PartialSendError, KIND_AUDIO, KIND_FILE, KIND_IMAGE, KIND_VIDEO,
 )
 
 
@@ -151,13 +151,26 @@ class SlackAdapter(ChannelAdapter):
         if msg.text:
             await self._client.chat_postMessage(channel=msg.chat_id, text=msg.text)
 
+        if not files:
+            return
+
+        # 逐个附件汇报成败：附件失败不该让上层以为已送达的文本也失败了
+        sent = ['文本'] if msg.text else []
+        failures = []
         for att in files:
-            await self._client.files_upload_v2(
-                channel=msg.chat_id,
-                file=att.path,
-                filename=att.name or os.path.basename(att.path),
-                initial_comment=att.caption or '',
-            )
+            try:
+                await self._client.files_upload_v2(
+                    channel=msg.chat_id,
+                    file=att.path,
+                    filename=att.name or os.path.basename(att.path),
+                    initial_comment=att.caption or '',
+                )
+                sent.append(att.name or att.path)
+            except Exception as e:
+                print(f'[slack] send attachment failed ({att.name or att.path}): {e}')
+                failures.append(f'- {att.name or att.path}: {e}')
+        if failures:
+            raise PartialSendError(sent, failures)
 
     # ── 接收 ─────────────────────────────────────────────────────────────────
 

--- a/agent-core/src/channel/adapters/slack.py
+++ b/agent-core/src/channel/adapters/slack.py
@@ -3,21 +3,33 @@ channel/adapters/slack.py — Slack Socket Mode 适配器。
 
 使用 Socket Mode（WebSocket），无需公网 IP。
 依赖：slack-sdk (>=3.27)
+
+支持收发图片 / 视频 / 文件：出站统一走 files_upload_v2；入站从 event['files'] 拿
+url_private_download，用 bot token 以 Bearer 认证下载后落盘（channel/store.py）。
+需要权限：files:read（下载）、files:write（上传）、chat:write。
 """
 
 import asyncio
+import mimetypes
+import os
 
-from channel.adapter import ChannelAdapter, InboundMessage, OutboundMessage, OnMessageCallback
+from channel.adapter import (
+    Attachment, ChannelAdapter, InboundMessage, OnMessageCallback, OutboundMessage,
+    KIND_AUDIO, KIND_FILE, KIND_IMAGE, KIND_VIDEO,
+)
 
 
 class SlackAdapter(ChannelAdapter):
     """Slack Socket Mode 适配器。"""
+
+    SUPPORTED_FILE_KINDS = (KIND_IMAGE, KIND_VIDEO, KIND_AUDIO, KIND_FILE)
 
     def __init__(self, channel_id: str, platform: str, config: dict,
                  on_message: OnMessageCallback):
         super().__init__(channel_id, platform, config, on_message)
         self._handler = None
         self._client = None
+        self._socket_client = None
         self._task: asyncio.Task | None = None
 
     async def start(self) -> None:
@@ -32,6 +44,8 @@ class SlackAdapter(ChannelAdapter):
         from slack_sdk.socket_mode.response import SocketModeResponse
 
         self._client = AsyncWebClient(token=bot_token)
+        # 凭据前置校验：token 无效时必须抛出，让上层状态变成 error
+        await self._client.auth_test()
         self._socket_client = SocketModeClient(app_token=app_token, web_client=self._client)
 
         async def _handle_event(client, req: SocketModeRequest):
@@ -40,20 +54,37 @@ class SlackAdapter(ChannelAdapter):
 
             if req.type == 'events_api' and req.payload:
                 event = req.payload.get('event', {})
-                if event.get('type') == 'message' and not event.get('subtype'):
-                    text = event.get('text', '')
-                    user_id = event.get('user', '')
-                    channel_id_slack = event.get('channel', '')
-                    if text and user_id:
-                        msg = InboundMessage(
-                            platform='slack',
-                            channel_id=self.channel_id,
-                            user_id=user_id,
-                            chat_id=channel_id_slack,
-                            display_name=user_id,  # Could resolve via users.info API
-                            text=text,
-                        )
-                        await self._on_message(msg)
+                if event.get('type') != 'message':
+                    return
+                # 只跳过非 file_share 的 subtype（编辑、加入频道等）
+                subtype = event.get('subtype')
+                if subtype and subtype != 'file_share':
+                    return
+                if event.get('bot_id'):
+                    return
+                text = event.get('text', '')
+                user_id = event.get('user', '')
+                chat = event.get('channel', '')
+                if not user_id:
+                    return
+
+                attachments = await self._download_files(event.get('files', []) or [])
+                if not text and not attachments:
+                    return
+                if not text and attachments:
+                    text = f'[{attachments[0].kind}] {attachments[0].name}'
+
+                msg = InboundMessage(
+                    platform='slack',
+                    channel_id=self.channel_id,
+                    user_id=user_id,
+                    chat_id=chat,
+                    display_name=user_id,  # Could resolve via users.info API
+                    text=text,
+                    message_id=event.get('client_msg_id', '') or event.get('ts', ''),
+                    attachments=attachments,
+                )
+                await self._on_message(msg)
 
         self._socket_client.socket_mode_request_listeners.append(_handle_event)
         self._task = asyncio.create_task(self._run())
@@ -88,18 +119,76 @@ class SlackAdapter(ChannelAdapter):
         self._client = None
         print(f'[slack] adapter stopped: {self.channel_id}')
 
+    # ── 健康状态 ─────────────────────────────────────────────────────────────
+
+    async def health_check(self) -> tuple[bool, str]:
+        if not self._running or not self._client:
+            return False, 'adapter not running'
+        try:
+            await self._client.auth_test()
+            return True, ''
+        except Exception as e:
+            return False, f'auth_test failed: {e}'
+
+    # ── 发送 ─────────────────────────────────────────────────────────────────
+
     async def send_message(self, msg: OutboundMessage) -> None:
         if not self._client:
-            return
+            raise RuntimeError(
+                '[slack] Cannot send: adapter not initialized. '
+                'Solution: check bot_token/app_token in Channel settings and restart the channel.'
+            )
+
+        files = list(msg.files)
         if msg.image_bytes:
+            from channel import store
+            files.append(store.save_bytes(self.channel_id, msg.image_bytes,
+                                          kind=KIND_IMAGE, name='image.jpg',
+                                          mime='image/jpeg', fallback_ext='.jpg'))
+            if msg.image_caption and not msg.text:
+                files[-1].caption = msg.image_caption
+
+        if msg.text:
+            await self._client.chat_postMessage(channel=msg.chat_id, text=msg.text)
+
+        for att in files:
             await self._client.files_upload_v2(
                 channel=msg.chat_id,
-                content=msg.image_bytes,
-                filename='image.jpg',
-                initial_comment=msg.image_caption or msg.text or '',
+                file=att.path,
+                filename=att.name or os.path.basename(att.path),
+                initial_comment=att.caption or '',
             )
-        elif msg.text:
-            await self._client.chat_postMessage(
-                channel=msg.chat_id,
-                text=msg.text,
-            )
+
+    # ── 接收 ─────────────────────────────────────────────────────────────────
+
+    async def _download_files(self, slack_files: list) -> list[Attachment]:
+        if not slack_files:
+            return []
+        import aiohttp
+        from channel import media, store
+
+        token = self.config.get('bot_token', '')
+        out: list[Attachment] = []
+        timeout = aiohttp.ClientTimeout(total=120)
+        headers = {'Authorization': f'Bearer {token}'}
+        async with aiohttp.ClientSession(timeout=timeout, headers=headers) as s:
+            for f in slack_files:
+                url = f.get('url_private_download') or f.get('url_private') or ''
+                if not url:
+                    continue
+                name = f.get('name', '') or 'file'
+                mime = f.get('mimetype', '') or mimetypes.guess_type(name)[0] or ''
+                try:
+                    async with s.get(url) as resp:
+                        if resp.status != 200:
+                            print(f'[slack] file download failed ({name}): HTTP {resp.status}'
+                                  f' — check the files:read scope')
+                            continue
+                        payload = await resp.read()
+                except Exception as e:
+                    print(f'[slack] file download failed ({name}): {e}')
+                    continue
+                out.append(store.save_bytes(self.channel_id, payload,
+                                            kind=media.infer_kind(name, mime),
+                                            name=name, mime=mime))
+        return out

--- a/agent-core/src/channel/adapters/telegram.py
+++ b/agent-core/src/channel/adapters/telegram.py
@@ -13,7 +13,7 @@ import asyncio
 
 from channel.adapter import (
     Attachment, ChannelAdapter, InboundMessage, OnMessageCallback, OutboundMessage,
-    KIND_AUDIO, KIND_FILE, KIND_IMAGE, KIND_VIDEO,
+    PartialSendError, KIND_AUDIO, KIND_FILE, KIND_IMAGE, KIND_VIDEO,
 )
 
 _TEXT_CHUNK = 4000  # Telegram 单条上限 4096
@@ -148,18 +148,31 @@ class TelegramAdapter(ChannelAdapter):
             for chunk in _chunks(msg.text, _TEXT_CHUNK):
                 await bot.send_message(chat_id=chat_id, text=chunk)
 
+        if not files:
+            return
+
+        # 逐个附件汇报成败：附件失败不该让上层以为已送达的文本也失败了
+        sent = ['文本'] if msg.text else []
+        failures = []
         for att in files:
-            with open(att.path, 'rb') as f:
-                payload = f.read()
-            if att.kind == KIND_IMAGE:
-                await bot.send_photo(chat_id=chat_id, photo=payload, caption=att.caption or '')
-            elif att.kind == KIND_VIDEO:
-                await bot.send_video(chat_id=chat_id, video=payload, caption=att.caption or '')
-            elif att.kind == KIND_AUDIO:
-                await bot.send_audio(chat_id=chat_id, audio=payload, caption=att.caption or '')
-            else:
-                await bot.send_document(chat_id=chat_id, document=payload,
-                                        filename=att.name or None, caption=att.caption or '')
+            try:
+                with open(att.path, 'rb') as f:
+                    payload = f.read()
+                if att.kind == KIND_IMAGE:
+                    await bot.send_photo(chat_id=chat_id, photo=payload, caption=att.caption or '')
+                elif att.kind == KIND_VIDEO:
+                    await bot.send_video(chat_id=chat_id, video=payload, caption=att.caption or '')
+                elif att.kind == KIND_AUDIO:
+                    await bot.send_audio(chat_id=chat_id, audio=payload, caption=att.caption or '')
+                else:
+                    await bot.send_document(chat_id=chat_id, document=payload,
+                                            filename=att.name or None, caption=att.caption or '')
+                sent.append(att.name or att.path)
+            except Exception as e:
+                print(f'[telegram] send attachment failed ({att.name or att.path}): {e}')
+                failures.append(f'- {att.name or att.path}: {e}')
+        if failures:
+            raise PartialSendError(sent, failures)
 
     # ── 接收 ─────────────────────────────────────────────────────────────────
 

--- a/agent-core/src/channel/adapters/telegram.py
+++ b/agent-core/src/channel/adapters/telegram.py
@@ -3,15 +3,26 @@ channel/adapters/telegram.py — Telegram Bot 适配器。
 
 使用 long-polling (getUpdates) 模式，无需公网 IP。
 依赖：python-telegram-bot (>=21.0)
+
+支持收发图片 / 视频 / 语音 / 文件：入站附件下载后落盘到持久化目录
+（channel/store.py），出站按 Attachment.kind 选择 send_photo / send_video /
+send_document。
 """
 
 import asyncio
 
-from channel.adapter import ChannelAdapter, InboundMessage, OutboundMessage, OnMessageCallback
+from channel.adapter import (
+    Attachment, ChannelAdapter, InboundMessage, OnMessageCallback, OutboundMessage,
+    KIND_AUDIO, KIND_FILE, KIND_IMAGE, KIND_VIDEO,
+)
+
+_TEXT_CHUNK = 4000  # Telegram 单条上限 4096
 
 
 class TelegramAdapter(ChannelAdapter):
     """Telegram Bot API 适配器（long-polling）。"""
+
+    SUPPORTED_FILE_KINDS = (KIND_IMAGE, KIND_VIDEO, KIND_AUDIO, KIND_FILE)
 
     def __init__(self, channel_id: str, platform: str, config: dict,
                  on_message: OnMessageCallback):
@@ -30,24 +41,35 @@ class TelegramAdapter(ChannelAdapter):
         self._app = ApplicationBuilder().token(bot_token).build()
 
         async def _handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE):
-            if not update.message or not update.message.text:
+            if not update.message:
                 return
-            user = update.message.from_user
+            m = update.message
+            user = m.from_user
+            text, attachments = await self._extract(m)
+            if not text and not attachments:
+                return
             msg = InboundMessage(
                 platform='telegram',
                 channel_id=self.channel_id,
                 user_id=str(user.id),
-                chat_id=str(update.message.chat_id),
+                chat_id=str(m.chat_id),
                 display_name=user.username or user.first_name or str(user.id),
-                text=update.message.text,
+                text=text,
+                message_id=str(m.message_id),
+                attachments=attachments,
             )
             await self._on_message(msg)
 
-        self._app.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, _handle_message))
+        media_filter = (filters.PHOTO | filters.VIDEO | filters.Document.ALL
+                        | filters.VOICE | filters.AUDIO)
+        self._app.add_handler(MessageHandler(
+            (filters.TEXT & ~filters.COMMAND) | media_filter, _handle_message))
 
         # 启动 polling（在后台 task 中运行）
         await self._app.initialize()
         await self._app.start()
+        # 凭据校验：getMe 失败说明 token 无效，此时必须抛出而不是假装启动成功
+        await self._app.bot.get_me()
         self._task = asyncio.create_task(self._poll_loop())
         self._running = True
         print(f'[telegram] adapter started: {self.channel_id}')
@@ -89,19 +111,123 @@ class TelegramAdapter(ChannelAdapter):
         self._app = None
         print(f'[telegram] adapter stopped: {self.channel_id}')
 
+    # ── 健康状态 ─────────────────────────────────────────────────────────────
+
+    async def health_check(self) -> tuple[bool, str]:
+        if not self._running or not self._app or not self._app.bot:
+            return False, 'adapter not running'
+        if self._app.updater and not self._app.updater.running:
+            return False, 'polling stopped — restart the channel'
+        try:
+            await self._app.bot.get_me()
+            return True, ''
+        except Exception as e:
+            return False, f'getMe failed: {e}'
+
+    # ── 发送 ─────────────────────────────────────────────────────────────────
+
     async def send_message(self, msg: OutboundMessage) -> None:
         if not self._app or not self._app.bot:
-            return
+            raise RuntimeError(
+                '[telegram] Cannot send: adapter not initialized. '
+                'Solution: check bot_token in Channel settings and restart the channel.'
+            )
         bot = self._app.bot
+        chat_id = int(msg.chat_id)
+
+        files = list(msg.files)
         if msg.image_bytes:
-            from io import BytesIO
-            await bot.send_photo(
-                chat_id=int(msg.chat_id),
-                photo=BytesIO(msg.image_bytes),
-                caption=msg.image_caption or msg.text or '',
-            )
-        elif msg.text:
-            await bot.send_message(
-                chat_id=int(msg.chat_id),
-                text=msg.text,
-            )
+            from channel import store
+            files.append(store.save_bytes(self.channel_id, msg.image_bytes,
+                                          kind=KIND_IMAGE, name='image.jpg',
+                                          mime='image/jpeg', fallback_ext='.jpg'))
+            if msg.image_caption and not msg.text:
+                files[-1].caption = msg.image_caption
+
+        if msg.text:
+            for chunk in _chunks(msg.text, _TEXT_CHUNK):
+                await bot.send_message(chat_id=chat_id, text=chunk)
+
+        for att in files:
+            with open(att.path, 'rb') as f:
+                payload = f.read()
+            if att.kind == KIND_IMAGE:
+                await bot.send_photo(chat_id=chat_id, photo=payload, caption=att.caption or '')
+            elif att.kind == KIND_VIDEO:
+                await bot.send_video(chat_id=chat_id, video=payload, caption=att.caption or '')
+            elif att.kind == KIND_AUDIO:
+                await bot.send_audio(chat_id=chat_id, audio=payload, caption=att.caption or '')
+            else:
+                await bot.send_document(chat_id=chat_id, document=payload,
+                                        filename=att.name or None, caption=att.caption or '')
+
+    # ── 接收 ─────────────────────────────────────────────────────────────────
+
+    async def _extract(self, m) -> tuple[str, list[Attachment]]:
+        """从 telegram Message 提取文本与附件（附件下载后落盘）。"""
+        attachments: list[Attachment] = []
+        text = m.text or m.caption or ''
+
+        if m.photo:
+            # photo 是同一张图的多个尺寸，取最大的
+            biggest = max(m.photo, key=lambda p: p.file_size or 0)
+            att = await self._download(biggest.file_id, KIND_IMAGE,
+                                       name='photo.jpg', fallback_ext='.jpg')
+            if att:
+                attachments.append(att)
+            text = text or '[图片]'
+        elif m.video:
+            att = await self._download(m.video.file_id, KIND_VIDEO,
+                                       name=m.video.file_name or 'video.mp4',
+                                       mime=m.video.mime_type or '', fallback_ext='.mp4')
+            if att:
+                attachments.append(att)
+            text = text or '[视频]'
+        elif m.voice:
+            att = await self._download(m.voice.file_id, KIND_AUDIO,
+                                       name='voice.ogg',
+                                       mime=m.voice.mime_type or '', fallback_ext='.ogg')
+            if att:
+                attachments.append(att)
+            text = text or '[语音]'
+        elif m.audio:
+            att = await self._download(m.audio.file_id, KIND_AUDIO,
+                                       name=m.audio.file_name or 'audio.mp3',
+                                       mime=m.audio.mime_type or '', fallback_ext='.mp3')
+            if att:
+                attachments.append(att)
+            text = text or '[音频]'
+        elif m.document:
+            d = m.document
+            kind = KIND_IMAGE if (d.mime_type or '').startswith('image/') else KIND_FILE
+            att = await self._download(d.file_id, kind, name=d.file_name or 'file',
+                                       mime=d.mime_type or '')
+            if att:
+                attachments.append(att)
+            text = text or f'[文件] {d.file_name or ""}'.strip()
+
+        return text, attachments
+
+    async def _download(self, file_id: str, kind: str, *, name: str = '',
+                        mime: str = '', fallback_ext: str = '') -> Attachment | None:
+        try:
+            tg_file = await self._app.bot.get_file(file_id)
+            payload = await tg_file.download_as_bytearray()
+        except Exception as e:
+            print(f'[telegram] download failed ({file_id}): {e}')
+            return None
+        from channel import store
+        return store.save_bytes(self.channel_id, bytes(payload), kind=kind,
+                                name=name, mime=mime, fallback_ext=fallback_ext)
+
+
+def _chunks(text: str, size: int):
+    while text:
+        if len(text) <= size:
+            yield text
+            return
+        cut = text.rfind('\n', 0, size)
+        if cut < size // 2:
+            cut = size
+        yield text[:cut]
+        text = text[cut:].lstrip('\n')

--- a/agent-core/src/channel/manager.py
+++ b/agent-core/src/channel/manager.py
@@ -3,9 +3,9 @@ channel/manager.py — Channel 生命周期管理器。
 
 职责：
 - 管理 channel_configs（CRUD）
-- 启动/停止 adapters
-- 入站消息 → ACL 检查 → event_bus
-- 出站回复路由（trigger source 为 channel:* 时）
+- 启动/停止 adapters，并用 watchdog 周期探测健康度、自动重连
+- 入站消息 → ACL 检查 → topic 发布（附件已落盘，随事件带本地路径）
+- 出站回复路由：卡片实例配置的 channel → 最近会话上下文
 """
 
 import asyncio
@@ -96,6 +96,11 @@ class ChannelManager:
         self._adapters: dict[str, ChannelAdapter] = {}  # channel_id → adapter
         self._active_input_channels: set[str] = set()
         self._active_output_channels: set[str] = set()
+        self._watchdog_task: asyncio.Task | None = None
+        self._health: dict[str, tuple[bool, str]] = {}   # channel_id → (ok, reason)
+        self._retry_at: dict[str, float] = {}            # channel_id → 下次重连时间
+        self._retry_backoff: dict[str, float] = {}       # channel_id → 当前退避秒数
+        self._inactive_logged: set[str] = set()
 
     # ── Persistent conversation context ──────────────────────────────────────
 
@@ -104,10 +109,50 @@ class ChannelManager:
         return config.main.get('channel_last_context', {})
 
     def _set_last_context(self, channel_id: str, chat_id: str, user_id: str):
-        """Persist conversation context for a channel."""
+        """Persist conversation context for a channel.
+
+        带 ts —— 「最近一次会话」必须靠时间戳判断：dict 就地更新不改插入顺序，
+        用 list(ctx)[-1] 取到的是最早写入的那个 channel。
+        """
         ctx = config.main.get('channel_last_context', {})
-        ctx[channel_id] = {'chat_id': chat_id, 'user_id': user_id}
+        ctx[channel_id] = {'chat_id': chat_id, 'user_id': user_id, 'ts': time.time()}
         config.main['channel_last_context'] = ctx
+
+    def _latest_context_channel(self) -> str:
+        """返回最近有过会话的 channel_id（按 ts 最大），无则空串。"""
+        ctx = self._get_last_context()
+        if not ctx:
+            return ''
+        return max(ctx.items(), key=lambda kv: (kv[1] or {}).get('ts', 0))[0]
+
+    def resolve_target_channel(self, instance_id: str = '') -> tuple[str, str]:
+        """解析回复目标 channel，返回 (channel_id, error)。
+
+        优先级：
+        1. 输出卡片实例配置里选的 channel（画布上的连接才真正生效）
+        2. 最近有过会话的 channel（按 ts）
+        """
+        if instance_id:
+            cfg = config.main.get(f'tool_config:channel:channel_reply:{instance_id}', None)
+            channel_id = (cfg or {}).get('channel_id', '')
+            if channel_id:
+                if get_channel_config(channel_id) is None:
+                    return '', (
+                        f'Error: Channel "{channel_id}" configured on this card no longer exists.\n'
+                        f'Solution: pick an existing channel in the card config, '
+                        f'or re-add it in Settings → Channels.'
+                    )
+                return channel_id, ''
+
+        channel_id = self._latest_context_channel()
+        if channel_id:
+            return channel_id, ''
+        return '', (
+            'Error: No target channel.\n'
+            'Cause: the output card has no channel selected and no user has messaged the bot yet.\n'
+            'Solution: select a channel in the card config (Settings → Channels to add one), '
+            'or ask a user to message the bot first.'
+        )
 
     def sync_from_canvas(self):
         """从 canvas layout 读取 channel_msg_input/output 卡片的 instance config，
@@ -153,14 +198,25 @@ class ChannelManager:
         return self._active_output_channels
 
     async def start(self):
-        """启动所有 enabled 的 channel adapters。"""
+        """启动所有 enabled 的 channel adapters，并拉起 watchdog。"""
         for ch_cfg in _get_channel_configs():
             if ch_cfg.get('enabled'):
                 await self._start_adapter(ch_cfg)
+        if self._watchdog_task is None or self._watchdog_task.done():
+            self._watchdog_task = asyncio.create_task(self._watchdog())
+        # 清理历史遗留的入站媒体文件
+        try:
+            from channel import store
+            store.prune()
+        except Exception as e:
+            print(f'[channel] media prune skipped: {e}')
         print(f'[channel] manager started, {len(self._adapters)} adapters running')
 
     async def stop(self):
         """关闭所有运行中的 adapters。"""
+        if self._watchdog_task:
+            self._watchdog_task.cancel()
+            self._watchdog_task = None
         for adapter in list(self._adapters.values()):
             try:
                 await adapter.stop()
@@ -168,6 +224,113 @@ class ChannelManager:
                 print(f'[channel] stop adapter {adapter.channel_id} error: {e}')
         self._adapters.clear()
         print('[channel] manager stopped')
+
+    # ── Watchdog ─────────────────────────────────────────────────────────────
+
+    async def _watchdog(self, interval: float = 30.0):
+        """周期探测每个 enabled channel 的真实连通性，失败则退避重连。
+
+        WS 长连接会静默断开，SDK 的 auto_reconnect 也可能永久失败——没有这一层，
+        状态会一直停在 connected，而消息早就收不到了。
+        """
+        while True:
+            try:
+                await asyncio.sleep(interval)
+                for ch_cfg in _get_channel_configs():
+                    if not ch_cfg.get('enabled'):
+                        continue
+                    await self._check_one(ch_cfg['id'])
+            except asyncio.CancelledError:
+                raise
+            except Exception as e:
+                print(f'[channel] watchdog error: {e}')
+
+    async def _check_one(self, channel_id: str):
+        adapter = self._adapters.get(channel_id)
+        if adapter is None:
+            ok, reason = False, 'adapter not started'
+        else:
+            try:
+                ok, reason = await adapter.health_check()
+            except Exception as e:
+                ok, reason = False, f'health check raised: {e}'
+
+        prev_ok = self._health.get(channel_id, (None, ''))[0]
+        self._health[channel_id] = (ok, reason)
+
+        if ok:
+            if prev_ok is False:
+                print(f'[channel] {channel_id} recovered')
+            self._retry_backoff.pop(channel_id, None)
+            self._retry_at.pop(channel_id, None)
+            _update_status(channel_id, 'connected')
+            return
+
+        if prev_ok is not False:
+            msg = f'[channel] {channel_id} unhealthy: {reason}'
+            print(msg)
+            await self._push_error(msg)
+        _update_status(channel_id, 'error')
+
+        # 指数退避重连（30s → 60s → … → 300s）
+        now = time.time()
+        if now < self._retry_at.get(channel_id, 0):
+            return
+        backoff = min(300.0, max(30.0, self._retry_backoff.get(channel_id, 0) * 2 or 30.0))
+        self._retry_backoff[channel_id] = backoff
+        self._retry_at[channel_id] = now + backoff
+        print(f'[channel] {channel_id} reconnecting (next retry in {backoff:.0f}s if it fails)')
+        try:
+            # retries=1：watchdog 自己带退避，不要在这里堆内层重试拖住其他 channel 的探测
+            await self.restart_adapter(channel_id, retries=1)
+        except Exception as e:
+            print(f'[channel] {channel_id} reconnect failed: {e}')
+
+    async def ensure_connected(self, channel_id: str, timeout: float = 8.0) -> tuple[bool, str]:
+        """确保某 channel 的 adapter 已连接，必要时先拉起。供启动自检使用。
+
+        返回 (ok, 原因)。原因区分「未配置 / 已删除 / 未启用 / 凭据或网络失败」，
+        这样启动控制的报错能直接指向要改的地方。
+        """
+        if not channel_id:
+            return False, ('no channel selected on this card — pick one in the card config '
+                           '(add channels in Settings → Channels)')
+
+        ch_cfg = get_channel_config(channel_id)
+        if ch_cfg is None:
+            return False, (f'channel "{channel_id}" no longer exists — '
+                           f're-add it in Settings → Channels or fix the card config')
+        if not ch_cfg.get('enabled'):
+            # 画布上明确要用这个 channel，就是「我要它跑起来」——顺手启用，
+            # 而不是让启动控制卡在一个用户早就忘了自己 Stop 过的 channel 上。
+            print(f'[channel] {channel_id} was disabled; enabling it because a canvas card requires it')
+            update_channel_config(channel_id, enabled=True)
+
+        if channel_id not in self._adapters:
+            # 允许自愈：Stop 过或上次启动失败的 adapter 在这里被拉起
+            self._retry_at.pop(channel_id, None)
+            self._retry_backoff.pop(channel_id, None)
+            try:
+                await self.restart_adapter(channel_id, retries=1)
+            except Exception as e:
+                return False, f'channel "{channel_id}" failed to start: {e}'
+
+        deadline = time.time() + timeout
+        last_reason = 'adapter not connected'
+        while True:
+            adapter = self._adapters.get(channel_id)
+            if adapter is not None:
+                try:
+                    ok, reason = await adapter.health_check()
+                except Exception as e:
+                    ok, reason = False, f'health check raised: {e}'
+                self._health[channel_id] = (ok, reason)
+                if ok:
+                    return True, ''
+                last_reason = reason or last_reason
+            if time.time() >= deadline:
+                return False, f'channel "{channel_id}" not connected: {last_reason}'
+            await asyncio.sleep(0.5)
 
     async def _start_adapter(self, ch_cfg: dict, retries: int = 3, delay: float = 5.0):
         """为单个 channel 配置启动 adapter，带重试。"""
@@ -192,6 +355,7 @@ class ChannelManager:
             try:
                 await adapter.start()
                 self._adapters[channel_id] = adapter
+                self._health[channel_id] = (True, '')
                 _update_status(channel_id, 'connected')
                 return
             except Exception as e:
@@ -203,6 +367,7 @@ class ChannelManager:
                     error_msg = f'[channel] Failed to start {channel_id} ({platform}) after {retries} attempts: {e}'
                     print(error_msg)
                     await self._push_error(error_msg)
+                    self._health[channel_id] = (False, str(e))
                     _update_status(channel_id, 'error')
 
     async def _push_error(self, message: str):
@@ -216,7 +381,7 @@ class ChannelManager:
         except Exception:
             pass
 
-    async def restart_adapter(self, channel_id: str):
+    async def restart_adapter(self, channel_id: str, retries: int = 3):
         """重启指定 adapter（配置更新后调用）。"""
         # Stop existing
         if channel_id in self._adapters:
@@ -225,7 +390,7 @@ class ChannelManager:
         # Start fresh
         ch_cfg = get_channel_config(channel_id)
         if ch_cfg and ch_cfg.get('enabled'):
-            await self._start_adapter(ch_cfg)
+            await self._start_adapter(ch_cfg, retries=retries)
 
     # ── Inbound ──────────────────────────────────────────────────────────────
 
@@ -236,7 +401,13 @@ class ChannelManager:
 
         # 1. Check if this channel is activated on canvas (Input connection)
         if msg.channel_id not in self.active_input_channels:
-            return  # Not connected to AgentCore, discard
+            # 静默丢弃会让「消息发了但机器人没反应」完全无法排查，至少记一次
+            if msg.channel_id not in self._inactive_logged:
+                self._inactive_logged.add(msg.channel_id)
+                print(f'[channel] {msg.channel_id} message discarded: no channel_request card '
+                      f'on the canvas is configured for this channel')
+            return
+        self._inactive_logged.discard(msg.channel_id)
 
         # 2. ACL — ensure user exists, otherwise auto-register
         user = acl.get_user(msg.platform, msg.user_id)
@@ -264,18 +435,24 @@ class ChannelManager:
         self._set_last_context(msg.channel_id, msg.chat_id, msg.user_id)
 
         # 5. Publish to topic for dashboard and canvas data flow
+        #    附件已由 adapter 落盘到持久化目录，这里只带容器内本地路径给 LLM
         from api.inspection import publish_to_topic
+        files = [a.to_dict() for a in (msg.attachments or [])]
         topic_id = msg.channel_id.replace(' ', '_')
         topic = f'/channel/request/{topic_id}'
-        topic_data = json.dumps({
+        payload = {
             'platform': msg.platform,
+            'channel_id': msg.channel_id,
+            'message_id': msg.message_id,
             'user': msg.display_name,
             'user_id': msg.user_id,
             'chat_id': msg.chat_id,
             'text': msg.text,
             'user_role': user['role'],
-        }, ensure_ascii=False)
-        await publish_to_topic(topic, topic_data)
+        }
+        if files:
+            payload['files'] = files
+        await publish_to_topic(topic, json.dumps(payload, ensure_ascii=False))
 
         # 5. Broadcast to frontend activity stream
         from api.motus_stream import push_event
@@ -287,38 +464,15 @@ class ChannelManager:
                 'text': msg.text,
                 'platform': msg.platform,
                 'user': msg.display_name,
+                'files': files,
             }
         })
 
     # ── Outbound (Reply Routing) ─────────────────────────────────────────────
 
-    async def route_reply(self, trigger_event: dict, reply_text: str):
-        """
-        Send reply back to the channel that triggered this event.
-        Simple passthrough — no canvas connection check needed.
-        """
-        source = trigger_event.get('source', '')
-        if not source.startswith('channel:'):
-            return
-
-        payload = trigger_event.get('payload', {})
-        channel_id = payload.get('channel_id', '')
-        chat_id = payload.get('chat_id', '')
-
-        if not channel_id or not chat_id:
-            return
-
-        adapter = self._adapters.get(channel_id)
-        if adapter is None:
-            return
-
-        try:
-            await adapter.send_message(OutboundMessage(chat_id=chat_id, text=reply_text))
-        except Exception as e:
-            print(f'[channel] reply failed ({channel_id}→{chat_id}): {e}')
-
-    async def send_to_channel(self, channel_id: str, text: str) -> str:
-        """Send a message to a channel using the last known chat context.
+    async def send_to_channel(self, channel_id: str, text: str = '',
+                              files: list | None = None) -> str:
+        """Send text and/or attachments to a channel using its last chat context.
         Called by channel_reply tool dispatch."""
         ctx = self._get_last_context().get(channel_id)
         if not ctx:
@@ -337,10 +491,34 @@ class ChannelManager:
                 f'Solution: Go to Settings → Channels and click Restart for this channel.'
             )
 
+        # 出站附件：路径白名单 + 大小/类别校验（失败的逐条回报，不当作发送成功）
+        attachments = []
+        file_errors: list[str] = []
+        if files:
+            from channel import media
+            attachments, file_errors = media.resolve_outbound(files, adapter.platform)
+            unsupported = [a for a in attachments
+                           if a.kind not in adapter.SUPPORTED_FILE_KINDS]
+            for a in unsupported:
+                file_errors.append(f'{a.path}: {adapter.platform} adapter cannot send {a.kind}')
+            attachments = [a for a in attachments if a.kind in adapter.SUPPORTED_FILE_KINDS]
+            if not attachments and not text:
+                return 'Error: nothing sent.\n' + '\n'.join(file_errors)
+
         chat_id = ctx['chat_id']
         try:
-            await adapter.send_message(OutboundMessage(chat_id=chat_id, text=text))
-            return f'Reply sent ({len(text)} chars)'
+            await adapter.send_message(OutboundMessage(chat_id=chat_id, text=text,
+                                                       files=attachments))
+            parts = []
+            if text:
+                parts.append(f'{len(text)} chars')
+            if attachments:
+                parts.append(f'{len(attachments)} file(s): ' +
+                             ', '.join(a.name for a in attachments))
+            result = f'Reply sent to {channel_id} ({"; ".join(parts) or "empty"})'
+            if file_errors:
+                result += '\nSome files were NOT sent:\n' + '\n'.join(file_errors)
+            return result
         except Exception as e:
             error_msg = str(e)
             if '99991672' in error_msg or 'Permission denied' in error_msg or 'Access denied' in error_msg:
@@ -361,14 +539,17 @@ class ChannelManager:
             await self._push_error(result)
             return result
 
-    async def send_to_channel_any(self, text: str) -> str:
-        """Send to the most recent channel with conversation context."""
-        all_ctx = self._get_last_context()
-        if not all_ctx:
-            return 'No active conversation. A user must send a message first.'
-        # Use the most recently updated channel
-        channel_id = list(all_ctx.keys())[-1]
-        return await self.send_to_channel(channel_id, text)
+    async def send_reply(self, instance_id: str = '', text: str = '',
+                         files: list | None = None) -> str:
+        """channel_reply 的统一出口：先按卡片实例配置解析目标 channel，再发送。
+
+        画布上给输出卡片选的 channel 必须真正决定回复去向——之前两条 dispatch
+        路径都用「最后一个有上下文的 channel」猜目标，卡片配置形同装饰。
+        """
+        channel_id, err = self.resolve_target_channel(instance_id)
+        if err:
+            return err
+        return await self.send_to_channel(channel_id, text=text, files=files)
 
     # ── Status ───────────────────────────────────────────────────────────────
 
@@ -378,11 +559,13 @@ class ChannelManager:
         for ch_cfg in _get_channel_configs():
             channel_id = ch_cfg['id']
             adapter = self._adapters.get(channel_id)
+            health = self._health.get(channel_id)
             result.append({
                 'id': channel_id,
                 'platform': ch_cfg['platform'],
                 'enabled': ch_cfg.get('enabled', False),
                 'status': adapter.status() if adapter else 'disconnected',
+                'health_error': '' if not health or health[0] else health[1],
                 'active_input': channel_id in self.active_input_channels,
                 'active_output': channel_id in self.active_output_channels,
             })
@@ -397,10 +580,12 @@ class ChannelManager:
 
 
 def _update_status(channel_id: str, status: str):
-    """更新 channel_configs 中的 status 字段。"""
+    """更新 channel_configs 中的 status 字段（状态未变则不落库——watchdog 每 30s 会调）。"""
     configs = _get_channel_configs()
     for ch in configs:
         if ch['id'] == channel_id:
+            if ch.get('status') == status:
+                return
             ch['status'] = status
             ch['updated_at'] = time.time()
             break

--- a/agent-core/src/channel/manager.py
+++ b/agent-core/src/channel/manager.py
@@ -13,7 +13,7 @@ import json
 import time
 
 import config
-from channel.adapter import ChannelAdapter, InboundMessage, OutboundMessage
+from channel.adapter import ChannelAdapter, InboundMessage, OutboundMessage, PartialSendError
 from channel import acl
 
 
@@ -519,23 +519,30 @@ class ChannelManager:
             if file_errors:
                 result += '\nSome files were NOT sent:\n' + '\n'.join(file_errors)
             return result
+        except PartialSendError as e:
+            # 部分成功：必须让 LLM 知道哪部分已经到了，否则它会把文本重发一遍
+            print(f'[channel] {channel_id} partial send: {e}')
+            result = f'部分发送成功（目标 {channel_id}）：\n{e}'
+            if file_errors:
+                result += '\n其它未通过校验的文件：\n' + '\n'.join(file_errors)
+            await self._push_error(f'[channel] {channel_id} partial send: {e}')
+            return result
         except Exception as e:
             error_msg = str(e)
-            if '99991672' in error_msg or 'Permission denied' in error_msg or 'Access denied' in error_msg:
-                result = (
-                    f'Error: Permission denied when sending message.\n'
-                    f'Cause: The bot lacks "im:message:send_as_bot" permission.\n'
-                    f'Solution: Grant the permission in Feishu Developer Console, '
-                    f'then publish a new app version.'
-                )
-            elif 'not initialized' in error_msg or 'not running' in error_msg:
+            # 平台自己的报错通常已经写明缺哪个权限、给了授权链接 —— 原文透传，
+            # 不要用猜的原因盖掉它（曾经把「缺上传权限」说成「缺 im:message:send_as_bot」，
+            # LLM 就照着这句错话跟用户解释）。
+            if 'not initialized' in error_msg or 'not running' in error_msg:
                 result = (
                     f'Error: Channel adapter is not connected.\n'
                     f'Cause: The WebSocket connection may have dropped silently.\n'
                     f'Solution: Go to Settings → Channels and click Restart.'
                 )
             else:
-                result = f'Error sending reply: {error_msg}'
+                result = f'Error sending reply to {channel_id}: {error_msg}'
+            if file_errors:
+                result += '\nAlso rejected before sending:\n' + '\n'.join(file_errors)
+            print(f'[channel] send failed ({channel_id}→{chat_id}): {error_msg}')
             await self._push_error(result)
             return result
 

--- a/agent-core/src/channel/media.py
+++ b/agent-core/src/channel/media.py
@@ -1,0 +1,108 @@
+"""
+channel/media.py — 出站附件解析与校验。
+
+LLM 通过 `channel_reply(files=[{path, caption}])` 指定要发送的容器内文件。
+这里负责：
+
+1. **路径白名单**——复用 desktop 工具的 `_ALLOWED_DIRS`（`/work`、`/tmp`）。
+   没有这层校验，一句「把 /etc/shadow 发到群里」就能把机器人变成外传通道。
+2. **类别推断**——按扩展名/MIME 决定走图片、视频、音频还是普通文件接口。
+3. **大小校验**——各平台上限不同，超限时给出可读错误，让 LLM 知道该压缩或换方式。
+"""
+
+import mimetypes
+import os
+
+from channel.adapter import Attachment, KIND_AUDIO, KIND_FILE, KIND_IMAGE, KIND_VIDEO
+
+_IMAGE_EXT = {'.jpg', '.jpeg', '.png', '.gif', '.webp', '.bmp'}
+_VIDEO_EXT = {'.mp4', '.mov', '.m4v', '.avi', '.mkv', '.webm'}
+_AUDIO_EXT = {'.opus', '.mp3', '.wav', '.m4a', '.aac', '.ogg'}
+
+# 平台上限（字节）。飞书：图片 10MB、文件 30MB。
+LIMITS: dict[str, dict[str, int]] = {
+    'feishu':   {KIND_IMAGE: 10 * 1024 * 1024, '_default': 30 * 1024 * 1024},
+    'telegram': {KIND_IMAGE: 10 * 1024 * 1024, '_default': 50 * 1024 * 1024},
+    'slack':    {'_default': 1024 * 1024 * 1024},
+}
+
+
+def infer_kind(path: str, mime: str = '') -> str:
+    ext = os.path.splitext(path)[1].lower()
+    if ext in _IMAGE_EXT:
+        return KIND_IMAGE
+    if ext in _VIDEO_EXT:
+        return KIND_VIDEO
+    if ext in _AUDIO_EXT:
+        return KIND_AUDIO
+    if mime.startswith('image/'):
+        return KIND_IMAGE
+    if mime.startswith('video/'):
+        return KIND_VIDEO
+    if mime.startswith('audio/'):
+        return KIND_FILE  # 语音需要特定编码，普通音频按文件发更可靠
+    return KIND_FILE
+
+
+def limit_for(platform: str, kind: str) -> int:
+    table = LIMITS.get(platform, {'_default': 20 * 1024 * 1024})
+    return table.get(kind, table['_default'])
+
+
+def resolve_outbound(files: list, platform: str) -> tuple[list[Attachment], list[str]]:
+    """把 LLM 给的 files 参数解析为 Attachment 列表。
+
+    files 支持 `[{'path': ..., 'caption': ...}]` 或 `['/path/a.jpg', ...]`。
+    返回 (可发送的附件, 错误说明列表)——错误不抛异常，原样回报给 LLM，
+    这样它能知道「哪个文件为什么没发出去」而不是以为全部成功。
+    """
+    from event.desktop import _check_path_allowed, _resolve_path
+
+    out: list[Attachment] = []
+    errors: list[str] = []
+
+    for item in files or []:
+        if isinstance(item, str):
+            raw_path, caption = item, ''
+        elif isinstance(item, dict):
+            raw_path = item.get('path', '') or item.get('file_path', '')
+            caption = item.get('caption', '') or ''
+        else:
+            errors.append(f'Invalid file entry: {item!r} (expected path string or {{path, caption}})')
+            continue
+
+        if not raw_path:
+            errors.append('Invalid file entry: missing "path"')
+            continue
+
+        p = _resolve_path(raw_path)
+        err = _check_path_allowed(p)
+        if err:
+            errors.append(f'{raw_path}: {err}')
+            continue
+        if not p.exists():
+            errors.append(f'{p}: file not found')
+            continue
+        if not p.is_file():
+            errors.append(f'{p}: not a regular file')
+            continue
+
+        size = p.stat().st_size
+        if size == 0:
+            errors.append(f'{p}: file is empty')
+            continue
+
+        mime = mimetypes.guess_type(str(p))[0] or ''
+        kind = infer_kind(str(p), mime)
+        cap = limit_for(platform, kind)
+        if size > cap:
+            errors.append(
+                f'{p}: {size / 1e6:.1f}MB exceeds the {platform} limit for {kind} '
+                f'({cap / 1e6:.0f}MB). Compress or downscale it first.'
+            )
+            continue
+
+        out.append(Attachment(kind=kind, path=str(p), name=p.name,
+                              mime=mime, size=size, caption=caption))
+
+    return out, errors

--- a/agent-core/src/channel/store.py
+++ b/agent-core/src/channel/store.py
@@ -1,0 +1,143 @@
+"""
+channel/store.py — 入站媒体文件的持久化存储。
+
+落盘位置：`./resource/channel_files/{channel_id}/{YYYYMMDD}/{ts}_{rand}_{name}`
+`./resource` 在部署时挂载为宿主持久卷（deploy/docker-compose.yml:
+`/opt/phanthy-motus/data:/work/resource`），因此容器重建后文件仍在。
+
+给出的 `Attachment.path` 是容器内绝对路径，直接随 trigger 事件传给 LLM
+（LLM 可用 Read/Bash 访问，`/work` 在 desktop 工具白名单内）。
+
+嵌入式设备磁盘有限，`prune()` 按「保留天数 + 总字节上限」清理，启动时跑一次、
+之后每次保存后节流触发。
+"""
+
+import os
+import pathlib
+import re
+import threading
+import time
+
+from channel.adapter import Attachment
+
+# 相对 cwd（/work）；与 config.py 的 './resource/...' 约定一致
+_ROOT = pathlib.Path('./resource/channel_files')
+
+# 保留策略
+_MAX_AGE_DAYS = 14
+_MAX_TOTAL_BYTES = 2 * 1024 * 1024 * 1024   # 2 GiB
+_PRUNE_MIN_INTERVAL = 300                    # 两次 prune 最短间隔（秒）
+
+_prune_lock = threading.Lock()
+_last_prune = 0.0
+
+_UNSAFE_CHARS = re.compile(r'[^\w.\-一-鿿]+')
+
+
+def _safe_name(name: str, fallback_ext: str = '') -> str:
+    """把平台给的文件名压成安全的 basename（去目录分隔符、限长）。"""
+    name = os.path.basename(name or '').strip()
+    name = _UNSAFE_CHARS.sub('_', name).strip('._') or 'file'
+    if len(name) > 80:
+        stem, ext = os.path.splitext(name)
+        name = stem[:80 - len(ext)] + ext
+    if fallback_ext and not os.path.splitext(name)[1]:
+        name += fallback_ext
+    return name
+
+
+def dir_for(channel_id: str) -> pathlib.Path:
+    """返回某 channel 今天的落盘目录（已创建）。"""
+    day = time.strftime('%Y%m%d')
+    d = _ROOT / _safe_name(channel_id) / day
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def save_bytes(channel_id: str, data: bytes, *, kind: str, name: str = '',
+               mime: str = '', fallback_ext: str = '') -> Attachment:
+    """把入站媒体写入持久化目录，返回带绝对路径的 Attachment。"""
+    d = dir_for(channel_id)
+    fname = f'{int(time.time() * 1000)}_{os.urandom(3).hex()}_{_safe_name(name, fallback_ext)}'
+    p = (d / fname).resolve()
+    with open(p, 'wb') as f:
+        f.write(data)
+    maybe_prune()
+    return Attachment(
+        kind=kind,
+        path=str(p),
+        name=_safe_name(name, fallback_ext),
+        mime=mime,
+        size=len(data),
+    )
+
+
+def maybe_prune() -> None:
+    """节流版 prune：距上次超过 _PRUNE_MIN_INTERVAL 才真正执行。"""
+    global _last_prune
+    now = time.time()
+    with _prune_lock:
+        if now - _last_prune < _PRUNE_MIN_INTERVAL:
+            return
+        _last_prune = now
+    try:
+        prune()
+    except Exception as e:
+        print(f'[channel/store] prune failed: {e}')
+
+
+def prune(max_age_days: int = _MAX_AGE_DAYS,
+          max_total_bytes: int = _MAX_TOTAL_BYTES) -> dict:
+    """删除过期文件；若总量仍超限，按最旧优先继续删。返回统计信息。"""
+    if not _ROOT.exists():
+        return {'deleted': 0, 'freed': 0, 'remaining': 0}
+
+    files = []
+    for p in _ROOT.rglob('*'):
+        if p.is_file():
+            try:
+                st = p.stat()
+            except OSError:
+                continue
+            files.append((st.st_mtime, st.st_size, p))
+
+    deleted = freed = 0
+    cutoff = time.time() - max_age_days * 86400
+    kept = []
+    for mtime, size, p in files:
+        if mtime < cutoff:
+            try:
+                p.unlink()
+                deleted += 1
+                freed += size
+                continue
+            except OSError:
+                pass
+        kept.append((mtime, size, p))
+
+    total = sum(s for _, s, _ in kept)
+    if total > max_total_bytes:
+        kept.sort(key=lambda t: t[0])  # 最旧优先
+        for mtime, size, p in kept:
+            if total <= max_total_bytes:
+                break
+            try:
+                p.unlink()
+                deleted += 1
+                freed += size
+                total -= size
+            except OSError:
+                pass
+
+    # 清理空目录
+    for d in sorted((p for p in _ROOT.rglob('*') if p.is_dir()),
+                    key=lambda p: len(p.parts), reverse=True):
+        try:
+            d.rmdir()
+        except OSError:
+            pass
+
+    if deleted:
+        print(f'[channel/store] pruned {deleted} files, freed {freed / 1e6:.1f}MB, '
+              f'remaining {total / 1e6:.1f}MB')
+    return {'deleted': deleted, 'freed': freed, 'remaining': total}

--- a/agent-core/src/event/desktop.py
+++ b/agent-core/src/event/desktop.py
@@ -23,6 +23,11 @@ _MAX_OUTPUT = 51200  # 50 KB output cap
 
 _ALLOWED_DIRS = ['/work', '/tmp']
 
+# Read 直接返回给 LLM 的图片：超过此大小先用 ffmpeg 缩放重编码，避免 context 爆掉
+_IMAGE_EXT = {'.jpg', '.jpeg', '.png', '.gif', '.webp', '.bmp'}
+_IMAGE_INLINE_MAX = 1_500_000   # 1.5 MB
+_IMAGE_MAX_EDGE = 1280          # 缩放后最长边
+
 _BASH_BLOCKED = [
     'rm -rf /', 'rm -rf /*', 'mkfs', 'reboot', 'shutdown', 'poweroff',
     'dd if=', 'dd of=/dev',
@@ -63,6 +68,57 @@ def _truncate(text: str, max_bytes: int = _MAX_OUTPUT) -> str:
     encoded = text.encode('utf-8', errors='replace')[:max_bytes]
     truncated = encoded.decode('utf-8', errors='ignore')
     return truncated + f'\n\n... [output truncated at {max_bytes} bytes]'
+
+
+async def _read_image(p: pathlib.Path):
+    """把图片文件读成 OpenAI multi-modal 内容块。
+
+    返回值形如 [{'type':'text',...},{'type':'image_url','image_url':'data:...'}]，
+    与 mcp_client.call_tool 处理 MCP 图片结果的格式一致；event/llm.py::_trim 已能
+    处理 list 型 tool content（超出 max_images 时替换为占位符）。
+
+    大图先用 ffmpeg 缩放重编码为 JPEG（镜像内自带 ffmpeg，见 start.py::publish_image_file），
+    否则一张手机照片就能占满上下文。
+    """
+    import base64
+
+    raw = p.read_bytes()
+    mime = 'image/jpeg'
+    suffix = p.suffix.lower()
+    if suffix == '.png':
+        mime = 'image/png'
+    elif suffix == '.gif':
+        mime = 'image/gif'
+    elif suffix == '.webp':
+        mime = 'image/webp'
+    elif suffix == '.bmp':
+        mime = 'image/bmp'
+
+    note = ''
+    if len(raw) > _IMAGE_INLINE_MAX:
+        proc = await asyncio.create_subprocess_exec(
+            'ffmpeg', '-y', '-i', str(p), '-frames:v', '1',
+            '-vf', f'scale=\'min({_IMAGE_MAX_EDGE},iw)\':-2',
+            '-q:v', '4', '-f', 'mjpeg', 'pipe:1',
+            stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE,
+        )
+        try:
+            out, _err = await asyncio.wait_for(proc.communicate(), timeout=30)
+        except asyncio.TimeoutError:
+            proc.kill()
+            out = b''
+        if out:
+            note = f' (downscaled from {len(raw) / 1e6:.1f}MB for the model)'
+            raw, mime = out, 'image/jpeg'
+        else:
+            return (f'[{p} | {len(raw)} bytes] Image too large to inline and ffmpeg '
+                    f'downscaling failed. Use Bash + ffmpeg to shrink it first.')
+
+    b64 = base64.b64encode(raw).decode('ascii')
+    return [
+        {'type': 'text', 'text': f'[{p} | image | {len(raw)} bytes{note}]'},
+        {'type': 'image_url', 'image_url': f'data:{mime};base64,{b64}'},
+    ]
 
 
 # ── Tools class ──────────────────────────────────────────────────────────────────
@@ -199,7 +255,7 @@ class DesktopTools:
         offset: typing.Annotated[int, 'Line number to start reading from (1-indexed)'] = 1,
         limit: typing.Annotated[int, 'Maximum number of lines to return (default 200)'] = 200,
     ) -> str:
-        """Read file contents with line numbers. Supports reading specific line ranges for large files."""
+        """Read file contents with line numbers. Supports reading specific line ranges for large files. Images (jpg/png/gif/webp/bmp) are returned as viewable images — use this to look at photos received from messaging channels or captured by the robot."""
         p = _resolve_path(file_path)
 
         err = _check_path_allowed(p)
@@ -210,6 +266,10 @@ class DesktopTools:
             return f'Error: file not found: {p}'
         if not p.is_file():
             return f'Error: not a file: {p}'
+
+        # 图片 → 多模态内容（与 mcp_client 的图片返回格式一致，LLM 可直接“看到”）
+        if p.suffix.lower() in _IMAGE_EXT:
+            return await _read_image(p)
 
         # Check if binary
         try:

--- a/agent-core/src/mcp_client.py
+++ b/agent-core/src/mcp_client.py
@@ -545,20 +545,16 @@ async def _dispatch_internal(mcp_id: str, tool_name: str, args: dict) -> str:
     if tool_name == 'channel_reply':
         action = args.get('action', '')
         if action == 'send':
-            text = args.get('text', '')
-            if not text:
-                return 'Error: "text" field is required.'
+            text = args.get('text', '') or ''
+            files = args.get('files', []) or []
+            if not text and not files:
+                return 'Error: provide "text" and/or "files".'
             from channel.manager import manager as channel_mgr
-            channels_with_context = list(channel_mgr._get_last_context().keys())
-            if not channels_with_context:
-                return (
-                    'Error: No active conversation context. '
-                    'A user must send a message to the bot first before it can reply. '
-                    'Ask the user to send a message in Feishu/Telegram/Slack.'
-                )
-            channel_id = channels_with_context[-1]
-            return await channel_mgr.send_to_channel(channel_id, text)
-        return f'Error: Unknown action "{action}". Use action="send" with a "text" field.'
+            # instance_id 由 llm.py 从画布绑定注入（_bound_instance_ids），
+            # 用它解析卡片上选的 channel —— 卡片配置必须真正决定回复去向
+            return await channel_mgr.send_reply(
+                instance_id=args.get('instance_id', ''), text=text, files=files)
+        return f'Error: Unknown action "{action}". Use action="send" with "text" and/or "files".'
 
     # Default: return info for other internal tools
     return json.dumps({'status': 'ok', 'tool': tool_name})

--- a/agent-core/src/start.py
+++ b/agent-core/src/start.py
@@ -227,14 +227,28 @@ def _register_core_mcp(silent=False):
             {
                 'name': 'channel_reply',
                 'type': 'actuator',
-                'description': 'Reply to a message from a messaging platform (Feishu/Telegram/Slack). ONLY use this tool when the triggering event has channel="channel:*". Never use for local_mic/remote_mic/remote_web events — those should be answered via TTS/speaker on the robot body.',
+                'description': 'Reply to a message from a messaging platform (Feishu/Telegram/Slack). Can send text and/or files (images, videos, documents). ONLY use this tool when the triggering event has channel="channel:*". Never use for local_mic/remote_mic/remote_web events — those should be answered via TTS/speaker on the robot body.',
                 'inputSchema': {
                     'type': 'object',
                     'properties': {
                         'action': {'type': 'string', 'enum': ['send'], 'description': 'Action'},
                         'text': {'type': 'string', 'description': 'Reply text to send to the user'},
+                        'files': {
+                            'type': 'array',
+                            'description': ('Optional files to send. Each item is {"path": "<absolute path inside the container>", '
+                                            '"caption": "<optional>"}. Paths must be under /work or /tmp (e.g. camera snapshots '
+                                            'or files received earlier at /work/resource/channel_files/...). Images ≤10MB, other files ≤30MB on Feishu.'),
+                            'items': {
+                                'type': 'object',
+                                'properties': {
+                                    'path': {'type': 'string', 'description': 'Absolute path of the file to send'},
+                                    'caption': {'type': 'string', 'description': 'Optional caption sent with the file'},
+                                },
+                                'required': ['path'],
+                            },
+                        },
                     },
-                    'required': ['action', 'text'],
+                    'required': ['action'],
                 },
                 'configSchema': {
                     'type': 'object',

--- a/agent-core/src/subagent/agent.py
+++ b/agent-core/src/subagent/agent.py
@@ -475,6 +475,13 @@ class Subagent:
             try:
                 fn = _event_instance._sys_tools[name]['object']
                 result = await fn(**args)
+                if isinstance(result, list):
+                    # 多模态结果（如 Read 读图片）——子代理的消息装配是纯文本的，
+                    # 直接 str() 会把整段 base64 塞进上下文，只保留文字部分
+                    texts = [p.get('text', '') for p in result
+                             if isinstance(p, dict) and p.get('type') == 'text']
+                    return ('\n'.join(t for t in texts if t) +
+                            '\n(图片内容无法在子代理中查看，请把该路径交给主代理处理)')
                 result_str = str(result) if result else '(no output)'
                 # 截断大结果（WebSearch/WebFetch 等可能返回 6K+ chars）
                 _MAX_TOOL_RESULT = 2500

--- a/agent-core/web/css/style.css
+++ b/agent-core/web/css/style.css
@@ -6203,6 +6203,14 @@ html, body {
   background: rgba(239, 68, 68, 0.1);
   color: #ef4444;
 }
+.channel-item-error {
+  margin-top: 6px;
+  font-size: 0.7rem;
+  line-height: 1.4;
+  color: #ef4444;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
 .channel-item-actions {
   display: flex;
   gap: 6px;

--- a/agent-core/web/js/channels.js
+++ b/agent-core/web/js/channels.js
@@ -55,8 +55,10 @@ function _renderChannels(channels) {
         <span class="channel-item-icon">${_platformIcon(ch.platform)}</span>
         <span class="channel-item-name">${_esc(ch.id)}</span>
         <span class="channel-item-platform">${_esc(ch.platform)}</span>
-        <span class="channel-item-status ${ch.status === 'connected' ? 'online' : 'offline'}">${_esc(ch.status)}</span>
+        <span class="channel-item-status ${ch.status === 'connected' ? 'online' : 'offline'}"
+              title="${_esc(ch.health_error || '')}">${_esc(ch.status)}</span>
       </div>
+      ${ch.health_error ? `<div class="channel-item-error">${_esc(ch.health_error)}</div>` : ''}
       <div class="channel-item-actions">
         <button class="btn-ghost btn-sm" onclick="window._channelStop('${_esc(ch.id)}')">Stop</button>
         <button class="btn-ghost btn-sm" onclick="window._channelRestart('${_esc(ch.id)}')">Restart</button>


### PR DESCRIPTION
## 背景

飞书两张画布卡片（`channel_request` 输入 / `channel_reply` 输出）此前无论如何都「启动成功」，且只能收发纯文本。本 PR 修三个真实缺陷并打通图片/视频/文件双向收发。

## 1. 连接状态是假的 → 启动自检形同虚设

`ChannelAdapter.status()` 只看 `_running`，而 `FeishuAdapter.start()` 起了 SDK 线程就置 True——凭据错误、网络不通、WS 静默断开，一律显示 `connected`。于是：

- `channel_request` 自检等 `status() == 'connected'`，恒真；
- `channel_reply` 自检写作 `result = await send_to_channel_any(...)` + `if result:`，而该函数**失败时也返回字符串**（`'Error: No conversation context…'`），所以永远「通过」；顺带还给用户发一句「我上线啦！」当探针；
- `_do_start_project()` 里「重连断开的 adapter」放在所有卡片启动**之后** —— adapter 掉线时自检先失败触发整体回滚，那段自愈代码永远执行不到。

修复：
- `start()` 在起线程前换 tenant token + 探测 API，失败直接抛（重试与 `error` 状态才有意义，前端「验证中…」才名副其实）
- `health_check()` = WS 线程存活 **且** 15s 缓存的 API 探测通过；`status()` 新增 `degraded`
- 新增 30s watchdog，不健康则指数退避重连（30s→300s），状态变化播报一次
- ensure-connected 前移到卡片启动之前；两个自检改为静默探测，并区分报错原因（未选 channel / channel 已删除 / 未连接）

## 2. 输出卡片选的 channel 不起作用

两条 dispatch 路径都用 `send_to_channel_any()` 猜目标，忽略卡片实例配置；且 `list(ctx.keys())[-1]` 读的是插入顺序而非「最近」（dict 就地更新不改顺序）。

新增 `resolve_target_channel(instance_id)`：**卡片配置的 channel → 最近会话（按 ts）**，`mcp_client._dispatch_internal` 与 `mcp_manage` 统一走 `send_reply()`。

## 3. 图片 / 视频 / 文件收发（飞书 + Telegram + Slack）

- **入站**：下载后落盘 `resource/channel_files/{channel}/{日期}/`（宿主持久卷），事件 JSON 带容器内本地路径（另加 `channel_id`/`message_id`）；`Read()` 读图片返回多模态内容（>1.5MB 先用 ffmpeg 缩到 1280px），LLM 可以真正看图
- **出站**：`channel_reply(files=[{path, caption}])`，经 `channel/media.py` 做**路径白名单**（复用 desktop 工具的 `/work`、`/tmp`——否则「把 /etc/shadow 发到群里」是可行的）+ 按平台大小上限；被拒的文件逐条回报，不当作发送成功
- 飞书 REST 改走 aiohttp 直连（SDK 只用于 WS 事件流），每个 adapter 独立 event loop——原先共用 SDK 模块级 `ws_mod.loop`，第二个飞书 channel 启动会覆盖它，停第一个就停错 loop

## 其它

- 飞书 `message_id` LRU 去重（重投递不再触发两次）、>3500 字文本自动分片
- Settings 里的 Stop 现在持久化 `enabled=false`（否则 watchdog 30s 后又拉起来），Restart 置回 true
- 未激活 channel 丢弃消息时记一行日志（原先完全静默，无法排查）
- 删除死代码 `route_reply()`（无调用方，且读的 payload key 从未被写入）
- `inspection.py` perf-span 处理里重复的 `if row:` 越出了 `else` 分支：凡是带 `trace_id` 的 span 都会 NameError 落进 `except: pass`，perception 的 TTS span 被静默丢弃

## 部署要求

飞书应用需新增 **`im:resource`** 权限并发布新版本（上传/下载图片与文件必需）。

## 验证

本地（无 ROS2）：全部文件编译通过；用 mock 跑通飞书发送序列（text→image→media→file）、入站 image/file/media/post 解析与落盘、去重、分片、路由优先级、白名单与超限拒绝、以及自检五个分支（未选 channel / 健康 / 不健康 8s 超时 / channel 已删除 / send 缺参数）。

真机（G1/Go2）待验收：
1. 卡片不选 channel → 启动控制必须报错回滚；app_secret 改错 → 状态 `error` 且被拦住；Stop 后点启动控制 → 自动拉起并通过；启动过程中不再有「我上线啦！」
2. 断网 30s → 日志出现 unhealthy + 重连，`/api/channel/list` 状态跟随，恢复后自动 `connected`
3. 两个 channel + 两张输出卡片各选其一 → 回复回到正确的会话
4. 飞书发图片/视频/pdf → `ls /opt/phanthy-motus/data/channel_files/...` 有文件、事件里有 path、"描述这张图片" 能正确描述；让它发 `/etc/hosts` → 被白名单拒绝并说明原因

🤖 Generated with [Claude Code](https://claude.com/claude-code)