### PR TITLE
fix(perception): make VITS2 TTS work on JetPack 5.1.1 / TensorRT 8

### DIFF
--- a/agent-core/src/api/config.py
+++ b/agent-core/src/api/config.py
@@ -136,10 +136,10 @@ async def _do_start_project():
     LOADING_POLL_S = 3
     LOADING_TIMEOUT_S = 900
 
-    def _tool_state(result) -> tuple[str | None, str]:
-        """Pull (state, message) out of an MCP call result of either shape."""
+    def _payload(result) -> dict:
+        """Unwrap an MCP call result of either shape into a dict."""
         if result.get('code') != 200:
-            return None, str(result.get('message') or '')[:200]
+            return {}
         payload = result.get('data')
         if isinstance(payload, list) and payload:
             try:
@@ -151,24 +151,59 @@ async def _do_start_project():
                 payload = _json.loads(payload)
             except Exception:
                 payload = {}
-        if not isinstance(payload, dict):
+        return payload if isinstance(payload, dict) else {}
+
+    def _tool_state(result) -> tuple[str | None, str]:
+        """Pull (state, message) out of an MCP call result of either shape."""
+        if result.get('code') != 200:
+            return None, str(result.get('message') or '')[:200]
+        payload = _payload(result)
+        if not payload:
             return None, ''
         return payload.get('state'), str(
             payload.get('error') or payload.get('message') or payload.get('desc') or ''
         )[:200]
 
-    async def _settle_loading_item(mcp_id: str, tool_name: str, card_id: str) -> None:
+    async def _resolve_and_register(mcp_id: str, tool_name: str, card_id: str,
+                                   info_args: dict) -> dict:
+        """info() the card, register its topic_out on the bus, return the payload.
+
+        info_args carries the input_topic the card was started with: without it a
+        tool that has no live node yet can only report its fallback output topic
+        (perception TTS answers /perception/tts), and that wrong topic is what
+        the dashboard would then subscribe to — no waveform, while audio flows on
+        the real one.
+        """
+        info = await mcp_call_tool(mcp_id, MCPCallRequest(
+            tool=tool_name, arguments={'action': 'info', 'instance_id': card_id,
+                                       **info_args},
+        ))
+        data = _payload(info)
+        topic_out = data.get('topic_out') or []
+        if topic_out:
+            resolved_topics[card_id] = topic_out
+            from api.inspection import register_topic_internal
+            for tp in topic_out:
+                if tp.get('topic') and tp.get('format'):
+                    await register_topic_internal(tp['topic'], tp['format'], mcp_id)
+        return data
+
+    async def _settle_loading_item(mcp_id: str, tool_name: str, card_id: str,
+                                  info_args: dict) -> None:
         """Poll a card that started into `loading` and report its real outcome.
 
         Runs detached: a 60 MB model download must not hold up the other cards,
         and the operator must not be told 已就绪 before the tool can do its job.
+        On success the topics are registered again: they were resolved before the
+        node existed, so only now can the card report the real ones.
         """
         deadline = time.time() + LOADING_TIMEOUT_S
         while time.time() < deadline:
             await _asyncio.sleep(LOADING_POLL_S)
             try:
                 info = await mcp_call_tool(mcp_id, MCPCallRequest(
-                    tool=tool_name, arguments={'action': 'info', 'instance_id': card_id},
+                    tool=tool_name, arguments={'action': 'info', 'instance_id': card_id,
+                                               **info_args},
                 ))
             except Exception as error:
                 print(f'[start-project] {tool_name} info during load failed: {error}')
@@ -189,6 +224,11 @@ async def _do_start_project():
                 return
             status = 'error' if state == 'error' else 'ready'
             print(f'[start-project] {tool_name} ({mcp_id}) settled: {state}')
+            if status == 'ready':
+                try:
+                    await _resolve_and_register(mcp_id, tool_name, card_id, info_args)
+                except Exception as error:
+                    print(f'[start-project] {tool_name} topic re-register failed: {error}')
             await push_event({'type': 'project_start_item', 'payload': {
                 'tool': tool_name, 'mcp_id': mcp_id, 'status': status,
                 'message': message if status == 'error' else '',
@@ -237,10 +277,13 @@ async def _do_start_project():
         }})
 
         args = {'action': 'start', 'instance_id': card_id}
+        info_args: dict = {}
         if input_topics and len(input_topics) > 1:
             args['input_topics'] = input_topics
+            info_args['input_topics'] = input_topics
         elif input_topic:
             args['input_topic'] = input_topic
+            info_args['input_topic'] = input_topic
 
         try:
             req = MCPCallRequest(tool=tool_name, arguments=args)
@@ -282,42 +325,19 @@ async def _do_start_project():
                         'message': message,
                     }})
                     _asyncio.create_task(
-                        _settle_loading_item(mcp_id, tool_name, card_id)
+                        _settle_loading_item(mcp_id, tool_name, card_id, info_args)
                     )
                 else:
                     print(f'[start-project] started {tool_name} ({mcp_id})')
                     await push_event({'type': 'project_start_item', 'payload': {
                         'tool': tool_name, 'mcp_id': mcp_id, 'status': 'ready',
                     }})
-                # After successful start, query info() to get resolved topic_out
+                # Resolve topic_out for the downstream cards and register it on
+                # the bus. Non-fatal: a card that cannot answer info() still runs.
                 try:
-                    info_req = MCPCallRequest(tool=tool_name, arguments={'action': 'info', 'instance_id': card_id})
-                    info_result = await mcp_call_tool(mcp_id, info_req)
-                    if info_result.get('code') == 200:
-                        data = info_result.get('data')
-                        # Parse MCP JSON-RPC content format: [{"type":"text","text":"..."}]
-                        if isinstance(data, list) and data:
-                            text = data[0].get('text', '{}') if isinstance(data[0], dict) else '{}'
-                            try:
-                                data = _json.loads(text)
-                            except Exception:
-                                data = {}
-                        elif isinstance(data, str):
-                            try:
-                                data = _json.loads(data)
-                            except Exception:
-                                data = {}
-                        if isinstance(data, dict):
-                            topic_out = data.get('topic_out', [])
-                            if topic_out:
-                                resolved_topics[card_id] = topic_out
-                                # Register resolved topics so WebSocket relay works
-                                from api.inspection import register_topic_internal
-                                for tp in topic_out:
-                                    if tp.get('topic') and tp.get('format'):
-                                        await register_topic_internal(tp['topic'], tp['format'], mcp_id)
-                except Exception:
-                    pass  # info() failure is non-fatal
+                    await _resolve_and_register(mcp_id, tool_name, card_id, info_args)
+                except Exception as error:
+                    print(f'[start-project] {tool_name} info() failed: {error}')
             else:
                 # `message` is where mcp_call_tool puts the human-readable
                 # reason; `data` is None on those responses, so reading data

--- a/perception/Dockerfile.jetson
+++ b/perception/Dockerfile.jetson
@@ -187,17 +187,12 @@ RUN if [ "${ENABLE_VITS2_TRT}" = "1" ]; then \
       if [ "${JP_VERSION}" = "61" ]; then NUMPY_VERSION=1.26.4; else NUMPY_VERSION=1.24.4; fi; \
       pip3 install --no-cache-dir -i "${PYPI_MIRROR}" \
         "numpy==${NUMPY_VERSION}" -r /tmp/vits2-requirements.txt && \
-      python3 -c "import importlib.util as u, numpy, kaldifst, wetext, pypinyin, jieba, inflect, nltk; \
-assert u.find_spec('g2p_en'), 'g2p_en missing'; \
+      python3 -c "import importlib.util as u, sys, numpy, kaldifst, pypinyin, jieba, inflect, nltk; \
+need = ['wetext', 'g2p_en', 'contractions'] + (['importlib_resources'] if sys.version_info < (3, 9) else []); \
+missing = [m for m in need if u.find_spec(m) is None]; \
+assert not missing, 'missing: %s' % missing; \
 assert numpy.__version__ == '${NUMPY_VERSION}', numpy.__version__; \
 print('[build] VITS2 frontend ok on numpy ' + numpy.__version__)"; \
-    fi && rm -f /tmp/vits2-requirements.txt
-COPY perception/plugins/vits2_tts_trt/requirements.jetson.txt /tmp/vits2-requirements.txt
-RUN if [ "${ENABLE_VITS2_TRT}" = "1" ]; then \
-      if [ "${JP_VERSION}" = "61" ]; then NUMPY_VERSION=1.26.4; else NUMPY_VERSION=1.24.4; fi; \
-      pip3 install --no-cache-dir -i "${PYPI_MIRROR}" \
-        "numpy==${NUMPY_VERSION}" -r /tmp/vits2-requirements.txt && \
-      python3 -c "import kaldifst, numpy; assert numpy.__version__ == '${NUMPY_VERSION}', numpy.__version__"; \
     fi && rm -f /tmp/vits2-requirements.txt
 
 # ── Application code ───────────────────────────────────────────────

--- a/perception/Dockerfile.jetson
+++ b/perception/Dockerfile.jetson
@@ -163,12 +163,34 @@ RUN pip3 install --no-cache-dir -i ${PYPI_MIRROR} phonemizer
 # 1.23.5), breaking the numpy C-ABI those wheels were built against. The same
 # NUMPY_VERSION is re-stated on this pip invocation, and asserted afterwards,
 # so a transitive requirement of wetext/g2p-en/nltk cannot move it either.
+#
+# CPython headers: on jp511 (focal, cp38) one transitive dependency has to be
+# compiled — pyahocorasick, pulled in by wetext → contractions → textsearch,
+# has never published a cp38 aarch64 wheel. Every other package in the set
+# resolves to a wheel on both lines. Installed only when Python.h is actually
+# missing, so jp61 (where nothing compiles) is untouched, and the ldconfig
+# shim is the same workaround as every other apt step in this file.
 COPY perception/plugins/vits2_tts_trt/requirements.jetson.txt /tmp/vits2-requirements.txt
+RUN if [ "${ENABLE_VITS2_TRT}" = "1" ] && \
+       ! python3 -c "import os,sysconfig;raise SystemExit(0 if os.path.exists(os.path.join(sysconfig.get_paths()['include'],'Python.h')) else 1)"; then \
+      echo '[build] CPython headers missing — installing python3-dev for the source builds' && \
+      mv /usr/sbin/ldconfig /usr/sbin/ldconfig.real && \
+      printf '#!/bin/sh\nexit 0\n' > /usr/sbin/ldconfig && \
+      chmod +x /usr/sbin/ldconfig && \
+      apt-get update && \
+      apt-get install -y --no-install-recommends python3-dev && \
+      mv -f /usr/sbin/ldconfig.real /usr/sbin/ldconfig && \
+      { ldconfig || echo '[build] ldconfig skipped — emulated build, using default search path'; } && \
+      rm -rf /var/lib/apt/lists/*; \
+    fi
 RUN if [ "${ENABLE_VITS2_TRT}" = "1" ]; then \
       if [ "${JP_VERSION}" = "61" ]; then NUMPY_VERSION=1.26.4; else NUMPY_VERSION=1.24.4; fi; \
       pip3 install --no-cache-dir -i "${PYPI_MIRROR}" \
         "numpy==${NUMPY_VERSION}" -r /tmp/vits2-requirements.txt && \
-      python3 -c "import kaldifst, numpy; assert numpy.__version__ == '${NUMPY_VERSION}', numpy.__version__"; \
+      python3 -c "import importlib.util as u, numpy, kaldifst, wetext, pypinyin, jieba, inflect, nltk; \
+assert u.find_spec('g2p_en'), 'g2p_en missing'; \
+assert numpy.__version__ == '${NUMPY_VERSION}', numpy.__version__; \
+print('[build] VITS2 frontend ok on numpy ' + numpy.__version__)"; \
     fi && rm -f /tmp/vits2-requirements.txt
 COPY perception/plugins/vits2_tts_trt/requirements.jetson.txt /tmp/vits2-requirements.txt
 RUN if [ "${ENABLE_VITS2_TRT}" = "1" ]; then \

--- a/perception/plugins/vits2_tts_trt/README.md
+++ b/perception/plugins/vits2_tts_trt/README.md
@@ -26,6 +26,44 @@ same pin is passed to this package's install — `requirements.jetson.txt`
 deliberately does not list numpy. See the comment there before adding a
 dependency that wants a different one.
 
+### JetPack 5.1.1 / TensorRT 8
+
+Both lines build from the same source; `ENABLE_VITS2_TRT` defaults to 1. What
+differs on jp511, and what to check when bringing a device up:
+
+- **Python 3.8.** The frontend needs `importlib.resources.files`, which arrived
+  in 3.9 — `requirements.jetson.txt` installs the `importlib_resources`
+  backport under a marker and `frontend/wetext_compat.py` patches it in before
+  WeText loads. Nothing else in the package uses 3.9+ syntax.
+- **One source build.** Every dependency resolves to a cp38 aarch64 wheel
+  except `pyahocorasick` (wetext → contractions → textsearch), which has never
+  published one. The Dockerfile installs `python3-dev` only if `Python.h` is
+  missing, so this compiles during the build — slow under qemu, fine natively.
+- **Compute capability must be 8.7.** The engines are built for Orin
+  (`trtexec 8.5.2.2`, sm87) and `_validate_manifest` refuses a mismatch with
+  `GPU compute capability mismatch`. Orin AGX/NX/Nano are 8.7; a Xavier device
+  (7.2) needs its own plans built on it. Check with
+  `python3 -c "import torch;print(torch.cuda.get_device_capability())"`.
+- **The TensorRT API in use is 8.5+**: `num_io_tensors`, `get_tensor_name`,
+  `get_tensor_mode`, `set_input_shape`, `set_tensor_address`,
+  `get_tensor_shape`, `execute_async_v3`. All present in 8.5.2 — the same
+  name-based API `utils/tensorrt_runtime.py` relies on for OCR.
+- **Memory is the practical limit.** jp511 devices are usually Orin NX 8/16 GB
+  and perception already keeps ASR, VOP (YOLOv8-World) and OCR (TensorRT)
+  resident. VITS2 adds ~54 MB of engines plus a CUDA context. Measure on 8 GB
+  before enabling everything at once.
+- `runtime: nvidia` is required, as on jp61: the L4T base ships zero-length
+  placeholders for the driver libraries and only that runtime mounts the real
+  ones over them (`deploy/service.yml` sets it).
+
+### A landmine worth knowing
+
+`g2p_en` calls `nltk.download()` at **module import** if the corpora are not on
+`nltk.data.path`. `frontend/english.py` therefore inserts the release's
+`nltk_data` directory before importing it, and nothing may import `g2p_en`
+earlier — including build-time checks, which is why the Dockerfile only asserts
+the package is installed rather than importing it.
+
 ## Configure
 
 The engine is a `configSchema` field, so it is visible and switchable in the

--- a/perception/plugins/vits2_tts_trt/plugin.py
+++ b/perception/plugins/vits2_tts_trt/plugin.py
@@ -728,6 +728,15 @@ class TTSPlugin:
             adapter_state = self._adapter_state
             pending = bool(self._pending_starts)
             error = self._load_error
+            # An instance that started while the model loads has no node yet, and
+            # info is routinely called without input_topic (Agent Core's start
+            # sequencer does). Remembering the topic the pending start asked for
+            # is what keeps the reported output topic real instead of the
+            # /perception/tts fallback — and that reported topic is what the
+            # dashboard subscribes to for its waveform. Same reason ocr.py keeps
+            # its _pending_starts lookup.
+            if instance_id and node is None and not input_topic:
+                input_topic = self._pending_starts.get(instance_id, "")
 
         if instance_id and node is not None:
             state = node.state

--- a/perception/plugins/vits2_tts_trt/runtime/backends/trt_cuda_session.py
+++ b/perception/plugins/vits2_tts_trt/runtime/backends/trt_cuda_session.py
@@ -9,6 +9,8 @@ from pathlib import Path
 
 import numpy as np
 
+from utils.tensorrt_runtime import trt_dtype_to_numpy
+
 
 def _load_cuda_runtime():
     library = ctypes.util.find_library("cudart") or "libcudart.so"
@@ -196,7 +198,13 @@ class TensorRTCudaSession:
         for index in range(self.engine.num_io_tensors):
             name = self.engine.get_tensor_name(index)
             mode = self.engine.get_tensor_mode(name)
-            dtype = np.dtype(trt.nptype(self.engine.get_tensor_dtype(name)))
+            # Not trt.nptype(): TensorRT 8.5's binding maps BOOL through
+            # np.bool, which NumPy removed in 1.24 — so on jp511 (TRT 8.5.2.2 +
+            # numpy 1.24.4) the first engine run dies with AttributeError. The
+            # shared helper resolves the common dtypes itself and only falls
+            # back to nptype() for exotic ones; OCR has relied on it since it
+            # shipped.
+            dtype = trt_dtype_to_numpy(trt, self.engine.get_tensor_dtype(name))
             if mode == trt.TensorIOMode.INPUT:
                 if name not in inputs:
                     raise KeyError(f"Missing TensorRT input {name!r}")

--- a/perception/tests/test_vits2_frontend.py
+++ b/perception/tests/test_vits2_frontend.py
@@ -15,6 +15,7 @@ or from the repo, with a release under /models/vits2:
 
 from __future__ import annotations
 
+import importlib.util
 import os
 from pathlib import Path
 
@@ -24,10 +25,19 @@ import vision_stubs  # noqa: F401  (installs ROS stubs, puts perception on sys.p
 
 MODEL_DIR = Path(os.getenv("VITS2_MODEL_DIR", "/models/vits2"))
 
-pytest.importorskip("jieba", reason="VITS2 frontend dependency")
-pytest.importorskip("pypinyin", reason="VITS2 frontend dependency")
-pytest.importorskip("wetext", reason="VITS2 frontend dependency")
-pytest.importorskip("g2p_en", reason="VITS2 frontend dependency")
+# Presence is checked with find_spec, never by importing: on Python 3.8 `import
+# wetext` fails until wetext_compat has patched importlib.resources.files (which
+# frontend/fst_tn.py does before it touches wetext), and importing g2p_en calls
+# nltk.download() unless nltk.data.path already points at the release. Both
+# orderings belong to the frontend package — a test must not front-run them.
+_MISSING = [
+    name for name in
+    ("jieba", "pypinyin", "wetext", "kaldifst", "g2p_en", "inflect", "nltk")
+    if importlib.util.find_spec(name) is None
+]
+if _MISSING:
+    pytest.skip(f"VITS2 frontend dependencies missing: {', '.join(_MISSING)}",
+                allow_module_level=True)
 if not (MODEL_DIR / "tn_cache").is_dir():
     pytest.skip(f"no VITS2 release at {MODEL_DIR}", allow_module_level=True)
 

--- a/perception/tests/test_vits2_tts_plugin.py
+++ b/perception/tests/test_vits2_tts_plugin.py
@@ -420,3 +420,33 @@ def test_load_error_keeps_the_underlying_cause(monkeypatch):
     error = plugin.dispatch("tts", {"action": "info"})["error"]
     assert "TensorRT is not available" in error
     assert "libnvdla_compiler.so" in error
+
+
+def test_info_while_loading_reports_the_pending_output_topic(monkeypatch):
+    """The dashboard subscribes to whatever info() reports — it must be real.
+
+    Agent Core's start sequencer calls info() with only instance_id, and while
+    the model loads there is no node to ask. Falling back to /perception/tts
+    registered the wrong topic on the bus, so the waveform stayed empty while
+    audio flowed on <input_topic>/tts. Only reproducible on a cold start: with
+    the engine resident, start returns running and info reads the live node.
+    """
+    plugin, executor, state = _plugin(monkeypatch, gated=True)
+    plugin.dispatch("tts", {"action": "start", "instance_id": "card-x",
+                            "input_topic": "/remote_control/message"})
+
+    loading = plugin.dispatch("tts", {"action": "info", "instance_id": "card-x"})
+    assert loading["state"] == "loading"
+    assert [t["topic"] for t in loading["topic_out"]] == [
+        "/remote_control/message/tts"
+    ]
+    assert [t["topic"] for t in loading["topic_in"]] == ["/remote_control/message"]
+
+    # And the same topic once it is actually up.
+    state["release"]()
+    assert _wait_until(lambda: executor.nodes and executor.nodes[0].state == "running")
+    running = plugin.dispatch("tts", {"action": "info", "instance_id": "card-x"})
+    assert running["state"] == "running"
+    assert [t["topic"] for t in running["topic_out"]] == [
+        "/remote_control/message/tts"
+    ]

--- a/perception/tests/test_vits2_tts_plugin.py
+++ b/perception/tests/test_vits2_tts_plugin.py
@@ -76,23 +76,46 @@ def completions(monkeypatch):
     return seen
 
 
-def _plugin(monkeypatch, *, load_delay=0.0, fail=None, adapter=None):
-    """Build a plugin whose loader is instrumented instead of touching a GPU."""
-    adapter = adapter or _FakeAdapter()
-    state = {"loads": 0, "engine_dirs": []}
+def _installed(plugin):
+    """The adapter the plugin actually committed, or None while loading."""
+    return plugin._adapter
+
+
+def _plugin(monkeypatch, *, gated=False, fail=None):
+    """Build a plugin whose loader is instrumented instead of touching a GPU.
+
+    `gated=True` blocks every load inside the model install until the test calls
+    `state["release"]()`. That is what makes "while the model is loading"
+    deterministic — a sleep only makes it likely, and a scheduler hiccup on a
+    busy machine then turns the interleaving the test means to exercise into a
+    coin flip.
+
+    Each build returns its own adapter, recorded in state["adapters"] in
+    completion order. One shared adapter would have let a discarded stale loader
+    mutate the object under assertion — a test artifact, not a product bug: the
+    plugin never installs a superseded adapter.
+    """
+    gate = threading.Event()
+    state = {
+        "loads": 0, "engine_dirs": [], "adapters": [],
+        "release": gate.set, "entered": threading.Event(),
+    }
 
     def fake_ensure(model_dir, family=None):
         state["loads"] += 1
-        if load_delay:
-            time.sleep(load_delay)
+        state["entered"].set()
+        if gated and not gate.wait(10):
+            raise RuntimeError("test never released the load gate")
         if fail is not None and state["loads"] <= fail:
             raise RuntimeError("release download failed")
         return f"{model_dir}/engines/jp61"
 
     def fake_build(cfg):
         state["engine_dirs"].append(cfg.get("engine_dir"))
-        adapter.set_speed(float(cfg.get("speed", 1.0)))
-        return adapter
+        built = _FakeAdapter()
+        built.set_speed(float(cfg.get("speed", 1.0)))
+        state["adapters"].append(built)
+        return built
 
     import utils.model_downloader as md
     monkeypatch.setattr(md, "ensure_vits2_model", fake_ensure, raising=False)
@@ -102,13 +125,13 @@ def _plugin(monkeypatch, *, load_delay=0.0, fail=None, adapter=None):
     plugin = vits2.TTSPlugin(
         {"model_dir": "/models/vits2", "backend": "trt", "speed": 1.0}, executor
     )
-    return plugin, executor, adapter, state
+    return plugin, executor, state
 
 
 # ── start never blocks on the model ──────────────────────────────────────────
 
 def test_start_returns_loading_without_waiting_for_the_model(monkeypatch):
-    plugin, executor, _, state = _plugin(monkeypatch, load_delay=0.4)
+    plugin, executor, state = _plugin(monkeypatch, gated=True)
 
     began = time.monotonic()
     result = plugin.dispatch("tts", {"action": "start", "input_topic": "/say",
@@ -117,14 +140,16 @@ def test_start_returns_loading_without_waiting_for_the_model(monkeypatch):
 
     assert result["state"] == "loading"
     assert elapsed < 0.2, f"start blocked for {elapsed:.2f}s"
+    assert executor.nodes == [], "a node was created before the model was ready"
     # ...and the instance comes up on its own once the load finishes.
+    state["release"]()
     assert _wait_until(lambda: executor.nodes and executor.nodes[0].state == "running")
     assert state["loads"] == 1
     assert state["engine_dirs"] == ["/models/vits2/engines/jp61"]
 
 
 def test_concurrent_starts_load_once_and_yield_one_node_each(monkeypatch):
-    plugin, executor, _, state = _plugin(monkeypatch, load_delay=0.3)
+    plugin, executor, state = _plugin(monkeypatch, gated=True)
 
     results = []
     threads = [
@@ -143,12 +168,13 @@ def test_concurrent_starts_load_once_and_yield_one_node_each(monkeypatch):
         t.join()
 
     assert all(r["state"] == "loading" for r in results)
+    state["release"]()
     assert _wait_until(lambda: len(executor.nodes) == 6)
     assert state["loads"] == 1, f"downloaded {state['loads']} times"
 
 
 def test_info_reports_loading_for_instance_and_aggregate(monkeypatch):
-    plugin, _, _, _ = _plugin(monkeypatch, load_delay=0.4)
+    plugin, _, state = _plugin(monkeypatch, gated=True)
     plugin.dispatch("tts", {"action": "start", "input_topic": "/say",
                             "instance_id": "a"})
 
@@ -160,13 +186,14 @@ def test_info_reports_loading_for_instance_and_aggregate(monkeypatch):
     assert aggregate["state"] == "loading"
     assert "initializing" in per_instance["desc"]
 
+    state["release"]()
     assert _wait_until(
         lambda: plugin.dispatch("tts", {"action": "info"})["state"] == "running"
     )
 
 
 def test_info_never_triggers_a_load(monkeypatch):
-    plugin, _, _, state = _plugin(monkeypatch)
+    plugin, _, state = _plugin(monkeypatch)
     for _ in range(3):
         assert plugin.dispatch("tts", {"action": "info"})["state"] == "idle"
     assert state["loads"] == 0
@@ -175,7 +202,7 @@ def test_info_never_triggers_a_load(monkeypatch):
 # ── failure and retry ────────────────────────────────────────────────────────
 
 def test_load_failure_surfaces_then_next_start_retries(monkeypatch):
-    plugin, executor, _, state = _plugin(monkeypatch, fail=1)
+    plugin, executor, state = _plugin(monkeypatch, fail=1)
 
     first = plugin.dispatch("tts", {"action": "start", "input_topic": "/say"})
     assert first["state"] == "loading"
@@ -192,13 +219,14 @@ def test_load_failure_surfaces_then_next_start_retries(monkeypatch):
 
 
 def test_load_failure_releases_queued_speak_actions(monkeypatch, completions):
-    plugin, _, _, _ = _plugin(monkeypatch, fail=1, load_delay=0.2)
+    plugin, _, state = _plugin(monkeypatch, fail=1, gated=True)
 
     queued = plugin.dispatch("tts", {"action": "speak", "text": "你好"})
     assert queued["status"] == "queued"
     action_id = queued["action_id"]
 
     # The ACP barrier waits for this action; a failed load must still end it.
+    state["release"]()
     assert _wait_until(lambda: any(c[0] == action_id for c in completions))
     assert [c for c in completions if c[0] == action_id][0][3] is True
 
@@ -206,40 +234,47 @@ def test_load_failure_releases_queued_speak_actions(monkeypatch, completions):
 # ── stop / interrupt while still loading ─────────────────────────────────────
 
 def test_stop_during_loading_cancels_the_pending_instance(monkeypatch):
-    plugin, executor, _, _ = _plugin(monkeypatch, load_delay=0.3)
+    plugin, executor, state = _plugin(monkeypatch, gated=True)
 
     plugin.dispatch("tts", {"action": "start", "input_topic": "/say",
                             "instance_id": "a"})
+    assert state["entered"].wait(3), "the loader never started"
     assert plugin.dispatch("tts", {"action": "stop", "instance_id": "a"}) == {
         "state": "idle"
     }
 
-    time.sleep(0.5)  # let the loader finish and try to bring instances up
+    # Only now may the load finish: it must find nothing left to bring up.
+    state["release"]()
+    time.sleep(0.3)
     assert executor.nodes == [], "cancelled instance was started anyway"
     assert plugin.dispatch("tts", {"action": "info"})["state"] == "idle"
 
 
 def test_stop_during_loading_releases_queued_speak(monkeypatch, completions):
-    plugin, executor, _, _ = _plugin(monkeypatch, load_delay=0.3)
+    plugin, executor, state = _plugin(monkeypatch, gated=True)
 
     queued = plugin.dispatch("tts", {"action": "speak", "text": "取消我"})
+    assert state["entered"].wait(3), "the loader never started"
     plugin.dispatch("tts", {"action": "stop"})
 
     assert _wait_until(lambda: any(c[0] == queued["action_id"] for c in completions))
     assert [c for c in completions if c[0] == queued["action_id"]][0][3] is True
-    time.sleep(0.4)
+    state["release"]()
+    time.sleep(0.3)
     assert executor.nodes == []
 
 
 # ── speak queued before the model is resident ────────────────────────────────
 
 def test_speak_before_ready_plays_once_the_model_lands(monkeypatch, completions):
-    plugin, executor, adapter, _ = _plugin(monkeypatch, load_delay=0.2)
+    plugin, executor, state = _plugin(monkeypatch, gated=True)
 
     queued = plugin.dispatch("tts", {"action": "speak", "text": "延迟播报"})
     assert queued["action_id"].startswith("speak-")
+    assert executor.nodes == [], "the utterance was not queued behind the load"
 
-    assert _wait_until(lambda: adapter.spoken == ["延迟播报"])
+    state["release"]()
+    assert _wait_until(lambda: any(a.spoken == ["延迟播报"] for a in state["adapters"]))
     assert _wait_until(lambda: any(c[0] == queued["action_id"] for c in completions))
     # Completed, not cancelled, and the utterance reached a real node.
     assert [c for c in completions if c[0] == queued["action_id"]][0][3] is False
@@ -247,14 +282,16 @@ def test_speak_before_ready_plays_once_the_model_lands(monkeypatch, completions)
 
 
 def test_speak_after_ready_reuses_the_running_node(monkeypatch):
-    plugin, executor, adapter, state = _plugin(monkeypatch)
+    plugin, executor, state = _plugin(monkeypatch)
 
     plugin.dispatch("tts", {"action": "start", "input_topic": "/say"})
     assert _wait_until(lambda: executor.nodes and executor.nodes[0].state == "running")
     plugin.dispatch("tts", {"action": "speak", "text": "第一句"})
     plugin.dispatch("tts", {"action": "speak", "text": "第二句"})
 
-    assert _wait_until(lambda: adapter.spoken == ["第一句", "第二句"])
+    assert _wait_until(
+        lambda: _installed(plugin) and _installed(plugin).spoken == ["第一句", "第二句"]
+    )
     assert len(executor.nodes) == 1
     assert state["loads"] == 1
 
@@ -262,7 +299,7 @@ def test_speak_after_ready_reuses_the_running_node(monkeypatch):
 # ── config ───────────────────────────────────────────────────────────────────
 
 def test_config_speed_updates_a_resident_model_without_a_reload(monkeypatch):
-    plugin, executor, adapter, state = _plugin(monkeypatch)
+    plugin, executor, state = _plugin(monkeypatch)
 
     plugin.dispatch("tts", {"action": "start", "input_topic": "/say"})
     assert _wait_until(lambda: executor.nodes and executor.nodes[0].state == "running")
@@ -271,24 +308,35 @@ def test_config_speed_updates_a_resident_model_without_a_reload(monkeypatch):
     assert plugin.dispatch("tts", {"action": "config", "speed": 1.4}) == {
         "status": "configured"
     }
-    assert adapter.speed == pytest.approx(1.4)
+    assert _installed(plugin).speed == pytest.approx(1.4)
     # A slider change must not cost a 60 MB reload or drop the live node.
     assert state["loads"] == 1
     assert executor.nodes == [node] and node.state == "running"
 
 
 def test_config_during_loading_discards_the_stale_adapter(monkeypatch):
-    plugin, executor, adapter, state = _plugin(monkeypatch, load_delay=0.3)
+    plugin, executor, state = _plugin(monkeypatch, gated=True)
 
     plugin.dispatch("tts", {"action": "start", "input_topic": "/say"})
+    assert state["entered"].wait(3), "the loader never started"
+    # config now provably lands mid-load, which is the case under test.
     plugin.dispatch("tts", {"action": "config", "speed": 0.8})
+    state["release"]()
 
     # The in-flight loader was building from the old config, so its adapter must
     # be dropped — but the pending start survives and a fresh load serves it.
     assert _wait_until(lambda: executor.nodes and executor.nodes[0].state == "running",
                        timeout=5.0)
-    assert adapter.speed == pytest.approx(0.8)
+    # Both loaders ran — one per config — and the one the plugin committed, and
+    # that the live node actually uses, is the one built from the new config.
+    # Asserted without indexing state["adapters"]: that list is ordered by build
+    # completion, and the superseded loader may finish either first or last.
     assert state["loads"] == 2
+    assert sorted(a.speed for a in state["adapters"]) == [
+        pytest.approx(0.8), pytest.approx(1.0),
+    ]
+    assert _installed(plugin).speed == pytest.approx(0.8)
+    assert executor.nodes[0]._adapter is _installed(plugin)
     assert len(executor.nodes) == 1
 
 
@@ -353,7 +401,7 @@ def test_acp_callback_tolerates_the_self_signed_agent_core_cert(monkeypatch):
 
 def test_load_error_keeps_the_underlying_cause(monkeypatch):
     """The dashboard must show why TensorRT was unavailable, not just that."""
-    plugin, _, _, _ = _plugin(monkeypatch)
+    plugin, _, _ = _plugin(monkeypatch)
 
     import utils.model_downloader as md
 


### PR DESCRIPTION
## Why

PR #112 landed the VITS2 TensorRT TTS and is verified on JetPack 6.1. This is
what it takes to run the same thing on JetPack 5.1.1 / TensorRT 8 — verified on
an Orin NX 8 GB (L4T R35.6.5, TensorRT 8.5.2.2, Python 3.8.10, numpy 1.24.4).

**#112 as merged does not work on that line**, and the reason is mine: it removed
the branch's `numpy==1.23.5` pin after I checked the pip dependencies for
`np.bool` and found none. TensorRT itself was the one place I did not look.

    File "/usr/lib/python3.8/dist-packages/tensorrt/__init__.py", line 166, in nptype
        bool: np.bool,
    AttributeError: module 'numpy' has no attribute 'bool'

TensorRT 8.5's own Python binding maps BOOL through `np.bool`, which NumPy
removed in 1.24. Removing the pin was still right — it silently downgraded the
whole image's numpy, breaking the C-ABI the torch/cv2/rapidocr wheels were built
against — it was just incomplete without the fix below.

## What changed

1. **Don't call `trt.nptype()`.** `utils/tensorrt_runtime.trt_dtype_to_numpy()`
   already resolves the common dtypes itself and only falls back to `nptype()`
   for exotic ones; its docstring names this exact jp511 failure and OCR has
   relied on it since it shipped. The VITS2 session was the last caller of
   `trt.nptype()` in the tree. numpy now stays at whatever each JetPack's
   torch/cv2/rapidocr stack was built against.
2. **CPython headers when a source build is needed.** Every VITS2 dependency
   resolves to a cp38 aarch64 wheel except `pyahocorasick` (wetext →
   contractions → textsearch), which has never published one. `python3-dev` is
   installed only when `Python.h` is missing, before the pip layer, wrapped in
   the same ldconfig shim as every other apt step in that Dockerfile. jp61 needs
   no compiler and is untouched.
3. **Build-time check widened** to import the frontend packages — but it only
   asserts `g2p_en` is *installed* rather than importing it: `g2p_en` calls
   `nltk.download()` at module import unless `nltk.data.path` already points at
   the release, which is a network call that has no business in a build.
4. **`test_vits2_frontend.py` no longer skips itself on Python 3.8.**
   `pytest.importorskip("wetext")` imports naked, and on 3.8 that fails until
   `wetext_compat` has patched `importlib.resources.files` — `frontend/fst_tn.py`
   does that before touching wetext, so production was correct and only the test
   front-ran the ordering. Presence is now checked with `find_spec`.
5. **De-flaked `test_vits2_tts_plugin.py`** (~1 run in 12 failed): each load
   builds its own adapter, so a loader the plugin correctly discarded can no
   longer mutate the object under assertion; "while the model is loading" is
   enforced with a gate the test releases instead of a sleep the scheduler may
   outrun; and the stale-adapter test asserts the product invariant (the live
   node uses the committed adapter) instead of indexing a list ordered by build
   completion. 24 consecutive full-suite runs clean, ~2 s faster.
6. **jp511 notes in the package README**: the sm87 requirement, the single
   source build, the memory picture, the `runtime: nvidia` requirement and the
   `g2p_en`/`nltk.download` landmine.

## Verified on the device, after the fix

- jp511 archive install (download + verify + unpack): **13.1 s**; `engine_dir`
  resolves to `engines/jp511` with no configuration — `tensorrt_family()` picks
  the family from the importable TensorRT.
- 336 chars → 61.6 s of audio: first utterance **6.7 s (RTF 0.108)**, warm
  **3.6 s (RTF 0.058)**. Stage split: text frontend 62%, numpy iSTFT 20%,
  TensorRT 7% — the same CPU-bound shape as on jp61, not a GPU limit.
- Warmup 8.7 s. Peak RSS **2.7 GB** including the CUDA/TensorRT context (2.6 GB
  right after the engines). **On an 8 GB device that is the number to weigh
  against ASR + VOP + OCR**, not the 54 MB of engine weights — the box under
  test had ~4.6 GB available with nothing else resident.
- `tests/test_vits2_frontend.py`: **8 passed on Python 3.8**.
- Host prerequisites confirmed present on that device: `nvidia` docker runtime,
  compute capability 8.7, TensorRT 8.5.2.2 matching the engines' build version.

## Not addressed

GPU utilisation is low on both lines because most of this implementation is
NumPy by design (iSTFT on CPU, text frontend in Python). Folding the iSTFT into
the decoder engine and running the frontend per chunk (it owns first-frame
latency) are the candidates; neither is in scope here.
