### PR TITLE
feat(solutions): 解决方案打包 / 载入 / 市场

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -161,6 +161,21 @@ All runtime configuration is managed through the Web UI and persisted to SQLite 
 3. Ensure code runs locally
 4. Submit a PR with a clear description
 
+### Review Checklist
+
+- [ ] **Sensitive config fields are declared.** Any perception/actucore plugin
+      `configSchema` property holding a credential, token or private endpoint
+      declares `"format": "password"` or `"x-sensitive": true`. Canvas config gets
+      packaged into shareable Solutions and uploaded to the Resource Center, and
+      packaging only blanks declared fields — an unmarked secret is published in
+      clear text. Spec: `phanthymotus-driver/README_dev.md` § "Marking sensitive fields".
+- [ ] Plugins holding per-instance state follow the concurrency rules in
+      [perception/README.md](perception/README.md) (`tools/call` runs per-thread;
+      `stop` must be able to cancel a concurrent `start`; `destroy_node()` on stop)
+- [ ] Actuator paths keep the confirmation/safety behaviour intact
+- [ ] New API routes are registered in `agent-core/src/start.py` and, if they must
+      skip auth, listed in `agent-core/src/auth.py`
+
 ## Code Style
 
 - Python: Follow PEP 8, use type hints where practical

--- a/README.md
+++ b/README.md
@@ -131,6 +131,32 @@ A community-driven Skill Marketplace where users share and discover skills. Brow
 
 ![Skills](docs/images/skills.png)
 
+### Solutions — Package & Load a Whole Setup
+
+Open **Solutions** from the top-left of the dashboard. A solution bundles everything
+that makes one robot work — canvas topology and per-card config, active skills,
+prompt files, and tasks — into one shareable package on the Resource Center
+marketplace.
+
+- **Save**: pick which blocks to package. The canvas is mandatory; skills, each of
+  the three prompt files, and tasks are optional. Only skills that are already
+  published on the Skill Marketplace can be packaged, so recipients can actually
+  install them.
+- **Load**: Agent Core first checks that every required driver / perception /
+  actucore image is installed (offering one-click install for images already in
+  the local catalog), then lists exactly what will be overwritten before applying.
+- **Align versions** (optional): tick it and each involved container is redeployed
+  at the image tag recorded in the package before the solution is applied — only
+  the tag is taken, the local registry is kept. Agent Core itself is never
+  auto-aligned, since restarting it would abort the load; the dashboard shows the
+  recorded core version so you can upgrade manually if needed.
+- **Secrets stay home**: fields a tool declares sensitive (`format: password` or
+  `x-sensitive: true` in its `configSchema`) are blanked during packaging and
+  reported to the loading user as "needs configuration".
+
+Cards reference devices by MCP `server_name`, not by the machine-local
+`mcp-<timestamp>` id, so a package loads onto a different robot of the same model.
+
 ### Service Deployment
 
 Deploy and manage Agent Core and hardware driver containers from the dashboard.
@@ -240,6 +266,7 @@ on the host — schedule it rather than doing it mid-session.
 The platform can optionally connect to a [Resource Center](https://motus.phanthy.com) for:
 - Browsing and deploying pre-built driver/perception images
 - Managing skills and extensions
+- Publishing and installing solutions (canvas + skills + prompt + tasks bundles)
 - OTA updates
 
 Configure via the `RESOURCE_CENTER_URL` environment variable.

--- a/agent-core/src/api/account.py
+++ b/agent-core/src/api/account.py
@@ -1,0 +1,146 @@
+"""
+api/account.py — Resource Center 账号（登录 / 注册 / 当前身份）。
+
+仪表盘的「我的」界面只跟这里打交道。账号态本身存在浏览器 localStorage 的
+`rc_token` 里（bearer token），Agent Core 不持久化任何用户凭据 —— 它只是代理，
+避免浏览器直连 Resource Center 时的跨域与自签证书问题。
+
+为什么需要 /session：登录时只拿到一个 token，要显示"我是谁"、以及判断 token
+是否已经过期，都得回问 Resource Center。没有这个校验的话，一个过期 token 会让下游每个需要
+登录的操作各自回一句 Unauthorized，用户根本不知道该去哪重新登录。
+"""
+
+import fastapi
+from pydantic import BaseModel
+from typing import Optional
+
+router = fastapi.APIRouter(prefix='/account', tags=['account'])
+
+
+# ── Resource Center 交互 ─────────────────────────────────────────────────────────────────
+
+def _rc_token(request: fastapi.Request) -> Optional[str]:
+    """与技能 / 解决方案一致的 X-RC-Token 头。"""
+    return request.headers.get('x-rc-token')
+
+
+async def _rc(method: str, path: str, token: Optional[str] = None,
+              json_body=None, timeout: float = 15) -> dict:
+    """复用 api/solutions.py 的 Resource Center 请求封装，不再写第二份。"""
+    from api.solutions import _rc_request
+    return await _rc_request(method, path, token, json_body, timeout)
+
+
+# Resource Center 的 401 响应体是 `{"ok":false,"error":"Unauthorized"}`。原样透给前端的话，
+# 用户看到的就是一个英文单词，既不知道发生了什么也不知道去哪登录。
+_UNAUTHORIZED_TEXTS = ('unauthorized', 'not authenticated', 'invalid token')
+UNAUTHORIZED_MESSAGE = '未登录或登录已过期，请在「我的」中登录'
+
+
+def normalize_rc_error(status: int, error: str) -> str:
+    """把 Resource Center 的鉴权类报错换成能指向下一步动作的中文。"""
+    if status == 401 or (error or '').strip().lower() in _UNAUTHORIZED_TEXTS:
+        return UNAUTHORIZED_MESSAGE
+    return error or '请求失败'
+
+
+# ── 端点 ────────────────────────────────────────────────────────────────────
+
+class LoginRequest(BaseModel):
+    identifier: str = ''
+    password:   str = ''
+
+
+@router.post('/login')
+async def login(req: LoginRequest):
+    """登录 Resource Center，返回 bearer token 与身份。"""
+    identifier = req.identifier.strip()
+    if not identifier or not req.password:
+        return {'code': 422, 'error': '请输入账号和密码'}
+
+    result = await _rc('POST', '/api/auth/login', None,
+                       {'identifier': identifier, 'password': req.password})
+    if not result['ok']:
+        # 登录接口的 401 是"账号或密码错误"，不是"登录已过期"，别套用通用文案
+        error = result['error']
+        if result['status'] == 401:
+            error = '账号或密码错误'
+        return {'code': result['status'], 'error': error}
+
+    # 登录响应把结果放在顶层：{ok, role, token, userId}
+    data = result.get('payload') or {}
+    return {'code': 200, 'data': {
+        'token':  data.get('token', ''),
+        'userId': data.get('userId', ''),
+        'role':   data.get('role', ''),
+    }}
+
+
+class RegisterRequest(BaseModel):
+    identifier: str = ''
+    password:   str = ''
+    name:       str = ''
+
+
+@router.post('/register')
+async def register(req: RegisterRequest):
+    """注册 Resource Center 账号，成功后直接登录换取 token。
+
+    Resource Center 的注册接口只种 cookie、不发 token（`app/api/auth/register/route.ts`），
+    而仪表盘是跨域调用、拿不到那个 cookie，所以注册成功后必须再走一次登录。
+    """
+    identifier = req.identifier.strip()
+    if not identifier or not req.password:
+        return {'code': 422, 'error': '请输入账号和密码'}
+    if len(req.password) < 8:
+        return {'code': 422, 'error': '密码至少 8 位'}
+
+    body = {'identifier': identifier, 'password': req.password}
+    if req.name.strip():
+        body['name'] = req.name.strip()
+
+    result = await _rc('POST', '/api/auth/register', None, body)
+    if not result['ok']:
+        error = result['error']
+        if result['status'] == 409:
+            error = '该账号已注册，请直接登录'
+        return {'code': result['status'], 'error': error}
+
+    return await login(LoginRequest(identifier=identifier, password=req.password))
+
+
+@router.get('/session')
+async def session(request: fastapi.Request):
+    """用浏览器存的 token 问 Resource Center "我是谁"。
+
+    三种结果要分开，否则会误伤：
+      200 + user   → 身份有效
+      401          → token 真的失效了，前端应该清掉
+      其它（含 200 但 ok=false）→ 无法确认。老版本 Resource Center 的 /api/auth/session 只认
+        cookie、不认 Bearer，对 token 一律回 `{ok:false,user:null}`；要是把这种
+        情况也当成失效，仪表盘在 Resource Center 升级前就永远登不上了。回 503 让前端保留
+        token、退化用登录时拿到的身份显示。
+    """
+    token = _rc_token(request)
+    if not token:
+        return {'code': 401, 'error': '未登录'}
+
+    result = await _rc('GET', '/api/auth/session', token)
+    if not result['ok']:
+        if result['status'] == 401:
+            return {'code': 401, 'error': UNAUTHORIZED_MESSAGE}
+        return {'code': 503,
+                'error': f'无法确认登录状态（Resource Center 返回 {result["status"]}）'}
+
+    # session 响应把身份放在顶层的 user 里：{ok, user:{id, role, name, email}}
+    user = (result.get('payload') or {}).get('user') or {}
+    if not user.get('id'):
+        return {'code': 503, 'error': '无法确认登录状态：Resource Center 未返回身份'}
+    return {'code': 200, 'data': user}
+
+
+@router.get('/rc-url')
+async def rc_url():
+    """当前连的 Resource Center 地址（前端用来给"去网页版注册/管理"的链接）。"""
+    from api.skills import _get_rc_url
+    return {'code': 200, 'data': {'url': _get_rc_url()}}

--- a/agent-core/src/api/canvas.py
+++ b/agent-core/src/api/canvas.py
@@ -35,6 +35,55 @@ def _check_editor_expired():
         _editor_last_seen = 0.0
 
 
+def current_editor() -> Optional[str]:
+    """Session id currently holding the edit lock, or None.
+
+    Used by api/solutions.py: applying a solution rewrites canvas_layout behind
+    the lock's back, so it has to refuse while someone is editing — their next
+    autosave would otherwise clobber the freshly loaded layout.
+    """
+    _check_editor_expired()
+    return _editor_session
+
+
+def apply_tool_config(mcp_id: str, tool_name: str, body: Any,
+                      instance_id: str = '') -> None:
+    """Push a saved config down to the MCP plugin (fire-and-forget).
+
+    Shared by the tool-config endpoints below and by api/solutions.py when a
+    solution is applied, so both paths send the exact same `action: config`
+    call shape.
+    """
+    from api.mcp_manage import mcp_call_tool, MCPCallRequest
+
+    args = dict(body) if isinstance(body, dict) else {}
+    if instance_id:
+        args['instance_id'] = instance_id
+
+    async def _apply():
+        try:
+            req = MCPCallRequest(tool=tool_name, arguments={'action': 'config', **args})
+            await mcp_call_tool(mcp_id, req)
+        except Exception:
+            pass
+
+    try:
+        asyncio.create_task(_apply())
+    except RuntimeError:
+        # No running loop (called from a sync context outside a request). The
+        # config row is already persisted, and mcp_manage._restore_saved_configs
+        # re-sends it when the device next comes online — so skipping the live
+        # push here degrades timing, not correctness.
+        pass
+
+
+def tool_config_key(mcp_id: str, tool_name: str, instance_id: str = '') -> str:
+    """ConfigDB key for a tool config row."""
+    key = f'{_TOOL_CONFIG_PREFIX}{mcp_id}:{tool_name}'
+    return f'{key}:{instance_id}' if instance_id else key
+
+
+
 class CanvasLayout(BaseModel):
     cards:           list  = []
     connections:     list  = []
@@ -119,13 +168,12 @@ async def save_layout(layout: CanvasLayout):
 @router.get('/tool-config/{mcp_id}/{tool_name}')
 async def get_tool_config(mcp_id: str, tool_name: str):
     """Get saved config for a tool."""
-    data = config.main.get(f'{_TOOL_CONFIG_PREFIX}{mcp_id}:{tool_name}', None)
+    data = config.main.get(tool_config_key(mcp_id, tool_name), None)
     return {'code': 200, 'data': data}
 
 
-@router.get('/tool-configs')
-async def get_all_tool_configs():
-    """Batch-get all tool configs."""
+def all_tool_configs() -> dict:
+    """Every saved tool config, keyed by "mcp_id:tool_name[:instance_id]"."""
     result = {}
     try:
         conn = config._get_conn()
@@ -138,24 +186,38 @@ async def get_all_tool_configs():
             result[tool_key] = json.loads(value)
     except Exception:
         pass
-    return {'code': 200, 'data': result}
+    return result
+
+
+def delete_all_tool_configs() -> int:
+    """Drop every saved tool config. Returns the number of rows removed.
+
+    Only used when a solution replaces the whole canvas: the incoming cards
+    bring their own configs, and leftovers would keep pushing stale settings
+    (old topics, old device paths) to plugins that the new canvas reuses.
+    """
+    try:
+        conn = config._get_conn()
+        cur = conn.execute("DELETE FROM config WHERE key LIKE ?",
+                           (f'{_TOOL_CONFIG_PREFIX}%',))
+        conn.commit()
+        return cur.rowcount or 0
+    except Exception:
+        return 0
+
+
+@router.get('/tool-configs')
+async def get_all_tool_configs():
+    """Batch-get all tool configs."""
+    return {'code': 200, 'data': all_tool_configs()}
+
 
 
 @router.put('/tool-config/{mcp_id}/{tool_name}')
 async def save_tool_config(mcp_id: str, tool_name: str, body: Any = fastapi.Body(...)):
     """Save config for a tool and apply it to the MCP plugin."""
-    config.main[f'{_TOOL_CONFIG_PREFIX}{mcp_id}:{tool_name}'] = body
-
-    # Apply config to the MCP plugin (fire-and-forget, don't block response)
-    from api.mcp_manage import mcp_call_tool, MCPCallRequest
-    async def _apply():
-        try:
-            req = MCPCallRequest(tool=tool_name, arguments={'action': 'config', **body})
-            await mcp_call_tool(mcp_id, req)
-        except Exception:
-            pass
-    asyncio.create_task(_apply())
-
+    config.main[tool_config_key(mcp_id, tool_name)] = body
+    apply_tool_config(mcp_id, tool_name, body)
     return {'code': 200}
 
 
@@ -165,7 +227,7 @@ async def delete_tool_config(mcp_id: str, tool_name: str):
     try:
         conn = config._get_conn()
         conn.execute("DELETE FROM config WHERE key = ?",
-                     (f'{_TOOL_CONFIG_PREFIX}{mcp_id}:{tool_name}',))
+                     (tool_config_key(mcp_id, tool_name),))
         conn.commit()
     except Exception:
         pass
@@ -177,24 +239,15 @@ async def delete_tool_config(mcp_id: str, tool_name: str):
 @router.get('/tool-config/{mcp_id}/{tool_name}/{instance_id}')
 async def get_instance_config(mcp_id: str, tool_name: str, instance_id: str):
     """Get saved config for a specific tool instance."""
-    data = config.main.get(f'{_TOOL_CONFIG_PREFIX}{mcp_id}:{tool_name}:{instance_id}', None)
+    data = config.main.get(tool_config_key(mcp_id, tool_name, instance_id), None)
     return {'code': 200, 'data': data}
 
 
 @router.put('/tool-config/{mcp_id}/{tool_name}/{instance_id}')
 async def save_instance_config(mcp_id: str, tool_name: str, instance_id: str, body: Any = fastapi.Body(...)):
     """Save config for a specific tool instance and apply it."""
-    config.main[f'{_TOOL_CONFIG_PREFIX}{mcp_id}:{tool_name}:{instance_id}'] = body
-
-    # Apply instance config to the MCP plugin (fire-and-forget)
-    from api.mcp_manage import mcp_call_tool, MCPCallRequest
-    async def _apply():
-        try:
-            req = MCPCallRequest(tool=tool_name, arguments={'action': 'config', 'instance_id': instance_id, **body})
-            await mcp_call_tool(mcp_id, req)
-        except Exception:
-            pass
-    asyncio.create_task(_apply())
+    config.main[tool_config_key(mcp_id, tool_name, instance_id)] = body
+    apply_tool_config(mcp_id, tool_name, body, instance_id)
     return {'code': 200}
 
 
@@ -204,7 +257,7 @@ async def delete_instance_config(mcp_id: str, tool_name: str, instance_id: str):
     try:
         conn = config._get_conn()
         conn.execute("DELETE FROM config WHERE key = ?",
-                     (f'{_TOOL_CONFIG_PREFIX}{mcp_id}:{tool_name}:{instance_id}',))
+                     (tool_config_key(mcp_id, tool_name, instance_id),))
         conn.commit()
     except Exception:
         pass

--- a/agent-core/src/api/drivers.py
+++ b/agent-core/src/api/drivers.py
@@ -397,6 +397,14 @@ def _upsert_from_catalog(manifest: list, catalog: dict) -> tuple[int, int]:
             # Also sync port from registry catalog for hardware drivers
             if item.get('port') and not existing.get('port'):
                 existing['port'] = item['port']
+            # Backfill provider/model on manifests written before these were stored.
+            # The id alone can't be split back apart ('x-humanoid-tianyi2.0' — the
+            # provider itself contains a hyphen), and 适用机型 is derived from model.
+            if category == 'driver':
+                if item.get('provider'):
+                    existing['provider'] = item['provider']
+                if item.get('model'):
+                    existing['model'] = item['model']
             updated += 1
         else:
             # Build human-readable name
@@ -414,6 +422,9 @@ def _upsert_from_catalog(manifest: list, catalog: dict) -> tuple[int, int]:
                 'description':    '',
                 **_SERVICE_ENDPOINTS.get(image_name, {}),
             }
+            if category == 'driver':
+                new_entry['provider'] = item.get('provider', '')
+                new_entry['model'] = item.get('model', '')
             # Preserve port from registry catalog for hardware drivers (used to derive mcp_url)
             if item.get('port') and 'port' not in new_entry:
                 new_entry['port'] = item['port']

--- a/agent-core/src/api/skills.py
+++ b/agent-core/src/api/skills.py
@@ -65,7 +65,7 @@ async def fetch_rc_skill(slug: str, rc_token: str | None = None) -> dict:
 
 
 async def install_from_rc(slug: str, rc_token: str | None = None) -> dict:
-    """安装一个 RC 技能到本地 ConfigDB。
+    """安装一个 Resource Center 技能到本地 ConfigDB。
 
     返回 {'ok': True, 'data': {...}} / {'ok': False, 'error': ...}。
     已安装时视为成功并回 already=True —— 载入解决方案时会批量调用，
@@ -140,7 +140,7 @@ async def install_skill(request: fastapi.Request, body: dict = fastapi.Body(...)
     if any(s['slug'] == slug for s in installed):
         return {'code': 409, 'error': f'技能 "{slug}" 已安装'}
 
-    # 传递 RC token 以允许作者安装自己的未发布技能
+    # 传递 Resource Center token 以允许作者安装自己的未发布技能
     result = await install_from_rc(slug, request.headers.get('x-rc-token'))
     if not result.get('ok'):
         return {'code': 404, 'error': result.get('error', '安装失败')}
@@ -288,40 +288,33 @@ async def deactivate(body: dict = fastapi.Body(...)):
 # ── Resource Center proxy endpoints ─────────────────────────────────────────
 
 def _get_rc_token(request: fastapi.Request) -> str | None:
-    """从请求头 X-RC-Token 中获取 RC bearer token。"""
+    """从请求头 X-RC-Token 中获取 Resource Center bearer token。"""
     return request.headers.get('x-rc-token')
+
+
+def _rc_error(status: int, error: str) -> str:
+    """Resource Center 报错中文化。鉴权类的原文是 Unauthorized，用户看不懂。"""
+    from api.account import normalize_rc_error
+    return normalize_rc_error(status, error)
 
 
 @router.post('/rc/login')
 async def rc_login(body: dict = fastapi.Body(...)):
-    """代理登录 Resource Center，返回 bearer token。"""
-    rc_url = _get_rc_url()
-    identifier = body.get('identifier', '').strip()
-    password = body.get('password', '')
-    if not identifier or not password:
-        return {'code': 422, 'error': '请输入账号和密码'}
+    """代理登录 Resource Center，返回 bearer token。
 
-    try:
-        import httpx
-        async with httpx.AsyncClient(timeout=10) as http:
-            resp = await http.post(f'{rc_url}/api/auth/login', json={
-                'identifier': identifier, 'password': password
-            })
-            data = resp.json()
-            if resp.status_code == 200 and data.get('ok'):
-                return {'code': 200, 'data': {
-                    'token': data['token'],
-                    'userId': data.get('userId'),
-                    'role': data.get('role'),
-                }}
-            return {'code': resp.status_code, 'error': data.get('error', '登录失败')}
-    except Exception as e:
-        return {'code': 502, 'error': f'无法连接 Resource Center: {e}'}
+    实现在 api/account.py —— 这里保留端点是为了兼容仍在调用它的前端代码，
+    新代码请直接用 /api/account/login。
+    """
+    from api.account import login as account_login, LoginRequest
+    return await account_login(LoginRequest(
+        identifier=body.get('identifier', ''),
+        password=body.get('password', ''),
+    ))
 
 
 @router.get('/rc/mine')
 async def rc_my_skills(request: fastapi.Request):
-    """代理获取用户在 RC 上的技能列表。"""
+    """代理获取用户在 Resource Center 上的技能列表。"""
     token = _get_rc_token(request)
     if not token:
         return {'code': 401, 'error': '未登录 Resource Center'}
@@ -336,14 +329,15 @@ async def rc_my_skills(request: fastapi.Request):
             data = resp.json()
             if resp.status_code == 200:
                 return {'code': 200, 'data': data.get('data', [])}
-            return {'code': resp.status_code, 'error': data.get('error', '获取失败')}
+            return {'code': resp.status_code,
+                    'error': _rc_error(resp.status_code, data.get('error', '获取失败'))}
     except Exception as e:
         return {'code': 502, 'error': f'无法连接 Resource Center: {e}'}
 
 
 @router.post('/rc/mine')
 async def rc_create_skill(request: fastapi.Request, body: dict = fastapi.Body(...)):
-    """代理在 RC 上创建/更新技能。"""
+    """代理在 Resource Center 上创建/更新技能。"""
     token = _get_rc_token(request)
     if not token:
         return {'code': 401, 'error': '未登录 Resource Center'}
@@ -359,14 +353,15 @@ async def rc_create_skill(request: fastapi.Request, body: dict = fastapi.Body(..
             data = resp.json()
             if resp.status_code == 200 and data.get('ok'):
                 return {'code': 200, 'data': data.get('data')}
-            return {'code': resp.status_code, 'error': data.get('error', '操作失败')}
+            return {'code': resp.status_code,
+                    'error': _rc_error(resp.status_code, data.get('error', '操作失败'))}
     except Exception as e:
         return {'code': 502, 'error': f'无法连接 Resource Center: {e}'}
 
 
 @router.put('/rc/mine/{skill_id}')
 async def rc_update_skill(skill_id: str, request: fastapi.Request, body: dict = fastapi.Body(...)):
-    """代理更新 RC 上的技能。"""
+    """代理更新 Resource Center 上的技能。"""
     token = _get_rc_token(request)
     if not token:
         return {'code': 401, 'error': '未登录 Resource Center'}
@@ -382,14 +377,15 @@ async def rc_update_skill(skill_id: str, request: fastapi.Request, body: dict = 
             data = resp.json()
             if resp.status_code == 200 and data.get('ok'):
                 return {'code': 200, 'data': data.get('data')}
-            return {'code': resp.status_code, 'error': data.get('error', '更新失败')}
+            return {'code': resp.status_code,
+                    'error': _rc_error(resp.status_code, data.get('error', '更新失败'))}
     except Exception as e:
         return {'code': 502, 'error': f'无法连接 Resource Center: {e}'}
 
 
 @router.delete('/rc/mine/{skill_id}')
 async def rc_delete_skill(skill_id: str, request: fastapi.Request):
-    """代理删除 RC 上的技能。"""
+    """代理删除 Resource Center 上的技能。"""
     token = _get_rc_token(request)
     if not token:
         return {'code': 401, 'error': '未登录 Resource Center'}
@@ -404,7 +400,8 @@ async def rc_delete_skill(skill_id: str, request: fastapi.Request):
             data = resp.json()
             if resp.status_code == 200 and data.get('ok'):
                 return {'code': 200, 'data': {'id': skill_id}}
-            return {'code': resp.status_code, 'error': data.get('error', '删除失败')}
+            return {'code': resp.status_code,
+                    'error': _rc_error(resp.status_code, data.get('error', '删除失败'))}
     except Exception as e:
         return {'code': 502, 'error': f'无法连接 Resource Center: {e}'}
 
@@ -426,6 +423,7 @@ async def rc_submit_skill(skill_id: str, request: fastapi.Request):
             data = resp.json()
             if resp.status_code == 200 and data.get('ok'):
                 return {'code': 200, 'data': data.get('data')}
-            return {'code': resp.status_code, 'error': data.get('error', '提交失败')}
+            return {'code': resp.status_code,
+                    'error': _rc_error(resp.status_code, data.get('error', '提交失败'))}
     except Exception as e:
         return {'code': 502, 'error': f'无法连接 Resource Center: {e}'}

--- a/agent-core/src/api/skills.py
+++ b/agent-core/src/api/skills.py
@@ -25,6 +25,86 @@ def _get_rc_url() -> str:
     return 'https://motus.phanthy.com'
 
 
+async def fetch_rc_skill(slug: str, rc_token: str | None = None) -> dict:
+    """从 Resource Center 拉取技能定义。
+
+    返回 {'ok': True, 'data': {...}} 或 {'ok': False, 'error': '...'}。
+    rc_token 用于让作者取到自己尚未上架的技能。
+    """
+    rc_url = _get_rc_url()
+    headers = {}
+    if rc_token:
+        headers['Authorization'] = f'Bearer {rc_token}'
+    try:
+        import httpx
+        async with httpx.AsyncClient(timeout=10) as http:
+            resp = await http.get(f'{rc_url}/api/skills/{slug}', headers=headers)
+            if resp.status_code != 200:
+                return {'ok': False,
+                        'error': f'技能 "{slug}" 未在 Resource Center 找到 (HTTP {resp.status_code})'}
+            data = resp.json()
+            if not data.get('ok'):
+                return {'ok': False, 'error': data.get('error', '获取失败')}
+            return {'ok': True, 'data': data['data']}
+    except ImportError:
+        # httpx 未安装时 fallback 到 urllib
+        import urllib.request, json as _json
+        try:
+            req = urllib.request.Request(f'{rc_url}/api/skills/{slug}')
+            for k, v in headers.items():
+                req.add_header(k, v)
+            with urllib.request.urlopen(req, timeout=10) as resp:
+                data = _json.loads(resp.read())
+                if not data.get('ok'):
+                    return {'ok': False, 'error': data.get('error', '获取失败')}
+                return {'ok': True, 'data': data['data']}
+        except Exception as e:
+            return {'ok': False, 'error': f'无法连接 Resource Center: {e}'}
+    except Exception as e:
+        return {'ok': False, 'error': f'无法连接 Resource Center: {e}'}
+
+
+async def install_from_rc(slug: str, rc_token: str | None = None) -> dict:
+    """安装一个 RC 技能到本地 ConfigDB。
+
+    返回 {'ok': True, 'data': {...}} / {'ok': False, 'error': ...}。
+    已安装时视为成功并回 already=True —— 载入解决方案时会批量调用，
+    重复安装不该让整包失败。
+    """
+    installed = _skills_mod.installed_skills()
+    if any(s['slug'] == slug for s in installed):
+        return {'ok': True, 'already': True, 'data': {'slug': slug}}
+
+    fetched = await fetch_rc_skill(slug, rc_token)
+    if not fetched.get('ok'):
+        return fetched
+    skill_data = fetched['data']
+
+    import datetime
+    new_skill = {
+        'slug': skill_data['slug'],
+        'name': skill_data['name'],
+        'description': skill_data.get('description', ''),
+        'icon': skill_data.get('icon'),
+        'oneLiner': skill_data['oneLiner'],
+        'instruction': skill_data['instruction'],
+        'category': skill_data.get('category', ''),
+        'version': skill_data.get('version', '1.0.0'),
+        'requiredTools': skill_data.get('requiredTools', []),
+        'configSchema': skill_data.get('configSchema'),
+        'author': (skill_data.get('author') or {}).get('name', ''),
+        'installedAt': datetime.datetime.now().isoformat(),
+        'active': True,
+    }
+
+    skills_cfg = config.main.get('skills', {'installed': []})
+    skills_cfg['installed'].append(new_skill)
+    config.main['skills'] = skills_cfg
+
+    return {'ok': True, 'already': False, 'data': {'slug': slug, 'name': new_skill['name']}}
+
+
+
 @router.get('')
 async def list_skills():
     """列出已安装技能及其激活状态。"""
@@ -54,68 +134,17 @@ async def install_skill(request: fastapi.Request, body: dict = fastapi.Body(...)
     if not slug:
         return {'code': 422, 'error': 'slug is required'}
 
-    # 检查是否已安装
+    # 检查是否已安装（install_from_rc 对已安装是幂等的，这里保留显式 409
+    # 是因为手动安装时用户需要知道"已经装过了"）
     installed = _skills_mod.installed_skills()
     if any(s['slug'] == slug for s in installed):
         return {'code': 409, 'error': f'技能 "{slug}" 已安装'}
 
-    # 从 Resource Center 获取技能定义
-    rc_url = _get_rc_url()
-    headers = {}
     # 传递 RC token 以允许作者安装自己的未发布技能
-    rc_token = request.headers.get('x-rc-token')
-    if rc_token:
-        headers['Authorization'] = f'Bearer {rc_token}'
-    try:
-        import httpx
-        async with httpx.AsyncClient(timeout=10) as http:
-            resp = await http.get(f'{rc_url}/api/skills/{slug}', headers=headers)
-            if resp.status_code != 200:
-                return {'code': 404, 'error': f'技能 "{slug}" 未在 Resource Center 找到 (HTTP {resp.status_code})'}
-            data = resp.json()
-            if not data.get('ok'):
-                return {'code': 404, 'error': data.get('error', '获取失败')}
-    except ImportError:
-        # httpx 未安装时 fallback 到 urllib
-        import urllib.request, json as _json
-        try:
-            req = urllib.request.Request(f'{rc_url}/api/skills/{slug}')
-            for k, v in headers.items():
-                req.add_header(k, v)
-            with urllib.request.urlopen(req, timeout=10) as resp:
-                data = _json.loads(resp.read())
-                if not data.get('ok'):
-                    return {'code': 404, 'error': data.get('error', '获取失败')}
-        except Exception as e:
-            return {'code': 502, 'error': f'无法连接 Resource Center: {e}'}
-    except Exception as e:
-        return {'code': 502, 'error': f'无法连接 Resource Center: {e}'}
-
-    skill_data = data['data']
-
-    # 存储到 ConfigDB
-    import datetime
-    new_skill = {
-        'slug': skill_data['slug'],
-        'name': skill_data['name'],
-        'description': skill_data.get('description', ''),
-        'icon': skill_data.get('icon'),
-        'oneLiner': skill_data['oneLiner'],
-        'instruction': skill_data['instruction'],
-        'category': skill_data.get('category', ''),
-        'version': skill_data.get('version', '1.0.0'),
-        'requiredTools': skill_data.get('requiredTools', []),
-        'configSchema': skill_data.get('configSchema'),
-        'author': skill_data.get('author', {}).get('name', ''),
-        'installedAt': datetime.datetime.now().isoformat(),
-        'active': True,
-    }
-
-    skills_cfg = config.main.get('skills', {'installed': []})
-    skills_cfg['installed'].append(new_skill)
-    config.main['skills'] = skills_cfg
-
-    return {'code': 200, 'data': {'slug': slug, 'name': new_skill['name']}}
+    result = await install_from_rc(slug, request.headers.get('x-rc-token'))
+    if not result.get('ok'):
+        return {'code': 404, 'error': result.get('error', '安装失败')}
+    return {'code': 200, 'data': result['data']}
 
 
 @router.post('/uninstall')

--- a/agent-core/src/api/solutions.py
+++ b/agent-core/src/api/solutions.py
@@ -1,0 +1,1029 @@
+"""
+api/solutions.py — 解决方案（Solution）打包 / 发布 / 载入。
+
+一个解决方案是"这台机器上跑得起来的整套配置"，可打包的块：
+
+    canvas          画布卡片 + 数据连线 + 执行连线 + 每张卡的 tool_config（必选）
+    skills          当前激活、且已在技能广场上架的技能
+    prompt.identity resource/memory/identity.md
+    prompt.system   resource/memory/prompt_system.md
+    prompt.memory   prompt_memory.md（LLM 可写的长期记忆）
+    tasks           task_store 里的活跃任务（goal / check_cron / metadata）
+
+包体格式（formatVersion 1）：
+
+    {
+      "formatVersion": 1,
+      "coreVersion": "release.xxx",
+      "devices": [{"ref": "d0", "serverName": "g1-device-bundle",
+                   "category": "driver", "driverId": "unitree-g1",
+                   "registryImage": "driver-unitree-g1",
+                   "image": "…:release.260529.x", "name": "…", "port": 15701}],
+      "canvas": {"cards": [{"id","deviceRef","toolName","x","y",
+                            "topicIn","topicOut"}],
+                 "connections": [], "execConnections": [], "transform": {},
+                 "toolConfigs": {"d0:tool": {...}, "d0:tool:<cardId>": {...}},
+                 "redactedFields": ["d0:tool:api_key"]},
+      "skills": [{"slug","version","name","icon"}],
+      "prompt": {"identity": "...", "system": "...", "memory": "..."},
+      "tasks":  [{"goal","check_cron","metadata"}]
+    }
+
+为什么卡片存 deviceRef 而不是 mcpId：mcpId 是本机在注册设备时生成的
+`mcp-<unix秒>`（见 api/mcp_manage.py:mcp_add），换一台机器一定对不上。
+deviceRef 指向 devices[]，devices 用 MCP initialize 返回的 server_name
+（如 `g1-device-bundle`）作为稳定标识，载入时再映射回本机 mcpId。
+
+敏感字段脱敏是"声明式"的：卡片自己在 configSchema 的属性上标
+`"x-sensitive": true`（或沿用已有的 `"format": "password"`），打包时把值清空
+并把路径记进 redactedFields。未声明的字段不会被自动清空 —— 打包接口会把
+候选清单给前端，作者可以通过 extraRedact 手工追加。
+"""
+
+import os
+import pathlib
+import time
+from typing import Any, Optional
+
+import fastapi
+from pydantic import BaseModel
+
+import config
+
+router = fastapi.APIRouter(prefix='/solutions', tags=['solutions'])
+
+FORMAT_VERSION = 1
+
+# 可打包的块名。canvas 必选，其余由用户勾选。
+BLOCK_CANVAS = 'canvas'
+BLOCK_SKILLS = 'skills'
+BLOCK_TASKS = 'tasks'
+PROMPT_BLOCKS = ('prompt.identity', 'prompt.system', 'prompt.memory')
+
+_CURRENT_KEY = 'solution_current'
+
+
+# ── RC 代理（复用 api/skills.py 的 URL / token 约定）────────────────────────
+
+def _get_rc_url() -> str:
+    from api.skills import _get_rc_url as rc_url
+    return rc_url()
+
+
+def _get_rc_token(request: fastapi.Request) -> Optional[str]:
+    """从请求头 X-RC-Token 中获取 RC bearer token（与技能一致）。"""
+    return request.headers.get('x-rc-token')
+
+
+async def _rc_request(method: str, path: str, token: Optional[str] = None,
+                      json_body: Any = None, timeout: float = 20) -> dict:
+    """向 Resource Center 发一个请求，返回 {'ok', 'status', 'data'|'error'}。"""
+    url = f'{_get_rc_url()}{path}'
+    headers = {'Content-Type': 'application/json'}
+    if token:
+        headers['Authorization'] = f'Bearer {token}'
+    try:
+        import httpx
+        async with httpx.AsyncClient(timeout=timeout) as http:
+            resp = await http.request(method, url, headers=headers, json=json_body)
+            try:
+                data = resp.json()
+            except Exception:
+                return {'ok': False, 'status': resp.status_code,
+                        'error': f'Resource Center 返回了非 JSON 响应 (HTTP {resp.status_code})'}
+            if resp.status_code in (200, 201) and data.get('ok'):
+                return {'ok': True, 'status': resp.status_code, 'data': data.get('data')}
+            return {'ok': False, 'status': resp.status_code,
+                    'error': data.get('error', f'请求失败 (HTTP {resp.status_code})')}
+    except Exception as e:
+        return {'ok': False, 'status': 502, 'error': f'无法连接 Resource Center: {e}'}
+
+
+def _core_version() -> str:
+    """当前 Agent Core 的镜像 tag（仅作记录，载入时不做比较）。"""
+    try:
+        return pathlib.Path('/work/VERSION').read_text().strip()
+    except Exception:
+        return os.environ.get('IMAGE_TAG', '')
+
+
+# ── 本机状态读取 ─────────────────────────────────────────────────────────────
+
+def _event_skills():
+    """event.skills 模块本身。
+
+    不能写 `import event.skills as skills_mod`：event/__init__.py 会把 `skills`
+    这个属性重新绑定成 Tools 实例，于是 `as` 拿到的是那个实例而不是模块
+    （api/skills.py 早就踩过，那里也是这么绕的）。
+    """
+    import sys
+    import event.skills  # noqa: F401  —— 确保模块已被导入
+    return sys.modules['event.skills']
+
+
+def _mcp_list() -> list:
+    return list(config.main.get('services', {}).get('mcp', []))
+
+
+def _driver_manifest() -> list:
+    return list(config.main.get('drivers') or [])
+
+
+def _layout() -> dict:
+    return config.main.get('canvas_layout', {}) or {}
+
+
+def _tool_schema(mcp: dict, tool_name: str) -> dict:
+    """某个工具的 configSchema（工具可能是纯字符串形式，那就没有 schema）。"""
+    for tool in mcp.get('tools', []) or []:
+        if isinstance(tool, dict) and tool.get('name') == tool_name:
+            return tool.get('configSchema') or {}
+    return {}
+
+
+def _sensitive_props(config_schema: dict) -> set:
+    """schema 里声明为敏感的属性名。
+
+    `x-sensitive` 是本文件引入的声明（见模块注释），`format: password` 是
+    driver 侧早就在用的写法（web/js/sidebar.js 用它渲染 password input），
+    两者都算敏感 —— 否则已有驱动的密钥字段会原样进包体。
+    """
+    props = (config_schema or {}).get('properties') or {}
+    out = set()
+    for name, spec in props.items():
+        if not isinstance(spec, dict):
+            continue
+        if spec.get('x-sensitive') is True or spec.get('format') == 'password':
+            out.add(name)
+    return out
+
+
+def _port_from_url(url: str) -> Optional[int]:
+    try:
+        from urllib.parse import urlparse
+        return urlparse(url).port
+    except Exception:
+        return None
+
+
+def _driver_entry_for(mcp: dict) -> dict:
+    """把 MCP 条目对应回 drivers manifest 里的那一项。
+
+    先按 mcp_url 完全相同匹配（drivers.py 给 perception/actucore 写死了
+    mcp_url），退化到按端口匹配（硬件驱动的 manifest 只有 port）。
+    """
+    url = mcp.get('url', '')
+    port = _port_from_url(url)
+    manifest = _driver_manifest()
+    for d in manifest:
+        if d.get('mcp_url') and d['mcp_url'] == url:
+            return d
+    if port:
+        for d in manifest:
+            if d.get('port') == port or d.get('host_port') == port:
+                return d
+    return {}
+
+
+def _device_descriptor(ref: str, mcp: dict) -> dict:
+    """构造包体里的一条 devices 记录。"""
+    driver = _driver_entry_for(mcp)
+    server_name = mcp.get('server_name') or mcp.get('name') or ''
+    return {
+        'ref':           ref,
+        'serverName':    server_name,
+        'category':      mcp.get('category') or driver.get('category') or 'driver',
+        'driverId':      driver.get('id', ''),
+        'registryImage': driver.get('registry_image', ''),
+        'image':         driver.get('image', ''),
+        'name':          driver.get('name') or mcp.get('name') or server_name,
+        'port':          _port_from_url(mcp.get('url', '')),
+    }
+
+
+def _canvas_devices() -> tuple[list, dict, list]:
+    """画布上用到的设备。
+
+    返回 (devices, mcp_id → ref, 无法解析的 mcp_id 列表)。
+    """
+    layout = _layout()
+    mcps = {m.get('id'): m for m in _mcp_list()}
+    devices: list = []
+    ref_of: dict = {}
+    unresolved: list = []
+
+    for card in layout.get('cards', []) or []:
+        mcp_id = card.get('mcpId', '')
+        if not mcp_id or mcp_id in ref_of:
+            continue
+        mcp = mcps.get(mcp_id)
+        if not mcp:
+            unresolved.append(mcp_id)
+            continue
+        ref = f'd{len(devices)}'
+        ref_of[mcp_id] = ref
+        devices.append(_device_descriptor(ref, mcp))
+
+    return devices, ref_of, unresolved
+
+
+# ── 打包 ────────────────────────────────────────────────────────────────────
+
+def _prompt_paths() -> dict:
+    """prompt 三个文件的路径（与 api/agent_definition.py 保持同一来源）。"""
+    import api.agent_definition as ad
+    return {
+        'identity': ad._IDENTITY_PATH,
+        'system':   ad._SYSTEM_PATH,
+        'memory':   ad._memory_path(),
+    }
+
+
+def _config_field_paths(ref_of: dict) -> list:
+    """画布上每个卡片配置字段的路径，标出哪些按 schema 声明是敏感的。
+
+    前端用它渲染"将被清空的字段"清单：声明过的默认勾选且不可取消，其余留给
+    作者手工勾选（extra_redact）—— 声明式脱敏管不到还没加标记的老驱动。
+    """
+    from api.canvas import all_tool_configs
+
+    mcps = {m.get('id'): m for m in _mcp_list()}
+    out = []
+    for key, value in all_tool_configs().items():
+        parts = key.split(':')
+        if len(parts) < 2:
+            continue
+        mcp_id, tool_name = parts[0], parts[1]
+        instance_id = parts[2] if len(parts) > 2 else ''
+        ref = ref_of.get(mcp_id)
+        if not ref or not isinstance(value, dict):
+            continue
+        sensitive = _sensitive_props(_tool_schema(mcps.get(mcp_id, {}), tool_name))
+        pkey = f'{ref}:{tool_name}:{instance_id}' if instance_id else f'{ref}:{tool_name}'
+        for prop in value:
+            out.append({
+                'path':       f'{pkey}:{prop}',
+                'tool':       tool_name,
+                'prop':       prop,
+                'instanceId': instance_id,
+                'sensitive':  prop in sensitive,
+            })
+    return sorted(out, key=lambda x: x['path'])
+
+
+def _pack_canvas(ref_of: dict, extra_redact: set) -> tuple[dict, list]:
+    """打包画布。返回 (canvas 块, 被清空的字段路径)。"""
+    from api.canvas import all_tool_configs
+
+    layout = _layout()
+    mcps = {m.get('id'): m for m in _mcp_list()}
+
+    cards = []
+    for card in layout.get('cards', []) or []:
+        ref = ref_of.get(card.get('mcpId', ''))
+        if not ref:
+            continue  # 设备已不在注册表里，连带这张卡一起丢掉
+        cards.append({
+            'id':        card.get('id', ''),
+            'deviceRef': ref,
+            'toolName':  card.get('toolName', ''),
+            'x':         card.get('x', 0),
+            'y':         card.get('y', 0),
+            'topicIn':   card.get('topicIn') or [],
+            'topicOut':  card.get('topicOut') or [],
+        })
+
+    card_ids = {c['id'] for c in cards}
+    connections = [c for c in layout.get('connections', []) or []
+                   if c.get('fromCardId') in card_ids and c.get('toCardId') in card_ids]
+    exec_connections = []
+    for c in layout.get('execConnections', []) or []:
+        if c.get('fromCardId') not in card_ids or c.get('toCardId') not in card_ids:
+            continue
+        c = dict(c)
+        # execConnections 缓存了目标卡的 mcpId；换机器后必须重新解析，
+        # 留着会让载入侧拿到一个不存在的设备 id。
+        c.pop('toMcpId', None)
+        exec_connections.append(c)
+
+    tool_configs: dict = {}
+    redacted: list = []
+    for key, value in all_tool_configs().items():
+        parts = key.split(':')
+        if len(parts) < 2:
+            continue
+        mcp_id, tool_name = parts[0], parts[1]
+        instance_id = parts[2] if len(parts) > 2 else ''
+        ref = ref_of.get(mcp_id)
+        if not ref:
+            continue
+        if instance_id and instance_id not in card_ids:
+            continue  # 属于已删除卡片的实例配置
+        pkey = f'{ref}:{tool_name}:{instance_id}' if instance_id else f'{ref}:{tool_name}'
+
+        if not isinstance(value, dict):
+            tool_configs[pkey] = value
+            continue
+
+        sensitive = _sensitive_props(_tool_schema(mcps.get(mcp_id, {}), tool_name))
+        packed = {}
+        for prop, val in value.items():
+            path = f'{pkey}:{prop}'
+            if prop in sensitive or path in extra_redact:
+                packed[prop] = '' if isinstance(val, str) or val is None else type(val)()
+                redacted.append(path)
+            else:
+                packed[prop] = val
+        tool_configs[pkey] = packed
+
+    return {
+        'cards':           cards,
+        'connections':     connections,
+        'execConnections': exec_connections,
+        'transform':       layout.get('transform', {}) or {},
+        'toolConfigs':     tool_configs,
+        'redactedFields':  sorted(redacted),
+    }, sorted(redacted)
+
+
+class PackInclude(BaseModel):
+    canvas: bool = True                 # 必选，传 False 也会被拒
+    skills: list[str] = []              # 要打包的技能 slug
+    prompt: list[str] = []              # identity | system | memory
+    tasks:  bool = False
+
+
+class PackRequest(BaseModel):
+    include: PackInclude = PackInclude()
+    extra_redact: list[str] = []        # 作者手工追加要清空的字段路径
+
+
+async def _market_skill_slugs(slugs: list[str]) -> tuple[list, list]:
+    """把技能 slug 分成 (广场上已上架的, 广场上没有的)。
+
+    只认公开可见（已上架）的技能：解决方案要能被别人载入，包体里引用一个
+    只有作者自己能看到的草稿技能，别人载入时必然装不上。所以这里刻意不带
+    RC token —— 带上会把作者的私有草稿也判成"有"。
+    """
+    from api.skills import fetch_rc_skill
+    available, missing = [], []
+    for slug in slugs:
+        result = await fetch_rc_skill(slug, None)
+        if result.get('ok') and (result['data'].get('status') == 'published'):
+            available.append(slug)
+        else:
+            missing.append(slug)
+    return available, missing
+
+
+async def _build_payload(req: PackRequest, token: Optional[str]) -> dict:
+    """构造包体。返回 {'ok': True, ...} 或 {'ok': False, 'error', 'detail'}。"""
+    skills_mod = _event_skills()
+
+    if not req.include.canvas:
+        return {'ok': False, 'error': '画布是解决方案的必选部分，不能取消勾选'}
+
+    devices, ref_of, unresolved = _canvas_devices()
+    if not devices:
+        return {'ok': False, 'error': '画布为空（或卡片引用的设备都已注销），无法打包'}
+    if unresolved:
+        return {'ok': False,
+                'error': '画布上有卡片引用了未注册的设备，请先在画布上删除这些卡片',
+                'detail': unresolved}
+
+    includes = [BLOCK_CANVAS]
+    payload: dict = {
+        'formatVersion': FORMAT_VERSION,
+        'coreVersion':   _core_version(),
+        'devices':       devices,
+    }
+
+    canvas_block, redacted = _pack_canvas(ref_of, set(req.extra_redact))
+    payload['canvas'] = canvas_block
+
+    # 技能：必须是当前激活的，且已在技能广场上架
+    if req.include.skills:
+        installed = {s['slug']: s for s in skills_mod.installed_skills()}
+        not_active = [s for s in req.include.skills
+                      if not installed.get(s, {}).get('active')]
+        if not_active:
+            return {'ok': False,
+                    'error': '只能打包当前已激活的技能',
+                    'detail': not_active}
+        available, off_market = await _market_skill_slugs(req.include.skills)
+        if off_market:
+            return {'ok': False,
+                    'error': '只能保存技能广场中已上架的技能，请先把这些技能发布并通过审核',
+                    'detail': off_market}
+        payload['skills'] = [{
+            'slug':    installed[s]['slug'],
+            'name':    installed[s].get('name', ''),
+            'icon':    installed[s].get('icon'),
+            'version': installed[s].get('version', ''),
+        } for s in available]
+        includes.append(BLOCK_SKILLS)
+
+    # Prompt：三项独立勾选
+    if req.include.prompt:
+        paths = _prompt_paths()
+        prompt: dict = {}
+        for key in req.include.prompt:
+            if key not in paths:
+                return {'ok': False, 'error': f'未知的 prompt 块: {key}'}
+            path = paths[key]
+            if not path.exists():
+                return {'ok': False, 'error': f'{path} 不存在，无法打包 prompt.{key}'}
+            prompt[key] = path.read_text()
+            includes.append(f'prompt.{key}')
+        payload['prompt'] = prompt
+
+    # 任务
+    if req.include.tasks:
+        import task_store
+        task_store.load_all()
+        payload['tasks'] = [{
+            'goal':       t.goal,
+            'check_cron': t.check_cron,
+            'metadata':   t.metadata or {},
+        } for t in task_store.active_tasks()]
+        includes.append(BLOCK_TASKS)
+
+    return {
+        'ok': True,
+        'payload':         payload,
+        'includes':        includes,
+        'requiredDrivers': devices,
+        'needsConfig':     redacted,
+        'coreVersion':     payload['coreVersion'],
+    }
+
+
+# ── 设备解析（载入前） ───────────────────────────────────────────────────────
+
+def _resolve_devices(devices: list) -> dict:
+    """把包体的 devices 映射到本机。
+
+    分三类：
+      matched   已注册 MCP，可直接用（ref → mcpId）
+      installable  drivers manifest 里有对应镜像，但还没起容器 → 可一键安装
+      missing   本机连镜像都没有，必须先同步/安装驱动
+    """
+    mcps = _mcp_list()
+    manifest = _driver_manifest()
+
+    mapping: dict = {}
+    matched, installable, missing = [], [], []
+
+    for dev in devices:
+        server_name = dev.get('serverName', '')
+        registry_image = dev.get('registryImage', '')
+        driver_id = dev.get('driverId', '')
+        port = dev.get('port')
+
+        # 1) 已注册 MCP：优先按 server_name（稳定），退化到端口
+        mcp = next((m for m in mcps if server_name and m.get('server_name') == server_name), None)
+        if not mcp and port:
+            mcp = next((m for m in mcps if _port_from_url(m.get('url', '')) == port), None)
+        if mcp:
+            mapping[dev.get('ref')] = mcp.get('id')
+            matched.append({**dev, 'mcpId': mcp.get('id'), 'mcpName': mcp.get('name', '')})
+            continue
+
+        # 2) 驱动清单里有：只是没部署 / 没注册
+        entry = next((d for d in manifest
+                      if (registry_image and d.get('registry_image') == registry_image)
+                      or (driver_id and d.get('id') == driver_id)), None)
+        if entry:
+            installable.append({**dev, 'localDriverId': entry.get('id'),
+                                'localImage': entry.get('image', '')})
+        else:
+            missing.append(dev)
+
+    return {'mapping': mapping, 'matched': matched,
+            'installable': installable, 'missing': missing}
+
+
+def _overwrite_summary(includes: list) -> dict:
+    """载入会覆盖掉的现状，逐项列给用户确认。"""
+    skills_mod = _event_skills()
+    import task_store
+
+    layout = _layout()
+    summary: dict = {}
+
+    if BLOCK_CANVAS in includes:
+        from api.canvas import all_tool_configs
+        summary['canvas'] = {
+            'cards':       len(layout.get('cards', []) or []),
+            'connections': len(layout.get('connections', []) or [])
+                           + len(layout.get('execConnections', []) or []),
+            'toolConfigs': len(all_tool_configs()),
+        }
+
+    if BLOCK_SKILLS in includes:
+        summary['skills'] = [
+            {'slug': s['slug'], 'name': s.get('name', '')}
+            for s in skills_mod.installed_skills() if s.get('active')
+        ]
+
+    prompt_files = []
+    paths = _prompt_paths()
+    for block in PROMPT_BLOCKS:
+        key = block.split('.', 1)[1]
+        if block in includes:
+            path = paths[key]
+            prompt_files.append({'block': block, 'path': str(path),
+                                 'exists': path.exists()})
+    if prompt_files:
+        summary['prompt'] = prompt_files
+
+    if BLOCK_TASKS in includes:
+        task_store.load_all()
+        summary['tasks'] = [{'id': t.id, 'goal': t.goal}
+                            for t in task_store.active_tasks()]
+
+    return summary
+
+
+# ── 端点：查看当前方案 ───────────────────────────────────────────────────────
+
+@router.get('/current')
+async def get_current():
+    """当前已载入的解决方案（没有则 data 为 null）。"""
+    return {'code': 200, 'data': config.main.get(_CURRENT_KEY, None)}
+
+
+@router.delete('/current')
+async def clear_current():
+    """清除"当前方案"标记。只动标记，不回滚任何实际配置。"""
+    config.main[_CURRENT_KEY] = None
+    return {'code': 200}
+
+
+# ── 端点：可打包内容 ─────────────────────────────────────────────────────────
+
+@router.get('/packable')
+async def packable(request: fastapi.Request):
+    """当前机器上有哪些东西可以打包，以及哪些技能不能打包。"""
+    skills_mod = _event_skills()
+    import task_store
+
+    devices, ref_of, unresolved = _canvas_devices()
+    layout = _layout()
+
+    active = [s for s in skills_mod.installed_skills() if s.get('active')]
+    on_market, off_market = await _market_skill_slugs([s['slug'] for s in active])
+
+    def _skill_brief(slug: str) -> dict:
+        s = next((x for x in active if x['slug'] == slug), {})
+        return {'slug': slug, 'name': s.get('name', ''), 'icon': s.get('icon'),
+                'version': s.get('version', '')}
+
+    paths = _prompt_paths()
+    task_store.load_all()
+
+    return {'code': 200, 'data': {
+        'coreVersion': _core_version(),
+        'canvas': {
+            'cards':       len(layout.get('cards', []) or []),
+            'devices':     devices,
+            'unresolved':  unresolved,
+        },
+        'skills': {
+            'available': [_skill_brief(s) for s in on_market],
+            'offMarket': [_skill_brief(s) for s in off_market],
+        },
+        'prompt': [
+            {'block': f'prompt.{key}', 'path': str(path),
+             'exists': path.exists(),
+             'chars': len(path.read_text()) if path.exists() else 0}
+            for key, path in paths.items()
+        ],
+        'tasks': [{'id': t.id, 'goal': t.goal, 'check_cron': t.check_cron}
+                  for t in task_store.active_tasks()],
+        'configFields': _config_field_paths(ref_of),
+    }}
+
+
+# ── 端点：打包 / 发布 ────────────────────────────────────────────────────────
+
+@router.post('/pack')
+async def pack(request: fastapi.Request, req: PackRequest):
+    """只打包，不落盘、不上传 —— 前端用它做发布前预览。"""
+    result = await _build_payload(req, _get_rc_token(request))
+    if not result.get('ok'):
+        return {'code': 422, 'error': result['error'], 'detail': result.get('detail')}
+    return {'code': 200, 'data': {k: v for k, v in result.items() if k != 'ok'}}
+
+
+class PublishMeta(BaseModel):
+    name:        str
+    slug:        str
+    oneLiner:    str
+    description: str
+    industry:    str = 'general'
+    icon:        Optional[str] = None
+    coverImage:  Optional[str] = None
+    tags:        list[str] = []
+    robotTypes:  list[str] = []
+    version:     str = '1.0.0'
+
+
+class PublishRequest(BaseModel):
+    meta:         PublishMeta
+    include:      PackInclude = PackInclude()
+    extra_redact: list[str] = []
+
+
+@router.post('/publish')
+async def publish(request: fastapi.Request, req: PublishRequest):
+    """打包并作为草稿推到 Resource Center（之后由作者提交审核）。"""
+    token = _get_rc_token(request)
+    if not token:
+        return {'code': 401, 'error': '未登录 Resource Center'}
+
+    built = await _build_payload(
+        PackRequest(include=req.include, extra_redact=req.extra_redact), token)
+    if not built.get('ok'):
+        return {'code': 422, 'error': built['error'], 'detail': built.get('detail')}
+
+    body = {
+        **req.meta.dict(),
+        'includes':        built['includes'],
+        'requiredDrivers': built['requiredDrivers'],
+        'payload':         built['payload'],
+        'needsConfig':     built['needsConfig'],
+        'coreVersion':     built['coreVersion'],
+    }
+    result = await _rc_request('POST', '/api/solutions/mine', token, body, timeout=60)
+    if not result['ok']:
+        return {'code': result['status'], 'error': result['error']}
+    return {'code': 200, 'data': result['data']}
+
+
+# ── 端点：载入前检查 ────────────────────────────────────────────────────────
+
+class LoadRequest(BaseModel):
+    slug:    str = ''
+    payload: Optional[dict] = None      # 直接给包体（调试用），优先于 slug
+    includes: list[str] = []            # 与 payload 搭配使用
+    confirm: bool = False
+    session_id: str = ''                # 画布编辑锁的持有者（前端传自己的）
+
+
+async def _load_solution(req: LoadRequest, token: Optional[str]) -> dict:
+    """取回要载入的方案：优先用请求里带的 payload，否则按 slug 拉 RC。"""
+    if req.payload:
+        return {'ok': True, 'solution': {
+            'slug':     req.slug,
+            'payload':  req.payload,
+            'includes': req.includes,
+        }}
+    if not req.slug:
+        return {'ok': False, 'status': 422, 'error': 'slug 或 payload 至少要给一个'}
+
+    result = await _rc_request('GET', f'/api/solutions/{req.slug}', token, timeout=60)
+    if not result['ok']:
+        return {'ok': False, 'status': result['status'], 'error': result['error']}
+    return {'ok': True, 'solution': result['data']}
+
+
+@router.post('/preflight')
+async def preflight(request: fastapi.Request, req: LoadRequest):
+    """检查能不能载入：缺哪些驱动、会覆盖掉什么。"""
+    loaded = await _load_solution(req, _get_rc_token(request))
+    if not loaded.get('ok'):
+        return {'code': loaded['status'], 'error': loaded['error']}
+
+    solution = loaded['solution']
+    payload = solution.get('payload') or {}
+    if payload.get('formatVersion') != FORMAT_VERSION:
+        return {'code': 422,
+                'error': f'不支持的包体版本 {payload.get("formatVersion")}，'
+                         f'本机支持 {FORMAT_VERSION}'}
+
+    includes = solution.get('includes') or []
+    devices = _resolve_devices(payload.get('devices') or [])
+
+    return {'code': 200, 'data': {
+        'solution': {
+            'slug':        solution.get('slug', ''),
+            'name':        solution.get('name', ''),
+            'version':     solution.get('version', ''),
+            'industry':    solution.get('industry', ''),
+            'includes':    includes,
+            'coreVersion': solution.get('coreVersion') or payload.get('coreVersion', ''),
+            'needsConfig': solution.get('needsConfig')
+                           or payload.get('canvas', {}).get('redactedFields', []),
+        },
+        'devices':   devices,
+        'canLoad':   not devices['missing'] and not devices['installable'],
+        'overwrite': _overwrite_summary(includes),
+        'canvasEditor': _canvas_editor_conflict(req.session_id),
+    }}
+
+
+def _canvas_editor_conflict(session_id: str) -> Optional[str]:
+    """别人正在编辑画布时返回其 session id。
+
+    载入会直接改写 canvas_layout，绕过 api/canvas.py 的编辑锁；如果另一个
+    浏览器正持有锁，它的下一次自动保存会把刚载入的画布覆盖回去。
+    """
+    from api.canvas import current_editor
+    editor = current_editor()
+    if editor and editor != session_id:
+        return editor
+    return None
+
+
+# ── 端点：载入 ──────────────────────────────────────────────────────────────
+
+@router.post('/apply')
+async def apply(request: fastapi.Request, req: LoadRequest):
+    """载入解决方案：覆盖画布 / 技能 / prompt / 任务中包体声明的部分。"""
+    if not req.confirm:
+        return {'code': 428, 'error': '需要 confirm=true —— 载入会覆盖当前配置'}
+
+    conflict = _canvas_editor_conflict(req.session_id)
+    if conflict:
+        return {'code': 423,
+                'error': '有其他会话正在编辑画布，请先让对方退出编辑再载入',
+                'editor': conflict}
+
+    token = _get_rc_token(request)
+    loaded = await _load_solution(req, token)
+    if not loaded.get('ok'):
+        return {'code': loaded['status'], 'error': loaded['error']}
+
+    solution = loaded['solution']
+    payload = solution.get('payload') or {}
+    if payload.get('formatVersion') != FORMAT_VERSION:
+        return {'code': 422,
+                'error': f'不支持的包体版本 {payload.get("formatVersion")}'}
+
+    includes = solution.get('includes') or []
+    resolved = _resolve_devices(payload.get('devices') or [])
+    if resolved['missing'] or resolved['installable']:
+        return {'code': 409,
+                'error': '所需驱动尚未就绪，请先安装并启动这些驱动',
+                'devices': resolved}
+
+    applied: dict = {}
+
+    # 1) 画布 —— deviceRef 换回本机 mcpId
+    if BLOCK_CANVAS in includes:
+        applied['canvas'] = _apply_canvas(payload.get('canvas') or {},
+                                          resolved['mapping'])
+
+    # 2) 技能
+    if BLOCK_SKILLS in includes:
+        applied['skills'] = await _apply_skills(payload.get('skills') or [], token)
+
+    # 3) Prompt
+    prompt_applied = _apply_prompt(payload.get('prompt') or {}, includes)
+    if prompt_applied:
+        applied['prompt'] = prompt_applied
+
+    # 4) 任务
+    if BLOCK_TASKS in includes:
+        applied['tasks'] = _apply_tasks(payload.get('tasks') or [])
+
+    needs_config = (solution.get('needsConfig')
+                    or (payload.get('canvas') or {}).get('redactedFields') or [])
+    config.main[_CURRENT_KEY] = {
+        'slug':        solution.get('slug', ''),
+        'name':        solution.get('name', ''),
+        'version':     solution.get('version', ''),
+        'industry':    solution.get('industry', ''),
+        'includes':    includes,
+        'coreVersion': solution.get('coreVersion') or payload.get('coreVersion', ''),
+        'needsConfig': needs_config,
+        'appliedAt':   int(time.time()),
+        'devices':     payload.get('devices') or [],
+    }
+
+    # 记一次载入量（失败无所谓，别影响载入结果）
+    if solution.get('slug') and not req.payload:
+        await _rc_request('POST', f'/api/solutions/{solution["slug"]}', None, {})
+
+    return {'code': 200, 'data': {'applied': applied, 'needsConfig': needs_config}}
+
+
+def _apply_canvas(canvas: dict, mapping: dict) -> dict:
+    """写画布布局与卡片配置。"""
+    from api.canvas import (apply_tool_config, delete_all_tool_configs,
+                            tool_config_key)
+
+    cards = []
+    for card in canvas.get('cards') or []:
+        mcp_id = mapping.get(card.get('deviceRef'))
+        if not mcp_id:
+            continue
+        cards.append({
+            'id':       card.get('id', ''),
+            'mcpId':    mcp_id,
+            'toolName': card.get('toolName', ''),
+            'x':        card.get('x', 0),
+            'y':        card.get('y', 0),
+            'topicIn':  card.get('topicIn') or [],
+            'topicOut': card.get('topicOut') or [],
+        })
+    card_ids = {c['id'] for c in cards}
+
+    connections = [c for c in canvas.get('connections') or []
+                   if c.get('fromCardId') in card_ids and c.get('toCardId') in card_ids]
+    exec_connections = []
+    for c in canvas.get('execConnections') or []:
+        if c.get('fromCardId') not in card_ids or c.get('toCardId') not in card_ids:
+            continue
+        c = dict(c)
+        target = next((x for x in cards if x['id'] == c.get('toCardId')), None)
+        if target:
+            c['toMcpId'] = target['mcpId']
+        exec_connections.append(c)
+
+    config.main['canvas_layout'] = {
+        'cards':           cards,
+        'connections':     connections,
+        'execConnections': exec_connections,
+        'transform':       canvas.get('transform') or {},
+    }
+
+    # 卡片配置：先清空旧的，再写包体里的
+    removed = delete_all_tool_configs()
+    written = 0
+    for key, value in (canvas.get('toolConfigs') or {}).items():
+        parts = key.split(':')
+        if len(parts) < 2:
+            continue
+        ref, tool_name = parts[0], parts[1]
+        instance_id = parts[2] if len(parts) > 2 else ''
+        mcp_id = mapping.get(ref)
+        if not mcp_id:
+            continue
+        if instance_id and instance_id not in card_ids:
+            continue
+        config.main[tool_config_key(mcp_id, tool_name, instance_id)] = value
+        apply_tool_config(mcp_id, tool_name, value, instance_id)
+        written += 1
+
+    return {'cards': len(cards),
+            'connections': len(connections) + len(exec_connections),
+            'toolConfigsWritten': written, 'toolConfigsRemoved': removed}
+
+
+async def _apply_skills(skills: list, token: Optional[str]) -> dict:
+    """安装（若缺）并激活包体里的技能。原有技能停用但不卸载。"""
+    skills_mod = _event_skills()
+    from api.skills import install_from_rc
+
+    wanted = [s.get('slug') for s in skills if s.get('slug')]
+    installed_now, failed = [], []
+
+    for slug in wanted:
+        result = await install_from_rc(slug, token)
+        if result.get('ok'):
+            if not result.get('already'):
+                installed_now.append(slug)
+        else:
+            failed.append({'slug': slug, 'error': result.get('error', '安装失败')})
+
+    # 先全停，再按包体激活 —— 否则上一套方案的技能会一起注入 prompt
+    for s in skills_mod.installed_skills():
+        if s.get('active') and s['slug'] not in wanted:
+            skills_mod.active_skills.discard(s['slug'])
+    for slug in wanted:
+        if not any(f['slug'] == slug for f in failed):
+            skills_mod.active_skills.add(slug)
+
+    return {'activated': [s for s in wanted if not any(f['slug'] == s for f in failed)],
+            'installed': installed_now, 'failed': failed}
+
+
+def _apply_prompt(prompt: dict, includes: list) -> list:
+    """写 prompt 文件，只写 includes 里声明过的那几项。"""
+    paths = _prompt_paths()
+    written = []
+    for block in PROMPT_BLOCKS:
+        if block not in includes:
+            continue
+        key = block.split('.', 1)[1]
+        content = prompt.get(key)
+        if content is None:
+            continue
+        path = paths[key]
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content)
+        written.append(block)
+    return written
+
+
+def _apply_tasks(tasks: list) -> dict:
+    """清空现有任务后按包体重建（新 id），并重新挂上 cron。"""
+    import scheduler
+    import task_store
+
+    task_store.load_all()
+    existing = task_store.active_tasks()
+    for t in existing:
+        scheduler.remove_job(f'task:{t.id}')
+        task_store.done(t.id, summary='载入解决方案时清除')
+
+    created = []
+    for spec in tasks:
+        goal = (spec.get('goal') or '').strip()
+        if not goal:
+            continue
+        task = task_store.create(goal, spec.get('check_cron', '') or '',
+                                 spec.get('metadata') or {})
+        created.append(task.id)
+        if task.check_cron:
+            try:
+                scheduler.add_job(
+                    f'task:{task.id}', task.check_cron,
+                    f'任务定时检查 [{task.id}]：{task.goal}。请查询实际状态并更新进展。')
+            except Exception:
+                pass  # cron 表达式坏了不该让整包载入失败
+
+    return {'cleared': len(existing), 'created': created}
+
+
+# ── 端点：RC 代理（与 api/skills.py 的 /rc/* 一一对应）──────────────────────
+
+@router.get('/rc/mine')
+async def rc_my_solutions(request: fastapi.Request):
+    """代理获取用户在 RC 上的解决方案列表。"""
+    token = _get_rc_token(request)
+    if not token:
+        return {'code': 401, 'error': '未登录 Resource Center'}
+    result = await _rc_request('GET', '/api/solutions/mine', token)
+    if not result['ok']:
+        return {'code': result['status'], 'error': result['error']}
+    return {'code': 200, 'data': result['data']}
+
+
+@router.put('/rc/mine/{solution_id}')
+async def rc_update_solution(solution_id: str, request: fastapi.Request,
+                             body: dict = fastapi.Body(...)):
+    """代理更新 RC 上的解决方案（只改展示信息）。"""
+    token = _get_rc_token(request)
+    if not token:
+        return {'code': 401, 'error': '未登录 Resource Center'}
+    result = await _rc_request('PUT', f'/api/solutions/mine/{solution_id}', token, body)
+    if not result['ok']:
+        return {'code': result['status'], 'error': result['error']}
+    return {'code': 200, 'data': result['data']}
+
+
+@router.delete('/rc/mine/{solution_id}')
+async def rc_delete_solution(solution_id: str, request: fastapi.Request):
+    """代理删除 RC 上的解决方案。"""
+    token = _get_rc_token(request)
+    if not token:
+        return {'code': 401, 'error': '未登录 Resource Center'}
+    result = await _rc_request('DELETE', f'/api/solutions/mine/{solution_id}', token)
+    if not result['ok']:
+        return {'code': result['status'], 'error': result['error']}
+    return {'code': 200, 'data': {'id': solution_id}}
+
+
+@router.post('/rc/mine/{solution_id}/submit')
+async def rc_submit_solution(solution_id: str, request: fastapi.Request):
+    """代理提交解决方案送审。"""
+    token = _get_rc_token(request)
+    if not token:
+        return {'code': 401, 'error': '未登录 Resource Center'}
+    result = await _rc_request('POST', f'/api/solutions/mine/{solution_id}/submit',
+                               token, {})
+    if not result['ok']:
+        return {'code': result['status'], 'error': result['error']}
+    return {'code': 200, 'data': result['data']}
+
+
+@router.get('/market')
+async def market(search: str = '', industry: str = 'all', limit: int = 20):
+    """代理方案市场列表。
+
+    走后端代理而不是浏览器直连 RC：dashboard 走 HTTPS 自签证书，浏览器对
+    跨域 + 混合内容的处理会因环境而异，而后端本来就有 RC 连接。
+    """
+    params = [f'limit={limit}']
+    if search:
+        from urllib.parse import quote
+        params.append(f'search={quote(search)}')
+    if industry and industry != 'all':
+        params.append(f'industry={industry}')
+    result = await _rc_request('GET', f'/api/solutions?{"&".join(params)}')
+    if not result['ok']:
+        return {'code': result['status'], 'error': result['error']}
+    return {'code': 200, 'data': result['data']}
+
+
+@router.get('/market/{slug}')
+async def market_detail(slug: str, request: fastapi.Request):
+    """代理单个方案详情（含包体）。"""
+    result = await _rc_request('GET', f'/api/solutions/{slug}',
+                               _get_rc_token(request), timeout=60)
+    if not result['ok']:
+        return {'code': result['status'], 'error': result['error']}
+    return {'code': 200, 'data': result['data']}

--- a/agent-core/src/api/solutions.py
+++ b/agent-core/src/api/solutions.py
@@ -486,7 +486,10 @@ def _resolve_devices(devices: list) -> dict:
             mcp = next((m for m in mcps if _port_from_url(m.get('url', '')) == port), None)
         if mcp:
             mapping[dev.get('ref')] = mcp.get('id')
-            matched.append({**dev, 'mcpId': mcp.get('id'), 'mcpName': mcp.get('name', '')})
+            entry = _driver_entry_for(mcp)
+            matched.append({**dev, 'mcpId': mcp.get('id'), 'mcpName': mcp.get('name', ''),
+                            'localDriverId': entry.get('id', ''),
+                            'localImage': entry.get('image', '')})
             continue
 
         # 2) 驱动清单里有：只是没部署 / 没注册
@@ -501,6 +504,76 @@ def _resolve_devices(devices: list) -> dict:
 
     return {'mapping': mapping, 'matched': matched,
             'installable': installable, 'missing': missing}
+
+
+# ── 版本对齐 ────────────────────────────────────────────────────────────────
+
+def _image_tag(image_ref: str) -> str:
+    """镜像 ref 的 tag 部分（没有 tag 则返回空串）。"""
+    if not image_ref or ':' not in image_ref:
+        return ''
+    repo, tag = image_ref.rsplit(':', 1)
+    return '' if '/' in tag else tag     # 端口号形如 host:5000/img，不是 tag
+
+
+def _align_image_for(dev: dict) -> str:
+    """把方案记录的 tag 套到本机的镜像仓库上。
+
+    只换 tag、保留本机 repo：包体可能来自另一个 registry（作者的私有仓库），
+    照搬整个 ref 会拉不到镜像；而"对齐版本"要的本来也只是 tag 一致。
+    """
+    package_tag = _image_tag(dev.get('image', ''))
+    local_image = dev.get('localImage', '')
+    if not package_tag or not local_image:
+        return ''
+    local_repo = local_image.rsplit(':', 1)[0] if _image_tag(local_image) else local_image
+    return f'{local_repo}:{package_tag}'
+
+
+async def _augment_versions(resolved: dict) -> None:
+    """给 matched / installable 的设备补上版本对齐信息（原地修改）。
+
+    只在 preflight 里调用：要问 Docker 当前跑的是哪个镜像，比较慢，而 apply
+    只需要 ref → mcpId 的映射。
+    """
+    import asyncio as _asyncio
+    from api.drivers import _get_status_sync, _load_manifest
+
+    manifest = {d.get('id'): d for d in _load_manifest()}
+    loop = _asyncio.get_event_loop()
+
+    for dev in resolved['matched'] + resolved['installable']:
+        dev['packageImage'] = dev.get('image', '')
+        dev['packageTag'] = _image_tag(dev.get('image', ''))
+        dev['alignImage'] = _align_image_for(dev)
+        dev['runningImage'] = ''
+        dev['runningTag'] = ''
+        dev['aligned'] = None            # None = 问不到（没有 Docker / 容器没起）
+
+        driver_id = dev.get('localDriverId') or ''
+        if not driver_id:
+            continue
+        entry = manifest.get(driver_id, {})
+        try:
+            status = await loop.run_in_executor(
+                None, _get_status_sync, driver_id, entry.get('container_name', ''))
+        except Exception:
+            continue
+        running = status.get('running_image', '') or ''
+        dev['runningImage'] = running
+        dev['runningTag'] = _image_tag(running)
+        if dev['alignImage'] and running:
+            dev['aligned'] = (running == dev['alignImage'])
+
+
+def _misaligned(resolved: dict) -> list:
+    """需要重新部署才能对上方案记录版本的设备。
+
+    `aligned is None`（问不到 Docker 状态）不算不一致 —— 那种情况下拒绝载入
+    只会让没有 Docker socket 的部署方式完全用不了这个开关。
+    """
+    return [d for d in resolved['matched'] + resolved['installable']
+            if d.get('aligned') is False]
 
 
 def _overwrite_summary(includes: list) -> dict:
@@ -669,6 +742,8 @@ class LoadRequest(BaseModel):
     includes: list[str] = []            # 与 payload 搭配使用
     confirm: bool = False
     session_id: str = ''                # 画布编辑锁的持有者（前端传自己的）
+    align_versions: bool = False        # 要求所有相关容器与包体记录的 tag 一致
+    ref: str = ''                       # /align-device 用：要对齐哪个设备
 
 
 async def _load_solution(req: LoadRequest, token: Optional[str]) -> dict:
@@ -704,6 +779,7 @@ async def preflight(request: fastapi.Request, req: LoadRequest):
 
     includes = solution.get('includes') or []
     devices = _resolve_devices(payload.get('devices') or [])
+    await _augment_versions(devices)
 
     return {'code': 200, 'data': {
         'solution': {
@@ -718,6 +794,9 @@ async def preflight(request: fastapi.Request, req: LoadRequest):
         },
         'devices':   devices,
         'canLoad':   not devices['missing'] and not devices['installable'],
+        # 版本不一致不阻止载入 —— 只有用户勾了"对齐版本"才需要先重新部署
+        'misaligned':  _misaligned(devices),
+        'selfVersion': _core_version(),
         'overwrite': _overwrite_summary(includes),
         'canvasEditor': _canvas_editor_conflict(req.session_id),
     }}
@@ -734,6 +813,45 @@ def _canvas_editor_conflict(session_id: str) -> Optional[str]:
     if editor and editor != session_id:
         return editor
     return None
+
+
+@router.post('/align-device')
+async def align_device(request: fastapi.Request, req: LoadRequest):
+    """把某个设备的容器重新部署到方案记录的 tag（"对齐版本"逐个设备执行）。
+
+    走 api/drivers.py 的 deploy 而不是另写一套：那边已经处理了 service.yml
+    合并、日志轮转策略与旧容器清理。这里只负责决定"部署哪个镜像 ref"。
+    前端逐个调用并轮询 preflight，因为拉镜像慢，需要给用户进度。
+    """
+    loaded = await _load_solution(req, _get_rc_token(request))
+    if not loaded.get('ok'):
+        return {'code': loaded['status'], 'error': loaded['error']}
+
+    payload = loaded['solution'].get('payload') or {}
+    resolved = _resolve_devices(payload.get('devices') or [])
+    await _augment_versions(resolved)
+
+    dev = next((d for d in resolved['matched'] + resolved['installable']
+                if d.get('ref') == req.ref), None)
+    if not dev:
+        return {'code': 404, 'error': f'包体里没有 ref={req.ref} 的设备，或本机没有对应驱动'}
+
+    align_image = dev.get('alignImage') or ''
+    driver_id = dev.get('localDriverId') or ''
+    if not driver_id:
+        return {'code': 422, 'error': f'{dev.get("name") or dev.get("serverName")} 在本机驱动清单里没有对应条目'}
+    if not align_image:
+        return {'code': 422,
+                'error': f'{dev.get("name") or dev.get("serverName")} 没有可对齐的版本：'
+                         f'包体未记录镜像 tag'}
+
+    from api.drivers import driver_deploy
+    result = await driver_deploy(driver_id, {'image': align_image})
+    if result.get('code') != 200:
+        return {'code': 500, 'error': result.get('message', '部署失败'),
+                'driverId': driver_id, 'image': align_image}
+    return {'code': 200, 'data': {'driverId': driver_id, 'image': align_image,
+                                  'deploy': result.get('data')}}
 
 
 # ── 端点：载入 ──────────────────────────────────────────────────────────────
@@ -768,6 +886,16 @@ async def apply(request: fastapi.Request, req: LoadRequest):
                 'error': '所需驱动尚未就绪，请先安装并启动这些驱动',
                 'devices': resolved}
 
+    # 勾了"对齐版本"就在这里再核一遍：前端是逐个设备部署的，中间任何一个失败
+    # 都不该让方案以混合版本落地。没勾则完全不看版本（打包时只记录、不判断）。
+    if req.align_versions:
+        await _augment_versions(resolved)
+        misaligned = _misaligned(resolved)
+        if misaligned:
+            return {'code': 409,
+                    'error': '以下容器的版本还没对齐到方案记录的 tag，请先完成对齐',
+                    'misaligned': misaligned}
+
     applied: dict = {}
 
     # 1) 画布 —— deviceRef 换回本机 mcpId
@@ -799,6 +927,7 @@ async def apply(request: fastapi.Request, req: LoadRequest):
         'coreVersion': solution.get('coreVersion') or payload.get('coreVersion', ''),
         'needsConfig': needs_config,
         'appliedAt':   int(time.time()),
+        'versionAligned': bool(req.align_versions),
         'devices':     payload.get('devices') or [],
     }
 

--- a/agent-core/src/api/solutions.py
+++ b/agent-core/src/api/solutions.py
@@ -80,9 +80,24 @@ def _get_rc_token(request: fastapi.Request) -> Optional[str]:
     return request.headers.get('x-rc-token')
 
 
+def _rc_error(status: int, error: str) -> str:
+    """Resource Center 报错中文化。鉴权类的原文是 Unauthorized，用户看不懂。"""
+    from api.account import normalize_rc_error
+    return normalize_rc_error(status, error)
+
+
+_UNAUTHORIZED = '未登录或登录已过期，请在「我的」中登录'
+
+
 async def _rc_request(method: str, path: str, token: Optional[str] = None,
                       json_body: Any = None, timeout: float = 20) -> dict:
-    """向 Resource Center 发一个请求，返回 {'ok', 'status', 'data'|'error'}。"""
+    """向 Resource Center 发一个请求。
+
+    返回 {'ok', 'status', 'data'|'error', 'payload'}。`data` 是 RC 的 `data`
+    字段（大多数端点的约定），`payload` 是整个响应体 —— 登录与 session 这类
+    端点把结果放在顶层（`{ok, token, userId}` / `{ok, user}`），调用方要自己从
+    payload 里取。
+    """
     url = f'{_get_rc_url()}{path}'
     headers = {'Content-Type': 'application/json'}
     if token:
@@ -94,14 +109,16 @@ async def _rc_request(method: str, path: str, token: Optional[str] = None,
             try:
                 data = resp.json()
             except Exception:
-                return {'ok': False, 'status': resp.status_code,
+                return {'ok': False, 'status': resp.status_code, 'payload': {},
                         'error': f'Resource Center 返回了非 JSON 响应 (HTTP {resp.status_code})'}
             if resp.status_code in (200, 201) and data.get('ok'):
-                return {'ok': True, 'status': resp.status_code, 'data': data.get('data')}
-            return {'ok': False, 'status': resp.status_code,
+                return {'ok': True, 'status': resp.status_code,
+                        'data': data.get('data'), 'payload': data}
+            return {'ok': False, 'status': resp.status_code, 'payload': data,
                     'error': data.get('error', f'请求失败 (HTTP {resp.status_code})')}
     except Exception as e:
-        return {'ok': False, 'status': 502, 'error': f'无法连接 Resource Center: {e}'}
+        return {'ok': False, 'status': 502, 'payload': {},
+                'error': f'无法连接 Resource Center: {e}'}
 
 
 def _core_version() -> str:
@@ -754,7 +771,7 @@ async def publish(request: fastapi.Request, req: PublishRequest):
     """打包并作为草稿推到 Resource Center（之后由作者提交审核）。"""
     token = _get_rc_token(request)
     if not token:
-        return {'code': 401, 'error': '未登录 Resource Center'}
+        return {'code': 401, 'error': _UNAUTHORIZED}
 
     built = await _build_payload(
         PackRequest(include=req.include, extra_redact=req.extra_redact), token)
@@ -771,7 +788,8 @@ async def publish(request: fastapi.Request, req: PublishRequest):
     }
     result = await _rc_request('POST', '/api/solutions/mine', token, body, timeout=60)
     if not result['ok']:
-        return {'code': result['status'], 'error': result['error']}
+        return {'code': result['status'],
+                'error': _rc_error(result['status'], result['error'])}
     return {'code': 200, 'data': result['data']}
 
 
@@ -788,7 +806,7 @@ class LoadRequest(BaseModel):
 
 
 async def _load_solution(req: LoadRequest, token: Optional[str]) -> dict:
-    """取回要载入的方案：优先用请求里带的 payload，否则按 slug 拉 RC。"""
+    """取回要载入的方案：优先用请求里带的 payload，否则按 slug 拉 Resource Center。"""
     if req.payload:
         return {'ok': True, 'solution': {
             'slug':     req.slug,
@@ -1122,38 +1140,41 @@ def _apply_tasks(tasks: list) -> dict:
 
 @router.get('/rc/mine')
 async def rc_my_solutions(request: fastapi.Request):
-    """代理获取用户在 RC 上的解决方案列表。"""
+    """代理获取用户在 Resource Center 上的解决方案列表。"""
     token = _get_rc_token(request)
     if not token:
-        return {'code': 401, 'error': '未登录 Resource Center'}
+        return {'code': 401, 'error': _UNAUTHORIZED}
     result = await _rc_request('GET', '/api/solutions/mine', token)
     if not result['ok']:
-        return {'code': result['status'], 'error': result['error']}
+        return {'code': result['status'],
+                'error': _rc_error(result['status'], result['error'])}
     return {'code': 200, 'data': result['data']}
 
 
 @router.put('/rc/mine/{solution_id}')
 async def rc_update_solution(solution_id: str, request: fastapi.Request,
                              body: dict = fastapi.Body(...)):
-    """代理更新 RC 上的解决方案（只改展示信息）。"""
+    """代理更新 Resource Center 上的解决方案（只改展示信息）。"""
     token = _get_rc_token(request)
     if not token:
-        return {'code': 401, 'error': '未登录 Resource Center'}
+        return {'code': 401, 'error': _UNAUTHORIZED}
     result = await _rc_request('PUT', f'/api/solutions/mine/{solution_id}', token, body)
     if not result['ok']:
-        return {'code': result['status'], 'error': result['error']}
+        return {'code': result['status'],
+                'error': _rc_error(result['status'], result['error'])}
     return {'code': 200, 'data': result['data']}
 
 
 @router.delete('/rc/mine/{solution_id}')
 async def rc_delete_solution(solution_id: str, request: fastapi.Request):
-    """代理删除 RC 上的解决方案。"""
+    """代理删除 Resource Center 上的解决方案。"""
     token = _get_rc_token(request)
     if not token:
-        return {'code': 401, 'error': '未登录 Resource Center'}
+        return {'code': 401, 'error': _UNAUTHORIZED}
     result = await _rc_request('DELETE', f'/api/solutions/mine/{solution_id}', token)
     if not result['ok']:
-        return {'code': result['status'], 'error': result['error']}
+        return {'code': result['status'],
+                'error': _rc_error(result['status'], result['error'])}
     return {'code': 200, 'data': {'id': solution_id}}
 
 
@@ -1162,11 +1183,12 @@ async def rc_submit_solution(solution_id: str, request: fastapi.Request):
     """代理提交解决方案送审。"""
     token = _get_rc_token(request)
     if not token:
-        return {'code': 401, 'error': '未登录 Resource Center'}
+        return {'code': 401, 'error': _UNAUTHORIZED}
     result = await _rc_request('POST', f'/api/solutions/mine/{solution_id}/submit',
                                token, {})
     if not result['ok']:
-        return {'code': result['status'], 'error': result['error']}
+        return {'code': result['status'],
+                'error': _rc_error(result['status'], result['error'])}
     return {'code': 200, 'data': result['data']}
 
 
@@ -1185,7 +1207,8 @@ async def market(search: str = '', industry: str = 'all', limit: int = 20):
         params.append(f'industry={industry}')
     result = await _rc_request('GET', f'/api/solutions?{"&".join(params)}')
     if not result['ok']:
-        return {'code': result['status'], 'error': result['error']}
+        return {'code': result['status'],
+                'error': _rc_error(result['status'], result['error'])}
     return {'code': 200, 'data': result['data']}
 
 
@@ -1195,5 +1218,6 @@ async def market_detail(slug: str, request: fastapi.Request):
     result = await _rc_request('GET', f'/api/solutions/{slug}',
                                _get_rc_token(request), timeout=60)
     if not result['ok']:
-        return {'code': result['status'], 'error': result['error']}
+        return {'code': result['status'],
+                'error': _rc_error(result['status'], result['error'])}
     return {'code': 200, 'data': result['data']}

--- a/agent-core/src/api/solutions.py
+++ b/agent-core/src/api/solutions.py
@@ -36,8 +36,9 @@ deviceRef 指向 devices[]，devices 用 MCP initialize 返回的 server_name
 
 敏感字段脱敏是"声明式"的：卡片自己在 configSchema 的属性上标
 `"x-sensitive": true`（或沿用已有的 `"format": "password"`），打包时把值清空
-并把路径记进 redactedFields。未声明的字段不会被自动清空 —— 打包接口会把
-候选清单给前端，作者可以通过 extraRedact 手工追加。
+并把路径记进 redactedFields。反过来，固定的出厂密码这类"要打码但不是秘密"的
+字段可以标 `"x-sensitive": false` 显式豁免。未声明的字段不会被自动清空 ——
+打包接口会把候选清单给前端，作者可以通过 extraRedact 手工追加。
 
 同样会被清空的是"本机专属"字段（`format: channel-select` /
 `audio-input-device`）：它们存的是本机 channel id 或声卡设备名，换机器不是
@@ -148,16 +149,28 @@ def _tool_schema(mcp: dict, tool_name: str) -> dict:
 def _sensitive_props(config_schema: dict) -> set:
     """schema 里声明为敏感的属性名。
 
-    `x-sensitive` 是本文件引入的声明（见模块注释），`format: password` 是
-    driver 侧早就在用的写法（web/js/sidebar.js 用它渲染 password input），
-    两者都算敏感 —— 否则已有驱动的密钥字段会原样进包体。
+    判定顺序：
+      1. `x-sensitive: true`  → 敏感（本文件引入的显式声明）
+      2. `x-sensitive: false` → 不敏感，即使 format 是 password。给"输入框要打码
+         但值本身不是秘密"的字段用，例如固定的出厂密码 —— 清掉只会让载入方
+         被迫重新敲一遍同一个默认值。
+      3. `format: password`   → 敏感（driver 侧早就在用的写法，见
+         web/js/sidebar.js 用它渲染 password input）
+
+    第 3 条是安全默认：没表态的密码框一律当秘密，否则已有驱动的密钥字段会
+    原样进包体。要豁免就按第 2 条显式写出来。
     """
     props = (config_schema or {}).get('properties') or {}
     out = set()
     for name, spec in props.items():
         if not isinstance(spec, dict):
             continue
-        if spec.get('x-sensitive') is True or spec.get('format') == 'password':
+        declared = spec.get('x-sensitive')
+        if declared is True:
+            out.add(name)
+        elif declared is False:
+            continue
+        elif spec.get('format') == 'password':
             out.add(name)
     return out
 

--- a/agent-core/src/api/solutions.py
+++ b/agent-core/src/api/solutions.py
@@ -250,7 +250,26 @@ def _device_descriptor(ref: str, mcp: dict) -> dict:
         'image':         driver.get('image', ''),
         'name':          driver.get('name') or mcp.get('name') or server_name,
         'port':          _port_from_url(mcp.get('url', '')),
+        # 机型：只有硬件驱动才有。适用机型（robotTypes）由它推出来，不让作者手填 ——
+        # 手填的话方案会声称支持一台本机根本没有驱动的机器。
+        'provider':      driver.get('provider', ''),
+        'model':         driver.get('model', ''),
     }
+
+
+def _robot_models(devices: list) -> list:
+    """本机这套画布对应的机型列表 = 画布上硬件驱动的 model，去重保序。
+
+    没有硬件驱动（纯 core + perception 的方案）就返回空 —— 前端显示 None。
+    """
+    models: list = []
+    for d in devices:
+        if d.get('category') != 'driver':
+            continue
+        model = (d.get('model') or '').strip()
+        if model and model not in models:
+            models.append(model)
+    return models
 
 
 def _canvas_devices() -> tuple[list, dict, list]:
@@ -720,6 +739,8 @@ async def packable(request: fastapi.Request):
             'devices':     devices,
             'unresolved':  unresolved,
         },
+        # 适用机型：由画布上的硬件驱动推出，前端只展示不让改
+        'robotTypes': _robot_models(devices),
         'skills': {
             'available': [_skill_brief(s) for s in on_market],
             'offMarket': [_skill_brief(s) for s in off_market],

--- a/agent-core/src/api/solutions.py
+++ b/agent-core/src/api/solutions.py
@@ -38,6 +38,10 @@ deviceRef 指向 devices[]，devices 用 MCP initialize 返回的 server_name
 `"x-sensitive": true`（或沿用已有的 `"format": "password"`），打包时把值清空
 并把路径记进 redactedFields。未声明的字段不会被自动清空 —— 打包接口会把
 候选清单给前端，作者可以通过 extraRedact 手工追加。
+
+同样会被清空的是"本机专属"字段（`format: channel-select` /
+`audio-input-device`）：它们存的是本机 channel id 或声卡设备名，换机器不是
+泄密而是根本指不到东西，载入方必须重选。
 """
 
 import os
@@ -158,6 +162,24 @@ def _sensitive_props(config_schema: dict) -> set:
     return out
 
 
+# 值只在本机有意义的字段格式：channel-select 存的是本机 channel_configs 里的
+# id，audio-input-device 存的是本机声卡的设备名/序号。带到另一台机器上不是
+# 泄密，而是根本指不到东西，所以同样清空并让载入方重选。
+_LOCAL_ONLY_FORMATS = ('channel-select', 'audio-input-device')
+
+
+def _local_only_props(config_schema: dict) -> set:
+    """schema 里"值只对本机有效"的属性名。"""
+    props = (config_schema or {}).get('properties') or {}
+    return {name for name, spec in props.items()
+            if isinstance(spec, dict) and spec.get('format') in _LOCAL_ONLY_FORMATS}
+
+
+def _must_clear_props(config_schema: dict) -> tuple[set, set]:
+    """(敏感字段, 本机专属字段) —— 两类都必须在打包时清空。"""
+    return _sensitive_props(config_schema), _local_only_props(config_schema)
+
+
 def _port_from_url(url: str) -> Optional[int]:
     try:
         from urllib.parse import urlparse
@@ -258,7 +280,7 @@ def _config_field_paths(ref_of: dict) -> list:
         ref = ref_of.get(mcp_id)
         if not ref or not isinstance(value, dict):
             continue
-        sensitive = _sensitive_props(_tool_schema(mcps.get(mcp_id, {}), tool_name))
+        sensitive, local_only = _must_clear_props(_tool_schema(mcps.get(mcp_id, {}), tool_name))
         pkey = f'{ref}:{tool_name}:{instance_id}' if instance_id else f'{ref}:{tool_name}'
         for prop in value:
             out.append({
@@ -267,6 +289,7 @@ def _config_field_paths(ref_of: dict) -> list:
                 'prop':       prop,
                 'instanceId': instance_id,
                 'sensitive':  prop in sensitive,
+                'localOnly':  prop in local_only,
             })
     return sorted(out, key=lambda x: x['path'])
 
@@ -325,11 +348,11 @@ def _pack_canvas(ref_of: dict, extra_redact: set) -> tuple[dict, list]:
             tool_configs[pkey] = value
             continue
 
-        sensitive = _sensitive_props(_tool_schema(mcps.get(mcp_id, {}), tool_name))
+        sensitive, local_only = _must_clear_props(_tool_schema(mcps.get(mcp_id, {}), tool_name))
         packed = {}
         for prop, val in value.items():
             path = f'{pkey}:{prop}'
-            if prop in sensitive or path in extra_redact:
+            if prop in sensitive or prop in local_only or path in extra_redact:
                 packed[prop] = '' if isinstance(val, str) or val is None else type(val)()
                 redacted.append(path)
             else:
@@ -480,10 +503,15 @@ def _resolve_devices(devices: list) -> dict:
         driver_id = dev.get('driverId', '')
         port = dev.get('port')
 
-        # 1) 已注册 MCP：优先按 server_name（稳定），退化到端口
+        # 1) 已注册 MCP：优先按 server_name（稳定），退化到端口，再退化到 name。
+        #    name 兜底是给 agentcore / channel 这种内部伪设备用的：它们 url 为空、
+        #    没有端口也没有 manifest 条目，一旦 server_name 对不上就会被误判成
+        #    "本机缺驱动"，而实际上每台机器启动时都会注册它们。
         mcp = next((m for m in mcps if server_name and m.get('server_name') == server_name), None)
         if not mcp and port:
             mcp = next((m for m in mcps if _port_from_url(m.get('url', '')) == port), None)
+        if not mcp and dev.get('name'):
+            mcp = next((m for m in mcps if m.get('name') == dev['name']), None)
         if mcp:
             mapping[dev.get('ref')] = mcp.get('id')
             entry = _driver_entry_for(mcp)

--- a/agent-core/src/start.py
+++ b/agent-core/src/start.py
@@ -454,6 +454,9 @@ app_api.include_router(api.agent_definition.router)
 import api.skills
 app_api.include_router(api.skills.router)
 
+import api.account
+app_api.include_router(api.account.router)
+
 import api.solutions
 app_api.include_router(api.solutions.router)
 

--- a/agent-core/src/start.py
+++ b/agent-core/src/start.py
@@ -454,6 +454,9 @@ app_api.include_router(api.agent_definition.router)
 import api.skills
 app_api.include_router(api.skills.router)
 
+import api.solutions
+app_api.include_router(api.solutions.router)
+
 import api.history
 app_api.include_router(api.history.router)
 

--- a/agent-core/web/css/style.css
+++ b/agent-core/web/css/style.css
@@ -4243,11 +4243,6 @@ html, body {
   line-height: 1.8;
   padding: 40px 24px;
 }
-/* 空态里的按钮独占一行并居中，别和说明文字挤在一起 */
-.skill-empty .skill-btn {
-  display: block;
-  margin: 18px auto 0;
-}
 .skill-empty.hidden { display: none; }
 
 .skill-card {

--- a/agent-core/web/css/style.css
+++ b/agent-core/web/css/style.css
@@ -7044,7 +7044,25 @@ html, body {
 
 /* ── 保存 / 打包 ── */
 
+/* 保存面板是 div 而不是 form，拿不到 .skill-form-body form 的 gap:12px，
+   所以这里显式给字段行之间留出竖向节奏 —— 否则每一行的 label 会紧贴上一行的
+   输入框，密到看不出分组。 */
 .solution-save-form { padding-bottom: 8px; }
+.solution-save-form .skill-form-row,
+.solution-save-form > .skill-form-field { margin-top: 14px; }
+/* 紧跟小标题的第一行不再叠加：标题自己的 8px 下边距就够了 */
+.solution-save-form .solution-section-label + .skill-form-row,
+.solution-save-form .solution-section-label + .skill-form-field,
+.solution-save-form .solution-section-label + .solution-check-group { margin-top: 0; }
+.solution-save-form .skill-form-field { gap: 6px; }
+.solution-save-form .skill-form-field textarea { min-height: 76px; }
+.solution-save-form .skill-form-error { margin-top: 14px; }
+.solution-save-form .skill-form-footer {
+  margin-top: 20px;
+  padding-top: 14px;
+  align-items: center;
+  gap: 12px;
+}
 .solution-check-group {
   margin-top: 14px;
   padding: 10px 12px;

--- a/agent-core/web/css/style.css
+++ b/agent-core/web/css/style.css
@@ -172,7 +172,10 @@ html, body {
   margin-left: auto;
   display: flex;
   align-items: center;
-  gap: 8px;
+  /* 2px 而不是 8px：设置 / 我的 两个按钮自己还有 10px 内边距，pill 边到图标已经隔了
+     12px；原来 gap:8 + padding:14 是 22px，读起来像两个不相干的入口。
+     更新提示不属于这一组，用自己的 margin-right 补回间距。 */
+  gap: 2px;
 }
 
 .topbar-btn {
@@ -187,7 +190,7 @@ html, body {
   display: flex;
   align-items: center;
   gap: 6px;
-  padding: 6px 14px;
+  padding: 6px 10px;
   font-size: 12px;
   font-weight: 500;
   border: none;
@@ -279,6 +282,8 @@ html, body {
   display: flex;
   align-items: center;
   gap: 8px;
+  /* .topbar-actions 的 gap 收成 2px 是为了让设置/我的靠成一组，更新提示不属于那一组 */
+  margin-right: 8px;
   background: var(--yellow-bg);
   border: 1px solid var(--yellow);
   border-radius: var(--radius-sm);

--- a/agent-core/web/css/style.css
+++ b/agent-core/web/css/style.css
@@ -7096,3 +7096,21 @@ html, body {
   .solution-entry-label { display: none; }
   .solution-entry-badge { max-width: 72px; }
 }
+
+/* 载入弹窗里的容器版本格挡：本机 tag → 方案 tag */
+.solution-ver {
+  padding: 1px 6px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg-input);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+.solution-ver-diff {
+  border-color: var(--yellow);
+  background: var(--yellow-bg);
+  color: var(--yellow);
+}
+.solution-ver-unknown { color: var(--text-dim); }

--- a/agent-core/web/css/style.css
+++ b/agent-core/web/css/style.css
@@ -2695,6 +2695,12 @@ html, body {
   overflow: hidden;
   box-shadow: var(--shadow-lg);
 }
+/* .modal-body 没有基础样式，是有意的：history 那种左右分栏的 body 需要
+   padding:0 + overflow:hidden，由内层面板各自滚动。代价是每个新弹窗都必须自己声明
+   padding 和 overflow-y —— 漏了的表现是：内容贴着弹窗边框（标题却是缩进的，看起来
+   就是"挤在一起"），且因为上面 .modal 是 max-height + overflow:hidden，超出的内容会
+   被直接裁掉而不是滚动。这个坑已经踩过三次（account / solution-load 都是事后才修），
+   加新弹窗时记得写。刻意不声明的只有 .history-body。 */
 .modal-header {
   display: flex;
   align-items: center;
@@ -6857,9 +6863,7 @@ html, body {
   display: flex;
   flex-direction: column;
 }
-/* .modal-body 没有基础 padding（见 .account-modal-body 上方那段说明），不自己声明的话
-   内容会贴着弹窗边框，而标题却是缩进的 —— 看起来就是"挤在一起"。overflow-y 同样必须
-   自己声明：.modal 是 max-height + overflow:hidden，驱动多的时候底部会被直接裁掉。 */
+/* padding + overflow-y 必须自己声明，原因见 .modal 上方那段注释 */
 .solution-load-modal .modal-body {
   padding: 18px 24px 22px;
   overflow-y: auto;
@@ -7176,9 +7180,7 @@ html, body {
 .topbar-account-badge.hidden { display: none; }
 
 .account-modal { width: 480px; }
-/* 必须自己声明滚动：.modal 是 max-height:88vh + overflow:hidden，body 不滚动的话
-   超出的内容会被直接裁掉（表现为最后一行文字被切、看不到下边距）。
-   .skill-modal-body / .reset-modal .modal-body 也都是各自声明的。 */
+/* padding + overflow-y 必须自己声明，原因见 .modal 上方那段注释 */
 .account-modal-body {
   padding: 18px 24px 26px;
   overflow-y: auto;

--- a/agent-core/web/css/style.css
+++ b/agent-core/web/css/style.css
@@ -4240,7 +4240,13 @@ html, body {
   text-align: center;
   color: var(--text-dim);
   font-size: 13px;
-  padding: 40px 0;
+  line-height: 1.8;
+  padding: 40px 24px;
+}
+/* 空态里的按钮独占一行并居中，别和说明文字挤在一起 */
+.skill-empty .skill-btn {
+  display: block;
+  margin: 18px auto 0;
 }
 .skill-empty.hidden { display: none; }
 
@@ -7119,7 +7125,14 @@ html, body {
 .topbar-account-badge.hidden { display: none; }
 
 .account-modal { width: 480px; }
-.account-modal-body { padding: 18px 24px 22px; }
+/* 必须自己声明滚动：.modal 是 max-height:88vh + overflow:hidden，body 不滚动的话
+   超出的内容会被直接裁掉（表现为最后一行文字被切、看不到下边距）。
+   .skill-modal-body / .reset-modal .modal-body 也都是各自声明的。 */
+.account-modal-body {
+  padding: 18px 24px 26px;
+  overflow-y: auto;
+  flex: 1;
+}
 
 .account-notice {
   margin-bottom: 14px;
@@ -7292,7 +7305,8 @@ html, body {
   white-space: nowrap;
 }
 .account-hint {
-  margin: 10px 0 0;
+  /* 最后一个元素，和容器下边界之间要留出呼吸感（否则贴着描边） */
+  margin: 14px 0 2px;
   font-size: 11px;
   line-height: 1.7;
   color: var(--text-dim);

--- a/agent-core/web/css/style.css
+++ b/agent-core/web/css/style.css
@@ -6844,45 +6844,9 @@ html, body {
 
 
 /* ══════════════════════════════════════════════════════════════════════════
-   Solutions — 解决方案（左上角入口 + 当前方案 / 市场 / 保存）
+   Solutions — 解决方案（入口在「我的」里 + 当前方案 / 市场 / 保存）
    复用 .skill-* 的 modal / card / button 语言，这里只加方案特有的部件。
    ══════════════════════════════════════════════════════════════════════════ */
-
-.solution-entry-btn {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  margin-left: 10px;
-  padding: 5px 10px;
-  max-width: 260px;
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  background: var(--bg-card);
-  color: var(--text-muted);
-  font-size: 12px;
-  font-weight: 500;
-  cursor: pointer;
-  transition: border-color .15s, color .15s, background .15s;
-}
-.solution-entry-btn:hover {
-  border-color: var(--accent);
-  color: var(--accent);
-  background: var(--accent-dim);
-}
-.solution-entry-label { white-space: nowrap; }
-.solution-entry-badge {
-  max-width: 110px;
-  padding: 1px 6px;
-  border-radius: 999px;
-  background: var(--accent-dim);
-  color: var(--accent);
-  font-size: 10px;
-  font-weight: 600;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-.solution-entry-badge.hidden { display: none; }
 
 .solution-modal { width: 680px; }
 .solution-load-modal {
@@ -7109,10 +7073,10 @@ html, body {
   color: var(--text-muted);
 }
 
-/* 中等宽度下 topbar 挤，入口收成纯图标（角标保留，用户还需要知道载入了什么） */
+/* 中等宽度下 topbar 挤，「我的」收成纯图标（角标里的账号名先省略） */
 @media (max-width: 1100px) {
-  .solution-entry-label { display: none; }
-  .solution-entry-badge { max-width: 72px; }
+  .topbar-account-btn > span:not(.topbar-account-badge) { display: none; }
+  .topbar-account-badge { max-width: 72px; }
 }
 
 /* 载入弹窗里的容器版本格挡：本机 tag → 方案 tag */
@@ -7132,3 +7096,220 @@ html, body {
   color: var(--yellow);
 }
 .solution-ver-unknown { color: var(--text-dim); }
+
+/* ══════════════════════════════════════════════════════════════════════════
+   我的（账号）—— 顶栏按钮 + 桌面 modal + 移动端整页面板
+   桌面与移动共用 .account-content 里的同一份 HTML（js/account.js 渲染），
+   所以这里的样式不区分端，只在移动端断点里放大触摸目标。
+   ══════════════════════════════════════════════════════════════════════════ */
+
+.topbar-account-btn { position: relative; }
+.topbar-account-badge {
+  max-width: 110px;
+  padding: 1px 6px;
+  border-radius: 999px;
+  background: var(--accent-dim);
+  color: var(--accent);
+  font-size: 10px;
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.topbar-account-badge.hidden { display: none; }
+
+.account-modal { width: 480px; }
+.account-modal-body { padding: 18px 24px 22px; }
+
+.account-notice {
+  margin-bottom: 14px;
+  padding: 9px 12px;
+  border: 1px solid var(--yellow);
+  border-radius: var(--radius-sm);
+  background: var(--yellow-bg);
+  font-size: 12px;
+  color: var(--yellow);
+}
+
+.account-card {
+  padding: 16px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg-card);
+}
+.account-card-signed {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+.account-card-head {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 14px;
+}
+.account-avatar {
+  flex: 0 0 40px;
+  width: 40px;
+  height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: var(--accent);
+  color: #fff;
+  font-size: 16px;
+  font-weight: 600;
+}
+.account-avatar-empty {
+  background: var(--bg-input);
+  color: var(--text-dim);
+}
+.account-identity { flex: 1; min-width: 0; }
+.account-identity-name {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.account-identity-sub,
+.account-identity-meta {
+  margin-top: 3px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 11px;
+  color: var(--text-dim);
+  flex-wrap: wrap;
+}
+.account-role {
+  padding: 1px 6px;
+  border-radius: 999px;
+  background: var(--accent-dim);
+  color: var(--accent);
+  font-weight: 600;
+}
+.account-id {
+  font-family: var(--font-mono);
+  max-width: 150px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.account-copy-btn {
+  border: none;
+  background: none;
+  padding: 0;
+  color: var(--accent);
+  font-size: 11px;
+  cursor: pointer;
+}
+
+.account-form {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.account-form input {
+  height: 38px;
+  padding: 0 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--bg);
+  color: var(--text);
+  font-size: 13px;
+  outline: none;
+}
+.account-form input:focus { border-color: var(--accent); }
+.account-form-error {
+  margin: 0;
+  font-size: 11px;
+  color: var(--red);
+}
+.account-submit-btn {
+  height: 40px;
+  border: none;
+  border-radius: var(--radius-sm);
+  background: var(--accent);
+  color: #fff;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+}
+.account-submit-btn:disabled { opacity: .6; cursor: default; }
+/* 一行只放一件事，且居中：三项 space-between 会把"注册"甩到左右之间的随机位置 */
+.account-switch {
+  margin-top: 12px;
+  text-align: center;
+  font-size: 11px;
+  color: var(--text-dim);
+}
+.account-web-link {
+  margin-top: 6px;
+  padding-top: 8px;
+  border-top: 1px solid var(--border);
+  text-align: center;
+}
+.account-link {
+  border: none;
+  background: none;
+  padding: 0;
+  color: var(--accent);
+  font-size: 11px;
+  cursor: pointer;
+  text-decoration: none;
+}
+
+.account-section-label {
+  margin: 18px 0 8px;
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: .1em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+}
+/* 桌面 modal 里的入口行比移动端的 52px 紧一些 */
+.account-entry-list .settings-item {
+  padding: 12px 14px;
+  min-height: 0;
+  font-size: 13px;
+}
+.settings-item-text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+  text-align: left;
+}
+.settings-item-sub {
+  font-size: 11px;
+  font-weight: 400;
+  color: var(--text-dim);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.account-hint {
+  margin: 10px 0 0;
+  font-size: 11px;
+  line-height: 1.7;
+  color: var(--text-dim);
+}
+
+@media (max-width: 768px) {
+  /* 移动端是整页面板，触摸目标放大回 52px（与设置列表一致） */
+  .account-entry-list .settings-item {
+    padding: 14px 18px;
+    min-height: 52px;
+    font-size: 15px;
+  }
+  .account-card { padding: 18px 16px; }
+  .account-form input { height: 44px; font-size: 15px; }
+  .account-submit-btn { height: 46px; font-size: 15px; }
+  .account-id { max-width: 40vw; }
+}
+
+/* 「我的」tab 上的圆点表示"已登录"，不是未读/告警，所以不用 .tabbar-badge 的红色 */
+#account-tab-badge { background: var(--accent); }

--- a/agent-core/web/css/style.css
+++ b/agent-core/web/css/style.css
@@ -6842,3 +6842,257 @@ html, body {
   white-space: nowrap;
 }
 
+
+/* ══════════════════════════════════════════════════════════════════════════
+   Solutions — 解决方案（左上角入口 + 当前方案 / 市场 / 保存）
+   复用 .skill-* 的 modal / card / button 语言，这里只加方案特有的部件。
+   ══════════════════════════════════════════════════════════════════════════ */
+
+.solution-entry-btn {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-left: 10px;
+  padding: 5px 10px;
+  max-width: 260px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg-card);
+  color: var(--text-muted);
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: border-color .15s, color .15s, background .15s;
+}
+.solution-entry-btn:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+  background: var(--accent-dim);
+}
+.solution-entry-label { white-space: nowrap; }
+.solution-entry-badge {
+  max-width: 110px;
+  padding: 1px 6px;
+  border-radius: 999px;
+  background: var(--accent-dim);
+  color: var(--accent);
+  font-size: 10px;
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.solution-entry-badge.hidden { display: none; }
+
+.solution-modal { width: 680px; }
+.solution-load-modal {
+  width: 620px;
+  max-width: 95vw;
+  max-height: 85vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.solution-section-label {
+  margin: 16px 0 8px;
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: .1em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+}
+.solution-section-label:first-child { margin-top: 0; }
+.solution-warn { color: var(--yellow); }
+
+.solution-pills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+}
+.solution-pill {
+  padding: 2px 8px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--bg-input);
+  font-size: 11px;
+  color: var(--text-muted);
+}
+.solution-pill-sm { font-size: 10px; padding: 1px 6px; }
+.solution-pill-driver {
+  border-color: var(--accent-glow);
+  background: var(--accent-dim);
+  color: var(--accent);
+  font-size: 10px;
+  padding: 1px 6px;
+}
+
+/* ── 当前方案 ── */
+
+.solution-current-card {
+  padding: 16px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg-card);
+}
+.solution-current-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+.solution-current-name {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--text);
+}
+.solution-current-meta {
+  margin-top: 2px;
+  font-size: 11px;
+  color: var(--text-dim);
+}
+
+.solution-driver-list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.solution-driver-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 7px 10px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg-input);
+  font-size: 12px;
+}
+.solution-driver-row-warn  { border-color: var(--yellow); background: var(--yellow-bg); }
+.solution-driver-row-error { border-color: var(--red);    background: var(--red-bg); }
+.solution-driver-name { font-weight: 500; color: var(--text); }
+.solution-driver-image {
+  margin-left: auto;
+  font-family: var(--font-mono, monospace);
+  font-size: 10px;
+  color: var(--text-dim);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.solution-driver-ok   { color: var(--green);  font-weight: 700; }
+.solution-driver-warn { color: var(--yellow); font-weight: 700; }
+.solution-driver-err  { color: var(--red);    font-weight: 700; }
+
+.solution-needs-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+}
+.solution-need-item {
+  padding: 3px 8px;
+  border: 1px solid var(--yellow);
+  border-radius: var(--radius);
+  background: var(--yellow-bg);
+  font-family: var(--font-mono, monospace);
+  font-size: 11px;
+  color: var(--yellow);
+  cursor: pointer;
+}
+.solution-need-item:hover { filter: brightness(.97); }
+.solution-need-item-static { cursor: default; }
+
+/* ── 市场 ── */
+
+.solution-market-bar {
+  display: flex;
+  gap: 8px;
+}
+.solution-market-bar select {
+  padding: 8px 10px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg-input);
+  font-size: 13px;
+  color: var(--text);
+  outline: none;
+}
+.solution-market-card .skill-card-header { align-items: center; }
+.solution-market-card .solution-pills { margin-top: 8px; }
+
+/* ── 载入确认 ── */
+
+.solution-load-error {
+  margin: 10px 0;
+  padding: 10px 12px;
+  border: 1px solid var(--red);
+  border-radius: var(--radius);
+  background: var(--red-bg);
+  font-size: 12px;
+  line-height: 1.6;
+  color: var(--red);
+}
+.solution-load-error code {
+  font-family: var(--font-mono, monospace);
+  font-size: 11px;
+}
+.solution-overwrite-list {
+  margin: 0;
+  padding-left: 18px;
+  font-size: 12px;
+  line-height: 1.8;
+  color: var(--text-muted);
+}
+
+/* ── 保存 / 打包 ── */
+
+.solution-save-form { padding-bottom: 8px; }
+.solution-check-group {
+  margin-top: 14px;
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg-card);
+}
+.solution-check-group-title {
+  margin-bottom: 6px;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text);
+}
+.solution-check {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 4px 0;
+  font-size: 12px;
+  color: var(--text-muted);
+  cursor: pointer;
+}
+.solution-check input { margin-top: 2px; }
+.solution-check em {
+  font-style: normal;
+  color: var(--text-dim);
+  font-size: 11px;
+}
+.solution-check code {
+  font-family: var(--font-mono, monospace);
+  font-size: 11px;
+  color: var(--text-muted);
+}
+.solution-check-locked,
+.solution-check-disabled { cursor: default; opacity: .75; }
+.solution-hint {
+  margin: 4px 0;
+  font-size: 11px;
+  line-height: 1.7;
+  color: var(--text-dim);
+}
+.solution-hint code {
+  font-family: var(--font-mono, monospace);
+  color: var(--text-muted);
+}
+
+/* 中等宽度下 topbar 挤，入口收成纯图标（角标保留，用户还需要知道载入了什么） */
+@media (max-width: 1100px) {
+  .solution-entry-label { display: none; }
+  .solution-entry-badge { max-width: 72px; }
+}

--- a/agent-core/web/css/style.css
+++ b/agent-core/web/css/style.css
@@ -6851,15 +6851,23 @@ html, body {
 
 .solution-modal { width: 680px; }
 .solution-load-modal {
-  width: 620px;
+  width: 680px;
   max-width: 95vw;
   max-height: 85vh;
   display: flex;
   flex-direction: column;
 }
+/* .modal-body 没有基础 padding（见 .account-modal-body 上方那段说明），不自己声明的话
+   内容会贴着弹窗边框，而标题却是缩进的 —— 看起来就是"挤在一起"。overflow-y 同样必须
+   自己声明：.modal 是 max-height + overflow:hidden，驱动多的时候底部会被直接裁掉。 */
+.solution-load-modal .modal-body {
+  padding: 18px 24px 22px;
+  overflow-y: auto;
+  flex: 1;
+}
 
 .solution-section-label {
-  margin: 16px 0 8px;
+  margin: 22px 0 8px;
   font-size: 10px;
   font-weight: 600;
   letter-spacing: .1em;
@@ -6919,30 +6927,60 @@ html, body {
 .solution-driver-list {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 6px;
 }
+/* 两行布局：第一行是"是什么"（名字 / 类别 / 状态），第二行是"哪个版本"。
+   之前挤在一行里的 5 个元素（图标 + 名字 + 类别 + 长 tag + 镜像 + 按钮）在 620px 下
+   正好塞满，jetson tag 一来就把「一键安装」压成两个字宽。 */
 .solution-driver-row {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 7px 10px;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  /* start 而不是 center：行会有 2~3 行高（版本 + 镜像），图标和按钮要跟"名字"那一行
+     对齐，居中的话会飘到镜像地址旁边 */
+  align-items: start;
+  column-gap: 10px;
+  padding: 9px 12px;
   border: 1px solid var(--border);
   border-radius: var(--radius);
   background: var(--bg-input);
   font-size: 12px;
 }
+.solution-driver-main {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  min-width: 0;
+}
+.solution-driver-line {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 6px;
+}
 .solution-driver-row-warn  { border-color: var(--yellow); background: var(--yellow-bg); }
 .solution-driver-row-error { border-color: var(--red);    background: var(--red-bg); }
 .solution-driver-name { font-weight: 500; color: var(--text); }
-.solution-driver-image {
+/* 状态词（已就绪 / 待安装 / 缺失）—— 不再重复左边已经写过的驱动名 */
+.solution-driver-state {
   margin-left: auto;
+  font-size: 10px;
+  color: var(--text-dim);
+  white-space: nowrap;
+}
+.solution-driver-row-warn  .solution-driver-state { color: var(--yellow); }
+.solution-driver-row-error .solution-driver-state { color: var(--red); }
+/* 第二行：镜像 / 版本。长 tag 在这里换行，不再挤压同行的其它元素 */
+.solution-driver-sub {
   font-family: var(--font-mono, monospace);
   font-size: 10px;
   color: var(--text-dim);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  overflow-wrap: anywhere;
 }
+.solution-driver-row .skill-btn { flex-shrink: 0; white-space: nowrap; }
+/* 图标和按钮跟第一行文字对齐（.solution-driver-line 的行高约 18px） */
+.solution-driver-ok,
+.solution-driver-warn,
+.solution-driver-err { line-height: 18px; }
 .solution-driver-ok   { color: var(--green);  font-weight: 700; }
 .solution-driver-warn { color: var(--yellow); font-weight: 700; }
 .solution-driver-err  { color: var(--red);    font-weight: 700; }
@@ -6951,6 +6989,20 @@ html, body {
   display: flex;
   flex-wrap: wrap;
   gap: 5px;
+}
+/* 适用机型：由画布上的硬件驱动推出，是展示而不是输入。高度对齐同一行的
+   「标签」输入框，两个 field 才不会一高一低。 */
+.solution-robots {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 5px;
+  min-height: 34px;
+}
+.solution-robots-none {
+  font-family: var(--font-mono, monospace);
+  font-size: 11px;
+  color: var(--text-dim);
 }
 .solution-need-item {
   padding: 3px 8px;
@@ -7081,7 +7133,11 @@ html, body {
 }
 
 /* 载入弹窗里的容器版本格挡：本机 tag → 方案 tag */
+/* 版本 chip。在驱动行里它自己占一行（.solution-driver-main 是纵向 flex），所以用
+   align-self 收窄到内容宽度，而不是撑满整行。long tag 允许换行，不再压缩兄弟元素。 */
 .solution-ver {
+  align-self: flex-start;
+  max-width: 100%;
   padding: 1px 6px;
   border: 1px solid var(--border);
   border-radius: var(--radius);
@@ -7089,7 +7145,7 @@ html, body {
   font-family: var(--font-mono);
   font-size: 10px;
   color: var(--text-muted);
-  white-space: nowrap;
+  overflow-wrap: anywhere;
 }
 .solution-ver-diff {
   border-color: var(--yellow);

--- a/agent-core/web/index.html
+++ b/agent-core/web/index.html
@@ -23,6 +23,11 @@
         <div class="brand-name-row"><span class="brand-name">Phanthy</span><span class="brand-name-accent">Motus</span></div>
         <span class="brand-tagline">Robot Agent OS</span>
       </div>
+      <button class="solution-entry-btn" id="btn-solutions" title="解决方案">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="m12 2 9 5-9 5-9-5 9-5"/><path d="m3 12 9 5 9-5"/><path d="m3 17 9 5 9-5"/></svg>
+        <span class="solution-entry-label">解决方案</span>
+        <span class="solution-entry-badge hidden" id="solution-entry-badge"></span>
+      </button>
     </div>
     <!-- Mode toggle: 配置 / 监控 -->
     <div class="mode-toggle-group" id="mode-toggle-group">
@@ -504,6 +509,51 @@
           <button type="submit" class="skill-btn skill-btn-primary" id="skill-form-submit-btn">保存</button>
         </div>
       </form>
+    </div>
+  </div>
+</div>
+
+<!-- Solution Modal (载入 / 市场 / 保存) -->
+<div class="modal-overlay hidden" id="solution-overlay">
+  <div class="modal skill-modal solution-modal">
+    <div class="modal-header">
+      <span class="modal-title">解决方案</span>
+      <div class="skill-rc-login-status" id="solution-rc-login-status"></div>
+      <button class="btn-icon" id="solution-close">✕</button>
+    </div>
+    <div class="skill-tabs">
+      <button class="skill-tab active" data-tab="current">当前方案</button>
+      <button class="skill-tab" data-tab="market">方案市场</button>
+      <button class="skill-tab" data-tab="save">保存当前方案</button>
+    </div>
+    <div class="modal-body skill-modal-body">
+      <div class="skill-panel active" data-panel="current" id="solution-current-panel"></div>
+
+      <div class="skill-panel" data-panel="market" id="solution-market-panel">
+        <div class="skill-search-bar solution-market-bar">
+          <input type="text" id="solution-search" placeholder="搜索解决方案…" autocomplete="off" spellcheck="false">
+          <select id="solution-industry-filter"></select>
+        </div>
+        <div class="skill-list" id="solution-market-list"></div>
+        <div class="skill-empty hidden" id="solution-market-empty">未找到解决方案</div>
+      </div>
+
+      <div class="skill-panel" data-panel="save" id="solution-save-panel"></div>
+    </div>
+  </div>
+</div>
+
+<!-- Solution Load Confirm Modal (缺失驱动 + 覆盖提示) -->
+<div class="modal-overlay hidden" id="solution-load-overlay">
+  <div class="modal solution-load-modal">
+    <div class="modal-header">
+      <span class="modal-title" id="solution-load-title">载入解决方案</span>
+      <button class="btn-icon" id="solution-load-close">✕</button>
+    </div>
+    <div class="modal-body" id="solution-load-body"></div>
+    <div class="skill-form-footer">
+      <button type="button" class="skill-btn" id="solution-load-cancel">取消</button>
+      <button type="button" class="skill-btn skill-btn-primary" id="solution-load-confirm">确认载入</button>
     </div>
   </div>
 </div>

--- a/agent-core/web/index.html
+++ b/agent-core/web/index.html
@@ -23,11 +23,6 @@
         <div class="brand-name-row"><span class="brand-name">Phanthy</span><span class="brand-name-accent">Motus</span></div>
         <span class="brand-tagline">Robot Agent OS</span>
       </div>
-      <button class="solution-entry-btn" id="btn-solutions" title="解决方案">
-        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="m12 2 9 5-9 5-9-5 9-5"/><path d="m3 12 9 5 9-5"/><path d="m3 17 9 5 9-5"/></svg>
-        <span class="solution-entry-label">解决方案</span>
-        <span class="solution-entry-badge hidden" id="solution-entry-badge"></span>
-      </button>
     </div>
     <!-- Mode toggle: 配置 / 监控 -->
     <div class="mode-toggle-group" id="mode-toggle-group">
@@ -57,7 +52,6 @@
           <button class="settings-dropdown-item" data-target="btn-network">网络</button>
           <button class="settings-dropdown-item" data-target="btn-history">历史日志</button>
           <button class="settings-dropdown-item" data-target="btn-agent-def">智能体定义</button>
-          <button class="settings-dropdown-item" data-target="btn-skills">技能</button>
           <button class="settings-dropdown-item" data-target="btn-channels">渠道</button>
           <button class="settings-dropdown-item" data-target="btn-deploy">部署</button>
           <button class="settings-dropdown-item" data-target="btn-performance">性能</button>
@@ -66,11 +60,18 @@
           <button class="settings-dropdown-item settings-dropdown-item--danger" data-target="btn-reset">重启与重置</button>
         </div>
       </div>
+      <!-- 我的：Resource Center 账号 + 技能广场 / 解决方案市场 -->
+      <button class="topbar-settings-btn topbar-account-btn" id="btn-account">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="8" r="4"/><path d="M4 21v-1a8 8 0 0 1 16 0v1"/></svg>
+        <span>我的</span>
+        <span class="topbar-account-badge hidden" id="account-badge"></span>
+      </button>
       <!-- Hidden buttons for existing JS handlers -->
       <button class="btn-ghost topbar-btn hidden" id="btn-network">网络</button>
       <button class="btn-ghost topbar-btn hidden" id="btn-history">历史日志</button>
       <button class="btn-ghost topbar-btn hidden" id="btn-agent-def">智能体定义</button>
       <button class="btn-ghost topbar-btn hidden" id="btn-skills">技能</button>
+      <button class="btn-ghost topbar-btn hidden" id="btn-solutions">解决方案</button>
       <button class="btn-ghost topbar-btn hidden" id="btn-channels">渠道</button>
       <button class="btn-ghost topbar-btn hidden" id="btn-reset">重置</button>
       <button class="btn-ghost topbar-btn hidden" id="btn-deploy">部署 ▾</button>
@@ -201,10 +202,6 @@
           <span class="settings-item-label">智能体定义</span>
           <span class="settings-item-arrow">›</span>
         </button>
-        <button class="settings-item" data-action="skills">
-          <span class="settings-item-label">技能</span>
-          <span class="settings-item-arrow">›</span>
-        </button>
         <button class="settings-item" data-action="channels">
           <span class="settings-item-label">渠道</span>
           <span class="settings-item-arrow">›</span>
@@ -226,6 +223,12 @@
           <span class="settings-item-arrow">›</span>
         </button>
       </div>
+    </div>
+
+    <!-- 我的（移动端第四个 tab；内容由 js/account.js 渲染，与桌面 modal 共用） -->
+    <div class="mobile-settings-panel mobile-account-panel hidden" id="mobile-account-panel">
+      <h2 class="settings-title">我的</h2>
+      <div class="account-content" id="mobile-account-content"></div>
     </div>
   </div>
 
@@ -251,6 +254,10 @@
     <button class="tabbar-btn" data-tab="settings">
       <span class="tabbar-icon"><svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15 1.65 1.65 0 0 0 3.17 14H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68 1.65 1.65 0 0 0 10 3.17V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg><span class="tabbar-badge hidden" id="settings-badge"></span></span>
       <span class="tabbar-label">设置</span>
+    </button>
+    <button class="tabbar-btn" data-tab="account">
+      <span class="tabbar-icon"><svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="8" r="4"/><path d="M4 21v-1a8 8 0 0 1 16 0v1"/></svg><span class="tabbar-badge hidden" id="account-tab-badge"></span></span>
+      <span class="tabbar-label">我的</span>
     </button>
   </nav>
 
@@ -400,7 +407,6 @@
   <div class="modal skill-modal">
     <div class="modal-header">
       <span class="modal-title">技能管理</span>
-      <div class="skill-rc-login-status" id="skill-rc-login-status"></div>
       <button class="btn-icon" id="skill-close">✕</button>
     </div>
     <div class="skill-tabs">
@@ -414,15 +420,10 @@
         <div class="skill-list" id="skill-installed-list"></div>
       </div>
       <div class="skill-panel" data-panel="mine" id="skill-mine-panel">
-        <!-- Login form (shown when not logged in) -->
+        <!-- 未登录：登录统一在「我的」里做，这里只给入口 -->
         <div id="skill-rc-login-form" class="skill-rc-login">
-          <p class="skill-rc-login-hint">登录 Resource Center 以管理您的技能</p>
-          <form id="skill-rc-login-form-el">
-            <input type="text" id="skill-rc-email" placeholder="账号" required autocomplete="username">
-            <input type="password" id="skill-rc-password" placeholder="密码" required autocomplete="current-password">
-            <button type="submit" class="skill-btn skill-btn-primary">登录</button>
-          </form>
-          <p class="skill-rc-login-error hidden" id="skill-rc-login-error"></p>
+          <p class="skill-rc-login-hint">管理自己的技能需要先登录 Resource Center</p>
+          <button class="skill-btn skill-btn-primary" id="skill-rc-login-btn">去「我的」登录</button>
         </div>
         <!-- My skills list (shown when logged in) -->
         <div id="skill-mine-content" class="hidden">
@@ -513,12 +514,24 @@
   </div>
 </div>
 
+<!-- 我的（桌面 modal；内容与移动端面板共用 account.js 的渲染） -->
+<div class="modal-overlay hidden" id="account-overlay">
+  <div class="modal account-modal">
+    <div class="modal-header">
+      <span class="modal-title">我的</span>
+      <button class="btn-icon" id="account-close">✕</button>
+    </div>
+    <div class="modal-body account-modal-body">
+      <div class="account-content" id="account-content"></div>
+    </div>
+  </div>
+</div>
+
 <!-- Solution Modal (载入 / 市场 / 保存) -->
 <div class="modal-overlay hidden" id="solution-overlay">
   <div class="modal skill-modal solution-modal">
     <div class="modal-header">
       <span class="modal-title">解决方案</span>
-      <div class="skill-rc-login-status" id="solution-rc-login-status"></div>
       <button class="btn-icon" id="solution-close">✕</button>
     </div>
     <div class="skill-tabs">

--- a/agent-core/web/js/account.js
+++ b/agent-core/web/js/account.js
@@ -1,0 +1,355 @@
+/**
+ * account.js — 「我的」：Resource Center 账号 + 技能广场 / 解决方案市场入口。
+ *
+ * 桌面端是顶栏「设置」右边的 modal，移动端是第四个底 tab 的整页面板 ——
+ * 两边渲染同一份 HTML（`_render()` 写进两个容器），避免两套逻辑各自漂移。
+ *
+ * 这里同时是 Resource Center 账号态的唯一出处：token 存在 localStorage.rc_token，
+ * skills.js / solutions.js 都从这里取，401 也统一在 `rcFetch` 里处理 ——
+ * 以前 Resource Center 的 401 原文（Unauthorized）会被十几处 alert 直接抛给用户，而登录
+ * 表单埋在「设置 → 技能 → 我的技能」里，用户根本找不到。
+ */
+
+const TOKEN_KEY = 'rc_token';
+const ROLE_KEY  = 'rc_role';
+const USER_KEY  = 'rc_user_id';
+
+let _overlay, _closeBtn;
+let _user = null;         // {id, role, name, email}，未登录为 null
+let _mode = 'login';      // login | register
+let _notice = '';         // 顶部提示（如"登录已过期"）
+let _busy = false;
+let _formError = '';
+let _rcUrl = '';
+
+// ── Token（唯一出处，skills.js / solutions.js 都 import 这里）──────────────
+
+export function getRcToken() { return localStorage.getItem(TOKEN_KEY) || ''; }
+
+export function setRcToken(token, role, userId) {
+  localStorage.setItem(TOKEN_KEY, token);
+  if (role) localStorage.setItem(ROLE_KEY, role);
+  if (userId) localStorage.setItem(USER_KEY, userId);
+}
+
+export function clearRcToken() {
+  localStorage.removeItem(TOKEN_KEY);
+  localStorage.removeItem(ROLE_KEY);
+  localStorage.removeItem(USER_KEY);
+  _user = null;
+}
+
+/** 登录时记下的身份，用于 Resource Center 暂时问不到 session 时兜底显示。 */
+function _storedUser() {
+  const id = localStorage.getItem(USER_KEY);
+  if (!id) return null;
+  return { id, role: localStorage.getItem(ROLE_KEY) || '', name: null, email: null };
+}
+
+export function isRcLoggedIn() { return !!getRcToken(); }
+
+/** 带 Resource Center token 的请求头。 */
+export function rcHeaders(extra = {}) {
+  const h = { 'Content-Type': 'application/json', ...extra };
+  const token = getRcToken();
+  if (token) h['X-RC-Token'] = token;
+  return h;
+}
+
+/**
+ * 统一的 Resource Center 请求：自动带 token，遇 401 就清 token 并把用户带到「我的」。
+ * 返回后端的 JSON（`{code, data|error}`）；401 时也会返回，调用方可以直接
+ * 忽略 —— 提示已经由这里给出了。
+ */
+export async function rcFetch(url, opts = {}) {
+  const res = await fetch(url, { ...opts, headers: rcHeaders(opts.headers || {}) });
+  let json;
+  try { json = await res.json(); } catch { json = { code: res.status, error: '响应解析失败' }; }
+  if (json.code === 401 || res.status === 401) {
+    const hadToken = isRcLoggedIn();
+    clearRcToken();
+    showAccount(hadToken ? '登录已过期，请重新登录' : '该操作需要先登录');
+  }
+  return json;
+}
+
+// ── Init ────────────────────────────────────────────────────────────────────
+
+export function initAccount() {
+  _overlay  = document.getElementById('account-overlay');
+  if (!_overlay) return;
+  _closeBtn = document.getElementById('account-close');
+
+  document.getElementById('btn-account').addEventListener('click', () => showAccount());
+  _closeBtn.addEventListener('click', hideAccount);
+  _overlay.addEventListener('click', (e) => { if (e.target === _overlay) hideAccount(); });
+
+  // 两个容器共用一套事件委托
+  ['account-content', 'mobile-account-content'].forEach(id => {
+    const el = document.getElementById(id);
+    if (el) el.addEventListener('click', _onClick);
+    if (el) el.addEventListener('submit', _onSubmit);
+  });
+
+  _loadRcUrl();
+  refreshAccount();
+}
+
+/**
+ * 打开「我的」。桌面开 modal；移动端切到第四个 tab（面板本身常驻 DOM）。
+ * notice 会显示在顶部，用于"登录已过期"这类被动跳转的说明。
+ */
+export function showAccount(notice = '') {
+  _notice = notice;
+  _formError = '';
+  const isMobileView = window.matchMedia('(max-width: 768px)').matches;
+  if (isMobileView) {
+    document.querySelector('.tabbar-btn[data-tab="account"]')?.click();
+  } else {
+    _overlay?.classList.remove('hidden');
+  }
+  refreshAccount();
+}
+
+export function hideAccount() {
+  _overlay?.classList.add('hidden');
+  _notice = '';
+}
+
+/** 重新拉身份与两个市场的摘要，然后重绘。 */
+export async function refreshAccount() {
+  _render();                       // 先用现有状态画一次，避免闪空白
+  if (getRcToken()) {
+    try {
+      const res = await fetch('/api/account/session', { headers: rcHeaders() });
+      const json = await res.json();
+      if (json.code === 200) {
+        _user = json.data;
+      } else if (json.code === 401) {
+        // token 真的失效了：静默回到未登录态。这是"过期 token 到处报
+        // Unauthorized"的根治点 —— 在用户动手之前就把状态纠正过来。
+        clearRcToken();
+        if (!_notice) _notice = '登录已过期，请重新登录';
+      } else {
+        // 问不到（Resource Center 还没升级到支持 Bearer 的 session、或临时不可用）：
+        // 保留 token，用登录时记下的身份兜底，别把用户踢下线。
+        _user = _storedUser();
+      }
+    } catch {
+      _user = _storedUser();       // 网络问题同样不清 token
+    }
+  } else {
+    _user = null;
+  }
+  _syncBadges();
+  _render();
+  _loadEntrySummaries();
+}
+
+async function _loadRcUrl() {
+  try {
+    const json = await (await fetch('/api/account/rc-url')).json();
+    _rcUrl = json.data?.url || '';
+  } catch { _rcUrl = ''; }
+}
+
+// ── 渲染 ────────────────────────────────────────────────────────────────────
+
+function _render() {
+  const html = `
+    ${_notice ? `<div class="account-notice">${_esc(_notice)}</div>` : ''}
+    ${_user ? _renderIdentity() : _renderAuthForm()}
+    <div class="account-section-label">内容</div>
+    <div class="settings-list account-entry-list">
+      <button class="settings-item" data-entry="skills">
+        <span class="settings-item-text">
+          <span class="settings-item-label">技能广场</span>
+          <span class="settings-item-sub" id="account-skills-sub">安装、激活、发布技能</span>
+        </span>
+        <span class="settings-item-arrow">›</span>
+      </button>
+      <button class="settings-item" data-entry="solutions">
+        <span class="settings-item-text">
+          <span class="settings-item-label">解决方案市场</span>
+          <span class="settings-item-sub" id="account-solutions-sub">整套画布 / 技能 / Prompt / 任务</span>
+        </span>
+        <span class="settings-item-arrow">›</span>
+      </button>
+    </div>
+    <p class="account-hint">浏览、安装、加载技能与解决方案不需要登录；发布、管理自己的内容才需要。</p>`;
+
+  ['account-content', 'mobile-account-content'].forEach(id => {
+    const el = document.getElementById(id);
+    if (el) el.innerHTML = html;
+  });
+}
+
+function _renderIdentity() {
+  const label = _user.email || _user.name || _user.id;
+  // id 是 cuid，窄屏上整串会把"复制"挤到第二行；只显示头尾，完整值给 title 与复制
+  const shortId = _user.id.length > 12
+    ? `${_user.id.slice(0, 6)}…${_user.id.slice(-4)}`
+    : _user.id;
+  return `
+    <div class="account-card account-card-signed">
+      <div class="account-avatar">${_esc((label || '?').slice(0, 1).toUpperCase())}</div>
+      <div class="account-identity">
+        <div class="account-identity-name">${_esc(label)}</div>
+        <div class="account-identity-meta">
+          <span class="account-role">${_esc(_user.role || 'viewer')}</span>
+          <code class="account-id" title="${_esc(_user.id)}">${_esc(shortId)}</code>
+          <button class="account-copy-btn" data-copy="${_esc(_user.id)}" title="复制完整 ID">复制</button>
+        </div>
+      </div>
+      <button class="skill-btn skill-btn-sm" data-action="logout">退出登录</button>
+    </div>`;
+}
+
+function _renderAuthForm() {
+  const isRegister = _mode === 'register';
+  return `
+    <div class="account-card">
+      <div class="account-card-head">
+        <div class="account-avatar account-avatar-empty">?</div>
+        <div>
+          <div class="account-identity-name">未登录</div>
+          <div class="account-identity-sub">登录后可发布技能与解决方案</div>
+        </div>
+      </div>
+      <form class="account-form" data-form="${isRegister ? 'register' : 'login'}">
+        <input type="text" name="identifier" placeholder="邮箱账号" autocomplete="username" required>
+        <input type="password" name="password" placeholder="${isRegister ? '密码（至少 8 位）' : '密码'}"
+               autocomplete="${isRegister ? 'new-password' : 'current-password'}" required
+               ${isRegister ? 'minlength="8"' : ''}>
+        ${isRegister ? `<input type="text" name="name" placeholder="昵称（可选）" autocomplete="nickname">` : ''}
+        ${_formError ? `<p class="account-form-error">${_esc(_formError)}</p>` : ''}
+        <button type="submit" class="account-submit-btn" ${_busy ? 'disabled' : ''}>
+          ${_busy ? '处理中…' : (isRegister ? '注册并登录' : '登录')}
+        </button>
+      </form>
+      <div class="account-switch">
+        ${isRegister
+          ? `<span>已有账号？<button class="account-link" data-action="to-login">去登录</button></span>`
+          : `<span>还没有账号？<button class="account-link" data-action="to-register">注册</button></span>`}
+      </div>
+      ${_rcUrl ? `
+        <div class="account-web-link">
+          <a class="account-link" href="${_esc(_rcUrl)}" target="_blank" rel="noreferrer">Resource Center 网页版 ↗</a>
+        </div>` : ''}
+    </div>`;
+}
+
+/** 两个入口的副文本：已装技能数 / 当前载入的方案。 */
+async function _loadEntrySummaries() {
+  try {
+    const skills = (await (await fetch('/api/skills')).json()).data || [];
+    const active = skills.filter(s => s.active).length;
+    _setText('account-skills-sub',
+      skills.length ? `已安装 ${skills.length} · 激活 ${active}` : '还没有安装技能');
+  } catch { /* 保持默认文案 */ }
+
+  try {
+    const current = (await (await fetch('/api/solutions/current')).json()).data;
+    _setText('account-solutions-sub', current && (current.name || current.slug)
+      ? `当前：${current.name || current.slug}${current.version ? ' v' + current.version : ''}`
+      : '尚未载入解决方案');
+  } catch { /* 保持默认文案 */ }
+}
+
+/** 顶栏按钮与移动端 tab 上的账号角标。 */
+function _syncBadges() {
+  const label = _user ? (_user.email || _user.name || _user.id).split('@')[0] : '';
+  const badge = document.getElementById('account-badge');
+  if (badge) {
+    badge.textContent = label;
+    badge.classList.toggle('hidden', !label);
+  }
+  // 移动端 tab 上只用一个圆点表示"已登录"，标签放不下文字
+  const tabBadge = document.getElementById('account-tab-badge');
+  if (tabBadge) {
+    tabBadge.textContent = '';
+    tabBadge.classList.toggle('hidden', !_user);
+  }
+}
+
+// ── 交互 ────────────────────────────────────────────────────────────────────
+
+function _onClick(e) {
+  const entry = e.target.closest('[data-entry]');
+  if (entry) {
+    // 两个市场都不需要登录就能浏览，直接点隐藏的原按钮，沿用它们自己的初始化
+    hideAccount();
+    document.getElementById(entry.dataset.entry === 'skills' ? 'btn-skills' : 'btn-solutions')?.click();
+    return;
+  }
+
+  const copyBtn = e.target.closest('[data-copy]');
+  if (copyBtn) {
+    navigator.clipboard?.writeText(copyBtn.dataset.copy);
+    copyBtn.textContent = '已复制';
+    setTimeout(() => { copyBtn.textContent = '复制'; }, 1500);
+    return;
+  }
+
+  const action = e.target.closest('[data-action]')?.dataset.action;
+  if (action === 'logout') {
+    clearRcToken();
+    _notice = '';
+    _mode = 'login';
+    refreshAccount();
+  } else if (action === 'to-register') {
+    _mode = 'register'; _formError = ''; _render();
+  } else if (action === 'to-login') {
+    _mode = 'login'; _formError = ''; _render();
+  }
+}
+
+async function _onSubmit(e) {
+  const form = e.target.closest('[data-form]');
+  if (!form) return;
+  e.preventDefault();
+  if (_busy) return;
+
+  const kind = form.dataset.form;   // login | register
+  const body = {
+    identifier: form.identifier.value.trim(),
+    password:   form.password.value,
+  };
+  if (kind === 'register' && form.name) body.name = form.name.value.trim();
+
+  _busy = true; _formError = ''; _render();
+  try {
+    const res = await fetch(`/api/account/${kind}`, {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    const json = await res.json();
+    if (json.code !== 200 || !json.data?.token) {
+      _formError = json.error || (kind === 'register' ? '注册失败' : '登录失败');
+      _busy = false; _render();
+      return;
+    }
+    setRcToken(json.data.token, json.data.role, json.data.userId);
+    _notice = '';
+    _mode = 'login';
+    _busy = false;
+    await refreshAccount();
+  } catch (err) {
+    _formError = `网络错误：${err.message}`;
+    _busy = false;
+    _render();
+  }
+}
+
+// ── Util ────────────────────────────────────────────────────────────────────
+
+function _setText(id, text) {
+  const el = document.getElementById(id);
+  if (el) el.textContent = text;
+}
+
+function _esc(str) {
+  if (!str) return '';
+  return String(str).replace(/&/g, '&amp;').replace(/</g, '&lt;')
+                    .replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+}

--- a/agent-core/web/js/app.js
+++ b/agent-core/web/js/app.js
@@ -12,6 +12,7 @@ import { initActivityLog }   from './activity-log.js';
 import { initDetailPanel }   from './detail-panel.js';
 import { initMonitorMode }   from './monitor-mode.js';
 import { initSkills }        from './skills.js';
+import { initSolutions }     from './solutions.js';
 import { initHistory }       from './history.js';
 import { initNetwork }       from './network.js';
 import { initChannels }      from './channels.js';
@@ -42,6 +43,7 @@ async function main() {
   initMonitorMode();
   initDeployPanel();
   initSkills();
+  initSolutions();
   initHistory();
   initNetwork();
   initChannels();

--- a/agent-core/web/js/app.js
+++ b/agent-core/web/js/app.js
@@ -13,6 +13,7 @@ import { initDetailPanel }   from './detail-panel.js';
 import { initMonitorMode }   from './monitor-mode.js';
 import { initSkills }        from './skills.js';
 import { initSolutions }     from './solutions.js';
+import { initAccount }       from './account.js';
 import { initHistory }       from './history.js';
 import { initNetwork }       from './network.js';
 import { initChannels }      from './channels.js';
@@ -44,6 +45,7 @@ async function main() {
   initDeployPanel();
   initSkills();
   initSolutions();
+  initAccount();
   initHistory();
   initNetwork();
   initChannels();

--- a/agent-core/web/js/canvas.js
+++ b/agent-core/web/js/canvas.js
@@ -90,6 +90,14 @@ export function ensureEdit() { return _ensureEdit(); }
 export function isEditor() { return _isEditor; }
 
 /**
+ * Discard the in-memory canvas and re-read it from the server.
+ * Used after a solution is loaded — the backend rewrote canvas_layout directly,
+ * so what's on screen is stale.
+ */
+export function reloadFromServer() { return _reloadLayout(); }
+
+
+/**
  * Programmatically add a card to the canvas (used by mobile tap-to-add).
  * Returns true if added, false if rejected.
  */

--- a/agent-core/web/js/mobile.js
+++ b/agent-core/web/js/mobile.js
@@ -4,6 +4,7 @@
  */
 
 import { enterMonitorMode, exitMonitorMode } from './monitor-mode.js';
+import { refreshAccount } from './account.js';
 
 const MQ = window.matchMedia('(max-width: 768px)');
 let _isMobile = MQ.matches;
@@ -109,42 +110,55 @@ function _switchTab(tab) {
   // Log fab: in configure and monitor
   const logFab = document.getElementById('mobile-log-fab');
   if (logFab) {
-    logFab.classList.toggle('hidden', tab === 'settings');
+    logFab.classList.toggle('hidden', tab === 'settings' || tab === 'account');
   }
 
   const settingsPanel = document.getElementById('mobile-settings-panel');
 
   if (tab === 'configure') {
     exitMonitorMode();
-    _hideSettingsPanel();
+    _hidePanels();
   } else if (tab === 'monitor') {
-    _hideSettingsPanel();
+    _hidePanels();
     enterMonitorMode();
   } else if (tab === 'settings') {
     exitMonitorMode();
-    _showSettingsPanel();
+    _showPanel('mobile-settings-panel');
+  } else if (tab === 'account') {
+    exitMonitorMode();
+    _showPanel('mobile-account-panel');
+    refreshAccount();
   }
 }
 
-function _showSettingsPanel() {
-  const panel = document.getElementById('mobile-settings-panel');
+// 设置与「我的」是两个同构的整页面板，共用 .settings-active 那套让画布/监控
+// 让位的布局状态，所以切换时必须先把另一个收起来。
+const _PANEL_IDS = ['mobile-settings-panel', 'mobile-account-panel'];
+
+function _showPanel(id) {
   const app = document.getElementById('app');
-  if (panel) {
-    panel.classList.remove('hidden');
-    panel.classList.add('active');
-  }
+  _PANEL_IDS.forEach(pid => {
+    const panel = document.getElementById(pid);
+    if (!panel) return;
+    const on = pid === id;
+    panel.classList.toggle('hidden', !on);
+    panel.classList.toggle('active', on);
+  });
   app?.classList.add('settings-active');
 }
 
-function _hideSettingsPanel() {
-  const panel = document.getElementById('mobile-settings-panel');
+function _hidePanels() {
   const app = document.getElementById('app');
-  if (panel) {
+  _PANEL_IDS.forEach(pid => {
+    const panel = document.getElementById(pid);
+    if (!panel) return;
     panel.classList.add('hidden');
     panel.classList.remove('active');
-  }
+  });
   app?.classList.remove('settings-active');
 }
+
+function _hideSettingsPanel() { _hidePanels(); }
 
 // ── Settings Panel ───────────────────────────────────────────────────────────
 
@@ -165,7 +179,6 @@ function _triggerSettingsAction(action) {
     'network': 'btn-network',
     'history': 'btn-history',
     'agent-def': 'btn-agent-def',
-    'skills': 'btn-skills',
     'channels': 'btn-channels',
     'deploy': 'btn-deploy',
     'performance': 'btn-performance',

--- a/agent-core/web/js/sidebar.js
+++ b/agent-core/web/js/sidebar.js
@@ -284,7 +284,7 @@ function _buildChip(mcp, tool) {
     chip.querySelector('.chip-config-btn').addEventListener('click', (e) => {
       e.stopPropagation();
       e.preventDefault();
-      _openToolConfigModal(mcp.id, tool.name, configSchema);
+      openToolConfigModal(mcp.id, tool.name, configSchema);
     });
   }
 
@@ -419,7 +419,7 @@ function _buildToolCard(mcp, tool) {
   if (hasSharedFields) {
     card.querySelector('.tool-card-config-btn').addEventListener('click', (e) => {
       e.stopPropagation();
-      _openToolConfigModal(mcp.id, tool.name, configSchema);
+      openToolConfigModal(mcp.id, tool.name, configSchema);
     });
   }
 
@@ -459,7 +459,7 @@ export function hasSharedRequired(configSchema) {
 
 // ── Tool config modal (shared fields only) ────────────────────────────────────
 
-async function _openToolConfigModal(mcpId, toolName, configSchema) {
+export async function openToolConfigModal(mcpId, toolName, configSchema) {
   if (isProjectRunning()) {
     alert('Stop agent before modifying');
     return;

--- a/agent-core/web/js/skills.js
+++ b/agent-core/web/js/skills.js
@@ -1,30 +1,13 @@
 /**
- * skills.js — 技能管理 modal（安装/卸载/浏览/详情/编辑/发布/我的技能/RC登录）
+ * skills.js — 技能管理 modal（安装/卸载/浏览/详情/编辑/发布/我的技能）
+ * 账号登录统一在「我的」（js/account.js）里，这里只留一个入口。
  */
+
+import { isRcLoggedIn as _isRcLoggedIn, rcHeaders as _rcHeaders, showAccount } from './account.js';
 
 let _overlay, _closeBtn, _tabs, _panels;
 let _installedList, _installedEmpty, _browseList, _browseEmpty, _searchInput;
 let _mineList, _mineEmpty, _mineContent, _loginForm;
-
-// ── RC Auth State ────────────────────────────────────────────────────────────
-
-function _getRcToken() { return localStorage.getItem('rc_token'); }
-function _setRcToken(token, role) {
-  localStorage.setItem('rc_token', token);
-  if (role) localStorage.setItem('rc_role', role);
-}
-function _clearRcToken() {
-  localStorage.removeItem('rc_token');
-  localStorage.removeItem('rc_role');
-}
-function _isRcLoggedIn() { return !!_getRcToken(); }
-
-function _rcHeaders() {
-  const h = { 'Content-Type': 'application/json' };
-  const token = _getRcToken();
-  if (token) h['X-RC-Token'] = token;
-  return h;
-}
 
 // ── Init ─────────────────────────────────────────────────────────────────────
 
@@ -67,8 +50,8 @@ export function initSkills() {
     _searchTimer = setTimeout(_loadBrowse, 300);
   });
 
-  // RC Login form
-  document.getElementById('skill-rc-login-form-el').addEventListener('submit', _handleRcLogin);
+  // 登录统一在「我的」里做，这里只留一个入口
+  document.getElementById('skill-rc-login-btn')?.addEventListener('click', () => showAccount());
 
   // My Skills create button
   document.getElementById('skill-mine-create-btn').addEventListener('click', () => _openSkillForm(null));
@@ -81,8 +64,6 @@ export function initSkills() {
   });
   document.getElementById('skill-form-el').addEventListener('submit', _handleSkillFormSubmit);
 
-  // Update login status display
-  _updateLoginStatus();
 }
 
 export function show() {
@@ -93,52 +74,6 @@ export function show() {
 
 export function hide() {
   _overlay.classList.add('hidden');
-}
-
-// ── RC Login ─────────────────────────────────────────────────────────────────
-
-function _updateLoginStatus() {
-  const el = document.getElementById('skill-rc-login-status');
-  if (_isRcLoggedIn()) {
-    el.innerHTML = `<span class="rc-logged-in">RC 已登录</span> <button class="rc-logout-btn" id="rc-logout-btn">退出</button>`;
-    el.querySelector('#rc-logout-btn').addEventListener('click', _handleRcLogout);
-  } else {
-    el.innerHTML = '';
-  }
-}
-
-async function _handleRcLogin(e) {
-  e.preventDefault();
-  const email = document.getElementById('skill-rc-email').value.trim();
-  const password = document.getElementById('skill-rc-password').value;
-  const errorEl = document.getElementById('skill-rc-login-error');
-  errorEl.classList.add('hidden');
-
-  try {
-    const res = await fetch('/api/skills/rc/login', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ identifier: email, password }),
-    });
-    const data = await res.json();
-    if (data.code === 200 && data.data?.token) {
-      _setRcToken(data.data.token, data.data.role);
-      _updateLoginStatus();
-      _loadMine();
-    } else {
-      errorEl.textContent = data.error || '登录失败';
-      errorEl.classList.remove('hidden');
-    }
-  } catch (err) {
-    errorEl.textContent = '网络错误: ' + err.message;
-    errorEl.classList.remove('hidden');
-  }
-}
-
-function _handleRcLogout() {
-  _clearRcToken();
-  _updateLoginStatus();
-  _loadMine();
 }
 
 // ── Installed tab ─────────────────────────────────────────────────────────
@@ -235,6 +170,7 @@ async function _loadMine() {
     _mineContent.classList.add('hidden');
     return;
   }
+
   _loginForm.classList.add('hidden');
   _mineContent.classList.remove('hidden');
 
@@ -243,8 +179,8 @@ async function _loadMine() {
     const res = await fetch('/api/skills/rc/mine', { headers: _rcHeaders() });
     const json = await res.json();
     if (json.code === 401) {
-      _clearRcToken();
-      _updateLoginStatus();
+      // token 失效：交给「我的」清理并提示，这里只回到未登录态
+      showAccount('登录已过期，请重新登录');
       _loadMine();
       return;
     }

--- a/agent-core/web/js/solutions.js
+++ b/agent-core/web/js/solutions.js
@@ -1,0 +1,724 @@
+/**
+ * solutions.js — 解决方案：查看当前方案 / 方案市场载入 / 打包保存。
+ *
+ * 入口在左上角品牌区旁边（index.html 的 #btn-solutions）。
+ *
+ * 包体格式与"为什么卡片用 deviceRef 而不是 mcpId"见 src/api/solutions.py 顶部注释。
+ * 这里只负责三件事：
+ *   1. 展示当前方案，并把打包时脱敏掉的字段引导用户补填
+ *   2. 市场载入：先 preflight（缺驱动 → 一键安装；覆盖清单 → 逐项确认），再 apply
+ *   3. 打包保存：画布强制勾选，技能只允许选"已激活且已上架"的
+ */
+
+import { openInstanceConfigModal, openToolConfigModal } from './sidebar.js';
+import { reloadFromServer } from './canvas.js';
+
+// 与 resource-center/lib/solution.ts 的 INDUSTRIES 保持一致
+const INDUSTRIES = [
+  ['general',       '泛行业'],
+  ['inspection',    '巡检'],
+  ['tour-guide',    '导览讲解'],
+  ['logistics',     '物流配送'],
+  ['education',     '教育'],
+  ['healthcare',    '医疗康养'],
+  ['security',      '安防'],
+  ['manufacturing', '工业制造'],
+  ['research',      '科研'],
+  ['service',       '商业服务'],
+];
+
+const BLOCK_LABELS = {
+  'canvas':          '画布',
+  'skills':          '技能',
+  'prompt.identity': '身份定义',
+  'prompt.system':   '系统提示',
+  'prompt.memory':   '长期记忆',
+  'tasks':           '任务',
+};
+
+let _overlay, _closeBtn, _tabs, _panels;
+let _marketCache = [];
+let _packable = null;
+let _loadTarget = null;   // 待载入的方案 {slug, name, ...}
+
+// ── RC 登录态（与 skills.js 共用 localStorage 里的 rc_token）───────────────
+
+function _rcToken() { return localStorage.getItem('rc_token'); }
+function _rcHeaders() {
+  const h = { 'Content-Type': 'application/json' };
+  const token = _rcToken();
+  if (token) h['X-RC-Token'] = token;
+  return h;
+}
+
+// ── Init ─────────────────────────────────────────────────────────────────────
+
+export function initSolutions() {
+  _overlay  = document.getElementById('solution-overlay');
+  if (!_overlay) return;
+  _closeBtn = document.getElementById('solution-close');
+  _tabs     = _overlay.querySelectorAll('.skill-tab');
+  _panels   = _overlay.querySelectorAll('.skill-panel');
+
+  document.getElementById('btn-solutions').addEventListener('click', show);
+  _closeBtn.addEventListener('click', hide);
+  _overlay.addEventListener('click', (e) => { if (e.target === _overlay) hide(); });
+
+  _tabs.forEach(tab => {
+    tab.addEventListener('click', () => {
+      const target = tab.dataset.tab;
+      _tabs.forEach(t => t.classList.toggle('active', t === tab));
+      _panels.forEach(p => p.classList.toggle('active', p.dataset.panel === target));
+      if (target === 'current') _loadCurrent();
+      if (target === 'market')  _loadMarket();
+      if (target === 'save')    _loadSavePanel();
+    });
+  });
+
+  // 市场搜索 / 行业筛选
+  const industrySelect = document.getElementById('solution-industry-filter');
+  industrySelect.innerHTML = `<option value="all">全部行业</option>` +
+    INDUSTRIES.map(([v, l]) => `<option value="${v}">${l}</option>`).join('');
+  industrySelect.addEventListener('change', _loadMarket);
+  let searchTimer;
+  document.getElementById('solution-search').addEventListener('input', () => {
+    clearTimeout(searchTimer);
+    searchTimer = setTimeout(_loadMarket, 300);
+  });
+
+  // 载入确认弹窗
+  document.getElementById('solution-load-close').addEventListener('click', _closeLoadModal);
+  document.getElementById('solution-load-cancel').addEventListener('click', _closeLoadModal);
+  document.getElementById('solution-load-confirm').addEventListener('click', _confirmLoad);
+
+  _syncEntryBadge();
+}
+
+export function show() {
+  _overlay.classList.remove('hidden');
+  _tabs[0].click();
+}
+
+export function hide() {
+  _overlay.classList.add('hidden');
+}
+
+/** 左上角入口上的当前方案角标。 */
+async function _syncEntryBadge() {
+  const badge = document.getElementById('solution-entry-badge');
+  if (!badge) return;
+  try {
+    const data = (await (await fetch('/api/solutions/current')).json()).data;
+    if (data && data.name) {
+      badge.textContent = data.name;
+      badge.classList.remove('hidden');
+    } else {
+      badge.classList.add('hidden');
+    }
+  } catch { badge.classList.add('hidden'); }
+}
+
+// ── Tab 1：当前方案 ─────────────────────────────────────────────────────────
+
+async function _loadCurrent() {
+  const panel = document.getElementById('solution-current-panel');
+  panel.innerHTML = `<div class="skill-empty">加载中…</div>`;
+
+  let current = null;
+  try {
+    current = (await (await fetch('/api/solutions/current')).json()).data;
+  } catch { /* 下面按"无方案"渲染 */ }
+
+  if (!current || !current.slug && !current.name) {
+    panel.innerHTML = `
+      <div class="skill-empty">
+        当前未载入任何解决方案。<br>
+        可以到「方案市场」载入一套，或在「保存当前方案」里把现在的配置打包发布。
+      </div>`;
+    return;
+  }
+
+  const industry = (INDUSTRIES.find(i => i[0] === current.industry) || [null, current.industry])[1];
+  const devices = current.devices || [];
+  const needs = current.needsConfig || [];
+
+  panel.innerHTML = `
+    <div class="solution-current-card">
+      <div class="solution-current-head">
+        <div>
+          <div class="solution-current-name">${_esc(current.name || current.slug)}</div>
+          <div class="solution-current-meta">
+            ${current.slug ? _esc(current.slug) + ' · ' : ''}v${_esc(current.version || '')}
+            ${industry ? ' · ' + _esc(industry) : ''}
+            ${current.appliedAt ? ' · 载入于 ' + new Date(current.appliedAt * 1000).toLocaleString() : ''}
+          </div>
+        </div>
+        <button class="skill-btn skill-btn-sm" id="solution-clear-current" title="只清除标记，不改动已载入的配置">清除标记</button>
+      </div>
+
+      <div class="solution-section-label">包含内容</div>
+      <div class="solution-pills">
+        ${(current.includes || []).map(b => `<span class="solution-pill">${_esc(BLOCK_LABELS[b] || b)}</span>`).join('')}
+      </div>
+
+      ${devices.length ? `
+        <div class="solution-section-label">所需驱动（记录版本）</div>
+        <div class="solution-driver-list">
+          ${devices.map(d => `
+            <div class="solution-driver-row">
+              <span class="solution-driver-name">${_esc(d.name || d.serverName)}</span>
+              <span class="solution-pill solution-pill-sm">${_esc(d.category || '')}</span>
+              <span class="solution-driver-image">${_esc(d.image || d.registryImage || '')}</span>
+            </div>`).join('')}
+        </div>` : ''}
+
+      ${needs.length ? `
+        <div class="solution-section-label solution-warn">待补填字段（打包时按卡片声明脱敏）</div>
+        <div class="solution-needs-list" id="solution-needs-list">
+          ${needs.map(p => `<button class="solution-need-item" data-path="${_esc(p)}">${_esc(p)}</button>`).join('')}
+        </div>` : ''}
+    </div>`;
+
+  panel.querySelector('#solution-clear-current').addEventListener('click', async () => {
+    if (!confirm('清除"当前方案"标记？已载入的画布 / 技能 / Prompt / 任务不会被改动。')) return;
+    await fetch('/api/solutions/current', { method: 'DELETE' });
+    _syncEntryBadge();
+    _loadCurrent();
+  });
+
+  panel.querySelectorAll('.solution-need-item').forEach(btn => {
+    btn.addEventListener('click', () => _openConfigForPath(btn.dataset.path, devices));
+  });
+}
+
+/**
+ * 把 needsConfig 里的 "d0:asr_start:card-x:api_key" 落到具体的配置弹窗。
+ * ref → 本机 mcpId 靠 devices[].serverName 与 /api/mcp 的 server_name 对上。
+ */
+async function _openConfigForPath(path, devices) {
+  const parts = path.split(':');
+  if (parts.length < 3) return;
+  const ref = parts[0];
+  const toolName = parts[1];
+  // 中间可能有 instance id：d0:tool:prop（3 段）或 d0:tool:cardId:prop（4 段）
+  const instanceId = parts.length >= 4 ? parts[2] : '';
+
+  const dev = devices.find(d => d.ref === ref);
+  if (!dev) { alert('无法定位该字段所属设备，请手动到卡片上配置'); return; }
+
+  let mcps = [];
+  try { mcps = (await (await fetch('/api/mcp')).json()).data || []; } catch { /* below */ }
+  const mcp = mcps.find(m => m.server_name && m.server_name === dev.serverName)
+           || mcps.find(m => dev.port && (m.url || '').includes(`:${dev.port}`));
+  if (!mcp) { alert(`设备 ${dev.name || dev.serverName} 当前不在线，无法打开配置`); return; }
+
+  const tool = (mcp.tools || []).find(t => typeof t === 'object' && t.name === toolName);
+  const schema = tool ? tool.configSchema : null;
+  if (!schema) { alert(`${toolName} 当前没有可编辑的配置项`); return; }
+
+  hide();
+  if (instanceId) openInstanceConfigModal(mcp.id, toolName, instanceId, schema);
+  else            openToolConfigModal(mcp.id, toolName, schema);
+}
+
+// ── Tab 2：方案市场 ─────────────────────────────────────────────────────────
+
+async function _loadMarket() {
+  const list = document.getElementById('solution-market-list');
+  const empty = document.getElementById('solution-market-empty');
+  const search = document.getElementById('solution-search').value.trim();
+  const industry = document.getElementById('solution-industry-filter').value;
+
+  list.innerHTML = `<div class="skill-empty">加载中…</div>`;
+  empty.classList.add('hidden');
+
+  const params = new URLSearchParams({ limit: '30' });
+  if (search) params.set('search', search);
+  if (industry) params.set('industry', industry);
+
+  let items = [];
+  try {
+    const json = await (await fetch(`/api/solutions/market?${params}`)).json();
+    if (json.code !== 200) {
+      list.innerHTML = `<div class="skill-empty">无法连接方案市场：${_esc(json.error || '')}</div>`;
+      return;
+    }
+    items = json.data || [];
+  } catch (e) {
+    list.innerHTML = `<div class="skill-empty">无法连接方案市场：${_esc(e.message)}</div>`;
+    return;
+  }
+
+  _marketCache = items;
+  empty.classList.toggle('hidden', items.length > 0);
+  list.innerHTML = items.map(s => {
+    const industryLabel = (INDUSTRIES.find(i => i[0] === s.industry) || [null, s.industry])[1];
+    const drivers = s.requiredDrivers || [];
+    return `
+      <div class="skill-card solution-market-card">
+        <div class="skill-card-header">
+          <span class="skill-card-icon">${s.icon || '◈'}</span>
+          <div class="skill-card-info">
+            <span class="skill-card-name">${_esc(s.name)}</span>
+            <span class="skill-card-meta">${_esc(industryLabel || '')} · v${_esc(s.version)} · ${_esc(s.author?.name || '匿名')} · ↓${s.downloads || 0}</span>
+          </div>
+          <button class="skill-btn skill-btn-sm skill-btn-primary" data-load="${_esc(s.slug)}">载入</button>
+        </div>
+        <p class="skill-card-desc">${_esc(s.oneLiner)}</p>
+        <div class="solution-pills">
+          ${(s.includes || []).map(b => `<span class="solution-pill solution-pill-sm">${_esc(BLOCK_LABELS[b] || b)}</span>`).join('')}
+          ${drivers.map(d => `<span class="solution-pill solution-pill-driver">${_esc(d.name || d.serverName)}</span>`).join('')}
+        </div>
+      </div>`;
+  }).join('');
+
+  list.querySelectorAll('[data-load]').forEach(btn => {
+    btn.addEventListener('click', () => _startLoad(btn.dataset.load));
+  });
+}
+
+// ── 载入流程：preflight → 缺驱动一键安装 → 覆盖确认 → apply ────────────────
+
+function _sessionId() { return sessionStorage.getItem('canvas_session_id') || ''; }
+
+async function _preflight(slug) {
+  const res = await fetch('/api/solutions/preflight', {
+    method: 'POST', headers: _rcHeaders(),
+    body: JSON.stringify({ slug, session_id: _sessionId() }),
+  });
+  return res.json();
+}
+
+async function _startLoad(slug) {
+  const body = document.getElementById('solution-load-body');
+  document.getElementById('solution-load-overlay').classList.remove('hidden');
+  body.innerHTML = `<div class="skill-empty">检查中…</div>`;
+  document.getElementById('solution-load-confirm').classList.add('hidden');
+
+  const json = await _preflight(slug);
+  if (json.code !== 200) {
+    body.innerHTML = `<div class="solution-load-error">${_esc(json.error || '检查失败')}</div>`;
+    return;
+  }
+  _loadTarget = { slug, ...json.data };
+  _renderLoadModal(json.data);
+}
+
+function _renderLoadModal(data) {
+  const body = document.getElementById('solution-load-body');
+  const confirmBtn = document.getElementById('solution-load-confirm');
+  const sol = data.solution || {};
+  const dev = data.devices || {};
+  const ow = data.overwrite || {};
+
+  document.getElementById('solution-load-title').textContent = `载入「${sol.name || sol.slug}」`;
+
+  const missing = dev.missing || [];
+  const installable = dev.installable || [];
+  const matched = dev.matched || [];
+
+  let html = '';
+
+  if (data.canvasEditor) {
+    html += `<div class="solution-load-error">
+      有其他会话正在编辑画布（${_esc(data.canvasEditor)}）。请让对方退出编辑后再载入，
+      否则它的自动保存会把刚载入的画布覆盖回去。
+    </div>`;
+  }
+
+  html += `<div class="solution-section-label">所需驱动</div><div class="solution-driver-list">`;
+  html += matched.map(d => `
+    <div class="solution-driver-row">
+      <span class="solution-driver-ok">✓</span>
+      <span class="solution-driver-name">${_esc(d.name || d.serverName)}</span>
+      <span class="solution-pill solution-pill-sm">${_esc(d.category || '')}</span>
+      <span class="solution-driver-image">已就绪 · ${_esc(d.mcpName || d.mcpId || '')}</span>
+    </div>`).join('');
+  html += installable.map(d => `
+    <div class="solution-driver-row solution-driver-row-warn">
+      <span class="solution-driver-warn">!</span>
+      <span class="solution-driver-name">${_esc(d.name || d.serverName)}</span>
+      <span class="solution-pill solution-pill-sm">${_esc(d.category || '')}</span>
+      <span class="solution-driver-image">${_esc(d.localImage || d.image || '')}</span>
+      <button class="skill-btn skill-btn-sm skill-btn-primary" data-install="${_esc(d.localDriverId)}">一键安装</button>
+    </div>`).join('');
+  html += missing.map(d => `
+    <div class="solution-driver-row solution-driver-row-error">
+      <span class="solution-driver-err">✕</span>
+      <span class="solution-driver-name">${_esc(d.name || d.serverName)}</span>
+      <span class="solution-pill solution-pill-sm">${_esc(d.category || '')}</span>
+      <span class="solution-driver-image">本机没有此驱动：${_esc(d.registryImage || d.serverName)}</span>
+    </div>`).join('');
+  html += `</div>`;
+
+  if (missing.length) {
+    html += `<div class="solution-load-error">
+      本机缺少上述驱动，无法载入。请先到「设置 → 部署」同步镜像仓库并安装
+      ${missing.map(d => `<code>${_esc(d.registryImage || d.serverName)}</code>`).join('、')}
+      ，安装完成后再回到这里载入。
+      <button class="skill-btn skill-btn-sm" id="solution-sync-registry">同步镜像仓库</button>
+    </div>`;
+  }
+
+  // 覆盖清单
+  html += `<div class="solution-section-label solution-warn">载入会覆盖以下内容</div>
+           <ul class="solution-overwrite-list">`;
+  if (ow.canvas) {
+    html += `<li>当前画布：${ow.canvas.cards} 张卡片、${ow.canvas.connections} 条连线、${ow.canvas.toolConfigs} 份卡片配置将被整体替换</li>`;
+  }
+  if (ow.skills) {
+    html += ow.skills.length
+      ? `<li>已激活技能将改为方案指定的一套（当前激活：${ow.skills.map(s => _esc(s.name || s.slug)).join('、')}；不会卸载，只是停用）</li>`
+      : `<li>技能：当前没有激活的技能，方案里的技能会被安装并激活</li>`;
+  }
+  (ow.prompt || []).forEach(p => {
+    html += `<li>${_esc(BLOCK_LABELS[p.block] || p.block)}：${_esc(p.path)} ${p.exists ? '将被覆盖' : '将被创建'}</li>`;
+  });
+  if (ow.tasks) {
+    html += ow.tasks.length
+      ? `<li>任务：现有 ${ow.tasks.length} 个任务将被清除（${ow.tasks.map(t => _esc(t.goal)).join('；')}），改为方案中的任务</li>`
+      : `<li>任务：当前无活跃任务，方案中的任务会被创建</li>`;
+  }
+  html += `</ul>`;
+
+  if ((sol.needsConfig || []).length) {
+    html += `<div class="solution-section-label solution-warn">载入后需要补填</div>
+      <div class="solution-needs-list">
+        ${sol.needsConfig.map(p => `<span class="solution-need-item solution-need-item-static">${_esc(p)}</span>`).join('')}
+      </div>`;
+  }
+
+  body.innerHTML = html;
+
+  body.querySelectorAll('[data-install]').forEach(btn => {
+    btn.addEventListener('click', () => _installDriver(btn.dataset.install, btn));
+  });
+  const syncBtn = body.querySelector('#solution-sync-registry');
+  if (syncBtn) {
+    syncBtn.addEventListener('click', async () => {
+      syncBtn.disabled = true;
+      syncBtn.textContent = '同步中…';
+      try { await fetch('/api/drivers/sync', { method: 'POST' }); } catch { /* 下面重查 */ }
+      _startLoad(_loadTarget.slug);
+    });
+  }
+
+  const ready = !missing.length && !installable.length && !data.canvasEditor;
+  confirmBtn.classList.toggle('hidden', !ready);
+  confirmBtn.disabled = !ready;
+}
+
+/** 部署一个已在驱动清单里、但还没跑起来的驱动，然后等它自注册成 MCP。 */
+async function _installDriver(driverId, btn) {
+  btn.disabled = true;
+  btn.textContent = '安装中…';
+  try {
+    const res = await fetch(`/api/drivers/${encodeURIComponent(driverId)}/deploy`, {
+      method: 'POST', headers: { 'Content-Type': 'application/json' }, body: '{}',
+    });
+    const json = await res.json();
+    if (json.code !== 200) {
+      btn.disabled = false;
+      btn.textContent = '重试安装';
+      alert(`部署失败：${json.message || '未知错误'}`);
+      return;
+    }
+  } catch (e) {
+    btn.disabled = false;
+    btn.textContent = '重试安装';
+    alert(`部署失败：${e.message}`);
+    return;
+  }
+
+  // 容器起来后驱动会自己 POST /api/mcp 注册（见 phanthymotus-driver/common
+  // 的 vendor_runtime.py），所以这里轮询 preflight 直到该设备变成 matched。
+  btn.textContent = '等待驱动上线…';
+  for (let i = 0; i < 40; i++) {           // 最多约 2 分钟
+    await new Promise(r => setTimeout(r, 3000));
+    const json = await _preflight(_loadTarget.slug);
+    if (json.code !== 200) continue;
+    const stillPending = (json.data.devices.installable || [])
+      .some(d => d.localDriverId === driverId);
+    if (!stillPending) {
+      _loadTarget = { slug: _loadTarget.slug, ...json.data };
+      _renderLoadModal(json.data);
+      return;
+    }
+  }
+  btn.disabled = false;
+  btn.textContent = '重试安装';
+  alert('驱动已部署但仍未上线，请到「设置 → 部署」查看容器日志。');
+}
+
+async function _confirmLoad() {
+  const confirmBtn = document.getElementById('solution-load-confirm');
+  const body = document.getElementById('solution-load-body');
+  confirmBtn.disabled = true;
+  confirmBtn.textContent = '载入中…';
+
+  try {
+    const res = await fetch('/api/solutions/apply', {
+      method: 'POST', headers: _rcHeaders(),
+      body: JSON.stringify({ slug: _loadTarget.slug, confirm: true, session_id: _sessionId() }),
+    });
+    const json = await res.json();
+    if (json.code !== 200) {
+      body.innerHTML = `<div class="solution-load-error">${_esc(json.error || '载入失败')}</div>` + body.innerHTML;
+      confirmBtn.disabled = false;
+      confirmBtn.textContent = '确认载入';
+      return;
+    }
+    const needs = json.data.needsConfig || [];
+    const failed = json.data.applied?.skills?.failed || [];
+    _closeLoadModal();
+    await reloadFromServer();
+    _syncEntryBadge();
+    _tabs[0].click();
+    let msg = '解决方案已载入。';
+    if (needs.length) msg += `\n有 ${needs.length} 个脱敏字段需要补填，见「当前方案」。`;
+    if (failed.length) msg += `\n以下技能安装失败：${failed.map(f => f.slug).join('、')}`;
+    alert(msg);
+  } catch (e) {
+    confirmBtn.disabled = false;
+    confirmBtn.textContent = '确认载入';
+    alert(`载入失败：${e.message}`);
+  }
+}
+
+function _closeLoadModal() {
+  document.getElementById('solution-load-overlay').classList.add('hidden');
+}
+
+// ── Tab 3：保存当前方案 ─────────────────────────────────────────────────────
+
+async function _loadSavePanel() {
+  const panel = document.getElementById('solution-save-panel');
+  panel.innerHTML = `<div class="skill-empty">加载中…</div>`;
+
+  if (!_rcToken()) {
+    panel.innerHTML = `
+      <div class="skill-empty">
+        发布解决方案需要先登录 Resource Center。<br>
+        请到「设置 → 技能 → 我的技能」登录后再回到这里。
+      </div>`;
+    return;
+  }
+
+  let data;
+  try {
+    const json = await (await fetch('/api/solutions/packable', { headers: _rcHeaders() })).json();
+    if (json.code !== 200) {
+      panel.innerHTML = `<div class="skill-empty">${_esc(json.error || '读取失败')}</div>`;
+      return;
+    }
+    data = json.data;
+  } catch (e) {
+    panel.innerHTML = `<div class="skill-empty">读取失败：${_esc(e.message)}</div>`;
+    return;
+  }
+  _packable = data;
+
+  if (!data.canvas.cards) {
+    panel.innerHTML = `<div class="skill-empty">画布为空。解决方案必须包含画布，请先在画布上搭好拓扑。</div>`;
+    return;
+  }
+
+  const sensitive = (data.configFields || []).filter(f => f.sensitive);
+  const others    = (data.configFields || []).filter(f => !f.sensitive);
+
+  panel.innerHTML = `
+    <div class="solution-save-form">
+      <div class="solution-section-label">打包内容</div>
+
+      <label class="solution-check solution-check-locked">
+        <input type="checkbox" checked disabled>
+        <span>画布（必选）—— ${data.canvas.cards} 张卡片、${data.canvas.devices.length} 个设备</span>
+      </label>
+      ${data.canvas.unresolved.length ? `
+        <div class="solution-load-error">
+          画布上有卡片引用了未注册的设备（${data.canvas.unresolved.map(_esc).join('、')}），
+          请先删除这些卡片再打包。
+        </div>` : ''}
+
+      <div class="solution-check-group">
+        <div class="solution-check-group-title">技能（仅当前激活）</div>
+        ${data.skills.available.length ? data.skills.available.map(s => `
+          <label class="solution-check">
+            <input type="checkbox" class="sol-skill" value="${_esc(s.slug)}" checked>
+            <span>${s.icon || '◆'} ${_esc(s.name || s.slug)} <em>v${_esc(s.version || '')}</em></span>
+          </label>`).join('') : `<div class="solution-hint">当前没有"已激活且已上架"的技能</div>`}
+        ${data.skills.offMarket.length ? `
+          <div class="solution-hint solution-warn">
+            以下技能只能在本机使用，无法打包 —— 只能保存技能广场中已上架的技能，
+            请先在「技能 → 我的技能」发布并通过审核：
+            ${data.skills.offMarket.map(s => `<code>${_esc(s.name || s.slug)}</code>`).join('、')}
+          </div>` : ''}
+      </div>
+
+      <div class="solution-check-group">
+        <div class="solution-check-group-title">Prompt 设定</div>
+        ${data.prompt.map(p => `
+          <label class="solution-check ${p.exists ? '' : 'solution-check-disabled'}">
+            <input type="checkbox" class="sol-prompt" value="${_esc(p.block.split('.')[1])}" ${p.exists ? '' : 'disabled'}>
+            <span>${_esc(BLOCK_LABELS[p.block] || p.block)} <em>${p.exists ? p.chars + ' 字符' : '文件不存在'}</em></span>
+          </label>`).join('')}
+      </div>
+
+      <div class="solution-check-group">
+        <div class="solution-check-group-title">任务</div>
+        <label class="solution-check ${data.tasks.length ? '' : 'solution-check-disabled'}">
+          <input type="checkbox" id="sol-tasks" ${data.tasks.length ? '' : 'disabled'}>
+          <span>打包 ${data.tasks.length} 个活跃任务${data.tasks.length ? '：' + data.tasks.map(t => _esc(t.goal)).join('；') : '（当前无任务）'}</span>
+        </label>
+      </div>
+
+      <div class="solution-check-group">
+        <div class="solution-check-group-title">敏感字段脱敏</div>
+        ${sensitive.length ? `
+          <div class="solution-hint">以下字段由卡片声明为敏感，打包时一定会被清空：</div>
+          ${sensitive.map(f => `
+            <label class="solution-check solution-check-locked">
+              <input type="checkbox" checked disabled>
+              <span><code>${_esc(f.path)}</code></span>
+            </label>`).join('')}` : `<div class="solution-hint">卡片没有声明任何敏感字段</div>`}
+        ${others.length ? `
+          <div class="solution-hint">如果下面还有不该外传的值，勾选它一并清空：</div>
+          ${others.map(f => `
+            <label class="solution-check">
+              <input type="checkbox" class="sol-redact" value="${_esc(f.path)}">
+              <span><code>${_esc(f.path)}</code></span>
+            </label>`).join('')}` : ''}
+      </div>
+
+      <div class="solution-section-label">方案信息</div>
+      <div class="skill-form-row">
+        <div class="skill-form-field">
+          <label>名称 <span class="required">*</span></label>
+          <input type="text" id="sol-name" required>
+        </div>
+        <div class="skill-form-field">
+          <label>Slug <span class="required">*</span></label>
+          <input type="text" id="sol-slug" required pattern="[a-z0-9-]+" placeholder="tour-guide-g1">
+        </div>
+      </div>
+      <div class="skill-form-row">
+        <div class="skill-form-field">
+          <label>行业 <span class="required">*</span></label>
+          <select id="sol-industry">${INDUSTRIES.map(([v, l]) => `<option value="${v}">${l}</option>`).join('')}</select>
+        </div>
+        <div class="skill-form-field skill-form-field-sm">
+          <label>图标</label>
+          <input type="text" id="sol-icon" placeholder="◈">
+        </div>
+        <div class="skill-form-field">
+          <label>版本 <span class="required">*</span></label>
+          <input type="text" id="sol-version" required value="1.0.0">
+        </div>
+      </div>
+      <div class="skill-form-field">
+        <label>一句话简介 <span class="required">*</span></label>
+        <input type="text" id="sol-oneliner" required maxlength="80">
+      </div>
+      <div class="skill-form-field">
+        <label>详细描述 <span class="required">*</span></label>
+        <textarea id="sol-description" rows="3" required></textarea>
+      </div>
+      <div class="skill-form-row">
+        <div class="skill-form-field">
+          <label>适用机型（逗号分隔）</label>
+          <input type="text" id="sol-robots" placeholder="humanoid, quadruped">
+        </div>
+        <div class="skill-form-field">
+          <label>标签（逗号分隔）</label>
+          <input type="text" id="sol-tags" placeholder="导览, 语音交互">
+        </div>
+      </div>
+
+      <p class="skill-form-error hidden" id="sol-error"></p>
+      <div class="skill-form-footer">
+        <span class="solution-hint">发布后为草稿，需在 Resource Center 提交审核</span>
+        <button type="button" class="skill-btn skill-btn-primary" id="sol-publish">发布到方案市场</button>
+      </div>
+    </div>`;
+
+  panel.querySelector('#sol-publish').addEventListener('click', _publish);
+}
+
+function _collectInclude() {
+  const panel = document.getElementById('solution-save-panel');
+  return {
+    canvas: true,
+    skills: [...panel.querySelectorAll('.sol-skill:checked')].map(el => el.value),
+    prompt: [...panel.querySelectorAll('.sol-prompt:checked')].map(el => el.value),
+    tasks:  !!panel.querySelector('#sol-tasks')?.checked,
+  };
+}
+
+async function _publish() {
+  const panel = document.getElementById('solution-save-panel');
+  const errorEl = panel.querySelector('#sol-error');
+  const btn = panel.querySelector('#sol-publish');
+  errorEl.classList.add('hidden');
+
+  const meta = {
+    name:        panel.querySelector('#sol-name').value.trim(),
+    slug:        panel.querySelector('#sol-slug').value.trim(),
+    industry:    panel.querySelector('#sol-industry').value,
+    icon:        panel.querySelector('#sol-icon').value.trim() || null,
+    version:     panel.querySelector('#sol-version').value.trim(),
+    oneLiner:    panel.querySelector('#sol-oneliner').value.trim(),
+    description: panel.querySelector('#sol-description').value.trim(),
+    robotTypes:  _splitList(panel.querySelector('#sol-robots').value),
+    tags:        _splitList(panel.querySelector('#sol-tags').value),
+  };
+  if (!meta.name || !meta.slug || !meta.oneLiner || !meta.description) {
+    errorEl.textContent = '名称 / Slug / 一句话简介 / 详细描述都是必填';
+    errorEl.classList.remove('hidden');
+    return;
+  }
+  if (!/^[a-z0-9-]+$/.test(meta.slug)) {
+    errorEl.textContent = 'Slug 只能包含小写字母、数字和连字符';
+    errorEl.classList.remove('hidden');
+    return;
+  }
+
+  btn.disabled = true;
+  btn.textContent = '发布中…';
+  try {
+    const res = await fetch('/api/solutions/publish', {
+      method: 'POST', headers: _rcHeaders(),
+      body: JSON.stringify({
+        meta,
+        include: _collectInclude(),
+        extra_redact: [...panel.querySelectorAll('.sol-redact:checked')].map(el => el.value),
+      }),
+    });
+    const json = await res.json();
+    if (json.code !== 200) {
+      const detail = json.detail ? `（${[].concat(json.detail).join('、')}）` : '';
+      errorEl.textContent = `${json.error || '发布失败'}${detail}`;
+      errorEl.classList.remove('hidden');
+      return;
+    }
+    alert('已作为草稿发布到方案市场。请到 Resource Center 的「我的方案」提交审核。');
+  } catch (e) {
+    errorEl.textContent = `发布失败：${e.message}`;
+    errorEl.classList.remove('hidden');
+  } finally {
+    btn.disabled = false;
+    btn.textContent = '发布到方案市场';
+  }
+}
+
+// ── Util ────────────────────────────────────────────────────────────────────
+
+function _splitList(raw) {
+  return raw ? raw.split(',').map(s => s.trim()).filter(Boolean) : [];
+}
+
+function _esc(str) {
+  if (str === 0) return '0';
+  if (!str) return '';
+  return String(str).replace(/&/g, '&amp;').replace(/</g, '&lt;')
+                    .replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+}

--- a/agent-core/web/js/solutions.js
+++ b/agent-core/web/js/solutions.js
@@ -601,9 +601,11 @@ async function _loadSavePanel() {
   panel.innerHTML = `<div class="skill-empty">加载中…</div>`;
 
   if (!isRcLoggedIn()) {
+    // 与技能 modal 的「我的技能」未登录态用同一套 .skill-rc-login 结构，
+    // 两处提示看起来才是一件事
     panel.innerHTML = `
-      <div class="skill-empty">
-        发布解决方案需要先登录 Resource Center。
+      <div class="skill-rc-login">
+        <p class="skill-rc-login-hint">发布解决方案需要先登录 Resource Center</p>
         <button class="skill-btn skill-btn-primary" id="sol-goto-login">去「我的」登录</button>
       </div>`;
     panel.querySelector('#sol-goto-login').addEventListener('click', () => showAccount());

--- a/agent-core/web/js/solutions.js
+++ b/agent-core/web/js/solutions.js
@@ -1,7 +1,7 @@
 /**
  * solutions.js — 解决方案：查看当前方案 / 方案市场载入 / 打包保存。
  *
- * 入口在左上角品牌区旁边（index.html 的 #btn-solutions）。
+ * 入口在「我的」里（js/account.js），它点的是隐藏的 #btn-solutions。
  *
  * 包体格式与"为什么卡片用 deviceRef 而不是 mcpId"见 src/api/solutions.py 顶部注释。
  * 这里只负责三件事：
@@ -12,6 +12,7 @@
 
 import { openInstanceConfigModal, openToolConfigModal } from './sidebar.js';
 import { reloadFromServer } from './canvas.js';
+import { isRcLoggedIn, rcHeaders, rcFetch, showAccount, refreshAccount } from './account.js';
 
 // 与 resource-center/lib/solution.ts 的 INDUSTRIES 保持一致
 const INDUSTRIES = [
@@ -41,16 +42,6 @@ let _marketCache = [];
 let _packable = null;
 let _loadTarget = null;   // 待载入的方案 {slug, name, ...}
 let _alignVersions = false;  // 载入时是否把相关容器对齐到方案记录的 tag
-
-// ── RC 登录态（与 skills.js 共用 localStorage 里的 rc_token）───────────────
-
-function _rcToken() { return localStorage.getItem('rc_token'); }
-function _rcHeaders() {
-  const h = { 'Content-Type': 'application/json' };
-  const token = _rcToken();
-  if (token) h['X-RC-Token'] = token;
-  return h;
-}
 
 // ── Init ─────────────────────────────────────────────────────────────────────
 
@@ -104,19 +95,12 @@ export function hide() {
   _overlay.classList.add('hidden');
 }
 
-/** 左上角入口上的当前方案角标。 */
-async function _syncEntryBadge() {
-  const badge = document.getElementById('solution-entry-badge');
-  if (!badge) return;
-  try {
-    const data = (await (await fetch('/api/solutions/current')).json()).data;
-    if (data && data.name) {
-      badge.textContent = data.name;
-      badge.classList.remove('hidden');
-    } else {
-      badge.classList.add('hidden');
-    }
-  } catch { badge.classList.add('hidden'); }
+/**
+ * 当前方案的展示位在「我的」里（解决方案条目的副文本），载入 / 清除后刷新它。
+ * 顶栏原来那个角标随入口按钮一起收进了「我的」。
+ */
+function _syncEntryBadge() {
+  refreshAccount();
 }
 
 // ── Tab 1：当前方案 ─────────────────────────────────────────────────────────
@@ -285,7 +269,7 @@ function _sessionId() { return sessionStorage.getItem('canvas_session_id') || ''
 
 async function _preflight(slug) {
   const res = await fetch('/api/solutions/preflight', {
-    method: 'POST', headers: _rcHeaders(),
+    method: 'POST', headers: rcHeaders(),
     body: JSON.stringify({ slug, session_id: _sessionId() }),
   });
   return res.json();
@@ -519,7 +503,7 @@ async function _confirmLoad() {
 
     confirmBtn.textContent = '载入中…';
     const res = await fetch('/api/solutions/apply', {
-      method: 'POST', headers: _rcHeaders(),
+      method: 'POST', headers: rcHeaders(),
       body: JSON.stringify({
         slug: _loadTarget.slug, confirm: true, session_id: _sessionId(),
         align_versions: _alignVersions,
@@ -571,7 +555,7 @@ async function _alignAllVersions(statusBtn) {
     let json;
     try {
       const res = await fetch('/api/solutions/align-device', {
-        method: 'POST', headers: _rcHeaders(),
+        method: 'POST', headers: rcHeaders(),
         body: JSON.stringify({ slug: _loadTarget.slug, ref }),
       });
       json = await res.json();
@@ -616,18 +600,19 @@ async function _loadSavePanel() {
   const panel = document.getElementById('solution-save-panel');
   panel.innerHTML = `<div class="skill-empty">加载中…</div>`;
 
-  if (!_rcToken()) {
+  if (!isRcLoggedIn()) {
     panel.innerHTML = `
       <div class="skill-empty">
         发布解决方案需要先登录 Resource Center。<br>
-        请到「设置 → 技能 → 我的技能」登录后再回到这里。
+        <button class="skill-btn skill-btn-primary" id="sol-goto-login">去「我的」登录</button>
       </div>`;
+    panel.querySelector('#sol-goto-login').addEventListener('click', () => showAccount());
     return;
   }
 
   let data;
   try {
-    const json = await (await fetch('/api/solutions/packable', { headers: _rcHeaders() })).json();
+    const json = await (await fetch('/api/solutions/packable', { headers: rcHeaders() })).json();
     if (json.code !== 200) {
       panel.innerHTML = `<div class="skill-empty">${_esc(json.error || '读取失败')}</div>`;
       return;
@@ -817,15 +802,14 @@ async function _publish() {
   btn.disabled = true;
   btn.textContent = '发布中…';
   try {
-    const res = await fetch('/api/solutions/publish', {
-      method: 'POST', headers: _rcHeaders(),
+    const json = await rcFetch('/api/solutions/publish', {
+      method: 'POST',
       body: JSON.stringify({
         meta,
         include: _collectInclude(),
         extra_redact: [...panel.querySelectorAll('.sol-redact:checked')].map(el => el.value),
       }),
     });
-    const json = await res.json();
     if (json.code !== 200) {
       const detail = json.detail ? `（${[].concat(json.detail).join('、')}）` : '';
       errorEl.textContent = `${json.error || '发布失败'}${detail}`;

--- a/agent-core/web/js/solutions.js
+++ b/agent-core/web/js/solutions.js
@@ -317,26 +317,40 @@ function _renderLoadModal(data) {
   html += matched.map(d => `
     <div class="solution-driver-row">
       <span class="solution-driver-ok">✓</span>
-      <span class="solution-driver-name">${_esc(d.name || d.serverName)}</span>
-      <span class="solution-pill solution-pill-sm">${_esc(d.category || '')}</span>
-      ${_versionCell(d)}
-      <span class="solution-driver-image">已就绪 · ${_esc(d.mcpName || d.mcpId || '')}</span>
+      <div class="solution-driver-main">
+        <div class="solution-driver-line">
+          <span class="solution-driver-name">${_esc(d.name || d.serverName)}</span>
+          <span class="solution-pill solution-pill-sm">${_esc(d.category || '')}</span>
+          <span class="solution-driver-state">已就绪</span>
+        </div>
+        ${_versionCell(d)}
+      </div>
     </div>`).join('');
   html += installable.map(d => `
     <div class="solution-driver-row solution-driver-row-warn">
       <span class="solution-driver-warn">!</span>
-      <span class="solution-driver-name">${_esc(d.name || d.serverName)}</span>
-      <span class="solution-pill solution-pill-sm">${_esc(d.category || '')}</span>
-      ${_versionCell(d)}
-      <span class="solution-driver-image">${_esc(d.localImage || d.image || '')}</span>
+      <div class="solution-driver-main">
+        <div class="solution-driver-line">
+          <span class="solution-driver-name">${_esc(d.name || d.serverName)}</span>
+          <span class="solution-pill solution-pill-sm">${_esc(d.category || '')}</span>
+          <span class="solution-driver-state">未启动</span>
+        </div>
+        ${_versionCell(d)}
+        <div class="solution-driver-sub">${_esc(d.localImage || d.image || '')}</div>
+      </div>
       <button class="skill-btn skill-btn-sm skill-btn-primary" data-install="${_esc(d.localDriverId)}">一键安装</button>
     </div>`).join('');
   html += missing.map(d => `
     <div class="solution-driver-row solution-driver-row-error">
       <span class="solution-driver-err">✕</span>
-      <span class="solution-driver-name">${_esc(d.name || d.serverName)}</span>
-      <span class="solution-pill solution-pill-sm">${_esc(d.category || '')}</span>
-      <span class="solution-driver-image">本机没有此驱动：${_esc(d.registryImage || d.serverName)}</span>
+      <div class="solution-driver-main">
+        <div class="solution-driver-line">
+          <span class="solution-driver-name">${_esc(d.name || d.serverName)}</span>
+          <span class="solution-pill solution-pill-sm">${_esc(d.category || '')}</span>
+          <span class="solution-driver-state">本机缺少</span>
+        </div>
+        <div class="solution-driver-sub">${_esc(d.registryImage || d.serverName)}</div>
+      </div>
     </div>`).join('');
   html += `</div>`;
 
@@ -635,6 +649,10 @@ async function _loadSavePanel() {
   const localOnly = (data.configFields || []).filter(f => f.localOnly && !f.sensitive);
   const others    = (data.configFields || []).filter(f => !f.sensitive && !f.localOnly);
 
+  // 适用机型由后端从画布上的硬件驱动推出（没有硬件驱动就是空）—— 作者不能手填，
+  // 否则方案会声称支持一台打包这边根本没有驱动的机器
+  const robots = data.robotTypes || [];
+
   panel.innerHTML = `
     <div class="solution-save-form">
       <div class="solution-section-label">打包内容</div>
@@ -744,8 +762,15 @@ async function _loadSavePanel() {
       </div>
       <div class="skill-form-row">
         <div class="skill-form-field">
-          <label>适用机型（逗号分隔）</label>
-          <input type="text" id="sol-robots" placeholder="humanoid, quadruped">
+          <label>适用机型</label>
+          <div class="solution-robots">
+            ${robots.length
+              ? robots.map(m => `<span class="solution-pill solution-pill-driver">${_esc(m)}</span>`).join('')
+              : `<span class="solution-robots-none">None</span>`}
+          </div>
+          <div class="solution-hint">${robots.length
+            ? '由画布上的硬件驱动自动确定'
+            : '画布上没有硬件驱动，方案不声明适用机型'}</div>
         </div>
         <div class="skill-form-field">
           <label>标签（逗号分隔）</label>
@@ -787,7 +812,8 @@ async function _publish() {
     version:     panel.querySelector('#sol-version').value.trim(),
     oneLiner:    panel.querySelector('#sol-oneliner').value.trim(),
     description: panel.querySelector('#sol-description').value.trim(),
-    robotTypes:  _splitList(panel.querySelector('#sol-robots').value),
+    // 机型不来自表单，来自 /packable 推导出的画布硬件驱动
+    robotTypes:  _packable?.robotTypes || [],
     tags:        _splitList(panel.querySelector('#sol-tags').value),
   };
   if (!meta.name || !meta.slug || !meta.oneLiner || !meta.description) {

--- a/agent-core/web/js/solutions.js
+++ b/agent-core/web/js/solutions.js
@@ -40,6 +40,7 @@ let _overlay, _closeBtn, _tabs, _panels;
 let _marketCache = [];
 let _packable = null;
 let _loadTarget = null;   // 待载入的方案 {slug, name, ...}
+let _alignVersions = false;  // 载入时是否把相关容器对齐到方案记录的 tag
 
 // ── RC 登录态（与 skills.js 共用 localStorage 里的 rc_token）───────────────
 
@@ -151,6 +152,7 @@ async function _loadCurrent() {
             ${current.slug ? _esc(current.slug) + ' · ' : ''}v${_esc(current.version || '')}
             ${industry ? ' · ' + _esc(industry) : ''}
             ${current.appliedAt ? ' · 载入于 ' + new Date(current.appliedAt * 1000).toLocaleString() : ''}
+            ${current.versionAligned ? ' · 已对齐容器版本' : ''}
           </div>
         </div>
         <button class="skill-btn skill-btn-sm" id="solution-clear-current" title="只清除标记，不改动已载入的配置">清除标记</button>
@@ -290,6 +292,7 @@ async function _preflight(slug) {
 }
 
 async function _startLoad(slug) {
+  _alignVersions = false;   // 每次重新进入载入流程都从"不对齐"开始
   const body = document.getElementById('solution-load-body');
   document.getElementById('solution-load-overlay').classList.remove('hidden');
   body.innerHTML = `<div class="skill-empty">检查中…</div>`;
@@ -332,6 +335,7 @@ function _renderLoadModal(data) {
       <span class="solution-driver-ok">✓</span>
       <span class="solution-driver-name">${_esc(d.name || d.serverName)}</span>
       <span class="solution-pill solution-pill-sm">${_esc(d.category || '')}</span>
+      ${_versionCell(d)}
       <span class="solution-driver-image">已就绪 · ${_esc(d.mcpName || d.mcpId || '')}</span>
     </div>`).join('');
   html += installable.map(d => `
@@ -339,6 +343,7 @@ function _renderLoadModal(data) {
       <span class="solution-driver-warn">!</span>
       <span class="solution-driver-name">${_esc(d.name || d.serverName)}</span>
       <span class="solution-pill solution-pill-sm">${_esc(d.category || '')}</span>
+      ${_versionCell(d)}
       <span class="solution-driver-image">${_esc(d.localImage || d.image || '')}</span>
       <button class="skill-btn skill-btn-sm skill-btn-primary" data-install="${_esc(d.localDriverId)}">一键安装</button>
     </div>`).join('');
@@ -350,6 +355,32 @@ function _renderLoadModal(data) {
       <span class="solution-driver-image">本机没有此驱动：${_esc(d.registryImage || d.serverName)}</span>
     </div>`).join('');
   html += `</div>`;
+
+  // 版本对齐：默认不对齐（打包只记录版本，不做判断），勾上则把相关容器
+  // 重新部署到方案记录的 tag。Agent Core 自身不在此列 —— 它就是正在处理这次
+  // 请求的容器，重启会让载入半路断掉，只能提示用户手动升级。
+  const misaligned = data.misaligned || [];
+  const alignable = [...matched, ...installable].filter(d => d.alignImage);
+  html += `<div class="solution-section-label">容器版本</div>`;
+  html += `<label class="solution-check" id="solution-align-wrap">
+      <input type="checkbox" id="solution-align-versions" ${alignable.length ? '' : 'disabled'}>
+      <span>对齐方案记录的容器版本${alignable.length ? '' : '（方案未记录可用的镜像 tag）'}</span>
+    </label>`;
+  if (misaligned.length) {
+    html += `<div class="solution-hint solution-warn">
+      勾选后会先把这些容器重新部署到方案记录的 tag，再载入：
+      ${misaligned.map(d => `<code>${_esc(d.name || d.serverName)} ${_esc(d.runningTag || '未知')} → ${_esc(d.packageTag)}</code>`).join('、')}
+    </div>`;
+  } else if (alignable.length) {
+    html += `<div class="solution-hint">当前各容器版本已与方案记录一致（或无法读取 Docker 状态）。</div>`;
+  }
+  if (sol.coreVersion && data.selfVersion && sol.coreVersion !== data.selfVersion) {
+    html += `<div class="solution-hint solution-warn">
+      方案打包自 Agent Core <code>${_esc(sol.coreVersion)}</code>，本机是
+      <code>${_esc(data.selfVersion)}</code>。Agent Core 自身不会自动对齐
+      （重启会中断本次载入），需要时请到「设置 → 部署」手动升级。
+    </div>`;
+  }
 
   if (missing.length) {
     html += `<div class="solution-load-error">
@@ -403,9 +434,29 @@ function _renderLoadModal(data) {
     });
   }
 
+  // 勾选状态要跨重渲染保留：装完一个驱动就会重新 preflight + 重画，
+  // 用户不该因此丢掉刚勾上的"对齐版本"。
+  const alignBox = body.querySelector('#solution-align-versions');
+  if (alignBox) {
+    alignBox.checked = _alignVersions && !alignBox.disabled;
+    alignBox.addEventListener('change', () => { _alignVersions = alignBox.checked; });
+  }
+
   const ready = !missing.length && !installable.length && !data.canvasEditor;
   confirmBtn.classList.toggle('hidden', !ready);
   confirmBtn.disabled = !ready;
+}
+
+/** 版本格挡：本机在跑的 tag vs 方案记录的 tag。 */
+function _versionCell(d) {
+  if (!d.packageTag) return '';
+  if (d.aligned === false) {
+    return `<span class="solution-ver solution-ver-diff" title="本机 ${_esc(d.runningTag || '未知')} → 方案 ${_esc(d.packageTag)}">${_esc(d.runningTag || '未知')} → ${_esc(d.packageTag)}</span>`;
+  }
+  if (d.aligned === true) {
+    return `<span class="solution-ver">${_esc(d.packageTag)}</span>`;
+  }
+  return `<span class="solution-ver solution-ver-unknown" title="读不到容器状态">方案 ${_esc(d.packageTag)}</span>`;
 }
 
 /** 部署一个已在驱动清单里、但还没跑起来的驱动，然后等它自注册成 MCP。 */
@@ -454,12 +505,25 @@ async function _confirmLoad() {
   const confirmBtn = document.getElementById('solution-load-confirm');
   const body = document.getElementById('solution-load-body');
   confirmBtn.disabled = true;
-  confirmBtn.textContent = '载入中…';
 
   try {
+    if (_alignVersions) {
+      confirmBtn.textContent = '对齐版本中…';
+      const ok = await _alignAllVersions(confirmBtn);
+      if (!ok) {
+        confirmBtn.disabled = false;
+        confirmBtn.textContent = '确认载入';
+        return;
+      }
+    }
+
+    confirmBtn.textContent = '载入中…';
     const res = await fetch('/api/solutions/apply', {
       method: 'POST', headers: _rcHeaders(),
-      body: JSON.stringify({ slug: _loadTarget.slug, confirm: true, session_id: _sessionId() }),
+      body: JSON.stringify({
+        slug: _loadTarget.slug, confirm: true, session_id: _sessionId(),
+        align_versions: _alignVersions,
+      }),
     });
     const json = await res.json();
     if (json.code !== 200) {
@@ -475,6 +539,7 @@ async function _confirmLoad() {
     _syncEntryBadge();
     _tabs[0].click();
     let msg = '解决方案已载入。';
+    if (_alignVersions) msg += '\n相关容器已对齐到方案记录的版本。';
     if (needs.length) msg += `\n有 ${needs.length} 个脱敏字段需要补填，见「当前方案」。`;
     if (failed.length) msg += `\n以下技能安装失败：${failed.map(f => f.slug).join('、')}`;
     alert(msg);
@@ -483,6 +548,62 @@ async function _confirmLoad() {
     confirmBtn.textContent = '确认载入';
     alert(`载入失败：${e.message}`);
   }
+}
+
+/**
+ * 逐个把版本不一致的容器重新部署到方案记录的 tag。
+ *
+ * 一个个来而不是并发：拉镜像很吃带宽和磁盘，几个驱动同时 pull 在机器人这种
+ * 硬件上容易把自己拖死。每部署完一个都重新 preflight，一是拿到最新的对齐
+ * 状态，二是确认容器真的重新注册上来了。
+ */
+async function _alignAllVersions(statusBtn) {
+  let pending = (_loadTarget.misaligned || []).map(d => d.ref);
+  const total = pending.length;
+  if (!total) return true;
+
+  for (let done = 0; done < total; done++) {
+    const ref = pending[0];
+    const dev = (_loadTarget.misaligned || []).find(d => d.ref === ref) || {};
+    const label = dev.name || dev.serverName || ref;
+    statusBtn.textContent = `对齐 ${label}（${done + 1}/${total}）…`;
+
+    let json;
+    try {
+      const res = await fetch('/api/solutions/align-device', {
+        method: 'POST', headers: _rcHeaders(),
+        body: JSON.stringify({ slug: _loadTarget.slug, ref }),
+      });
+      json = await res.json();
+    } catch (e) {
+      alert(`对齐 ${label} 失败：${e.message}`);
+      return false;
+    }
+    if (json.code !== 200) {
+      alert(`对齐 ${label} 失败：${json.error || '未知错误'}`);
+      return false;
+    }
+
+    // 等容器重新起来并注册；轮询 preflight 直到这个 ref 不再出现在 misaligned
+    let settled = false;
+    for (let i = 0; i < 40; i++) {          // 最多约 2 分钟
+      await new Promise(r => setTimeout(r, 3000));
+      const pf = await _preflight(_loadTarget.slug);
+      if (pf.code !== 200) continue;
+      _loadTarget = { slug: _loadTarget.slug, ...pf.data };
+      const still = (pf.data.misaligned || []).some(d => d.ref === ref);
+      const notReady = (pf.data.devices.installable || []).some(d => d.ref === ref);
+      if (!still && !notReady) { settled = true; break; }
+    }
+    if (!settled) {
+      _renderLoadModal(_loadTarget);
+      alert(`${label} 已按方案版本重新部署，但还没恢复上线。请到「设置 → 部署」看容器日志。`);
+      return false;
+    }
+    pending = (_loadTarget.misaligned || []).map(d => d.ref);
+    if (!pending.length) break;
+  }
+  return true;
 }
 
 function _closeLoadModal() {

--- a/agent-core/web/js/solutions.js
+++ b/agent-core/web/js/solutions.js
@@ -603,7 +603,7 @@ async function _loadSavePanel() {
   if (!isRcLoggedIn()) {
     panel.innerHTML = `
       <div class="skill-empty">
-        发布解决方案需要先登录 Resource Center。<br>
+        发布解决方案需要先登录 Resource Center。
         <button class="skill-btn skill-btn-primary" id="sol-goto-login">去「我的」登录</button>
       </div>`;
     panel.querySelector('#sol-goto-login').addEventListener('click', () => showAccount());

--- a/agent-core/web/js/solutions.js
+++ b/agent-core/web/js/solutions.js
@@ -645,7 +645,8 @@ async function _loadSavePanel() {
   }
 
   const sensitive = (data.configFields || []).filter(f => f.sensitive);
-  const others    = (data.configFields || []).filter(f => !f.sensitive);
+  const localOnly = (data.configFields || []).filter(f => f.localOnly && !f.sensitive);
+  const others    = (data.configFields || []).filter(f => !f.sensitive && !f.localOnly);
 
   panel.innerHTML = `
     <div class="solution-save-form">
@@ -694,14 +695,21 @@ async function _loadSavePanel() {
       </div>
 
       <div class="solution-check-group">
-        <div class="solution-check-group-title">敏感字段脱敏</div>
+        <div class="solution-check-group-title">打包时会清空的字段</div>
         ${sensitive.length ? `
-          <div class="solution-hint">以下字段由卡片声明为敏感，打包时一定会被清空：</div>
+          <div class="solution-hint">以下字段由卡片声明为敏感，一定会被清空：</div>
           ${sensitive.map(f => `
             <label class="solution-check solution-check-locked">
               <input type="checkbox" checked disabled>
               <span><code>${_esc(f.path)}</code></span>
             </label>`).join('')}` : `<div class="solution-hint">卡片没有声明任何敏感字段</div>`}
+        ${localOnly.length ? `
+          <div class="solution-hint">以下字段只对本机有效（渠道 / 声卡设备），载入方需要重选：</div>
+          ${localOnly.map(f => `
+            <label class="solution-check solution-check-locked">
+              <input type="checkbox" checked disabled>
+              <span><code>${_esc(f.path)}</code></span>
+            </label>`).join('')}` : ''}
         ${others.length ? `
           <div class="solution-hint">如果下面还有不该外传的值，勾选它一并清空：</div>
           ${others.map(f => `

--- a/agent-core/web/js/solutions.js
+++ b/agent-core/web/js/solutions.js
@@ -652,15 +652,18 @@ async function _loadSavePanel() {
     <div class="solution-save-form">
       <div class="solution-section-label">打包内容</div>
 
-      <label class="solution-check solution-check-locked">
-        <input type="checkbox" checked disabled>
-        <span>画布（必选）—— ${data.canvas.cards} 张卡片、${data.canvas.devices.length} 个设备</span>
-      </label>
-      ${data.canvas.unresolved.length ? `
-        <div class="solution-load-error">
-          画布上有卡片引用了未注册的设备（${data.canvas.unresolved.map(_esc).join('、')}），
-          请先删除这些卡片再打包。
-        </div>` : ''}
+      <div class="solution-check-group">
+        <div class="solution-check-group-title">画布（必选）</div>
+        <label class="solution-check solution-check-locked">
+          <input type="checkbox" checked disabled>
+          <span>${data.canvas.cards} 张卡片、${data.canvas.devices.length} 个设备 —— 解决方案必须包含画布</span>
+        </label>
+        ${data.canvas.unresolved.length ? `
+          <div class="solution-load-error">
+            画布上有卡片引用了未注册的设备（${data.canvas.unresolved.map(_esc).join('、')}），
+            请先删除这些卡片再打包。
+          </div>` : ''}
+      </div>
 
       <div class="solution-check-group">
         <div class="solution-check-group-title">技能（仅当前激活）</div>

--- a/perception/README.md
+++ b/perception/README.md
@@ -207,3 +207,25 @@ ASR result JSON:
   "asr_complete_ts": 1234567891.789
 }
 ```
+
+## Sensitive Config Fields
+
+Perception plugins hold real credentials (ASR/TTS API keys). Canvas configuration
+gets packaged into shareable **Solutions** and uploaded to the Resource Center,
+so every credential field must declare itself sensitive in its `configSchema` —
+packaging blanks declared fields only, there is no field-name blocklist:
+
+```python
+"configSchema": {
+    "type": "object",
+    "properties": {
+        "api_key": {"type": "string", "format": "password"},   # masked input + never packaged
+        "app_key": {"type": "string", "x-sensitive": True},    # visible input + never packaged
+        "model":   {"type": "string"},                         # packaged as-is
+    },
+}
+```
+
+An unmarked credential is uploaded in clear text and readable by anyone who
+downloads the solution. Full spec: `phanthymotus-driver/README_dev.md`
+§ "Marking sensitive fields".


### PR DESCRIPTION
## 做了什么

把"这台机器上跑得起来的整套配置"打包成可复用的**解决方案**：画布拓扑 + 卡片配置 + 技能 + prompt + 任务。入口在 dashboard 左上角品牌区旁边，三个 tab：当前方案 / 方案市场 / 保存当前方案。

配套的 Resource Center 侧（Solution 数据模型、市场页面、审核）在 GitLab 的 `feat/solutions-marketplace`；驱动侧的敏感字段约定文档在 phanthymotus-driver#(见下)。

## 关键设计

**卡片存 deviceRef，不存 mcpId。** `mcpId` 是本机注册设备时生成的 `mcp-<unix秒>`（`api/mcp_manage.py:mcp_add`），换机器一定对不上。包体的 `devices[]` 用 MCP `initialize` 返回的 `server_name`（`g1-device-bundle` 之类）作稳定标识，载入时映射回本机 mcpId。`execConnections` 里缓存的 `toMcpId` 同理：打包时丢弃，载入时按本机重算。

**脱敏是声明式的。** 工具在 `configSchema` 属性上标 `x-sensitive: true`，或沿用 driver 早就在用的 `format: password`。声明过的字段打包时一定清空并记入 `needsConfig`；其余字段在打包界面列出来，作者可手工追加（`extra_redact`）。不做字段名黑名单 —— 按名字猜既会漏掉真密钥，也会误清无害字段。

**技能只能打包"已激活 + 技能广场已上架"的。** 查上架状态时刻意不带 RC token，否则作者自己的私有草稿会被判成"有"，别人载入必然装不上。未上架的技能在界面上置灰并说明原因。

**载入前 preflight。** 设备分三类：已就绪 / 清单里有但没部署（一键安装）/ 本机没有此驱动（提示先装什么）。同时逐项列出会覆盖什么（N 张卡片、哪些技能、哪个 prompt 文件、几个任务）。

**可选"对齐容器版本"。** 勾上则先把涉及的容器重新部署到包体记录的 tag 再载入；只取 tag、保留本机 registry（包体可能来自作者的私有仓库）。逐个部署而非并发（机器人硬件上同时 pull 容易把自己拖死），apply 会再核一遍，避免混合版本落地。Agent Core 自身不自动对齐 —— 它就是处理这次请求的容器。

**载入会绕过画布编辑锁**直接改写 `canvas_layout`，所以有别人正在编辑时直接拒绝（423）：对方的下一次自动保存会把刚载入的画布覆盖回去。

## 抽出复用，没有复制

| 抽出 | 位置 | 复用方 |
|------|------|--------|
| 从 RC 拉技能 + 写 ConfigDB | `api/skills.py` `fetch_rc_skill` / `install_from_rc` | `/skills/install` 与解决方案载入 |
| tool_config key 拼接、`action:config` 下发、批量读写 | `api/canvas.py` `tool_config_key` / `apply_tool_config` / `all_tool_configs` / `delete_all_tool_configs` | 画布端点与解决方案载入 |
| 共享配置弹窗 | `web/js/sidebar.js` `openToolConfigModal`（改为导出） | "待补填字段"直接跳转 |

## 验证

本地用一个不依赖 rclpy 的 harness（macOS 上 `start.py` 的 DDS 检查过不去）跑通了：

- 打包 → 载入全链路，含跨机 mcpId 重映射（`mcp-1000/2000` → `mcp-7777/8888`）、卡片 id 与连线保持、execConnection 的 toMcpId 重新解析
- `x-sensitive` 与 `format: password` 双规则脱敏，兄弟字段不受影响，`extra_redact` 生效
- 孤儿实例配置（卡片已删）不进包体、载入时不落盘
- 只写勾选的 prompt 文件（未勾选的 `prompt_system.md` 保持原样）
- 任务清空重建并重新挂 cron
- 版本对齐：tag 解析避开 registry 端口、只换 repo 的 tag、`aligned=None` 不拦载入；align-device 的 404/422/部署失败路径
- 拒绝路径：apply 无 confirm → 428、取消勾选画布 → 422、技能未上架 → 422（带清单）、未登录 RC → 401
- 浏览器里点完了三个 tab、载入弹窗（缺驱动 / 全就绪两种）与"对齐版本"开关，确认请求顺序是 align-device → apply(align_versions=true)

**尚未在真机验证**（本地没有 ROS2/Docker）：驱动一键安装后的自注册、对齐版本的实际 pull/部署、载入后卡片 `start`。建议合并前在 G1 或 Go2 上走一遍。

🤖 Generated with [Claude Code](https://claude.com/claude-code)