### PR TITLE
fix(agent-core): honour configSchema scope when pushing saved tool config

### DIFF
--- a/agent-core/src/api/canvas.py
+++ b/agent-core/src/api/canvas.py
@@ -147,19 +147,30 @@ def apply_tool_config(mcp_id: str, tool_name: str, body: Any,
     Shared by the tool-config endpoints below and by api/solutions.py when a
     solution is applied, so both paths send the exact same `action: config`
     call shape.
+
+    The body is partitioned by declared scope — shared settings are sent
+    without instance_id even when saved under an instance key, because plugins
+    holding one engine per process reject shared keys addressed to a single
+    instance. See split_config_by_scope for why unknown keys are dropped.
     """
     from api.mcp_manage import mcp_call_tool, MCPCallRequest
+    from tool_config import find_tool, plan_config_calls
 
-    args = dict(body) if isinstance(body, dict) else {}
+    cfg = dict(body) if isinstance(body, dict) else {}
+    tool_obj = find_tool(mcp_id, tool_name)
     if instance_id:
-        args['instance_id'] = instance_id
+        calls = plan_config_calls(tool_obj, {}, cfg, instance_id)
+    else:
+        calls = plan_config_calls(tool_obj, cfg, {}, '')
 
     async def _apply():
-        try:
-            req = MCPCallRequest(tool=tool_name, arguments={'action': 'config', **args})
-            await mcp_call_tool(mcp_id, req)
-        except Exception:
-            pass
+        for cfg_body, extra_args in calls:
+            try:
+                req = MCPCallRequest(tool=tool_name,
+                                     arguments={'action': 'config', **cfg_body, **extra_args})
+                await mcp_call_tool(mcp_id, req)
+            except Exception:
+                pass
 
     try:
         asyncio.create_task(_apply())

--- a/agent-core/src/api/config.py
+++ b/agent-core/src/api/config.py
@@ -235,7 +235,13 @@ async def _do_start_project():
                 except Exception:
                     pass  # info() failure is non-fatal
             else:
-                msg = str(result.get('detail', result.get('data', '')))[:100]
+                # `message` is where mcp_call_tool puts the human-readable
+                # reason; `data` is None on those responses, so reading data
+                # first surfaced the literal string "None" to the operator.
+                msg = str(result.get('message')
+                          or result.get('detail')
+                          or result.get('data')
+                          or f'启动失败 (code={result.get("code")})')[:200]
                 print(f'[start-project] {tool_name} error: {result}')
                 await push_event({'type': 'project_start_item', 'payload': {
                     'tool': tool_name, 'mcp_id': mcp_id, 'status': 'error', 'message': msg,

--- a/agent-core/src/api/mcp_manage.py
+++ b/agent-core/src/api/mcp_manage.py
@@ -9,6 +9,8 @@ from pydantic import BaseModel
 
 import config
 import mcp_client
+from tool_config import (missing_required_config, plan_config_calls,
+                         split_config_by_scope)
 
 router = fastapi.APIRouter(prefix='/mcp', tags=['mcp'])
 
@@ -405,10 +407,16 @@ async def _restore_saved_configs(mcp_id: str, url: str, tools: list) -> None:
                 saved_cfg = config.main.get(f'tool_config:{mcp_id}:{tool_name}', None)
                 if not saved_cfg:
                     continue
+                # Drop keys the current schema no longer advertises, same as the
+                # start path — a stale row must not be replayed on every reconnect.
+                shared_cfg, instance_cfg = split_config_by_scope(tool, saved_cfg)
+                restore_cfg = {**shared_cfg, **instance_cfg}
+                if not restore_cfg:
+                    continue
                 cfg_payload = {
                     'jsonrpc': '2.0', 'id': 99,
                     'method': 'tools/call',
-                    'params': {'name': tool_name, 'arguments': {'action': 'config', **saved_cfg}},
+                    'params': {'name': tool_name, 'arguments': {'action': 'config', **restore_cfg}},
                 }
                 await session.post(url, json=cfg_payload, headers=headers)
                 sent.append(tool_name)
@@ -959,34 +967,48 @@ async def mcp_call_tool(mcp_id: str, req: MCPCallRequest):
             }
             await session.post(url, json=init_payload, headers=headers)
 
-            # Auto-config: start 前自动 apply 已保存的 config (shared + instance merged)
+            # Auto-config: start 前自动 apply 已保存的 config
             # Also send config for non-system actions (set_*/get_*) so driver can resolve device_path after restart
             action = req.arguments.get('action')
             _SYSTEM_ACTIONS_NO_CONFIG = {'info', 'stop', 'config'}
             if action and action not in _SYSTEM_ACTIONS_NO_CONFIG:
-                # Check if this tool has configSchema (requires config before start)
                 tools = target.get('tools') or []
                 tool_obj = next((t for t in tools if isinstance(t, dict) and t.get('name') == req.tool), None)
-                has_config_schema = bool(tool_obj and tool_obj.get('configSchema'))
 
                 instance_id = req.arguments.get('instance_id', '')
-                shared_cfg = config.main.get(f'tool_config:{mcp_id}:{req.tool}', None) or {}
-                instance_cfg = {}
+                saved_shared = config.main.get(f'tool_config:{mcp_id}:{req.tool}', None) or {}
+                saved_instance = {}
                 if instance_id:
-                    instance_cfg = config.main.get(f'tool_config:{mcp_id}:{req.tool}:{instance_id}', None) or {}
-                merged_cfg = {**shared_cfg, **instance_cfg}
+                    saved_instance = config.main.get(f'tool_config:{mcp_id}:{req.tool}:{instance_id}', None) or {}
 
-                if merged_cfg:
-                    cfg_args = {'action': 'config', **merged_cfg}
-                    if instance_id:
-                        cfg_args['instance_id'] = instance_id
+                # Partition both rows by declared scope, dropping keys the
+                # current schema no longer advertises. Either row can hold
+                # either kind of key: older UI builds saved without filtering.
+                shared_cfg, instance_cfg = split_config_by_scope(tool_obj, saved_shared)
+                inst_shared, inst_own = split_config_by_scope(tool_obj, saved_instance)
+                merged_for_required = {**shared_cfg, **inst_shared, **instance_cfg, **inst_own}
+
+                missing = missing_required_config(tool_obj, merged_for_required)
+                if missing:
+                    return {'code': 400,
+                            'message': f'[{req.tool}] 尚未配置：缺少 {"、".join(missing)}，请先在卡片配置里填写后再启动。',
+                            'data': None}
+
+                for cfg_body, extra_args in plan_config_calls(
+                        tool_obj, saved_shared, saved_instance, instance_id):
                     cfg_payload = {
                         'jsonrpc': '2.0', 'id': 2,
                         'method': 'tools/call',
-                        'params': {'name': req.tool, 'arguments': cfg_args},
+                        'params': {'name': req.tool,
+                                   'arguments': {'action': 'config', **cfg_body, **extra_args}},
                     }
                     async with session.post(url, json=cfg_payload, headers=headers) as resp:
                         cfg_data = await resp.json(content_type=None)
+                        cfg_error = cfg_data.get('error')
+                        if cfg_error:
+                            return {'code': 400,
+                                    'message': f'[{req.tool}] 配置失败：{cfg_error.get("message", "unknown error")}',
+                                    'data': None}
                         cfg_result = cfg_data.get('result', {})
                         cfg_content = (cfg_result.get('content') or [{}])[0].get('text', '{}')
                         try:
@@ -995,8 +1017,6 @@ async def mcp_call_tool(mcp_id: str, req: MCPCallRequest):
                                 return {'code': 400, 'message': f'[{req.tool}] 配置无效（缺少 url/key），请检查配置。', 'data': None}
                         except (json.JSONDecodeError, IndexError):
                             pass
-                elif has_config_schema:
-                    return {'code': 400, 'message': f'[{req.tool}] 尚未配置，请先完成配置后再启动。', 'data': None}
 
             call_payload = {
                 'jsonrpc': '2.0', 'id': 3,

--- a/agent-core/src/mcp_client.py
+++ b/agent-core/src/mcp_client.py
@@ -403,6 +403,12 @@ async def call_tool(full_name: str, args: dict) -> str:
         if meta.get('has_config_schema'):
             saved_cfg = _get_tool_config(mcp_id, tool_name)
             if saved_cfg:
+                # Drop keys the current schema no longer advertises; a stale row
+                # would otherwise be replayed on every start. See tool_config.
+                from tool_config import find_tool, split_config_by_scope
+                _shared, _inst = split_config_by_scope(find_tool(mcp_id, tool_name), saved_cfg)
+                saved_cfg = {**_shared, **_inst}
+            if saved_cfg:
                 async with aiohttp.ClientSession(timeout=timeout) as session:
                     cfg_result = await _jrpc(session, url, 'tools/call', {
                         'name':      tool_name,

--- a/agent-core/src/tool_config.py
+++ b/agent-core/src/tool_config.py
@@ -1,0 +1,88 @@
+"""
+tool_config.py — the saved-tool-config scope contract, in one place.
+
+A tool's `configSchema` marks each property with `scope: "instance"` or leaves
+it shared (the default). That split is not cosmetic — it decides how an
+`action: config` call must be addressed:
+
+  - shared settings go WITHOUT instance_id
+  - per-instance settings go WITH it
+
+A plugin that keeps one inference engine per process (perception's `ocr`, for
+one) rejects shared keys addressed to a single instance, so a merged payload
+fails outright rather than partially applying.
+
+Lives here rather than in api/mcp_manage.py because mcp_client.py needs it too,
+and api/mcp_manage.py already imports mcp_client — the reverse would cycle.
+"""
+
+import config
+
+
+def find_tool(mcp_id: str, tool_name: str) -> dict:
+    """The tool object for mcp_id:tool_name, or {} (tools may be bare strings)."""
+    mcps = config.main.get('services', {}).get('mcp', []) or []
+    target = next((m for m in mcps if m.get('id') == mcp_id), None)
+    for tool in (target or {}).get('tools', []) or []:
+        if isinstance(tool, dict) and tool.get('name') == tool_name:
+            return tool
+    return {}
+
+
+def split_config_by_scope(tool_obj: dict, cfg: dict) -> tuple[dict, dict]:
+    """Partition a saved config body into (shared, instance) by declared scope.
+
+    Keys absent from the *current* configSchema are dropped. A schema that no
+    longer advertises a field cannot accept it, and a stale row would otherwise
+    be replayed on every start forever — including malformed values such as the
+    literal '[object Object]' written by older UI builds that rendered
+    object-typed fields as text inputs. Those then blow up in the plugin's own
+    option parsing (`dict("[object Object]")`), turning a dead config row into a
+    hard start failure.
+    """
+    props = ((tool_obj or {}).get('configSchema') or {}).get('properties') or {}
+    shared: dict = {}
+    instance: dict = {}
+    for key, value in (cfg or {}).items():
+        prop = props.get(key)
+        if prop is None:
+            continue
+        (instance if prop.get('scope') == 'instance' else shared)[key] = value
+    return shared, instance
+
+
+def missing_required_config(tool_obj: dict, merged_cfg: dict) -> list[str]:
+    """Required configSchema keys that merged_cfg does not satisfy.
+
+    Only `required` counts. Having a configSchema at all is not evidence that a
+    tool needs configuring — perception's `ocr` and `vop` declare only optional
+    knobs with defaults, so blocking their start until *something* had been
+    saved rejected a perfectly startable card.
+    """
+    schema = (tool_obj or {}).get('configSchema') or {}
+    props = schema.get('properties') or {}
+    return [
+        key for key in (schema.get('required') or [])
+        if key in props and merged_cfg.get(key) in (None, '')
+    ]
+
+
+def plan_config_calls(tool_obj: dict, saved_shared: dict, saved_instance: dict,
+                      instance_id: str) -> list[tuple[dict, dict]]:
+    """Build the ordered (body, extra_args) config calls for a start.
+
+    Either saved row can hold either kind of key — older UI builds saved without
+    filtering by scope — so both are partitioned and then recombined by scope
+    rather than by which row they came from.
+    """
+    shared_a, instance_a = split_config_by_scope(tool_obj, saved_shared)
+    shared_b, instance_b = split_config_by_scope(tool_obj, saved_instance)
+    shared_cfg = {**shared_a, **shared_b}
+    instance_cfg = {**instance_a, **instance_b}
+
+    if instance_id:
+        calls = [(shared_cfg, {}), (instance_cfg, {'instance_id': instance_id})]
+    else:
+        # No instance to address: instance-scope values act as shared defaults.
+        calls = [({**shared_cfg, **instance_cfg}, {})]
+    return [(body, extra) for body, extra in calls if body]

--- a/agent-core/web/js/sidebar.js
+++ b/agent-core/web/js/sidebar.js
@@ -443,6 +443,70 @@ function _buildToolCard(mcp, tool) {
 
 // ── Helpers ────────────────────────────────────────────────────────────────────
 
+/**
+ * True for schema types that cannot round-trip through a plain text input.
+ *
+ * Setting `input.value` to an object coerces it to the literal string
+ * "[object Object]", which then gets persisted and pushed to the plugin — where
+ * e.g. perception's ocr does `dict("[object Object]")` and dies. Arrays fail the
+ * same way: the plugin expects a list and gets a string.
+ */
+function _isStructuredField(def) {
+  return def.type === 'object' || def.type === 'array';
+}
+
+/** A comma-separated line is friendlier than JSON for a plain list of strings. */
+function _isStringList(def) {
+  return def.type === 'array' && (def.items || {}).type === 'string';
+}
+
+/** Build the input element for a structured (object/array) config field. */
+function _makeStructuredInput(key, def, saved) {
+  const value = saved !== undefined ? saved : def.default;
+  if (_isStringList(def)) {
+    const input = document.createElement('input');
+    input.className = 'tool-config-input';
+    input.dataset.key = key;
+    input.dataset.valueKind = 'string-list';
+    input.type = 'text';
+    input.placeholder = '逗号分隔，如 person, chair';
+    input.value = Array.isArray(value) ? value.join(', ') : (value == null ? '' : String(value));
+    return input;
+  }
+  const input = document.createElement('textarea');
+  input.className = 'tool-config-input';
+  input.dataset.key = key;
+  input.dataset.valueKind = 'json';
+  input.rows = 4;
+  input.placeholder = def.default != null ? JSON.stringify(def.default, null, 2) : '{ }';
+  input.value = value == null ? '' : JSON.stringify(value, null, 2);
+  return input;
+}
+
+/**
+ * Read one config input into its schema-typed value.
+ * Throws with a field-scoped message when a JSON field will not parse, so the
+ * modal can refuse to save rather than persist a corrupt value.
+ */
+function _readConfigValue(input, def) {
+  const raw = input.value.trim();
+  const kind = input.dataset.valueKind;
+  if (kind === 'string-list') {
+    return raw.split(',').map(s => s.trim()).filter(Boolean);
+  }
+  if (kind === 'json') {
+    try {
+      return JSON.parse(raw);
+    } catch (err) {
+      throw new Error(`${def?.title || input.dataset.key}: JSON 格式错误 — ${err.message}`);
+    }
+  }
+  if (def?.type === 'integer') return parseInt(raw, 10);
+  if (def?.type === 'number')  return parseFloat(raw);
+  if (def?.type === 'boolean') return raw === 'true';
+  return raw;
+}
+
 /** Check if a configSchema has any instance-scope fields. */
 function _hasInstanceFields(configSchema) {
   if (!configSchema || !configSchema.properties) return false;
@@ -615,6 +679,8 @@ export async function openToolConfigModal(mcpId, toolName, configSchema) {
         errOpt.textContent = 'Failed to load channels';
         input.appendChild(errOpt);
       });
+    } else if (_isStructuredField(def)) {
+      input = _makeStructuredInput(key, def, savedValues[key]);
     } else {
       input = document.createElement('input');
       input.className = 'tool-config-input';
@@ -672,18 +738,18 @@ export async function openToolConfigModal(mcpId, toolName, configSchema) {
   const save = async () => {
     if (!(await ensureEdit())) return;
     const values = {};
-    bodyEl.querySelectorAll('[data-key]').forEach(input => {
-      const v = input.value.trim();
-      if (!v) return;
+    for (const input of bodyEl.querySelectorAll('[data-key]')) {
+      if (!input.value.trim()) continue;
       // Skip fields hidden by x-show-when (their parent .tool-config-field has display:none)
       const fieldWrapper = input.closest('.tool-config-field');
-      if (fieldWrapper && fieldWrapper.style.display === 'none') return;
-      const fieldDef = props[input.dataset.key];
-      if (fieldDef?.type === 'integer') values[input.dataset.key] = parseInt(v, 10);
-      else if (fieldDef?.type === 'number') values[input.dataset.key] = parseFloat(v);
-      else if (fieldDef?.type === 'boolean') values[input.dataset.key] = v === 'true';
-      else values[input.dataset.key] = v;
-    });
+      if (fieldWrapper && fieldWrapper.style.display === 'none') continue;
+      try {
+        values[input.dataset.key] = _readConfigValue(input, props[input.dataset.key]);
+      } catch (err) {
+        alert(err.message);
+        return;
+      }
+    }
 
     // Save to per-tool API
     try {
@@ -937,6 +1003,8 @@ export async function openInstanceConfigModal(mcpId, toolName, instanceId, confi
         errOpt.textContent = 'Failed to load channels';
         input.appendChild(errOpt);
       });
+    } else if (_isStructuredField(def)) {
+      input = _makeStructuredInput(key, def, savedValues[key]);
     } else {
       input = document.createElement('input');
       input.className = 'tool-config-input';
@@ -959,18 +1027,18 @@ export async function openInstanceConfigModal(mcpId, toolName, instanceId, confi
   const save = async () => {
     if (!(await ensureEdit())) return;
     const values = {};
-    bodyEl.querySelectorAll('[data-key]').forEach(input => {
-      const v = input.value.trim();
-      if (!v) return;
+    for (const input of bodyEl.querySelectorAll('[data-key]')) {
+      if (!input.value.trim()) continue;
       // Skip fields hidden by x-show-when (their parent .tool-config-field has display:none)
       const fieldWrapper = input.closest('.tool-config-field');
-      if (fieldWrapper && fieldWrapper.style.display === 'none') return;
-      const fieldDef = props[input.dataset.key];
-      if (fieldDef?.type === 'integer') values[input.dataset.key] = parseInt(v, 10);
-      else if (fieldDef?.type === 'number') values[input.dataset.key] = parseFloat(v);
-      else if (fieldDef?.type === 'boolean') values[input.dataset.key] = v === 'true';
-      else values[input.dataset.key] = v;
-    });
+      if (fieldWrapper && fieldWrapper.style.display === 'none') continue;
+      try {
+        values[input.dataset.key] = _readConfigValue(input, props[input.dataset.key]);
+      } catch (err) {
+        alert(err.message);
+        return;
+      }
+    }
 
     try {
       const resp = await fetch(`/api/canvas/tool-config/${encodeURIComponent(mcpId)}/${encodeURIComponent(toolName)}/${encodeURIComponent(instanceId)}`, {


### PR DESCRIPTION
## 背景

jetson-orin-02（10.100.121.16）上 `ocr` 和 `vop` 两张卡片始终起不来。三个缺陷叠加导致：

```
ERROR RPC error: OCR inference settings are shared: crop_refinement, det_box_thresh, ...
[start-project] vop error: {'code': 400, 'message': '[vop] 尚未配置...', 'data': None}
```

## 三个缺陷

### 1. ocr 报 "OCR inference settings are shared"

`mcp_manage.py` 的 start 前自动配置把 shared 行和 instance 行合成一个 payload，再统一盖上 `instance_id`。`ocr` 整个进程只有一份 TensorRT engine，它的 `_do_config` 会拒绝带 `instance_id` 的 shared key。

**修复**：按 `configSchema` 声明的 `scope` 拆成两次调用 —— shared 不带 `instance_id`，instance 带。

### 2. vop 报 "None"

守卫逻辑是 `elif has_config_schema: return 400`，只要工具**有** configSchema 就拦，不管字段是否 required。实测：

| 工具 | configSchema required | 结果 |
|---|---|---|
| `ocr` | ❌ 无 | 被误拦 |
| `vop` | ❌ 无 | 被误拦 |
| `asr` | ✅ 有 | 正常 |
| `tts` | ✅ 有 | 正常 |

**修复**：只在 required 字段确实缺失时拦截，并在消息里点名缺哪个。

### 3. 失败原因显示为字面量 "None"

`config.py` 读 `result['detail']` 再退到 `result['data']`，而 `mcp_call_tool` 把原因放在 `result['message']`、`data` 恒为 `None` → `str(None)` = `"None"`。

**修复**：优先读 `message`，兜底给带 code 的字符串。

## 连带修复

触发缺陷 1 的那行配置里存着 `"crop_refinement": "[object Object]"`。两个 config modal 都没处理 `type: object`/`array`，给文本框的 `input.value` 赋对象会被强制字符串化。

- object 字段 → JSON textarea，解析失败拒绝保存（而不是存坏值）
- string array → 逗号分隔输入框；否则 `vop` 的 `classes` 会以 `str` 到达 `plugin_cfg.get("classes")`，而那里期望 `list`

另外，保存的配置现在会**按当前 configSchema 过滤**再下发。`ocr` 已把专家参数移成 yaml-only，那些 key 早就不被接受，但陈旧行仍在每次 start 时重放 —— 而且一旦缺陷 1 修好、它们走通 shared 路径，就会撞上插件自己的 `dict("[object Object]")` 崩掉。四个重放点（start / 重连恢复 / solution apply / LLM 工具调用）统一丢弃未知 key，**不需要 DB 迁移**，以后 schema 再收窄也自动免疫。

## 结构

scope 契约收到新的 `src/tool_config.py`：`api/mcp_manage.py` 已经 `import mcp_client`，所以 mcp_client 不能反向 import，需要一个中立模块。

## 验证

用机器上的真实 payload 跑过：

| 场景 | 结果 |
|---|---|
| ocr 陈旧 shared 行 + card instance_id（原 ValueError） | 0 次 config 调用，start 放行 |
| ocr + 真实 instance 值 | 1 次带 instance_id 的调用 |
| vop 完全无保存配置（原 "None"） | 0 次调用，start 放行 |
| tts 缺 required 字段 | 仍然拦截，消息点名 `speaker_id` |
| shared 有值 + instance_id 存在 | shared 不带 instance_id 下发 ✅ |

前端 helper 单测：旧路径复现 `"[object Object]"`；新路径 object 往返正确、`" dog , cat ,, "` → `["dog","cat"]`、坏 JSON 被拒绝。

Python / JS 语法检查通过。**尚未实机验证** —— 需要部署到机器上重启 agent-core 后跑一次 start-project。

🤖 Generated with [Claude Code](https://claude.com/claude-code)