### PR TITLE
fix(canvas): 把编辑锁绑到 /ws/motus 连接，关掉页面立即释放

### DIFF
--- a/agent-core/src/api/canvas.py
+++ b/agent-core/src/api/canvas.py
@@ -21,18 +21,112 @@ router = fastapi.APIRouter(prefix='/canvas', tags=['canvas'])
 _TOOL_CONFIG_PREFIX = 'tool_config:'
 
 # ── Editor Lock State (in-memory, resets on restart) ─────────────────────────
+#
+# The lock's lifetime is tied to the holder's /ws/motus connection, not to a
+# browser unload handler: beforeunload/pagehide never fire on a killed process,
+# a reclaimed mobile tab or a crashed page, and sendBeacon may be dropped — so a
+# closed tab used to hold the canvas hostage until the TTL expired. api/motus_stream
+# reports connect/disconnect here; a disconnect releases the lock after a short
+# grace period, and a *live* connection means the lock never times out (an editor
+# staring at the canvas without touching it is not idle).
 
 _editor_session: Optional[str] = None   # session_id of current editor
 _editor_last_seen: float = 0.0          # monotonic timestamp of last activity
-_EDITOR_TIMEOUT = 60.0                  # seconds before auto-release
+_EDITOR_TIMEOUT = 60.0                  # TTL fallback for sessions with no live WS
+
+_live_sessions: dict[str, int] = {}     # session_id → open /ws/motus count
+_DISCONNECT_GRACE = 8.0                 # seconds to tolerate a WS reconnect flap
+
+_layout_rev = 0                         # bumped on every canvas_layout write
+
+
+def _broadcast(event: dict) -> None:
+    """Fire-and-forget push to /ws/motus clients.
+
+    Local import breaks the cycle (motus_stream is imported by everything);
+    tolerating "no running loop" mirrors apply_tool_config below — a missed
+    broadcast degrades cross-tab freshness, not correctness, since clients also
+    poll /canvas/edit-status.
+    """
+    from api.motus_stream import push_event
+
+    try:
+        asyncio.create_task(push_event(event))
+    except RuntimeError:
+        pass
+
+
+def _broadcast_editor(reason: str) -> None:
+    """Tell every client who holds the lock now (None = free)."""
+    _broadcast({'type': 'canvas_editor',
+                'payload': {'editor': _editor_session, 'reason': reason}})
+
+
+def notify_layout_changed(session_id: str = '') -> None:
+    """Tell every client the saved layout changed, so readers can reload.
+
+    `session_id` is the writer — clients use it to ignore the echo of their own
+    save. Also called by api/solutions.py, which rewrites canvas_layout directly.
+    """
+    global _layout_rev
+    _layout_rev += 1
+    _broadcast({'type': 'canvas_layout',
+                'payload': {'editor': session_id, 'rev': _layout_rev}})
 
 
 def _check_editor_expired():
-    """Release editor if inactive for too long."""
+    """Release the lock if its holder is gone.
+
+    A session with a live /ws/motus never expires; the TTL only covers holders we
+    have no connection for (WS never established, or an old client).
+    """
     global _editor_session, _editor_last_seen
-    if _editor_session and (time.monotonic() - _editor_last_seen) > _EDITOR_TIMEOUT:
+    if not _editor_session or _live_sessions.get(_editor_session):
+        return
+    if (time.monotonic() - _editor_last_seen) > _EDITOR_TIMEOUT:
         _editor_session = None
         _editor_last_seen = 0.0
+        _broadcast_editor('timeout')
+
+
+def session_connected(session_id: str) -> None:
+    """A /ws/motus connection opened for this session."""
+    if not session_id:
+        return
+    _live_sessions[session_id] = _live_sessions.get(session_id, 0) + 1
+
+
+def session_disconnected(session_id: str) -> None:
+    """A /ws/motus connection closed; release the lock if nothing reconnects.
+
+    Refcounted because one page may hold several connections and a reconnect can
+    overlap the old socket's teardown — decrementing to zero is the only reliable
+    "this session is gone" signal.
+    """
+    if not session_id:
+        return
+    remaining = _live_sessions.get(session_id, 0) - 1
+    if remaining > 0:
+        _live_sessions[session_id] = remaining
+        return
+    _live_sessions.pop(session_id, None)
+    try:
+        asyncio.create_task(_grace_release(session_id))
+    except RuntimeError:
+        pass
+
+
+async def _grace_release(session_id: str) -> None:
+    """Release `session_id`'s lock unless it reconnects within the grace period."""
+    global _editor_session, _editor_last_seen
+    await asyncio.sleep(_DISCONNECT_GRACE)
+    if _live_sessions.get(session_id):
+        return                          # reconnected — keep editing
+    if _editor_session != session_id:
+        return
+    _editor_session = None
+    _editor_last_seen = 0.0
+    _broadcast_editor('disconnect')
 
 
 def current_editor() -> Optional[str]:
@@ -112,24 +206,50 @@ async def claim_edit(body: dict = fastapi.Body(...)):
 
     _editor_session = session_id
     _editor_last_seen = time.monotonic()
+    _broadcast_editor('claim')
     return {'code': 200, 'editor': session_id}
 
 
 @router.post('/release-edit')
-async def release_edit(body: dict = fastapi.Body(...)):
-    """Release edit permission."""
+async def release_edit(request: fastapi.Request):
+    """Release edit permission.
+
+    Body is parsed by hand rather than via Body(...) because the page-close path
+    uses navigator.sendBeacon, which sends Content-Type: text/plain — FastAPI only
+    JSON-decodes an `application/*json` body, so a declared dict param 422'd and
+    the lock was never released.
+    """
     global _editor_session, _editor_last_seen
-    session_id = body.get('session_id', '')
-    if _editor_session == session_id:
-        _editor_session = None
-        _editor_last_seen = 0.0
+    _check_editor_expired()
+
+    try:
+        body = json.loads(await request.body() or b'{}')
+    except (ValueError, TypeError):
+        body = {}
+    session_id = body.get('session_id', '') if isinstance(body, dict) else ''
+
+    if not session_id or _editor_session != session_id:
+        return fastapi.responses.JSONResponse(
+            status_code=409, content={'code': 409, 'message': 'Not the current editor',
+                                      'editor': _editor_session})
+
+    _editor_session = None
+    _editor_last_seen = 0.0
+    _broadcast_editor('release')
     return {'code': 200}
 
 
 @router.get('/edit-status')
-async def edit_status():
-    """Check who is currently editing."""
+async def edit_status(session_id: str = ''):
+    """Check who is currently editing.
+
+    Passing your own session_id also refreshes the TTL — the frontend's 10s poll
+    thus acts as a heartbeat while the /ws/motus connection is down.
+    """
+    global _editor_last_seen
     _check_editor_expired()
+    if session_id and session_id == _editor_session:
+        _editor_last_seen = time.monotonic()
     return {'code': 200, 'editor': _editor_session}
 
 
@@ -140,7 +260,7 @@ async def get_layout():
     """Return the saved canvas layout + current editor info."""
     _check_editor_expired()
     data = config.main.get('canvas_layout', {'cards': []})
-    return {'code': 200, 'data': data, 'editor': _editor_session}
+    return {'code': 200, 'data': data, 'editor': _editor_session, 'rev': _layout_rev}
 
 
 @router.post('/layout')
@@ -160,6 +280,7 @@ async def save_layout(layout: CanvasLayout):
     save_data = layout.dict()
     save_data.pop('session_id', None)
     config.main['canvas_layout'] = save_data
+    notify_layout_changed(session_id or '')
     return {'code': 200}
 
 

--- a/agent-core/src/api/motus_stream.py
+++ b/agent-core/src/api/motus_stream.py
@@ -54,6 +54,13 @@ async def motus_ws(websocket: fastapi.WebSocket):
     queue: asyncio.Queue = asyncio.Queue(maxsize=256)
     _clients.add(queue)
 
+    # This connection is also the canvas editor lock's liveness signal: the lock
+    # is held by a session_id, and api/canvas releases it shortly after that
+    # session's last connection drops (see canvas.session_disconnected).
+    from api import canvas
+    session_id = websocket.query_params.get('session_id', '')
+    canvas.session_connected(session_id)
+
     # Send a welcome / connection-established event
     await websocket.send_text(json.dumps({
         'type': 'status',
@@ -75,3 +82,4 @@ async def motus_ws(websocket: fastapi.WebSocket):
         pass
     finally:
         _clients.discard(queue)
+        canvas.session_disconnected(session_id)

--- a/agent-core/src/api/solutions.py
+++ b/agent-core/src/api/solutions.py
@@ -1021,7 +1021,7 @@ async def apply(request: fastapi.Request, req: LoadRequest):
 def _apply_canvas(canvas: dict, mapping: dict) -> dict:
     """写画布布局与卡片配置。"""
     from api.canvas import (apply_tool_config, delete_all_tool_configs,
-                            tool_config_key)
+                            notify_layout_changed, tool_config_key)
 
     cards = []
     for card in canvas.get('cards') or []:
@@ -1057,6 +1057,8 @@ def _apply_canvas(canvas: dict, mapping: dict) -> dict:
         'execConnections': exec_connections,
         'transform':       canvas.get('transform') or {},
     }
+    # 绕过编辑锁直接改写了布局，所有开着画布的客户端都得重新拉一次
+    notify_layout_changed()
 
     # 卡片配置：先清空旧的，再写包体里的
     removed = delete_all_tool_configs()

--- a/agent-core/web/js/canvas.js
+++ b/agent-core/web/js/canvas.js
@@ -14,6 +14,8 @@
 import { showTopicDetail } from './detail-panel.js';
 import { showToolDetail, isToolConfigured, isInstanceConfigured, openInstanceConfigModal, hasSharedRequired } from './sidebar.js';
 import { toggleMicStream, isMicActive } from './mic-stream.js';
+import { sessionId } from './session.js';
+import { getToken } from './auth.js';
 
 let _canvasEl   = null;
 let _viewport   = null;
@@ -24,14 +26,11 @@ let _cards      = [];   // [{ id, mcpId, toolName, driverName, x, y, el }]
 let _allMcps    = [];
 
 // ── Editor Lock ──────────────────────────────────────────────────────────────
-// sessionStorage (not localStorage) so each tab/window gets its own session_id —
-// otherwise all tabs of the same browser would share one id and be treated as
-// the same editor, letting them edit concurrently and silently clobber each other's autosave.
-let _sessionId = sessionStorage.getItem('canvas_session_id');
-if (!_sessionId) {
-  _sessionId = 'sess-' + Date.now().toString(36) + Math.random().toString(36).slice(2, 6);
-  sessionStorage.setItem('canvas_session_id', _sessionId);
-}
+// The session id comes from session.js (per-tab, see the rationale there) and is
+// also sent on the /ws/motus connection — the backend releases this session's
+// lock shortly after that socket drops, so closing/killing the tab frees the
+// canvas without depending on an unload handler firing.
+const _sessionId = sessionId();
 let _isEditor = false;
 let _currentEditor = null;  // session_id of current editor (null = no one)
 
@@ -193,7 +192,7 @@ export async function initCanvas(initialMcps) {
 
     // Initialize editor lock state from layout response
     _currentEditor = layoutJson.editor || null;
-    if (_currentEditor === _sessionId) _isEditor = true;
+    _isEditor = _currentEditor === _sessionId;
   } catch { /* start empty */ }
 
   // Show editor status bar
@@ -210,7 +209,7 @@ export async function initCanvas(initialMcps) {
     }
   } catch { /* ignore */ }
 
-  // Cross-tab sync: listen for project_state events via WebSocket
+  // Cross-tab sync: listen for project_state / editor-lock / layout events via WebSocket
   const { onMotusEvent } = await import('./motus-stream.js');
   onMotusEvent(null, (event) => {
     if (event.type === 'project_state') {
@@ -222,12 +221,18 @@ export async function initCanvas(initialMcps) {
           btn.classList.toggle('locked', !_projectRunning);
         });
       }
+    } else if (event.type === 'canvas_editor') {
+      _applyEditorState(event.payload?.editor || null, event.payload?.reason || '');
+    } else if (event.type === 'canvas_layout') {
+      // Ignore the echo of our own autosave; readers reload to follow the editor.
+      if ((event.payload?.editor || '') !== _sessionId) _scheduleReload();
     }
   });
 
   // Re-sync state when tab becomes visible (fallback for WS disconnect)
   document.addEventListener('visibilitychange', () => {
     if (!document.hidden) {
+      _checkEditStatus();
       fetch('/api/config/project-running').then(r => r.json()).then(d => {
         if (d.running !== _projectRunning) {
           _projectRunning = d.running;
@@ -2091,7 +2096,9 @@ function _updateEditorUI() {
     bar.querySelector('#canvas-release-btn').onclick = _releaseEdit;
     _setCanvasReadonly(false);
   } else if (_currentEditor) {
-    bar.innerHTML = `${_SVG_LOCK}<span class="editor-label editor-label--locked">画布被占用，无法编辑</span>`;
+    // Read-only, not broken: reading the canvas and its data streams stays open to
+    // everyone, only writes need the lock.
+    bar.innerHTML = `${_SVG_LOCK}<span class="editor-label editor-label--locked">画布由其他人编辑中（只读）</span>`;
     _setCanvasReadonly(true);
   } else {
     bar.innerHTML = `${_SVG_PEN}<button class="editor-btn editor-btn--claim" id="canvas-claim-btn">编辑</button>`;
@@ -2120,21 +2127,53 @@ async function _releaseEdit() {
   _updateEditorUI();
 }
 
+/**
+ * Adopt a lock state pushed by the server (canvas_editor event) or read from a
+ * poll. Readers reload once the canvas is freed so they end up on the editor's
+ * final layout.
+ */
+function _applyEditorState(editor, reason) {
+  const wasEditor = _isEditor;
+  _currentEditor = editor;
+  _isEditor = editor === _sessionId;
+  _updateEditorUI();
+
+  if (!editor) {
+    if (!wasEditor) {
+      // Canvas just went free — pick up whatever the last editor left behind.
+      _scheduleReload(reason === 'release');
+      if (reason === 'release') _showToast('画布编辑权已释放，可点击「编辑」接管');
+    }
+  } else if (wasEditor && !_isEditor) {
+    _showToast('编辑权已被释放，画布转为只读');
+  }
+}
+
+// Reload debounce: an editor dragging cards autosaves repeatedly, and readers
+// should not refetch on every one of those.
+let _reloadTimer = null;
+let _lastReloadToast = 0;
+
+function _scheduleReload(silent = false) {
+  clearTimeout(_reloadTimer);
+  _reloadTimer = setTimeout(async () => {
+    await _reloadLayout();
+    // Throttled, and skipped when the caller already explained what happened —
+    // otherwise the reload toast would immediately replace that message.
+    if (!silent && Date.now() - _lastReloadToast > 5000) {
+      _lastReloadToast = Date.now();
+      _showToast('画布已更新');
+    }
+  }, 800);
+}
+
 async function _checkEditStatus() {
   try {
-    const resp = await fetch('/api/canvas/edit-status');
+    const resp = await fetch(`/api/canvas/edit-status?session_id=${encodeURIComponent(_sessionId)}`);
     const data = await resp.json();
-    const prevEditor = _isEditor;
-    _currentEditor = data.editor || null;
-    if (_currentEditor === _sessionId) {
-      _isEditor = true;
-    } else if (_isEditor) {
-      // We lost editor status (timeout)
-      _isEditor = false;
-      _logActivity('warn', '编辑权已超时释放（60秒无操作）');
-      _showToast('编辑权已超时释放，请重新操作');
-    }
-    _updateEditorUI();
+    const editor = data.editor || null;
+    if (editor === _currentEditor) return;   // no change — don't re-render or reload
+    _applyEditorState(editor, '');
   } catch { /* silent */ }
 }
 
@@ -2158,17 +2197,31 @@ async function _reloadLayout() {
     _syncEmptyState();
     // Update editor info
     _currentEditor = layoutJson.editor || null;
-    if (_currentEditor === _sessionId) _isEditor = true;
+    _isEditor = _currentEditor === _sessionId;
     _updateEditorUI();
   } catch { /* silent */ }
 }
 
-// Release on page close
-window.addEventListener('beforeunload', () => {
-  if (_isEditor) {
-    navigator.sendBeacon('/api/canvas/release-edit', JSON.stringify({ session_id: _sessionId }));
-  }
-});
+// Release on page close — a fast path only: correctness comes from the backend
+// dropping the lock when this tab's /ws/motus connection closes, since these
+// events never fire on a killed process or a reclaimed mobile tab.
+//
+// The beacon has to carry an application/json Blob (a plain string is sent as
+// text/plain, which FastAPI refuses to JSON-decode) and its own ?token= (it
+// bypasses the fetch patch in auth.js that injects the Authorization header).
+function _releaseBeacon() {
+  if (!_isEditor) return;
+  const token = getToken();
+  const url = '/api/canvas/release-edit' + (token ? `?token=${encodeURIComponent(token)}` : '');
+  const blob = new Blob([JSON.stringify({ session_id: _sessionId })],
+                        { type: 'application/json' });
+  navigator.sendBeacon(url, blob);
+}
+window.addEventListener('pagehide', _releaseBeacon);
+window.addEventListener('beforeunload', _releaseBeacon);
+// Restored from the back/forward cache: the beacon already released our lock, so
+// re-read the real state instead of trusting the stale in-memory flag.
+window.addEventListener('pageshow', (e) => { if (e.persisted) _checkEditStatus(); });
 
 // Periodically check edit status (piggyback on existing polling interval)
 setInterval(_checkEditStatus, 10000);

--- a/agent-core/web/js/motus-stream.js
+++ b/agent-core/web/js/motus-stream.js
@@ -1,11 +1,20 @@
 /**
  * motus-stream.js — WebSocket client for /ws/motus.
  * Emits events to registered listeners.
+ *
+ * The connection also carries the tab's session_id: the backend treats it as the
+ * canvas editor lock's liveness signal and releases the lock shortly after this
+ * socket drops. So there must be exactly one connection per tab — connectMotus()
+ * is idempotent for that reason (it is called from both app.js and dashboard.js).
  */
+
+import { sessionId } from './session.js';
 
 let _ws = null;
 let _retryDelay = 1000;
 let _listeners = [];  // Array of { mcpId: string|null, fn: Function }
+let _statusCbs = [];  // Status callbacks from every connectMotus() caller
+let _lastStatus = 'connecting';
 
 export function onMotusEvent(mcpId, fn) {
   _listeners.push({ mcpId, fn });
@@ -15,16 +24,31 @@ export function offMotusEvent(fn) {
   _listeners = _listeners.filter(l => l.fn !== fn);
 }
 
+function _notify(state) {
+  _lastStatus = state;
+  _statusCbs.forEach(cb => { try { cb(state); } catch { /* ignore */ } });
+}
+
 export function connectMotus(onStatusChange) {
-  const _cb = onStatusChange || (() => {});
+  if (onStatusChange) {
+    _statusCbs.push(onStatusChange);
+    onStatusChange(_lastStatus);   // late caller still gets the current state
+  }
+  // Already connected/connecting: reuse it. Opening a second socket would leak
+  // the old one (still open, just unreferenced) and make this tab look like two
+  // live sessions to the editor lock.
+  if (_ws && (_ws.readyState === WebSocket.OPEN || _ws.readyState === WebSocket.CONNECTING)) {
+    return;
+  }
   function connect() {
     const proto = location.protocol === 'https:' ? 'wss' : 'ws';
     const token = localStorage.getItem('phanthy_access_token') || '';
-    _ws = new WebSocket(`${proto}://${location.host}/ws/motus?token=${encodeURIComponent(token)}`);
+    _ws = new WebSocket(`${proto}://${location.host}/ws/motus`
+      + `?token=${encodeURIComponent(token)}&session_id=${encodeURIComponent(sessionId())}`);
 
     _ws.onopen = () => {
       _retryDelay = 1000;
-      _cb('connected');
+      _notify('connected');
     };
 
     _ws.onmessage = (e) => {
@@ -34,13 +58,13 @@ export function connectMotus(onStatusChange) {
     };
 
     _ws.onclose = () => {
-      _cb('connecting');
+      _notify('connecting');
       setTimeout(connect, _retryDelay);
       _retryDelay = Math.min(_retryDelay * 2, 30000);
     };
 
     _ws.onerror = () => {
-      _cb('error');
+      _notify('error');
     };
   }
   connect();

--- a/agent-core/web/js/session.js
+++ b/agent-core/web/js/session.js
@@ -1,0 +1,24 @@
+/**
+ * session.js — Per-tab session id, shared by the canvas editor lock and the
+ * /ws/motus connection.
+ *
+ * sessionStorage (not localStorage) so each tab/window gets its own id — otherwise
+ * all tabs of one browser would look like the same editor and could edit
+ * concurrently, silently clobbering each other's autosave. Surviving F5 in the
+ * same tab is intentional: a reload re-claims its own lock instead of locking
+ * itself out.
+ *
+ * Lives in its own module because both canvas.js and motus-stream.js need the id
+ * and neither can depend on the other's init order.
+ */
+
+const KEY = 'canvas_session_id';
+
+export function sessionId() {
+  let id = sessionStorage.getItem(KEY);
+  if (!id) {
+    id = 'sess-' + Date.now().toString(36) + Math.random().toString(36).slice(2, 6);
+    sessionStorage.setItem(KEY, id);
+  }
+  return id;
+}

--- a/agent-core/web/js/solutions.js
+++ b/agent-core/web/js/solutions.js
@@ -13,6 +13,7 @@
 import { openInstanceConfigModal, openToolConfigModal } from './sidebar.js';
 import { reloadFromServer } from './canvas.js';
 import { isRcLoggedIn, rcHeaders, rcFetch, showAccount, refreshAccount } from './account.js';
+import { sessionId } from './session.js';
 
 // 与 resource-center/lib/solution.ts 的 INDUSTRIES 保持一致
 const INDUSTRIES = [
@@ -265,7 +266,9 @@ async function _loadMarket() {
 
 // ── 载入流程：preflight → 缺驱动一键安装 → 覆盖确认 → apply ────────────────
 
-function _sessionId() { return sessionStorage.getItem('canvas_session_id') || ''; }
+// 与画布共用同一个 per-tab session id（见 session.js），否则 preflight 会把自己
+// 持有的编辑锁误判成"别人正在编辑"
+function _sessionId() { return sessionId(); }
 
 async function _preflight(slug) {
   const res = await fetch('/api/solutions/preflight', {


### PR DESCRIPTION
## 问题

关闭标签页后画布滞留「被占用」状态，新开的页面最多 60 秒无法编辑，`solutions` 的方案载入也被一起挡住（它复用同一把锁做冲突检查）。

## 根因

**1. 关闭页面的释放请求 100% 失败。**

`canvas.js` 用 `navigator.sendBeacon(url, JSON.stringify(...))`：

- 传字符串时 Content-Type 是 `text/plain`，FastAPI 只在 maintype 为 `application` 时才 JSON 解码 body，所以声明成 `body: dict = Body(...)` 的 `release-edit` 直接 **422**，锁没动。
- `sendBeacon` 绕过 `auth.js` 对 `window.fetch` 的 token 注入，URL 上也没有 `?token=` → 配了 ACCESS_TOKEN 时先挂 **401**。

**2. 只能等 TTL，而 TTL 计的是「无操作」不是「无连接」。**

`_editor_last_seen` 只被 `POST /canvas/layout` 刷新，所以同一个缺陷的另一面是：开着页面静置 60 秒也会被踢（「编辑权已超时释放（60秒无操作）」）。

刷新（F5）看起来正常只是因为 session_id 存在 sessionStorage 里、同标签页刷新后能重新 claim 自己的锁——所以「先刷新」不是必要条件，任何一次关闭标签页都会漏锁。

## 改动

### 锁绑定到 `/ws/motus` 生命周期

连接携带 per-tab `session_id`，`motus_stream` 只负责上报存活，锁逻辑仍全部在 `canvas.py`：

- 最后一条连接断开后 8 秒宽限期内没重连 → 释放（宽限抗网络抖动/休眠；引用计数抗一个页面多条连接与重连时新旧 socket 交叠）
- 持锁会话有活连接 → **永不过期**，顺带消掉「静置 60 秒被踢」
- 60 秒 TTL 保留，只兜底没建立 WS 的持有者

浏览器来不来得及善后不再影响正确性：进程被强杀、移动端标签被系统回收、页面崩溃都能回收锁。

### beacon 修好，作为快路径

`application/json` Blob + `?token=`，`pagehide` / `beforeunload` 都挂，`pageshow(persisted)` 兜底 bfcache 恢复。`release-edit` 改为手工解析 body 以接受 `text/plain`；session 不匹配时返回 **409** 而不是假装 200（原来成功失败都返回 200，问题不可见）。

### 补上广播（一写多读）

- 锁状态变化 → `canvas_editor`（带 reason: claim/release/disconnect/timeout）
- 布局落库 → `canvas_layout`（带自增 rev）；方案载入绕锁改写布局也走同一个助手

读者据此 800ms 防抖重载，不再需要手动刷新页面才能看到别人的改动（重载不动 viewport transform，读者自己的缩放平移不被打断）。只读文案从「画布被占用，无法编辑」改成「**画布由其他人编辑中（只读）**」——读取从来不需要锁，一写多读是正常状态不是故障。

| 角色 | 顶栏 | 收到 `canvas_layout` |
|------|------|----------------------|
| 编辑者 | `编辑中` + `释放` | 忽略（自己的回声） |
| 读者 | `画布由其他人编辑中（只读）` | 防抖重载 + 节流 toast |
| 空闲 | `编辑` 按钮 | 防抖重载 |

### 顺带

- `session_id` 抽到新的 `web/js/session.js` 单一来源，canvas / motus-stream / solutions 共用（`solutions.js` 原来自己读 sessionStorage）
- 修掉 `connectMotus()` 被 `app.js` 与 `dashboard.js` 各调一次、旧 socket 不关闭就被覆盖的泄漏——那会让一个页面看起来像两个活会话，直接污染锁的存活判断。状态回调随之改成列表，后注册者也能拿到当前状态

## 验证

后端用临时功能测试（FastAPI TestClient + 真实 WS 连接）跑通 12 项断言：

```
PASS  claim sets editor
PASS  release accepts text/plain (sendBeacon)
PASS  lock freed by text/plain release
PASS  foreign claim rejected  423
PASS  foreign release rejected (409, not silent 200)
PASS  lock still held by A
PASS  no TTL expiry while WS is live
PASS  lock released after WS disconnect
PASS  lock survives a reconnect flap
PASS  lock released once the last WS closes
PASS  TTL fallback for WS-less holder
PASS  claim/layout/release broadcast to other clients
```

仓库没有测试目录，该脚本没有一起提交。

待真机确认（依赖真实浏览器行为）：

1. 两窗口一写多读：A 移动/连接卡片 → B 约 1s 内同步，且 B 的缩放平移不被重置
2. A 点「释放」→ B 立即变可点的「编辑」并成功接管
3. 编辑中断网约 5 秒再恢复 → WS 重连、编辑权保留（宽限期生效）
4. 编辑中直接杀浏览器进程（beacon 一定不触发）→ 8 秒内锁被回收

🤖 Generated with [Claude Code](https://claude.com/claude-code)
