### PR TITLE
feat(perception): CUDA sherpa-onnx on jp5.11, with device-selected ASR/TTS weights

### DIFF
--- a/agent-core/src/api/canvas.py
+++ b/agent-core/src/api/canvas.py
@@ -290,7 +290,12 @@ async def save_layout(layout: CanvasLayout):
 
     save_data = layout.dict()
     save_data.pop('session_id', None)
+    old_cards = (config.main.get('canvas_layout', {}) or {}).get('cards', [])
     config.main['canvas_layout'] = save_data
+    # A card that leaves the layout is unreachable afterwards — stop-project only
+    # walks the saved cards — so its plugin instance would keep running forever.
+    from api.config import stop_removed_cards
+    await stop_removed_cards(old_cards, save_data.get('cards', []))
     notify_layout_changed(session_id or '')
     return {'code': 200}
 

--- a/agent-core/src/api/config.py
+++ b/agent-core/src/api/config.py
@@ -432,14 +432,16 @@ async def _do_start_project():
     return True
 
 
-async def _do_stop_project():
-    """停止所有 canvas cards。"""
+async def _stop_cards(cards) -> int:
+    """Send `stop` to each card's instance. Returns how many calls were made.
+
+    `stop` is idempotent — a plugin that is already idle returns
+    `{"state": "idle"}` — so this is safe to call on cards that were never
+    started.
+    """
     from api.mcp_manage import mcp_call_tool, MCPCallRequest
-    from api.motus_stream import push_event
 
-    layout = config.main.get('canvas_layout', {})
-    cards = layout.get('cards', [])
-
+    stopped = 0
     for card in cards:
         mcp_id = card.get('mcpId', '')
         tool_name = card.get('toolName', '')
@@ -449,8 +451,44 @@ async def _do_stop_project():
         try:
             req = MCPCallRequest(tool=tool_name, arguments={'action': 'stop', 'instance_id': card_id})
             await mcp_call_tool(mcp_id, req)
+            stopped += 1
         except Exception:
             pass
+    return stopped
+
+
+async def stop_removed_cards(old_cards, new_cards) -> int:
+    """Stop instances belonging to cards that just left the layout.
+
+    `_do_stop_project` stops what the *saved layout* lists, so a card removed
+    from the layout can never be reached again: its plugin instance keeps its ROS
+    node, its subscription, and any subprocess or CUDA context until perception
+    exits. The symptoms are a topic with a publisher nothing on the canvas
+    accounts for (an old TTS node still publishing to a topic whose connection
+    was deleted), duplicate output when a replacement card publishes alongside
+    it, and rclpy refusing the node name on restart.
+
+    The frontend stops the card it deletes itself, but that only covers one path.
+    Layout reload, loading a solution, and a browser that dies between removing
+    the card and saving all go through a layout write, so the diff is enforced
+    here where every path meets.
+    """
+    live = {c.get('id', '') for c in (new_cards or []) if c.get('id')}
+    removed = [c for c in (old_cards or []) if c.get('id') and c.get('id') not in live]
+    if not removed:
+        return 0
+    count = await _stop_cards(removed)
+    print(f'[layout] stopped {count} instance(s) for removed card(s): '
+          f'{", ".join(c.get("id", "") for c in removed)}')
+    return count
+
+
+async def _do_stop_project():
+    """停止所有 canvas cards。"""
+    from api.motus_stream import push_event
+
+    layout = config.main.get('canvas_layout', {})
+    await _stop_cards(layout.get('cards', []))
 
     core = config.main.get('core', {})
     core['project_running'] = False

--- a/agent-core/src/api/solutions.py
+++ b/agent-core/src/api/solutions.py
@@ -980,8 +980,8 @@ async def apply(request: fastapi.Request, req: LoadRequest):
 
     # 1) 画布 —— deviceRef 换回本机 mcpId
     if BLOCK_CANVAS in includes:
-        applied['canvas'] = _apply_canvas(payload.get('canvas') or {},
-                                          resolved['mapping'])
+        applied['canvas'] = await _apply_canvas(payload.get('canvas') or {},
+                                                resolved['mapping'])
 
     # 2) 技能
     if BLOCK_SKILLS in includes:
@@ -1018,7 +1018,7 @@ async def apply(request: fastapi.Request, req: LoadRequest):
     return {'code': 200, 'data': {'applied': applied, 'needsConfig': needs_config}}
 
 
-def _apply_canvas(canvas: dict, mapping: dict) -> dict:
+async def _apply_canvas(canvas: dict, mapping: dict) -> dict:
     """写画布布局与卡片配置。"""
     from api.canvas import (apply_tool_config, delete_all_tool_configs,
                             notify_layout_changed, tool_config_key)
@@ -1051,12 +1051,16 @@ def _apply_canvas(canvas: dict, mapping: dict) -> dict:
             c['toMcpId'] = target['mcpId']
         exec_connections.append(c)
 
+    old_cards = (config.main.get('canvas_layout', {}) or {}).get('cards', [])
     config.main['canvas_layout'] = {
         'cards':           cards,
         'connections':     connections,
         'execConnections': exec_connections,
         'transform':       canvas.get('transform') or {},
     }
+    # 方案里的卡片是整套替换的，被换掉的那些卡片的实例不会再有人来停它
+    from api.config import stop_removed_cards
+    await stop_removed_cards(old_cards, cards)
     # 绕过编辑锁直接改写了布局，所有开着画布的客户端都得重新拉一次
     notify_layout_changed()
 

--- a/agent-core/tests/test_layout_stop_removed.py
+++ b/agent-core/tests/test_layout_stop_removed.py
@@ -1,0 +1,122 @@
+"""Regression: a card removed from the layout must have its instance stopped.
+
+Observed on orin5 2026-08-24. The dashboard showed TTS running and silent. The ROS
+graph had two vits2 nodes — `vits2_trt_card_mt4rkb752py8` publishing to
+`/remote_control/message/tts`, and `vits2_trt_card_mt8rck6q87qd`, the live one, on
+`/remote_control/mic/asr/tts`. The first belonged to a card the operator had
+deleted. Nothing had stopped it: `_do_stop_project` walks
+`config.main['canvas_layout']['cards']`, and that card was no longer in the list,
+so it was unreachable the moment it was deleted. Its ROS node, its subscription and
+its CUDA context lived until perception exited, and the audio panel was watching
+the topic the orphan owned.
+
+Every removal path — deleting a card, another editor's layout reload, loading a
+solution — ends in a layout write, so the diff is enforced there.
+
+Run: cd agent-core && python3 -m pytest tests/test_layout_stop_removed.py
+"""
+import asyncio
+import os
+import pathlib
+import sys
+import tempfile
+
+import pytest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / 'src'))
+
+os.environ.setdefault('DB_PATH', os.path.join(tempfile.mkdtemp(), 'test.db'))
+
+from api import config as config_api  # noqa: E402
+
+TTS_OLD = {'id': 'card_mt4rkb752py8', 'mcpId': 'mcp-1', 'toolName': 'tts'}
+TTS_NEW = {'id': 'card_mt8rck6q87qd', 'mcpId': 'mcp-1', 'toolName': 'tts'}
+ASR = {'id': 'card_asr', 'mcpId': 'mcp-1', 'toolName': 'asr'}
+
+
+@pytest.fixture
+def calls(monkeypatch):
+    """Record every MCP call the layout write makes."""
+    seen = []
+
+    async def _fake_call(mcp_id, req):
+        seen.append((mcp_id, req.tool, dict(req.arguments)))
+        return {'state': 'idle'}
+
+    class _Req:
+        def __init__(self, tool, arguments):
+            self.tool = tool
+            self.arguments = arguments
+
+    mod = type(sys)('api.mcp_manage')
+    mod.mcp_call_tool = _fake_call
+    mod.MCPCallRequest = _Req
+    monkeypatch.setitem(sys.modules, 'api.mcp_manage', mod)
+    return seen
+
+
+def _run(old, new):
+    return asyncio.get_event_loop_policy().new_event_loop().run_until_complete(
+        config_api.stop_removed_cards(old, new))
+
+
+def test_the_orphan_case_stops_exactly_the_deleted_card(calls):
+    """The reported layout: the old TTS card is replaced by a new one."""
+    assert _run([TTS_OLD, ASR], [TTS_NEW, ASR]) == 1
+    assert calls == [('mcp-1', 'tts', {'action': 'stop', 'instance_id': 'card_mt4rkb752py8'})]
+
+
+def test_an_unchanged_layout_calls_nothing(calls):
+    """Layout writes happen on every drag; only removals may have side effects."""
+    assert _run([TTS_OLD, ASR], [TTS_OLD, ASR]) == 0
+    assert calls == []
+
+
+def test_a_moved_card_is_not_a_removed_card(calls):
+    """Identity is the card id, not the dict — x/y change on every drag."""
+    moved = dict(TTS_OLD, x=400, y=120)
+    assert _run([TTS_OLD], [moved]) == 0
+    assert calls == []
+
+
+def test_clearing_the_canvas_stops_every_card(calls):
+    assert _run([TTS_OLD, ASR], []) == 2
+    assert {c[2]['instance_id'] for c in calls} == {'card_mt4rkb752py8', 'card_asr'}
+
+
+def test_adding_a_card_stops_nothing(calls):
+    assert _run([ASR], [ASR, TTS_NEW]) == 0
+    assert calls == []
+
+
+def test_cards_without_a_device_are_skipped(calls):
+    """A half-built card has no mcpId; there is nothing to stop and no crash."""
+    assert _run([{'id': 'card_x'}, {'id': 'card_y', 'mcpId': '', 'toolName': 'tts'}], []) == 0
+    assert calls == []
+
+
+def test_a_card_with_no_id_is_ignored(calls):
+    assert _run([{'mcpId': 'mcp-1', 'toolName': 'tts'}], []) == 0
+    assert calls == []
+
+
+def test_a_failing_stop_does_not_block_the_others(monkeypatch, calls):
+    """The layout must still be saved even if one device is unreachable."""
+    seen = []
+
+    async def _flaky(mcp_id, req):
+        seen.append(req.arguments['instance_id'])
+        if req.arguments['instance_id'] == 'card_mt4rkb752py8':
+            raise RuntimeError('connection refused')
+        return {'state': 'idle'}
+
+    sys.modules['api.mcp_manage'].mcp_call_tool = _flaky
+    assert _run([TTS_OLD, ASR], []) == 1          # one of two succeeded
+    assert seen == ['card_mt4rkb752py8', 'card_asr']
+
+
+def test_none_layouts_are_tolerated(calls):
+    """An empty ConfigDB gives `canvas_layout` as {} — .get('cards') is None."""
+    assert _run(None, None) == 0
+    assert _run(None, [TTS_NEW]) == 0
+    assert calls == []

--- a/agent-core/web/js/canvas.js
+++ b/agent-core/web/js/canvas.js
@@ -642,7 +642,14 @@ async function _removeCard(id) {
   if (!(await _ensureEdit())) return;
   const idx = _cards.findIndex(c => c.id === id);
   if (idx === -1) return;
-  _cards[idx].el.remove();
+  const removed = _cards[idx];
+  // Stop the instance this card owns, before it stops being reachable. Nothing
+  // else can: stop-project walks the saved layout, and this card is about to
+  // leave it, so its ROS node, subscription and any CUDA context would live
+  // until perception exits — publishing to a topic no card accounts for.
+  // `stop` is idempotent, so doing this to a card that was never started is fine.
+  _triggerAction(removed.mcpId, removed.toolName, 'stop', { instance_id: removed.id });
+  removed.el.remove();
   _cards.splice(idx, 1);
   // Trigger stop for connections where this card was the source
   const outgoing = _connections.filter(c => c.fromCardId === id);
@@ -1546,7 +1553,11 @@ function _resolveAllTopics() {
 // ── Project lifecycle ─────────────────────────────────────────────────────────
 
 function _autoStopOnDisconnect(cardId, portIdx, topic) {
-  if (!_projectRunning) return;
+  // No `if (!_projectRunning) return` here. Every call site already refuses to
+  // edit while the project runs, so that check made this function a no-op at all
+  // of them — a card left subscribed to a topic the canvas no longer connects,
+  // which is how an old TTS node kept speaking on a deleted link. Stopping a
+  // stopped instance just returns {"state": "idle"}.
   // Only stop if no other connection still feeds this port
   const stillConnected = _connections.some(c => c.toCardId === cardId && c.toPortIdx === portIdx);
   if (stillConnected) return;

--- a/agent-core/web/js/renderers/audio.js
+++ b/agent-core/web/js/renderers/audio.js
@@ -197,12 +197,19 @@ export const AudioRenderer = {
 
     const cw = this._canvas.offsetWidth;
     const ch = this._canvas.offsetHeight;
-    if (cw > 0 && (this._canvas.width !== cw || this._canvas.height !== ch)) {
-      this._canvas.width  = cw * devicePixelRatio;
-      this._canvas.height = ch * devicePixelRatio;
+    // Compare against the backing-store size, not the CSS size: after a resize
+    // canvas.width is cw * devicePixelRatio, so `canvas.width !== cw` is always
+    // true on a HiDPI display and this reallocated the canvas and reset the
+    // transform on every animation frame.
+    const wantW = Math.round(cw * devicePixelRatio);
+    const wantH = Math.round(ch * devicePixelRatio);
+    if (cw > 0 && (this._canvas.width !== wantW || this._canvas.height !== wantH)) {
+      this._canvas.width  = wantW;
+      this._canvas.height = wantH;
       this._canvas.style.width  = cw + 'px';
       this._canvas.style.height = ch + 'px';
-      this._ctx2d.scale(devicePixelRatio, devicePixelRatio);
+      // Setting width/height resets the transform, so re-apply the DPR scale.
+      this._ctx2d.setTransform(devicePixelRatio, 0, 0, devicePixelRatio, 0, 0);
     }
     if (!this._canvas.width) {
       this._raf = requestAnimationFrame(() => this._draw());
@@ -249,6 +256,12 @@ export const AudioRenderer = {
     for (let col = 0; col < cols; col++) {
       const sampleStart = Math.floor(col * samplesPerCol);
       const sampleEnd   = Math.floor((col + 1) * samplesPerCol);
+      // A column with no samples of its own must draw nothing. Falling through
+      // with the sentinels below left mx at -1, which reads as "full negative
+      // amplitude" and painted a 1px bar at mid + amp — a solid line across the
+      // bottom of the panel whenever the buffer held fewer samples than the
+      // canvas is wide, which is every frame while the stream is silent.
+      if (sampleEnd <= sampleStart) continue;
       let mn = 1, mx = -1;
       for (let s = sampleStart; s < sampleEnd; s++) {
         const idx = (startIdx + s) % ringLen;

--- a/agent-core/web/js/sidebar.js
+++ b/agent-core/web/js/sidebar.js
@@ -696,14 +696,21 @@ export async function openToolConfigModal(mcpId, toolName, configSchema) {
     bodyEl.appendChild(fieldWrapper);
   }
 
-  // x-show-when / x-hide-when: toggle field visibility based on controlling field value
+  // x-show-when / x-hide-when: toggle field visibility based on controlling field value.
+  // A condition value may be a single value or an array; an array means "any of
+  // these". That is what lets one field depend on a subset of another field's enum
+  // — e.g. the ASR device selector only applies to the models that have GPU
+  // weights, so it hides itself for the rest instead of offering a choice the
+  // plugin would reject.
+  const _condMatches = (condVal, actual) =>
+    Array.isArray(condVal) ? condVal.includes(actual) : actual === condVal;
   function _applyShowWhen() {
     bodyEl.querySelectorAll('.tool-config-field[data-show-when]').forEach(el => {
       const cond = JSON.parse(el.dataset.showWhen);
       let visible = true;
       for (const [condKey, condVal] of Object.entries(cond)) {
         const ctrl = bodyEl.querySelector(`[data-key="${condKey}"]`);
-        if (ctrl && ctrl.value !== condVal) { visible = false; break; }
+        if (ctrl && !_condMatches(condVal, ctrl.value)) { visible = false; break; }
       }
       el.style.display = visible ? '' : 'none';
     });
@@ -712,7 +719,7 @@ export async function openToolConfigModal(mcpId, toolName, configSchema) {
       let hidden = false;
       for (const [condKey, condVal] of Object.entries(cond)) {
         const ctrl = bodyEl.querySelector(`[data-key="${condKey}"]`);
-        if (ctrl && ctrl.value === condVal) { hidden = true; break; }
+        if (ctrl && _condMatches(condVal, ctrl.value)) { hidden = true; break; }
       }
       el.style.display = hidden ? 'none' : '';
     });

--- a/perception/Dockerfile.jetson
+++ b/perception/Dockerfile.jetson
@@ -120,18 +120,20 @@ ENV YOLO_CONFIG_DIR=/work
 # jp5.11 installs a CUDA-enabled wheel built on an Orin against onnxruntime-gpu
 # 1.16.0 (CUDA 11.4, cuDNN 8) with -DSHERPA_ONNX_ENABLE_GPU=ON.
 #
-# Installing it does NOT move everything to the GPU: utils/onnx_provider.py only
-# routes fp32 models there, because ONNX Runtime's CUDA provider has no int8
-# kernels and falls back per node. Measured on an Orin NX at matched num_threads,
-# streaming int8 ASR came out 3.3x slower on CUDA while fp32 Matcha TTS came out
-# 4.3x faster — the numbers, the thread sweep and the reasoning are in
-# perception/README.md § sherpa-onnx Execution Provider, along with how to
-# rebuild this wheel.
+# Installing it does NOT move anything to the GPU on its own: that is opt-in via
+# `device: gpu` in the ASR/TTS config, and only for the (model, device) pairs
+# ASR_MODELS lists. int8 weights are *slower* on CUDA — ONNX Runtime's CUDA
+# provider has no int8 kernels and falls back per node — so `device: gpu` loads
+# different, non-quantised weights. Measured on an Orin NX at matched num_threads:
+# SenseVoice fp16 5.8x faster, streaming paraformer fp32 1.8x faster, while the
+# same models' int8 weights were 0.4-0.7x, i.e. worse. The numbers, the thread
+# sweep and the reasoning are in perception/README.md § sherpa-onnx Device
+# Selection, along with how to rebuild this wheel.
 #
 # The gate is on JP_VERSION, not on "is this a Jetson": the wheel links
 # libcudart.so.11.0, which jp6.1 (CUDA 12.6) does not provide. jp6.1 would need
-# its own build against onnxruntime-gpu 1.18.1 on a JetPack 6 host, so until
-# then it keeps the CPU wheel from PyPI and hw_provider: auto resolves to cpu.
+# its own build against onnxruntime-gpu 1.18.1 on a JetPack 6 host, so until then
+# it keeps the CPU wheel from PyPI and `device: gpu` falls back to cpu there.
 #
 # Cost: 74 MB compressed / ~250 MB unpacked, nearly all of it
 # libonnxruntime_providers_cuda.so, versus ~30 MB for the CPU wheel.

--- a/perception/Dockerfile.jetson
+++ b/perception/Dockerfile.jetson
@@ -189,6 +189,15 @@ RUN mv /usr/sbin/ldconfig /usr/sbin/ldconfig.real && \
     { ldconfig || echo '[build] ldconfig skipped — emulated build, using default search path'; } && \
     rm -rf /var/lib/apt/lists/*
 RUN pip3 install --no-cache-dir -i ${PYPI_MIRROR} phonemizer
+# phonemizer finds libespeak-ng with ctypes.util.find_library, which shells out to
+# `ldconfig -p` — and the ldconfig shimming above means libespeak-ng never makes it
+# into the cache, so find_library returns None and EspeakBackend raises "espeak not
+# installed" even though the package is installed. Pointing at the library directly
+# skips that lookup entirely. Without it asr_kws degrades to matching raw characters
+# *and* spends 5.2 s per utterance forking ldconfig from a multi-GB process — see
+# plugins/asr.py _phonemize_safe. asr.py also probes for it at runtime, so an image
+# built before this line still recovers; this makes it not depend on that.
+ENV PHONEMIZER_ESPEAK_LIBRARY=/usr/lib/aarch64-linux-gnu/libespeak-ng.so.1
 
 # ── VITS2 TTS frontend deps ───────────────────────────────────────
 # The model release contains compiled TN FSTs; the container executes them with

--- a/perception/Dockerfile.jetson
+++ b/perception/Dockerfile.jetson
@@ -117,7 +117,41 @@ RUN mkdir -p /work/weights/clip && \
 ENV YOLO_CONFIG_DIR=/work
 
 # ── sherpa-onnx (on-device ASR/TTS/KWS) ──────────────────────────
-RUN pip3 install --no-cache-dir -i ${PYPI_MIRROR} sherpa-onnx
+# jp5.11 installs a CUDA-enabled wheel built on an Orin against onnxruntime-gpu
+# 1.16.0 (CUDA 11.4, cuDNN 8) with -DSHERPA_ONNX_ENABLE_GPU=ON.
+#
+# Installing it does NOT move everything to the GPU: utils/onnx_provider.py only
+# routes fp32 models there, because ONNX Runtime's CUDA provider has no int8
+# kernels and falls back per node. Measured on an Orin NX, int8 ASR came out
+# 2-3x slower on CUDA while fp32 Matcha TTS came out 4.4x faster — the numbers
+# and the reasoning are in perception/README.md § sherpa-onnx Execution Provider,
+# along with how to rebuild this wheel.
+#
+# The gate is on JP_VERSION, not on "is this a Jetson": the wheel links
+# libcudart.so.11.0, which jp6.1 (CUDA 12.6) does not provide. jp6.1 would need
+# its own build against onnxruntime-gpu 1.18.1 on a JetPack 6 host, so until
+# then it keeps the CPU wheel from PyPI and hw_provider: auto resolves to cpu.
+#
+# Cost: 74 MB compressed / ~250 MB unpacked, nearly all of it
+# libonnxruntime_providers_cuda.so, versus ~30 MB for the CPU wheel.
+#
+# The URL needs %2B for the '+cuda' local version, but the file on disk must
+# keep the literal '+' or pip refuses to parse the version out of the filename.
+ARG SHERPA_GPU_WHEEL=sherpa_onnx-1.13.6+cuda-cp38-cp38-linux_aarch64.whl
+RUN if [ "${JP_VERSION}" = "511" ]; then \
+        python3 -c "import urllib.request, urllib.parse, sys; \
+name = sys.argv[1]; \
+urllib.request.urlretrieve('https://agi-phanthy-dev-1252788780.cos.ap-beijing.myqcloud.com/public/sherpa-onnx/' + urllib.parse.quote(name), '/tmp/' + name)" \
+            "${SHERPA_GPU_WHEEL}" && \
+        pip3 install --no-cache-dir "/tmp/${SHERPA_GPU_WHEEL}" && \
+        rm -f "/tmp/${SHERPA_GPU_WHEEL}" && \
+        python3 -c "import sherpa_onnx, pathlib; \
+lib = pathlib.Path(sherpa_onnx.__file__).parent / 'lib' / 'libonnxruntime_providers_cuda.so'; \
+assert lib.is_file(), 'CUDA provider missing from the installed wheel'; \
+print('sherpa-onnx', sherpa_onnx.__version__, 'with CUDA provider')"; \
+    else \
+        pip3 install --no-cache-dir -i ${PYPI_MIRROR} sherpa-onnx; \
+    fi
 
 # ── OCR runtime deps (PP-OCRv6 TensorRT engines; TensorRT/CUDA come from base) ──
 # libvips42 (apt, above) is the runtime library pyvips dlopens for JPEG decode

--- a/perception/Dockerfile.jetson
+++ b/perception/Dockerfile.jetson
@@ -122,10 +122,11 @@ ENV YOLO_CONFIG_DIR=/work
 #
 # Installing it does NOT move everything to the GPU: utils/onnx_provider.py only
 # routes fp32 models there, because ONNX Runtime's CUDA provider has no int8
-# kernels and falls back per node. Measured on an Orin NX, int8 ASR came out
-# 2-3x slower on CUDA while fp32 Matcha TTS came out 4.4x faster — the numbers
-# and the reasoning are in perception/README.md § sherpa-onnx Execution Provider,
-# along with how to rebuild this wheel.
+# kernels and falls back per node. Measured on an Orin NX at matched num_threads,
+# streaming int8 ASR came out 3.3x slower on CUDA while fp32 Matcha TTS came out
+# 4.3x faster — the numbers, the thread sweep and the reasoning are in
+# perception/README.md § sherpa-onnx Execution Provider, along with how to
+# rebuild this wheel.
 #
 # The gate is on JP_VERSION, not on "is this a Jetson": the wheel links
 # libcudart.so.11.0, which jp6.1 (CUDA 12.6) does not provide. jp6.1 would need

--- a/perception/README.md
+++ b/perception/README.md
@@ -88,11 +88,20 @@ just a different provider string.
 
 | `asr_model` | `device: cpu` | `device: gpu` | gpu speed-up |
 |-------------|---------------|---------------|--------------|
-| `sensevoice-small` (default) | int8, 228 MB | **fp16, 448 MB** | **5.81x** |
+| `sensevoice-small` (default) | int8, 228 MB | **fp16, 448 MB** | **~2.5x** per utterance |
 | `paraformer-zh-en` (streaming) | int8, 226 MB | **fp32, 825 MB** | **1.77x** |
 | `x-asr-zh-en` | int8 + fp32 | — not offered | 0.80x, i.e. slower |
 | `paraformer-offline` | int8 | — not offered | unmeasured |
 | `zipformer-en` | int8 | — not offered | unmeasured |
+
+**gpu costs about 2 GB of RAM, and ~1.4 GB of that is unreturnable.** Measured with
+only ASR resident: the cpu adapter adds 542 MB and drops back to 129 MB when
+released; the gpu adapter adds 1968 MB and still holds 1516 MB after release,
+because a process that has touched CUDA does not give its context and memory pool
+back. On a 7.4 GB Orin already running vop (YOLO), OCR (TensorRT) and TTS, turning
+on gpu ASR was enough to exhaust memory: perception was restarted in a loop, Agent
+Core could not reach port 15720, and the dashboard rolled the project back and the
+cards vanished. Budget for it before enabling.
 
 TTS is simpler: Matcha is fp32 only, so both devices load the same files and
 `device` only picks the provider (gpu measured ~4.3x). The `vits2_trt` engine
@@ -101,6 +110,30 @@ ignores `device` entirely — it is a TensorRT engine and never touches ONNX Run
 `device: gpu` also needs the CUDA sherpa-onnx wheel, which only the jp5.11 image
 installs (see § The jp5.11 CUDA wheel). On jp6.1 and x86 dev hosts it falls back to
 `cpu` with a warning rather than failing to start.
+
+### Latency per utterance, which is what an operator feels
+
+Same box, SenseVoice, real VAD segments (1–4 s of speech, the length a wake-word
+turn actually produces), decoded one at a time with a 3 s gap, with the rest of
+perception left running:
+
+| | cpu (int8) | gpu (fp16) | |
+|---|---|---|---|
+| first call | 185 ms | **1777 ms** | **gpu 9.6x slower** |
+| median after the first | 193 ms | **77 ms** | gpu 2.5x faster |
+| adapter build | 5.5 s | 11.6 s | |
+
+Two things follow. First, the 1777 ms is CUDA initialisation — lazy kernel loading,
+cuDNN autotuning, memory pool — and it lands on whatever utterance comes first.
+`_warmup_adapter()` therefore decodes a second of silence right after building, so
+that cost is paid inside the `loading` window the dashboard already shows. Set
+`warmup: false` to skip it.
+
+Second, **the steady-state speed-up on real utterances is ~2.5x, not the 5.81x in
+the table below.** That number came from the model's own `test_wavs`, which are 7 s
+each; short utterances give the GPU less to amortise its fixed cost against. The
+batch figures are still the right way to compare dtypes against each other — they
+are just not the latency a user sees.
 
 ### Measurements
 

--- a/perception/README.md
+++ b/perception/README.md
@@ -122,7 +122,7 @@ Inference is not the latency. Captured from the plugin's own spans on a live
 | `asr_transcribe` | 120 ms | 91 ms |
 | `kws_phonemize` | **5256 ms** | **5234 ms** |
 | `kws_match` | 0 ms | 0 ms |
-| unaccounted (queue wait + `_extract_after_keyword`) | 1775 ms | 5376 ms |
+| unaccounted (queue wait + cutting the wake word off) | 1775 ms | 5376 ms |
 
 Transcription was 91–120 ms. Almost all of it was `kws_phonemize` doing nothing
 useful — see § asr_kws and espeak below — and the growing unaccounted figure is the
@@ -396,6 +396,25 @@ The persistent-backend cache the code always claimed to have only starts working
 once construction succeeds — before this, the dict stayed empty and every segment
 rebuilt.
 
+**Cutting the wake word off the transcript used to guess.** The match returns a
+*phoneme* index, but what gets forwarded to the agent is *text*, so the two have to
+be related. The old code estimated: it re-phonemized the segment containing the
+match and scaled, `round(offset_in_seg * chars_in_seg / seg_ipa_count)`. Chinese
+characters are not a fixed number of phonemes each — 「小潘小潘，现在发生什么了？」
+phonemizes to 29 phonemes over 12 characters and the wake word ends at phoneme 12,
+where the estimate gives `round(12 * 11 / 29) = 5` and eats 现, so the agent was
+asked 「在发生什么了？」. Off-by-one on a syllable also silently changes the utterance
+in mixed script, where latin and CJK have very different phonemes-per-character and
+one ratio was applied to both.
+
+`_text_to_ipa(text, with_positions=True)` now also returns, per phoneme, the
+character offset in the original string that phoneme ends at — built from growing
+prefixes of each segment, phonemized through the same function that produced the
+phonemes. Segments are `(start, end, is_cjk)` offsets rather than `strip()`ed
+substrings, so punctuation and whitespace stay accounted for. `_text_after_phoneme`
+is then a lookup, which also removes the second phonemization pass. Positions are
+opt-in: callers that only need to match pay nothing for the prefix passes.
+
 ---
 
 ## Plugin Concurrency
@@ -511,6 +530,25 @@ iteration` in the middle of a start. Copy under the lock, then iterate the copy.
 Every MCP server in the project uses `ThreadingHTTPServer` — `perception/main.py`
 and each robot driver's `main.py`. Any plugin holding a `self._nodes` /
 `self._instances` / `self._streams` dict needs the treatment above.
+
+### The other way to orphan a node: nobody sends `stop`
+
+The same symptoms — two nodes publishing the same kind of output, one of them on a
+topic no card accounts for, and rclpy's duplicate-node-name warning — also appear
+when the plugin is correct and the `stop` simply never arrives.
+
+Agent Core's `stop-project` walks the cards in the *saved canvas layout*. A card
+deleted from the canvas is no longer in that list, so from that moment nothing can
+reach its instance again: it keeps its ROS node, its subscription, its subprocess
+and (on `device: gpu`) ~1.4 GB of CUDA context until perception exits. On orin5 a
+deleted TTS card left `vits2_trt_card_mt4rkb752py8` publishing to the topic of a
+connection that had already been deleted, while the live card published elsewhere —
+the dashboard read "running", and there was no sound.
+
+`api/canvas.py` and `api/solutions.py` now diff the card set on every layout write
+and `stop` whatever left it (`api/config.py: stop_removed_cards`). So when you see
+an orphan, check both sides: the plugin's locking *and* whether a `stop` for that
+instance_id ever showed up in the log.
 
 ---
 

--- a/perception/README.md
+++ b/perception/README.md
@@ -113,36 +113,53 @@ installs (see § The jp5.11 CUDA wheel). On jp6.1 and x86 dev hosts it falls bac
 
 ### Latency per utterance, which is what an operator feels
 
-Same box, SenseVoice, real VAD segments (1–4 s of speech, the length a wake-word
-turn actually produces), with the rest of perception left running:
+Inference is not the latency. Captured from the plugin's own spans on a live
+`device: gpu` instance, two consecutive wake-word utterances:
 
-| | cpu (int8) | gpu (fp16) | |
-|---|---|---|---|
-| first call, no warmup | 165 ms | **1659 ms** | gpu 10x slower |
-| first call, warmed | 162 ms | **82 ms** | gpu 2.0x faster |
-| sustained p50 (40 calls) | 195 ms | **58 ms** | gpu 3.4x faster |
-| sustained p90 | 319 ms | 70 ms | |
-| sustained p99 | 326 ms | **78 ms** | gpu's worst case beats cpu's median |
-| after 60 s idle | 159 ms | 73 ms | 1.3x its own p50 — no downclock cliff |
-| adapter build | 4.6 s | 5.3 s | |
+| span | utterance 1 | utterance 2 |
+|------|-------------|-------------|
+| `audio_end` → `asr_complete` (**felt latency**) | **7150 ms** | **10701 ms** |
+| `asr_transcribe` | 120 ms | 91 ms |
+| `kws_phonemize` | **5256 ms** | **5234 ms** |
+| `kws_match` | 0 ms | 0 ms |
+| unaccounted (queue wait + `_extract_after_keyword`) | 1775 ms | 5376 ms |
 
-Three things worth knowing:
+Transcription was 91–120 ms. Almost all of it was `kws_phonemize` doing nothing
+useful — see § asr_kws and espeak below — and the growing unaccounted figure is the
+utterance queue backing up behind it, because the VAD emits a segment every 2–3 s
+while each one took ~5.5 s to process. Latency accumulated over a session rather
+than being constant, which is why it felt worse the longer you talked.
 
-- **Warmup does its job.** 1659 ms cold versus 82 ms warmed, so
-  `_warmup_adapter()` (a second of silence right after building) is what keeps that
-  cost out of the operator's first utterance. `warmup: false` opts out.
-- **No drift and no idle cliff.** Across 40 back-to-back calls the first half and
-  second half both sat at a 57.7 ms p50, and a call after 60 s of silence took
-  73 ms — an idle Orin GPU downclocking was a plausible worry and did not
-  materialise.
-- **The GPU is also steadier.** cpu p99 is 1.7x its own p50 (326 vs 195 ms) because
-  vop and OCR compete for cores; gpu p99 is 1.35x (78 vs 58 ms). The GPU's worst
-  case is faster than the CPU's median.
+**Measure this from the spans, not from a `docker exec` one-liner.** The same
+`_text_to_ipa` call cost 320 ms in a small test process and 5256 ms inside
+perception, because the failure path forks `ldconfig` and forking a 3.6 GB
+many-threaded process is expensive. Out-of-process timing hid the entire problem.
+
+Inference alone, for comparison — real VAD segments (1–4 s), one at a time, rest of
+perception running:
+
+| | cpu (int8) | gpu (fp16) |
+|---|---|---|
+| first call, cold process | 165 ms | 1659–2269 ms |
+| sustained p50 (40 calls) | 195 ms | **58 ms** |
+| sustained p99 | 326 ms | **78 ms** |
+| after 60 s idle | 159 ms | 73 ms |
+
+No drift across 40 calls (both halves at a 57.7 ms p50) and no idle cliff. The gpu
+p99 beats the cpu median, because vop and OCR contend for cores but not for the GPU.
+
+`_warmup_adapter()` decodes a second of silence after building to keep CUDA's
+first-inference cost off the first real utterance. Be aware it does not fully
+absorb it: a cold process still measured 2269 ms on its first *real* segment after
+warming on silence, so the warmup does not cover every input shape. It is worth
+keeping — silence costs ~1.7 s inside the `loading` window either way — but the
+first utterance after a model switch can still be slow. (An earlier measurement
+that suggested warmup reduced this to 82 ms was an artifact of test ordering: an
+unwarmed adapter earlier in the same process had already paid the CUDA init.)
 
 The batch figures in § Measurements are larger (up to 23x) because they decode the
-model's own `test_wavs`, which are 7 s each — longer audio gives the GPU more to
-amortise its fixed cost against. Those numbers are the right way to compare dtypes
-with each other; the table above is the latency a user experiences.
+model's own `test_wavs`, which are 7 s each. Those compare dtypes with each other;
+this table is what a user experiences.
 
 ### Switching engine or device blocks for the bounded part
 
@@ -337,6 +354,47 @@ jp6.1 (CUDA 12.6). That target needs its own build with
 `PYTHON_EXECUTABLE=python3.10`, run on a JetPack 6 host inside
 `jetson-base:jp61-torch`. Until then jp6.1 stays on the CPU wheel and
 `device: gpu` falls back to `cpu` there.
+
+---
+
+## asr_kws and espeak
+
+`trigger_mode: asr_kws` transcribes every utterance and gates on a phoneme-level
+fuzzy match against the wake word, so it needs IPA for both. That path had two
+faults that together cost **5.2 s per utterance** and quietly degraded wake-word
+accuracy.
+
+**phonemizer could not find libespeak-ng.** It looks the library up with
+`ctypes.util.find_library('espeak-ng')`, which on Linux shells out to `ldconfig -p`.
+`Dockerfile.jetson` replaces `ldconfig` with a no-op during apt installs so the
+libc-bin trigger cannot segfault under qemu, and the cache is never rebuilt — so the
+package is installed (`/usr/bin/espeak-ng`, `libespeak-ng.so.1`, three debs) while
+`find_library` returns `None` and `EspeakBackend` raises "espeak not installed".
+`_text_to_ipa` caught that and fell back to comparing raw *characters*, which is
+also why 「小康小康」 failed to match 「小范小范」: at character level 康≠范 is a full
+mismatch, where the phonemes `kʰ ɑŋ` vs `f a n` still score a usable distance.
+
+Fixed by pointing at the library directly, both as an `ENV` in `Dockerfile.jetson`
+and as a runtime probe in `_point_phonemizer_at_espeak()` so an already-built image
+recovers too. `PHONEMIZER_ESPEAK_LIBRARY` set by the deployment always wins.
+
+**And every failure was retried.** `_text_to_ipa` splits an utterance into CJK /
+non-CJK segments — four for 「小范小范，你好。」, since fullwidth punctuation is outside
+`一-鿿` — and `_phonemize_safe` rebuilt the backend and retried on each one.
+Eight `find_library` calls per utterance, each forking `ldconfig` from a 3.6 GB
+many-threaded process. A construction failure is now remembered and never retried;
+the retry-on-crash path remains for a backend that worked once and then died.
+
+Measured in a deliberately large, threaded process:
+
+| | first call | subsequent | phonemes? |
+|---|---|---|---|
+| library located | 511 ms | **0.3–0.5 ms** | real IPA |
+| library missing | 385 ms | 0.0 ms (negative cache) | characters |
+
+The persistent-backend cache the code always claimed to have only starts working
+once construction succeeds — before this, the dict stayed empty and every segment
+rebuilt.
 
 ---
 

--- a/perception/README.md
+++ b/perception/README.md
@@ -88,7 +88,7 @@ just a different provider string.
 
 | `asr_model` | `device: cpu` | `device: gpu` | gpu speed-up |
 |-------------|---------------|---------------|--------------|
-| `sensevoice-small` (default) | int8, 228 MB | **fp16, 448 MB** | **~2.5x** per utterance |
+| `sensevoice-small` (default) | int8, 228 MB | **fp16, 448 MB** | **3.4x** per utterance |
 | `paraformer-zh-en` (streaming) | int8, 226 MB | **fp32, 825 MB** | **1.77x** |
 | `x-asr-zh-en` | int8 + fp32 | — not offered | 0.80x, i.e. slower |
 | `paraformer-offline` | int8 | — not offered | unmeasured |
@@ -114,26 +114,55 @@ installs (see § The jp5.11 CUDA wheel). On jp6.1 and x86 dev hosts it falls bac
 ### Latency per utterance, which is what an operator feels
 
 Same box, SenseVoice, real VAD segments (1–4 s of speech, the length a wake-word
-turn actually produces), decoded one at a time with a 3 s gap, with the rest of
-perception left running:
+turn actually produces), with the rest of perception left running:
 
 | | cpu (int8) | gpu (fp16) | |
 |---|---|---|---|
-| first call | 185 ms | **1777 ms** | **gpu 9.6x slower** |
-| median after the first | 193 ms | **77 ms** | gpu 2.5x faster |
-| adapter build | 5.5 s | 11.6 s | |
+| first call, no warmup | 165 ms | **1659 ms** | gpu 10x slower |
+| first call, warmed | 162 ms | **82 ms** | gpu 2.0x faster |
+| sustained p50 (40 calls) | 195 ms | **58 ms** | gpu 3.4x faster |
+| sustained p90 | 319 ms | 70 ms | |
+| sustained p99 | 326 ms | **78 ms** | gpu's worst case beats cpu's median |
+| after 60 s idle | 159 ms | 73 ms | 1.3x its own p50 — no downclock cliff |
+| adapter build | 4.6 s | 5.3 s | |
 
-Two things follow. First, the 1777 ms is CUDA initialisation — lazy kernel loading,
-cuDNN autotuning, memory pool — and it lands on whatever utterance comes first.
-`_warmup_adapter()` therefore decodes a second of silence right after building, so
-that cost is paid inside the `loading` window the dashboard already shows. Set
-`warmup: false` to skip it.
+Three things worth knowing:
 
-Second, **the steady-state speed-up on real utterances is ~2.5x, not the 5.81x in
-the table below.** That number came from the model's own `test_wavs`, which are 7 s
-each; short utterances give the GPU less to amortise its fixed cost against. The
-batch figures are still the right way to compare dtypes against each other — they
-are just not the latency a user sees.
+- **Warmup does its job.** 1659 ms cold versus 82 ms warmed, so
+  `_warmup_adapter()` (a second of silence right after building) is what keeps that
+  cost out of the operator's first utterance. `warmup: false` opts out.
+- **No drift and no idle cliff.** Across 40 back-to-back calls the first half and
+  second half both sat at a 57.7 ms p50, and a call after 60 s of silence took
+  73 ms — an idle Orin GPU downclocking was a plausible worry and did not
+  materialise.
+- **The GPU is also steadier.** cpu p99 is 1.7x its own p50 (326 vs 195 ms) because
+  vop and OCR compete for cores; gpu p99 is 1.35x (78 vs 58 ms). The GPU's worst
+  case is faster than the CPU's median.
+
+The batch figures in § Measurements are larger (up to 23x) because they decode the
+model's own `test_wavs`, which are 7 s each — longer audio gives the GPU more to
+amortise its fixed cost against. Those numbers are the right way to compare dtypes
+with each other; the table above is the latency a user experiences.
+
+### Switching engine or device blocks for the bounded part
+
+`action=config` on the `tts` tool waits up to `ENGINE_SWITCH_WAIT_S` (20 s) for the
+new engine before answering `loading`. Only some of a build is open-ended — a cold
+model download — while constructing the session afterwards took ~2 s on cpu and ~5 s
+on gpu. Reporting `loading` for that made the dashboard send its `start` into a
+facade with no engine, and the start was dropped: the engine then came up idle, and
+Agent Core's loading watcher (`api/config.py` `_settle_loading_item`) reports "启动已
+取消" the moment it sees `idle`.
+
+Waiting is safe on that path — `mcp_call_tool` sets no client timeout and the
+watcher polls for up to 900 s. (The 60 s often quoted in these plugins belongs to
+the *LLM* tool path in `agent-core/src/mcp_client.py`, which does not send `config`.)
+A build that outlives the bound still goes async, and `TTSPlugin` records any
+`start` that arrives mid-build and replays it once the engine is resident, so the
+card reaches `running` instead of being cancelled. A `stop` cancels a pending
+replay. The bound is a time limit rather than a "does it need to download?" check
+because the download is not the only slow phase: the gpu paraformer encoder is
+636 MB and reading it cold takes seconds by itself.
 
 ### Measurements
 

--- a/perception/README.md
+++ b/perception/README.md
@@ -101,45 +101,86 @@ and a single-thread-count comparison overstates the effect in both directions:
 |-------|-------|---------|----------|-------|----------|-----------|-------|
 | streaming paraformer `encoder.int8.onnx` (30.7 s audio) | int8 | 3383 ms | 11125 ms | **0.30x** | 3097 ms (t=4) | 10524 ms (t=4) | **0.29x** |
 | X-ASR offline transducer, beam search (28.7 s audio) | int8 encoder+joiner, fp32 decoder | 2832 ms | 5707 ms | **0.50x** | 2503 ms (t=4) | 5707 ms (t=2) | **0.44x** |
-| offline SenseVoice `model.int8.onnx` (28.7 s audio) | int8 | 2022 ms | 2341 ms | **0.86x** | 1354 ms (t=4) | 1694 ms (t=4) | **0.80x** |
+| offline SenseVoice `model.int8.onnx` (28.7 s audio) | int8 | 2086 ms | 2332 ms | **0.89x** | 1404 ms (t=4) | 1797 ms (t=4) | **0.78x** |
+| offline SenseVoice `model.onnx` (28.7 s audio) | **fp32** | 4905 ms | **426 ms** | **11.52x** | 2842 ms (t=4) | 426 ms (t=2) | **6.68x** |
 | Matcha TTS `model-steps-3.onnx` + vocos (13.3 s audio) | fp32 | 1784 ms | 416 ms | **4.28x** | 1175 ms (t=4) | 416 ms (t=1) | **2.83x** |
 
 `num_threads: 2` is what `config.yaml` deploys, so the `t=2` columns are the
 operationally relevant ones; the best-of-each columns are there because the CPU
 scales further with threads while CUDA does not (Matcha at t=4 regresses to
-538 ms, X-ASR to 6238 ms). Model load also gets slower on CUDA — X-ASR went from
-~8.6 s to ~11 s.
+538 ms, X-ASR to 6238 ms). Model load also gets slower on CUDA for int8 — X-ASR
+went from ~8.6 s to ~11 s.
 
 X-ASR is the useful case for the rule as written: its bundle is *mixed* precision
 (int8 encoder and joiner, fp32 decoder), `is_quantised()` treats any int8 file as
 disqualifying, and the measurement confirms that is the right call.
 
-Transcripts were byte-identical between providers on the greedy paraformer path.
-On X-ASR they were not — 1 of 4 clips differed, by one character, and both
-candidates were hesitation particles (「嗯」on CPU vs「呃」on CUDA). X-ASR decodes
-with `modified_beam_search` (`max_active_paths=10`), so provider-level numeric
-differences can reorder near-tied beams. That is a behavioural difference, not a
-correctness regression, but it is a reason not to switch providers casually on a
-beam-search model.
+The two SenseVoice rows are the same model in both dtypes, which is what makes
+this a dtype result rather than a per-model coincidence: int8 loses on CUDA, fp32
+wins by 11.5x. Mechanism confirmed two ways — fp32-CUDA is completely insensitive
+to thread count (433 / 426 / 431 ms at 1/2/4) with GR3D pinned at 97%, i.e. the
+graph really is on the GPU; int8-CUDA instead scales with **CPU** threads
+(3314 → 2332 → 1797 ms), i.e. much of it is not.
 
-The per-node fallback is not merely inferred from the int8/fp32 contrast: on the
-streaming int8 model the **CUDA** path speeds up 1.7x when given more **CPU**
-threads (17861 → 11125 → 10524 ms for 1/2/4 threads). Thread count would hardly
-matter if the graph were running on the GPU. Nor is GPU contention the
-explanation — the idle `GR3D_FREQ` baseline was 0%, and GR3D sat at 88–92% during
-the CUDA runs, so the work does reach the GPU; it is just slower there.
+### int8 on CUDA also changes the output
 
-So `auto` keeps every int8 ASR/KWS bundle on CPU and gives Matcha TTS the GPU.
-`is_quantised()` decides from the filename (`*.int8.onnx`), the same convention
-`asr.py`'s `_find(prefer_int8=...)` already relies on.
+Beyond throughput, the per-node fallback is numerically noisy: requantising at
+every int8↔fp32 partition boundary perturbs results. Same model, same audio,
+`num_threads=2`:
 
-Caveats: the int8 rule holds for these shapes only. A *streaming* fp32 model is
-untested, and the streaming-vs-offline gap at the same dtype is large (0.30x vs
-0.86x) — sherpa's per-chunk decode carries real GPU overhead of its own, so a
-streaming fp32 model may land nowhere near Matcha's speed-up. Pin
-`hw_provider: cpu` if you deploy one and it disappoints. Note also that offline
-int8 is close to parity (0.80–0.86x), not a cliff; the decisive regression is the
-streaming case.
+- SenseVoice **int8**: CPU vs CUDA differed on **3 of 4** clips — not only
+  punctuation but a real word substitution (`不然` → `主然`).
+- SenseVoice **fp32**: CPU vs CUDA differed on **0 of 4** clips.
+- X-ASR (int8 encoder/joiner, beam search): differed on 1 of 4, by one character
+  (「嗯」vs「呃」, both hesitation particles). Beam search reorders near-tied
+  hypotheses under provider-level numeric differences.
+- streaming paraformer int8 with greedy search: byte-identical.
+
+So keeping int8 models on CPU buys output stability as well as speed. Conversely,
+fp32 is provider-consistent, so moving an fp32 model to the GPU does not change
+what it transcribes.
+
+### Putting ASR on the GPU
+
+It is possible, and the code already supports it — but it needs a **model change,
+not a config change**. Ship the fp32 bundle instead of the int8 one and
+`hw_provider: auto` routes it to CUDA on its own. For offline SenseVoice that is
+426 ms versus the 2086 ms the deployed int8-on-CPU takes, a **4.9x** end-to-end
+win on the same audio.
+
+What that costs, and what is still unknown:
+
+- **Size.** SenseVoice fp32 `model.onnx` is 894 MB against 228 MB for int8 — on
+  the COS download and on disk, per robot.
+- **Accuracy is different, not obviously better.** On these four clips the two
+  dtypes disagree in both directions (int8 produced `礼拜2` where fp32 gave
+  `礼2`; fp32 emitted a spurious leading `，`). Four clips cannot settle it —
+  switching dtype needs a labelled set.
+- **Streaming is untested at fp32.** These fp32 numbers are the *offline*
+  recogniser. At int8 the streaming path was 3x worse than offline relative to CPU
+  (0.30x vs 0.89x), so sherpa's per-chunk decode carries real GPU overhead and a
+  streaming fp32 model may not see anything like 11x. The deployed default
+  (`paraformer-zh-en`) is streaming.
+- **fp16 is probably the better target than fp32** and has not been measured:
+  Orin's fp16 throughput is far above fp32 and ONNX Runtime's CUDA provider has
+  full fp16 kernel coverage (unlike int8), so it should keep the GPU win at
+  roughly half the memory and bandwidth. It needs an fp32→fp16 ONNX conversion
+  and a check that sherpa-onnx feeds it correctly.
+
+GPU contention is not an alternative explanation for any of the above: the idle
+`GR3D_FREQ` baseline was 0%, and GR3D sat at 88–97% during the CUDA runs, so the
+work does reach the GPU — int8 is simply slower there. The same thread-sensitivity
+signature shows up on the streaming int8 model too (17861 → 11125 → 10524 ms at
+1/2/4 threads on CUDA).
+
+So `auto` keeps every int8 ASR/KWS bundle on CPU and gives fp32 models — Matcha
+TTS today — the GPU. `is_quantised()` decides from the filename (`*.int8.onnx`),
+the same convention `asr.py`'s `_find(prefer_int8=...)` already relies on.
+
+One more caveat on the rule's reach: `int16` is not a middle ground worth trying.
+ONNX Runtime's int16 quantisation (`QInt16`/`QUInt16`, opset 21) is newer than
+int8, the CUDA provider has no kernels for it either, and the CPU side lacks the
+dot-product paths that make int8 fast — it would likely lose on both providers.
 
 **What follows `hw_provider`:** ASR (all sherpa adapters, including X-ASR), KWS,
 and the `sherpa_onnx` TTS engine.

--- a/perception/README.md
+++ b/perception/README.md
@@ -93,34 +93,41 @@ ONNX Runtime's CUDA execution provider has no kernels for the quantised ops in a
 int8 model. It partitions the graph and falls back to CPU node by node, inserting
 a host↔device copy at every boundary — so an int8 model runs *slower* on the GPU
 than on the CPU. Measured on orin5 (Orin NX, JetPack 5.11, CUDA 11.4, 6 cores),
-sherpa-onnx 1.13.6+cuda, same audio, steady-state median. Both providers were
-swept across 1/2/4 `num_threads`, because the ratio moves a lot with thread count
-and a single-thread-count comparison overstates the effect in both directions:
+sherpa-onnx 1.13.6+cuda, same audio, steady-state median, **on an idle box** (all
+services stopped, idle `GR3D_FREQ` 0%, verified per run). Both providers were swept
+across 1/2/4 `num_threads`, because the ratio moves a lot with thread count and a
+single-thread-count comparison overstates the effect in both directions:
 
 | model | dtype | CPU t=2 | CUDA t=2 | ratio | best CPU | best CUDA | ratio |
 |-------|-------|---------|----------|-------|----------|-----------|-------|
 | streaming paraformer `encoder.int8.onnx` (30.7 s audio) | int8 | 3383 ms | 11125 ms | **0.30x** | 3097 ms (t=4) | 10524 ms (t=4) | **0.29x** |
-| X-ASR offline transducer, beam search (28.7 s audio) | int8 encoder+joiner, fp32 decoder | 2832 ms | 5707 ms | **0.50x** | 2503 ms (t=4) | 5707 ms (t=2) | **0.44x** |
-| offline SenseVoice `model.int8.onnx` (28.7 s audio) | int8 | 2086 ms | 2332 ms | **0.89x** | 1404 ms (t=4) | 1797 ms (t=4) | **0.78x** |
-| offline SenseVoice `model.onnx` (28.7 s audio) | **fp32** | 4905 ms | **426 ms** | **11.52x** | 2842 ms (t=4) | 426 ms (t=2) | **6.68x** |
+| X-ASR offline transducer, beam search (28.7 s audio) | int8 encoder+joiner, fp32 decoder | 2645 ms | 3294 ms | **0.80x** | 2200 ms (t=4) | 2896 ms (t=4) | **0.76x** |
+| offline SenseVoice `model.int8.onnx` (28.7 s audio) | int8 | 1996 ms | 2753 ms | **0.73x** | 1314 ms (t=4) | 1905 ms (t=4) | **0.69x** |
+| offline SenseVoice `model.onnx` (28.7 s audio) | **fp32** | 4792 ms | **416 ms** | **11.52x** | 2784 ms (t=4) | 415 ms (t=4) | **6.71x** |
+| offline SenseVoice `model.fp16.onnx` (28.7 s audio) | **fp16** | 8117 ms | **344 ms** | **23.60x** | 5652 ms (t=4) | 343 ms (t=1) | **16.48x** |
 | Matcha TTS `model-steps-3.onnx` + vocos (13.3 s audio) | fp32 | 1784 ms | 416 ms | **4.28x** | 1175 ms (t=4) | 416 ms (t=1) | **2.83x** |
 
 `num_threads: 2` is what `config.yaml` deploys, so the `t=2` columns are the
 operationally relevant ones; the best-of-each columns are there because the CPU
 scales further with threads while CUDA does not (Matcha at t=4 regresses to
-538 ms, X-ASR to 6238 ms). Model load also gets slower on CUDA for int8 — X-ASR
-went from ~8.6 s to ~11 s.
+538 ms). Model load also gets slower on CUDA for int8 — X-ASR went from ~8.0 s to
+~10.4 s — but *faster* for fp16 (4.5 s versus 10.6 s on CPU).
 
 X-ASR is the useful case for the rule as written: its bundle is *mixed* precision
 (int8 encoder and joiner, fp32 decoder), `is_quantised()` treats any int8 file as
 disqualifying, and the measurement confirms that is the right call.
 
-The two SenseVoice rows are the same model in both dtypes, which is what makes
+The three SenseVoice rows are the same model in three dtypes, which is what makes
 this a dtype result rather than a per-model coincidence: int8 loses on CUDA, fp32
-wins by 11.5x. Mechanism confirmed two ways — fp32-CUDA is completely insensitive
-to thread count (433 / 426 / 431 ms at 1/2/4) with GR3D pinned at 97%, i.e. the
-graph really is on the GPU; int8-CUDA instead scales with **CPU** threads
-(3314 → 2332 → 1797 ms), i.e. much of it is not.
+wins by 11.5x, fp16 by 23.6x. Mechanism confirmed two ways — fp32 and fp16 on CUDA
+are completely insensitive to thread count (417/416/415 and 343/344/346 ms at
+1/2/4) with GR3D pinned at 95–97%, i.e. the graph really is on the GPU; int8-CUDA
+instead scales with **CPU** threads (3793 → 2753 → 1905 ms), i.e. much of it is
+not.
+
+fp16 is the mirror image: it is the fastest thing on the GPU and the *slowest*
+thing on the CPU (13051 ms at one thread, 4x worse than int8), because ONNX
+Runtime has no fp16 CPU kernels and casts everything. fp16 is a GPU-only choice.
 
 ### int8 on CUDA also changes the output
 
@@ -131,56 +138,73 @@ every int8↔fp32 partition boundary perturbs results. Same model, same audio,
 - SenseVoice **int8**: CPU vs CUDA differed on **3 of 4** clips — not only
   punctuation but a real word substitution (`不然` → `主然`).
 - SenseVoice **fp32**: CPU vs CUDA differed on **0 of 4** clips.
+- SenseVoice **fp16**: identical to fp32 on **all** clips, on both providers — so
+  the fp16 conversion cost nothing measurable here.
 - X-ASR (int8 encoder/joiner, beam search): differed on 1 of 4, by one character
   (「嗯」vs「呃」, both hesitation particles). Beam search reorders near-tied
   hypotheses under provider-level numeric differences.
 - streaming paraformer int8 with greedy search: byte-identical.
 
 So keeping int8 models on CPU buys output stability as well as speed. Conversely,
-fp32 is provider-consistent, so moving an fp32 model to the GPU does not change
-what it transcribes.
+fp32 and fp16 are provider-consistent, so moving them to the GPU does not change
+what they transcribe.
 
 ### Putting ASR on the GPU
 
-It is possible, and the code already supports it — but it needs a **model change,
-not a config change**. Ship the fp32 bundle instead of the int8 one and
-`hw_provider: auto` routes it to CUDA on its own. For offline SenseVoice that is
-426 ms versus the 2086 ms the deployed int8-on-CPU takes, a **4.9x** end-to-end
-win on the same audio.
+It is possible, and the code already supports fp32 — but it needs a **model
+change, not a config change**. Ship non-int8 weights and `hw_provider: auto`
+routes them to CUDA on its own. Against the 1996 ms the deployed int8-on-CPU takes
+on the same audio:
 
-What that costs, and what is still unknown:
+| option | model size | CUDA t=2 | vs deployed |
+|--------|-----------|----------|-------------|
+| int8 on CPU (deployed) | 228 MB | — | 1.00x |
+| int8 on CPU, `num_threads: 4` | 228 MB | — | 1.52x (no model change at all) |
+| fp32 on CUDA | 894 MB | 416 ms | **4.80x** |
+| fp16 on CUDA | 448 MB | 344 ms | **5.81x** |
 
-- **Size.** SenseVoice fp32 `model.onnx` is 894 MB against 228 MB for int8 — on
-  the COS download and on disk, per robot.
-- **Accuracy is different, not obviously better.** On these four clips the two
-  dtypes disagree in both directions (int8 produced `礼拜2` where fp32 gave
-  `礼2`; fp32 emitted a spurious leading `，`). Four clips cannot settle it —
+fp16 is the best of these: fastest, half the size of fp32, and transcript-identical
+to it. It is produced from the fp32 ONNX with
+`onnxconverter_common.float16.convert_float_to_float16(model, keep_io_types=True)`
+— `keep_io_types` is required because sherpa hands the session fp32 features, and
+shape inference must be left **on** (`disable_shape_infer=False`), otherwise the
+Cast fencing around block-listed ops is placed wrongly and ONNX Runtime rejects the
+model with `Type 'tensor(float16)' ... of operator (Range) ... is invalid`.
+
+Caveats before acting on this:
+
+- **`auto` does not yet know about fp16.** `is_quantised()` only looks for
+  `int8` in the filename, so an fp16 model resolves to `cuda` — correct — but it
+  would also resolve to `cuda` on a CPU-only wheel, where fp16 is catastrophic
+  (13 s vs 2 s). If fp16 models get deployed, that rule needs a matching guard.
+- **Accuracy versus int8 is different, not obviously better.** On these four clips
+  int8 and fp32/fp16 disagree in both directions (int8 produced `礼拜2` where fp32
+  gave `礼2`; fp32 emitted a spurious leading `，`). Four clips cannot settle it;
   switching dtype needs a labelled set.
-- **Streaming is untested at fp32.** These fp32 numbers are the *offline*
-  recogniser. At int8 the streaming path was 3x worse than offline relative to CPU
-  (0.30x vs 0.89x), so sherpa's per-chunk decode carries real GPU overhead and a
-  streaming fp32 model may not see anything like 11x. The deployed default
-  (`paraformer-zh-en`) is streaming.
-- **fp16 is probably the better target than fp32** and has not been measured:
-  Orin's fp16 throughput is far above fp32 and ONNX Runtime's CUDA provider has
-  full fp16 kernel coverage (unlike int8), so it should keep the GPU win at
-  roughly half the memory and bandwidth. It needs an fp32→fp16 ONNX conversion
-  and a check that sherpa-onnx feeds it correctly.
+- **Streaming is untested at fp32/fp16.** These numbers are the *offline*
+  recogniser. At int8 the streaming path was far worse than offline relative to CPU
+  (0.30x vs 0.73x), so sherpa's per-chunk decode carries real GPU overhead and a
+  streaming fp32/fp16 model may not see anything like these ratios. The deployed
+  default (`paraformer-zh-en`) is streaming.
+- **The cheapest win needs no GPU at all.** int8 at `num_threads: 4` is 1.52x for
+  a one-line config change and no extra bytes on disk.
+- **int16 is not a middle ground.** ONNX Runtime's int16 quantisation
+  (`QInt16`/`QUInt16`, opset 21) is newer than int8, the CUDA provider has no
+  kernels for it either, and the CPU side lacks the dot-product paths that make
+  int8 fast — it would likely lose on both providers.
 
-GPU contention is not an alternative explanation for any of the above: the idle
-`GR3D_FREQ` baseline was 0%, and GR3D sat at 88–97% during the CUDA runs, so the
-work does reach the GPU — int8 is simply slower there. The same thread-sensitivity
-signature shows up on the streaming int8 model too (17861 → 11125 → 10524 ms at
-1/2/4 threads on CUDA).
+GPU contention is not an alternative explanation for any of the above: every run
+above was taken with `embodied-perception` and `agent-core` stopped, the idle
+`GR3D_FREQ` baseline verified at 0% per run, and GR3D at 88–97% during the CUDA
+runs — so the work does reach the GPU, and int8 is simply slower there. The
+thread-sensitivity signature shows up on the streaming int8 model too
+(17861 → 11125 → 10524 ms at 1/2/4 threads on CUDA). Contention is not a
+hypothetical concern: an earlier X-ASR run taken while another container was
+building TensorRT engines read 0.50x instead of 0.80x.
 
 So `auto` keeps every int8 ASR/KWS bundle on CPU and gives fp32 models — Matcha
 TTS today — the GPU. `is_quantised()` decides from the filename (`*.int8.onnx`),
 the same convention `asr.py`'s `_find(prefer_int8=...)` already relies on.
-
-One more caveat on the rule's reach: `int16` is not a middle ground worth trying.
-ONNX Runtime's int16 quantisation (`QInt16`/`QUInt16`, opset 21) is newer than
-int8, the CUDA provider has no kernels for it either, and the CPU side lacks the
-dot-product paths that make int8 fast — it would likely lose on both providers.
 
 **What follows `hw_provider`:** ASR (all sherpa adapters, including X-ASR), KWS,
 and the `sherpa_onnx` TTS engine.

--- a/perception/README.md
+++ b/perception/README.md
@@ -93,24 +93,53 @@ ONNX Runtime's CUDA execution provider has no kernels for the quantised ops in a
 int8 model. It partitions the graph and falls back to CPU node by node, inserting
 a host↔device copy at every boundary — so an int8 model runs *slower* on the GPU
 than on the CPU. Measured on orin5 (Orin NX, JetPack 5.11, CUDA 11.4, 6 cores),
-sherpa-onnx 1.13.6+cuda, same audio, steady-state median over 5–10 rounds:
+sherpa-onnx 1.13.6+cuda, same audio, steady-state median. Both providers were
+swept across 1/2/4 `num_threads`, because the ratio moves a lot with thread count
+and a single-thread-count comparison overstates the effect in both directions:
 
-| model | CPU (2 threads) | CUDA | |
-|-------|-----------------|------|---|
-| streaming paraformer `encoder.int8.onnx` (30.7 s audio) | 3412 ms | 10804 ms | **0.32x** |
-| offline SenseVoice `model.int8.onnx` (28.7 s audio) | 2021 ms | 3787 ms | **0.53x** |
-| Matcha TTS fp32 `model-steps-3.onnx` (13.3 s audio) | 1751 ms | 400 ms | **4.38x** |
+| model | dtype | CPU t=2 | CUDA t=2 | ratio | best CPU | best CUDA | ratio |
+|-------|-------|---------|----------|-------|----------|-----------|-------|
+| streaming paraformer `encoder.int8.onnx` (30.7 s audio) | int8 | 3383 ms | 11125 ms | **0.30x** | 3097 ms (t=4) | 10524 ms (t=4) | **0.29x** |
+| X-ASR offline transducer, beam search (28.7 s audio) | int8 encoder+joiner, fp32 decoder | 2832 ms | 5707 ms | **0.50x** | 2503 ms (t=4) | 5707 ms (t=2) | **0.44x** |
+| offline SenseVoice `model.int8.onnx` (28.7 s audio) | int8 | 2022 ms | 2341 ms | **0.86x** | 1354 ms (t=4) | 1694 ms (t=4) | **0.80x** |
+| Matcha TTS `model-steps-3.onnx` + vocos (13.3 s audio) | fp32 | 1784 ms | 416 ms | **4.28x** | 1175 ms (t=4) | 416 ms (t=1) | **2.83x** |
 
-Transcripts were byte-identical between providers, so this is throughput, not
-correctness. `auto` therefore keeps every int8 ASR/KWS bundle on CPU and gives
-Matcha TTS the GPU. `is_quantised()` decides from the filename (`*.int8.onnx`),
-the same convention `asr.py`'s `_find(prefer_int8=...)` already relies on.
+`num_threads: 2` is what `config.yaml` deploys, so the `t=2` columns are the
+operationally relevant ones; the best-of-each columns are there because the CPU
+scales further with threads while CUDA does not (Matcha at t=4 regresses to
+538 ms, X-ASR to 6238 ms). Model load also gets slower on CUDA — X-ASR went from
+~8.6 s to ~11 s.
 
-Caveat: the int8 rule is what the data supports. A *streaming* fp32 model is
-untested — the streaming-vs-offline gap above (0.32x vs 0.53x at the same dtype)
-shows sherpa's per-chunk decode adds GPU overhead of its own, so a streaming fp32
-model may not approach Matcha's 4.4x. Pin `hw_provider: cpu` if you deploy one and
-it disappoints.
+X-ASR is the useful case for the rule as written: its bundle is *mixed* precision
+(int8 encoder and joiner, fp32 decoder), `is_quantised()` treats any int8 file as
+disqualifying, and the measurement confirms that is the right call.
+
+Transcripts were byte-identical between providers on the greedy paraformer path.
+On X-ASR they were not — 1 of 4 clips differed, by one character, and both
+candidates were hesitation particles (「嗯」on CPU vs「呃」on CUDA). X-ASR decodes
+with `modified_beam_search` (`max_active_paths=10`), so provider-level numeric
+differences can reorder near-tied beams. That is a behavioural difference, not a
+correctness regression, but it is a reason not to switch providers casually on a
+beam-search model.
+
+The per-node fallback is not merely inferred from the int8/fp32 contrast: on the
+streaming int8 model the **CUDA** path speeds up 1.7x when given more **CPU**
+threads (17861 → 11125 → 10524 ms for 1/2/4 threads). Thread count would hardly
+matter if the graph were running on the GPU. Nor is GPU contention the
+explanation — the idle `GR3D_FREQ` baseline was 0%, and GR3D sat at 88–92% during
+the CUDA runs, so the work does reach the GPU; it is just slower there.
+
+So `auto` keeps every int8 ASR/KWS bundle on CPU and gives Matcha TTS the GPU.
+`is_quantised()` decides from the filename (`*.int8.onnx`), the same convention
+`asr.py`'s `_find(prefer_int8=...)` already relies on.
+
+Caveats: the int8 rule holds for these shapes only. A *streaming* fp32 model is
+untested, and the streaming-vs-offline gap at the same dtype is large (0.30x vs
+0.86x) — sherpa's per-chunk decode carries real GPU overhead of its own, so a
+streaming fp32 model may land nowhere near Matcha's speed-up. Pin
+`hw_provider: cpu` if you deploy one and it disappoints. Note also that offline
+int8 is close to parity (0.80–0.86x), not a cliff; the decisive regression is the
+streaming case.
 
 **What follows `hw_provider`:** ASR (all sherpa adapters, including X-ASR), KWS,
 and the `sherpa_onnx` TTS engine.

--- a/perception/README.md
+++ b/perception/README.md
@@ -75,146 +75,154 @@ The VAD parameters can be adjusted per ASR canvas card via the instance config (
 
 ---
 
-## sherpa-onnx Execution Provider
+## sherpa-onnx Device Selection
 
-`hw_provider` (under `plugins.asr` and `plugins.tts` in `config.yaml`) selects the
-ONNX Runtime provider for everything that goes through sherpa-onnx. `auto` is the
-default and is resolved by `utils/onnx_provider.py`:
+`device: cpu | gpu` (under `plugins.asr` and `plugins.tts` in `config.yaml`, and on
+the dashboard's config form) selects where sherpa-onnx runs. It defaults to `cpu`.
 
-| Value | Behaviour |
-|-------|-----------|
-| `auto` | `cuda` only if the installed wheel bundles `libonnxruntime_providers_cuda.so` **and** the model's weight files are fp32. Otherwise `cpu`. |
-| `cuda` | Passed through unchanged. Either a deliberate override or a misconfigured deployment — both should stay visible. |
-| `cpu` | Passed through unchanged. |
+**The model follows the device, not the other way round.** `ASR_MODELS` in
+`plugins/asr.py` maps each (model, device) pair to the weights that pair loads,
+because the best weights differ per device: quantised weights are right on the CPU
+and wrong on the GPU. `device: gpu` therefore downloads a different bundle, not
+just a different provider string.
 
-### Why the fp32 condition exists
+| `asr_model` | `device: cpu` | `device: gpu` | gpu speed-up |
+|-------------|---------------|---------------|--------------|
+| `sensevoice-small` (default) | int8, 228 MB | **fp16, 448 MB** | **5.81x** |
+| `paraformer-zh-en` (streaming) | int8, 226 MB | **fp32, 825 MB** | **1.77x** |
+| `x-asr-zh-en` | int8 + fp32 | — not offered | 0.80x, i.e. slower |
+| `paraformer-offline` | int8 | — not offered | unmeasured |
+| `zipformer-en` | int8 | — not offered | unmeasured |
+
+TTS is simpler: Matcha is fp32 only, so both devices load the same files and
+`device` only picks the provider (gpu measured ~4.3x). The `vits2_trt` engine
+ignores `device` entirely — it is a TensorRT engine and never touches ONNX Runtime.
+
+`device: gpu` also needs the CUDA sherpa-onnx wheel, which only the jp5.11 image
+installs (see § The jp5.11 CUDA wheel). On jp6.1 and x86 dev hosts it falls back to
+`cpu` with a warning rather than failing to start.
+
+### Measurements
+
+orin5 (Orin NX, JetPack 5.11, CUDA 11.4, 6 cores), sherpa-onnx 1.13.6+cuda,
+steady-state median, **on an idle box** — `embodied-perception` and `agent-core`
+stopped, idle `GR3D_FREQ` verified 0% before each run. Both providers swept across
+1/2/4 `num_threads`, because the ratio moves a lot with thread count:
+
+| model | dtype | CPU t=2 | CUDA t=2 | ratio |
+|-------|-------|---------|----------|-------|
+| streaming paraformer (30.7 s audio) | int8 | 3295 ms | 8394 ms | **0.39x** |
+| streaming paraformer | fp32 | 8702 ms | **1859 ms** | **4.68x** |
+| streaming paraformer | fp16 | 42890 ms | 2077 ms | 20.65x ⚠️ broken, see below |
+| X-ASR, beam search (28.7 s audio) | int8 | 2645 ms | 3294 ms | **0.80x** |
+| offline SenseVoice (28.7 s audio) | int8 | 1996 ms | 2753 ms | **0.73x** |
+| offline SenseVoice | fp32 | 4792 ms | 416 ms | **11.52x** |
+| offline SenseVoice | fp16 | 8117 ms | **344 ms** | **23.60x** |
+| Matcha TTS (13.3 s audio) | fp32 | 1784 ms | 416 ms | **4.28x** |
+
+`num_threads: 2` is what `config.yaml` deploys. Threads matter on the CPU (4
+threads buys roughly 1.2–1.5x) and not at all on the GPU for non-quantised weights.
+
+### Why int8 loses on the GPU
 
 ONNX Runtime's CUDA execution provider has no kernels for the quantised ops in an
-int8 model. It partitions the graph and falls back to CPU node by node, inserting
-a host↔device copy at every boundary — so an int8 model runs *slower* on the GPU
-than on the CPU. Measured on orin5 (Orin NX, JetPack 5.11, CUDA 11.4, 6 cores),
-sherpa-onnx 1.13.6+cuda, same audio, steady-state median, **on an idle box** (all
-services stopped, idle `GR3D_FREQ` 0%, verified per run). Both providers were swept
-across 1/2/4 `num_threads`, because the ratio moves a lot with thread count and a
-single-thread-count comparison overstates the effect in both directions:
+int8 model. It partitions the graph and falls back to CPU node by node, inserting a
+host↔device copy at every boundary.
 
-| model | dtype | CPU t=2 | CUDA t=2 | ratio | best CPU | best CUDA | ratio |
-|-------|-------|---------|----------|-------|----------|-----------|-------|
-| streaming paraformer `encoder.int8.onnx` (30.7 s audio) | int8 | 3383 ms | 11125 ms | **0.30x** | 3097 ms (t=4) | 10524 ms (t=4) | **0.29x** |
-| X-ASR offline transducer, beam search (28.7 s audio) | int8 encoder+joiner, fp32 decoder | 2645 ms | 3294 ms | **0.80x** | 2200 ms (t=4) | 2896 ms (t=4) | **0.76x** |
-| offline SenseVoice `model.int8.onnx` (28.7 s audio) | int8 | 1996 ms | 2753 ms | **0.73x** | 1314 ms (t=4) | 1905 ms (t=4) | **0.69x** |
-| offline SenseVoice `model.onnx` (28.7 s audio) | **fp32** | 4792 ms | **416 ms** | **11.52x** | 2784 ms (t=4) | 415 ms (t=4) | **6.71x** |
-| offline SenseVoice `model.fp16.onnx` (28.7 s audio) | **fp16** | 8117 ms | **344 ms** | **23.60x** | 5652 ms (t=4) | 343 ms (t=1) | **16.48x** |
-| Matcha TTS `model-steps-3.onnx` + vocos (13.3 s audio) | fp32 | 1784 ms | 416 ms | **4.28x** | 1175 ms (t=4) | 416 ms (t=1) | **2.83x** |
+Two independent confirmations, not just the int8/fp32 correlation:
 
-`num_threads: 2` is what `config.yaml` deploys, so the `t=2` columns are the
-operationally relevant ones; the best-of-each columns are there because the CPU
-scales further with threads while CUDA does not (Matcha at t=4 regresses to
-538 ms). Model load also gets slower on CUDA for int8 — X-ASR went from ~8.0 s to
-~10.4 s — but *faster* for fp16 (4.5 s versus 10.6 s on CPU).
+- fp32 and fp16 on CUDA are **completely insensitive to CPU thread count**
+  (417/416/415 and 343/344/346 ms at 1/2/4) with GR3D pinned at 95–97% — the graph
+  really is on the GPU. int8 on CUDA instead **scales with CPU threads**
+  (3793 → 2753 → 1905 ms for SenseVoice, 17861 → 11125 → 10524 for streaming
+  paraformer), which only makes sense if much of it is executing on the CPU.
+- Requantising at every partition boundary perturbs the output. Same model, same
+  audio, `num_threads=2`, CPU vs CUDA: SenseVoice int8 differed on **3 of 4** clips,
+  including `不然` → `主然` — a real word error, not punctuation. SenseVoice fp32 and
+  fp16 differed on **0 of 4**.
 
-X-ASR is the useful case for the rule as written: its bundle is *mixed* precision
-(int8 encoder and joiner, fp32 decoder), `is_quantised()` treats any int8 file as
-disqualifying, and the measurement confirms that is the right call.
+GPU contention is not an alternative explanation: the idle `GR3D_FREQ` baseline was
+0% for every run above. That is not a hypothetical — an earlier X-ASR run taken
+while another container was building TensorRT engines read 0.50x instead of 0.80x.
 
-The three SenseVoice rows are the same model in three dtypes, which is what makes
-this a dtype result rather than a per-model coincidence: int8 loses on CUDA, fp32
-wins by 11.5x, fp16 by 23.6x. Mechanism confirmed two ways — fp32 and fp16 on CUDA
-are completely insensitive to thread count (417/416/415 and 343/344/346 ms at
-1/2/4) with GR3D pinned at 95–97%, i.e. the graph really is on the GPU; int8-CUDA
-instead scales with **CPU** threads (3793 → 2753 → 1905 ms), i.e. much of it is
-not.
+`int16` is not a middle ground worth trying: ONNX Runtime's int16 quantisation
+(`QInt16`/`QUInt16`, opset 21) is newer than int8, the CUDA provider has no kernels
+for it either, and the CPU side lacks the dot-product paths that make int8 fast.
 
-fp16 is the mirror image: it is the fastest thing on the GPU and the *slowest*
-thing on the CPU (13051 ms at one thread, 4x worse than int8), because ONNX
-Runtime has no fp16 CPU kernels and casts everything. fp16 is a GPU-only choice.
+### Admitting a new (model, device) pair
 
-### int8 on CUDA also changes the output
+The `gpu` column above is short because each entry had to earn its place. **A pair
+is only added to `ASR_MODELS` after decoding real audio on the target device and
+reading the text.**
 
-Beyond throughput, the per-node fallback is numerically noisy: requantising at
-every int8↔fp32 partition boundary perturbs results. Same model, same audio,
-`num_threads=2`:
+That rule exists because of one result. Streaming paraformer fp16 on CUDA:
 
-- SenseVoice **int8**: CPU vs CUDA differed on **3 of 4** clips — not only
-  punctuation but a real word substitution (`不然` → `主然`).
-- SenseVoice **fp32**: CPU vs CUDA differed on **0 of 4** clips.
-- SenseVoice **fp16**: identical to fp32 on **all** clips, on both providers — so
-  the fp16 conversion cost nothing measurable here.
-- X-ASR (int8 encoder/joiner, beam search): differed on 1 of 4, by one character
-  (「嗯」vs「呃」, both hesitation particles). Beam search reorders near-tied
-  hypotheses under provider-level numeric differences.
-- streaming paraformer int8 with greedy search: byte-identical.
+- created an ONNX Runtime session without complaint,
+- ran in 2077 ms, 20x faster than the same file on CPU,
+- produced byte-identical output across all three thread counts,
+- and emitted nothing but `</s> </s> </s> …`.
 
-So keeping int8 models on CPU buys output stability as well as speed. Conversely,
-fp32 and fp16 are provider-consistent, so moving them to the GPU does not change
-what they transcribe.
+The same fp16 file on CPU transcribed correctly, so the conversion was fine and the
+CUDA+fp16+streaming *combination* is not. Session creation, speed, and
+self-consistency were all green. Only reading the text caught it. (fp16 is also
+slower than fp32 for that model, so there was nothing to gain by debugging it —
+`paraformer-zh-en`'s gpu entry is fp32.)
 
-### Putting ASR on the GPU
+Checklist:
 
-It is possible, and the code already supports fp32 — but it needs a **model
-change, not a config change**. Ship non-int8 weights and `hw_provider: auto`
-routes them to CUDA on its own. Against the 1996 ms the deployed int8-on-CPU takes
-on the same audio:
+1. Benchmark both devices across 1/2/4 threads on an idle box, and verify the idle
+   `GR3D_FREQ` is 0% first.
+2. Decode real audio on the target device and read the transcripts. Compare against
+   the same weights on the other provider, and against the cpu entry.
+3. Add the entry to `ASR_MODELS` with its `dtype`, and add the pinned bundle to
+   `SHERPA_GPU_BUNDLES` in `utils/model_downloader.py`.
+4. Add the model to the `device` field's `x-show-when` list in the configSchema.
+   `tests/test_asr_device_registry.py` asserts that list matches the registry, that
+   no gpu entry is int8, and that no cpu entry is fp16.
 
-| option | model size | CUDA t=2 | vs deployed |
-|--------|-----------|----------|-------------|
-| int8 on CPU (deployed) | 228 MB | — | 1.00x |
-| int8 on CPU, `num_threads: 4` | 228 MB | — | 1.52x (no model change at all) |
-| fp32 on CUDA | 894 MB | 416 ms | **4.80x** |
-| fp16 on CUDA | 448 MB | 344 ms | **5.81x** |
+### Producing fp16 weights
 
-fp16 is the best of these: fastest, half the size of fp32, and transcript-identical
-to it. It is produced from the fp32 ONNX with
-`onnxconverter_common.float16.convert_float_to_float16(model, keep_io_types=True)`
-— `keep_io_types` is required because sherpa hands the session fp32 features, and
-shape inference must be left **on** (`disable_shape_infer=False`), otherwise the
-Cast fencing around block-listed ops is placed wrongly and ONNX Runtime rejects the
-model with `Type 'tensor(float16)' ... of operator (Range) ... is invalid`.
+`tools/convert_onnx_fp16.py` converts an fp32 sherpa-onnx model. Two flags are
+load-bearing:
 
-Caveats before acting on this:
+- `keep_io_types=True` — sherpa hands the session fp32 features, so only the graph
+  interior may be fp16.
+- shape inference must stay **on**. Ops that cannot take fp16 (`Range` above all)
+  are already in onnxconverter-common's default `op_block_list` and get fenced with
+  Cast nodes, but placing those Casts needs shape inference. Disabling it produces
+  a file that saves fine and then fails at session creation with
+  `Type 'tensor(float16)' of input parameter (…) of operator (Range) … is invalid`.
 
-- **`auto` does not yet know about fp16.** `is_quantised()` only looks for
-  `int8` in the filename, so an fp16 model resolves to `cuda` — correct — but it
-  would also resolve to `cuda` on a CPU-only wheel, where fp16 is catastrophic
-  (13 s vs 2 s). If fp16 models get deployed, that rule needs a matching guard.
-- **Accuracy versus int8 is different, not obviously better.** On these four clips
-  int8 and fp32/fp16 disagree in both directions (int8 produced `礼拜2` where fp32
-  gave `礼2`; fp32 emitted a spurious leading `，`). Four clips cannot settle it;
-  switching dtype needs a labelled set.
-- **Streaming is untested at fp32/fp16.** These numbers are the *offline*
-  recogniser. At int8 the streaming path was far worse than offline relative to CPU
-  (0.30x vs 0.73x), so sherpa's per-chunk decode carries real GPU overhead and a
-  streaming fp32/fp16 model may not see anything like these ratios. The deployed
-  default (`paraformer-zh-en`) is streaming.
-- **The cheapest win needs no GPU at all.** int8 at `num_threads: 4` is 1.52x for
-  a one-line config change and no extra bytes on disk.
-- **int16 is not a middle ground.** ONNX Runtime's int16 quantisation
-  (`QInt16`/`QUInt16`, opset 21) is newer than int8, the CUDA provider has no
-  kernels for it either, and the CPU side lacks the dot-product paths that make
-  int8 fast — it would likely lose on both providers.
+fp16 is a **GPU-only** choice: ONNX Runtime has no fp16 CPU kernels and casts
+everything, which is why the streaming fp16 CPU row above is 42890 ms against
+int8's 3295 ms. `provider_for_device()` logs an error if a cpu entry ever points at
+fp16 weights, and the registry test rejects it.
 
-GPU contention is not an alternative explanation for any of the above: every run
-above was taken with `embodied-perception` and `agent-core` stopped, the idle
-`GR3D_FREQ` baseline verified at 0% per run, and GR3D at 88–97% during the CUDA
-runs — so the work does reach the GPU, and int8 is simply slower there. The
-thread-sensitivity signature shows up on the streaming int8 model too
-(17861 → 11125 → 10524 ms at 1/2/4 threads on CUDA). Contention is not a
-hypothetical concern: an earlier X-ASR run taken while another container was
-building TensorRT engines read 0.50x instead of 0.80x.
+### What does not follow `device`
 
-So `auto` keeps every int8 ASR/KWS bundle on CPU and gives fp32 models — Matcha
-TTS today — the GPU. `is_quantised()` decides from the filename (`*.int8.onnx`),
-the same convention `asr.py`'s `_find(prefer_int8=...)` already relies on.
+- **KWS** is pinned to CPU. Its zipformer bundle ships int8 only, and int8 on CUDA
+  lost on every model measured, so there is nothing to gain.
+- **VAD** is pinned to CPU in both code paths (`_vad_worker` and
+  `_vad_segment_sync`). silero infers one 512-sample window at a time — too little
+  work to amortise a kernel launch plus two copies per 32 ms of audio — and in
+  `_vad_worker` it would hold a second CUDA context in a child process.
+- **`vits2_trt` TTS**, as above: TensorRT, not ONNX Runtime.
 
-**What follows `hw_provider`:** ASR (all sherpa adapters, including X-ASR), KWS,
-and the `sherpa_onnx` TTS engine.
+### GPU bundle distribution
 
-**What does not:** the VAD, in both `_vad_worker` and the `ws_asr` path, is pinned
-to `provider="cpu"`. silero VAD infers one 512-sample window at a time, so a CUDA
-session would pay a kernel launch plus a H2D/D2H copy per 32 ms of audio for a
-model that finishes on a single core — and in `_vad_worker` it would hold a second
-CUDA context in a child process. The `vits2_trt` TTS engine also ignores it: that
-is a TensorRT engine and never touches ONNX Runtime.
+`device: gpu` weights come from `SHERPA_GPU_BUNDLES` in `utils/model_downloader.py`
+and are fetched with `ensure_verified_bundle`, which pins every file's size and
+SHA256. The cpu bundles use `ensure_model`, whose only integrity check is "does
+`check_file` exist in the archive" — acceptable for a 230 MB archive, not for a
+780 MB one, where a truncated transfer would pass and then fail confusingly at
+session creation.
+
+Provenance: the fp32 weights come from `pengzhendong`'s ModelScope mirrors of the
+k2-fsa model zoo, accepted only after that mirror's int8 files were confirmed
+**byte-identical** (SHA256) to the copies we already deploy from COS. The fp16 files
+are converted from those with `tools/convert_onnx_fp16.py`.
+
+---
 
 ### The jp5.11 CUDA wheel
 
@@ -265,8 +273,8 @@ Notes:
 jp6.1 (CUDA 12.6). That target needs its own build with
 `SHERPA_ONNX_LINUX_ARM64_GPU_ONNXRUNTIME_VERSION=1.18.1` and
 `PYTHON_EXECUTABLE=python3.10`, run on a JetPack 6 host inside
-`jetson-base:jp61-torch`. Until then jp6.1 stays on the CPU wheel and `auto`
-resolves to `cpu`.
+`jetson-base:jp61-torch`. Until then jp6.1 stays on the CPU wheel and
+`device: gpu` falls back to `cpu` there.
 
 ---
 

--- a/perception/README.md
+++ b/perception/README.md
@@ -75,6 +75,107 @@ The VAD parameters can be adjusted per ASR canvas card via the instance config (
 
 ---
 
+## sherpa-onnx Execution Provider
+
+`hw_provider` (under `plugins.asr` and `plugins.tts` in `config.yaml`) selects the
+ONNX Runtime provider for everything that goes through sherpa-onnx. `auto` is the
+default and is resolved by `utils/onnx_provider.py`:
+
+| Value | Behaviour |
+|-------|-----------|
+| `auto` | `cuda` only if the installed wheel bundles `libonnxruntime_providers_cuda.so` **and** the model's weight files are fp32. Otherwise `cpu`. |
+| `cuda` | Passed through unchanged. Either a deliberate override or a misconfigured deployment — both should stay visible. |
+| `cpu` | Passed through unchanged. |
+
+### Why the fp32 condition exists
+
+ONNX Runtime's CUDA execution provider has no kernels for the quantised ops in an
+int8 model. It partitions the graph and falls back to CPU node by node, inserting
+a host↔device copy at every boundary — so an int8 model runs *slower* on the GPU
+than on the CPU. Measured on orin5 (Orin NX, JetPack 5.11, CUDA 11.4, 6 cores),
+sherpa-onnx 1.13.6+cuda, same audio, steady-state median over 5–10 rounds:
+
+| model | CPU (2 threads) | CUDA | |
+|-------|-----------------|------|---|
+| streaming paraformer `encoder.int8.onnx` (30.7 s audio) | 3412 ms | 10804 ms | **0.32x** |
+| offline SenseVoice `model.int8.onnx` (28.7 s audio) | 2021 ms | 3787 ms | **0.53x** |
+| Matcha TTS fp32 `model-steps-3.onnx` (13.3 s audio) | 1751 ms | 400 ms | **4.38x** |
+
+Transcripts were byte-identical between providers, so this is throughput, not
+correctness. `auto` therefore keeps every int8 ASR/KWS bundle on CPU and gives
+Matcha TTS the GPU. `is_quantised()` decides from the filename (`*.int8.onnx`),
+the same convention `asr.py`'s `_find(prefer_int8=...)` already relies on.
+
+Caveat: the int8 rule is what the data supports. A *streaming* fp32 model is
+untested — the streaming-vs-offline gap above (0.32x vs 0.53x at the same dtype)
+shows sherpa's per-chunk decode adds GPU overhead of its own, so a streaming fp32
+model may not approach Matcha's 4.4x. Pin `hw_provider: cpu` if you deploy one and
+it disappoints.
+
+**What follows `hw_provider`:** ASR (all sherpa adapters, including X-ASR), KWS,
+and the `sherpa_onnx` TTS engine.
+
+**What does not:** the VAD, in both `_vad_worker` and the `ws_asr` path, is pinned
+to `provider="cpu"`. silero VAD infers one 512-sample window at a time, so a CUDA
+session would pay a kernel launch plus a H2D/D2H copy per 32 ms of audio for a
+model that finishes on a single core — and in `_vad_worker` it would hold a second
+CUDA context in a child process. The `vits2_trt` TTS engine also ignores it: that
+is a TensorRT engine and never touches ONNX Runtime.
+
+### The jp5.11 CUDA wheel
+
+PyPI ships CPU-only `sherpa-onnx`, so `Dockerfile.jetson` downloads a wheel built
+in-house for JetPack 5.11 from COS
+(`public/sherpa-onnx/sherpa_onnx-<ver>+cuda-cp38-cp38-linux_aarch64.whl`) and
+falls back to the PyPI CPU wheel for every other `JP_VERSION`.
+
+To rebuild it, build **inside a container started from the perception image** for
+the target JetPack — that image already carries cmake, g++, the matching CPython
+headers and CUDA, so the pybind extension lands on the right CPython ABI and
+glibc. Building on the host instead is what produces an unusable wheel: the
+extension is tagged `cp<major><minor>` and will not import under a different
+Python.
+
+```bash
+# on the build host (must match the target JetPack: jp5.11 → L4T R35, jp6.1 → R36)
+docker run -d --name sherpa-build \
+  -v /path/to/k2-fsa/sherpa-onnx:/src:ro -v /path/to/outdir:/out \
+  --entrypoint bash <perception-image-for-that-jp> /out/build.sh
+
+# inside, against a *writable* copy of the tree (setup.py appends __version__ to it):
+export SHERPA_ONNX_ENABLE_GPU=ON
+export SHERPA_ONNX_LINUX_ARM64_GPU_ONNXRUNTIME_VERSION=1.16.0   # jp5.11 / CUDA 11.4
+export SHERPA_ONNX_MAKE_ARGS="-j2"                              # Orin has 6 cores but ~4 GB free
+SHERPA_ONNX_CMAKE_ARGS="-DCMAKE_BUILD_TYPE=Release \
+  -DSHERPA_ONNX_ENABLE_GPU=ON \
+  -DSHERPA_ONNX_LINUX_ARM64_GPU_ONNXRUNTIME_VERSION=1.16.0 \
+  -DPYTHON_EXECUTABLE=/usr/bin/python3.8 \
+  -DPython_EXECUTABLE=/usr/bin/python3.8" \
+  python3.8 setup.py bdist_wheel
+```
+
+Notes:
+
+- `setup.py bdist_wheel` builds its **own** cmake tree at
+  `build/temp.linux-aarch64-cpython-<ver>/` with `SHERPA_ONNX_ENABLE_PYTHON=ON`. A
+  tree left behind by `build-aarch64-linux-gnu.sh` has `ENABLE_PYTHON=OFF` and is
+  not reusable — expect a full compile.
+- To avoid re-downloading onnxruntime, drop
+  `onnxruntime-linux-aarch64-gpu-<ver>.tar.bz2` in `/tmp/`;
+  `cmake/onnxruntime-linux-aarch64-gpu.cmake` checks there before GitHub.
+- Upload the result under the `public/` COS prefix (anonymous read, same prefix
+  `utils/model_downloader.py` uses) and bump `SHERPA_GPU_WHEEL` in
+  `Dockerfile.jetson`.
+
+**TODO — jp6.1.** The jp5.11 wheel links `libcudart.so.11.0` and cannot run on
+jp6.1 (CUDA 12.6). That target needs its own build with
+`SHERPA_ONNX_LINUX_ARM64_GPU_ONNXRUNTIME_VERSION=1.18.1` and
+`PYTHON_EXECUTABLE=python3.10`, run on a JetPack 6 host inside
+`jetson-base:jp61-torch`. Until then jp6.1 stays on the CPU wheel and `auto`
+resolves to `cpu`.
+
+---
+
 ## Plugin Concurrency
 
 **`dispatch()` is not single-threaded.** `main.py` serves MCP over

--- a/perception/config.yaml
+++ b/perception/config.yaml
@@ -3,16 +3,19 @@ mcp_port: 15720
 plugins:
   asr:
     enabled: true
-    asr_model: paraformer-zh-en   # paraformer-zh-en | zipformer-en | sensevoice-small
-    model_dir: /models/sherpa-onnx/asr
-    # auto | cuda | cpu — auto picks cuda only when the image installed the CUDA
-    # sherpa-onnx wheel (jetson jp5.11) AND the model's weights are fp32. Every
-    # ASR/KWS bundle here is int8, and ONNX Runtime's CUDA provider has no int8
-    # kernels — it falls back per node, measured 1.25x-3.3x SLOWER than CPU at
-    # the same num_threads on an Orin NX. So this resolves to cpu today. Numbers
-    # and method in utils/onnx_provider.py.
-    hw_provider: auto
-    num_threads: 2
+    # Matches the configSchema default. SenseVoice on CPU is also the faster of
+    # the two int8 options (RTF 14.2x vs 9.1x for streaming paraformer) and has
+    # the largest gpu upside (fp16, ~5.8x).
+    asr_model: sensevoice-small   # x-asr-zh-en | paraformer-zh-en | paraformer-offline | zipformer-en | sensevoice-small
+    # cpu | gpu — which weights get loaded is per (model, device) in
+    # plugins/asr.py ASR_MODELS. gpu needs the CUDA sherpa-onnx wheel (jetson
+    # jp5.11 only) and is only offered for models where it was benchmarked and
+    # the transcripts were read: sensevoice-small (fp16, ~5.8x) and
+    # paraformer-zh-en (fp32, ~1.8x). Everything else is cpu-only — int8 weights
+    # are slower on CUDA, not faster, because ONNX Runtime's CUDA provider has no
+    # int8 kernels. Numbers and method in utils/onnx_provider.py.
+    device: cpu
+    num_threads: 2   # cpu only; 4 buys ~1.2-1.5x. Ignored on gpu.
     language: zh-CN
     vad:
       model: sherpa_onnx    # sherpa_onnx | silero (same silero_vad.onnx, via sherpa-onnx) | webrtc
@@ -35,9 +38,9 @@ plugins:
     warmup: true
     max_chunk_tokens: 256
     # sherpa_onnx engine only — vits2_trt runs on TensorRT and ignores this.
-    # Matcha's weights are fp32, so auto resolves to cuda on jp5.11 (measured
-    # 4.3x faster than CPU at num_threads=2, 2.8x at each side's best).
-    hw_provider: auto
+    # Matcha is fp32, so both devices load the same weights and only the provider
+    # changes; gpu measured ~4.3x faster at num_threads=2.
+    device: cpu
 
   vop:
     enabled: true

--- a/perception/config.yaml
+++ b/perception/config.yaml
@@ -10,12 +10,21 @@ plugins:
     # cpu | gpu — which weights get loaded is per (model, device) in
     # plugins/asr.py ASR_MODELS. gpu needs the CUDA sherpa-onnx wheel (jetson
     # jp5.11 only) and is only offered for models where it was benchmarked and
-    # the transcripts were read: sensevoice-small (fp16, ~5.8x) and
-    # paraformer-zh-en (fp32, ~1.8x). Everything else is cpu-only — int8 weights
-    # are slower on CUDA, not faster, because ONNX Runtime's CUDA provider has no
-    # int8 kernels. Numbers and method in utils/onnx_provider.py.
+    # the transcripts were read: sensevoice-small (fp16) and paraformer-zh-en
+    # (fp32). Everything else is cpu-only — int8 weights are slower on CUDA, not
+    # faster, because ONNX Runtime's CUDA provider has no int8 kernels.
+    #
+    # gpu is ~2.5x faster per utterance (77 ms vs 193 ms on a 1-4 s utterance)
+    # and costs ~2 GB RAM against ~0.5 GB on cpu, ~1.4 GB of it a CUDA context
+    # the process never returns. On a 7.4 GB Orin already running vop + OCR +
+    # TTS that is enough to run the box out of memory, so cpu is the default
+    # even on images that could use the GPU. Numbers in utils/onnx_provider.py.
     device: cpu
     num_threads: 2   # cpu only; 4 buys ~1.2-1.5x. Ignored on gpu.
+    # Decode 1 s of silence after the model loads. On gpu the first inference
+    # costs ~1.8 s (lazy kernels, cuDNN autotune, memory pool) against a 77 ms
+    # steady state; without this the operator pays it on their first utterance.
+    warmup: true
     language: zh-CN
     vad:
       model: sherpa_onnx    # sherpa_onnx | silero (same silero_vad.onnx, via sherpa-onnx) | webrtc

--- a/perception/config.yaml
+++ b/perception/config.yaml
@@ -5,7 +5,7 @@ plugins:
     enabled: true
     # Matches the configSchema default. SenseVoice on CPU is also the faster of
     # the two int8 options (RTF 14.2x vs 9.1x for streaming paraformer) and has
-    # the largest gpu upside (fp16, ~5.8x).
+    # the largest gpu upside (fp16).
     asr_model: sensevoice-small   # x-asr-zh-en | paraformer-zh-en | paraformer-offline | zipformer-en | sensevoice-small
     # cpu | gpu — which weights get loaded is per (model, device) in
     # plugins/asr.py ASR_MODELS. gpu needs the CUDA sherpa-onnx wheel (jetson
@@ -14,7 +14,7 @@ plugins:
     # (fp32). Everything else is cpu-only — int8 weights are slower on CUDA, not
     # faster, because ONNX Runtime's CUDA provider has no int8 kernels.
     #
-    # gpu is ~2.5x faster per utterance (77 ms vs 193 ms on a 1-4 s utterance)
+    # gpu is ~3.4x faster per utterance (58 ms vs 195 ms p50 on 1-4 s of speech)
     # and costs ~2 GB RAM against ~0.5 GB on cpu, ~1.4 GB of it a CUDA context
     # the process never returns. On a 7.4 GB Orin already running vop + OCR +
     # TTS that is enough to run the box out of memory, so cpu is the default
@@ -22,7 +22,7 @@ plugins:
     device: cpu
     num_threads: 2   # cpu only; 4 buys ~1.2-1.5x. Ignored on gpu.
     # Decode 1 s of silence after the model loads. On gpu the first inference
-    # costs ~1.8 s (lazy kernels, cuDNN autotune, memory pool) against a 77 ms
+    # costs ~1.7 s (lazy kernels, cuDNN autotune, memory pool) against a 58 ms
     # steady state; without this the operator pays it on their first utterance.
     warmup: true
     language: zh-CN

--- a/perception/config.yaml
+++ b/perception/config.yaml
@@ -5,7 +5,12 @@ plugins:
     enabled: true
     asr_model: paraformer-zh-en   # paraformer-zh-en | zipformer-en | sensevoice-small
     model_dir: /models/sherpa-onnx/asr
-    hw_provider: cpu
+    # auto | cuda | cpu — auto picks cuda only when the image installed the CUDA
+    # sherpa-onnx wheel (jetson jp5.11) AND the model's weights are fp32. Every
+    # ASR/KWS bundle here is int8, and ONNX Runtime's CUDA provider has no int8
+    # kernels — it falls back per node and measured 2-3x SLOWER than 2-thread CPU
+    # on an Orin NX. So this resolves to cpu today. See utils/onnx_provider.py.
+    hw_provider: auto
     num_threads: 2
     language: zh-CN
     vad:
@@ -28,6 +33,10 @@ plugins:
     speed: 1.0
     warmup: true
     max_chunk_tokens: 256
+    # sherpa_onnx engine only — vits2_trt runs on TensorRT and ignores this.
+    # Matcha's weights are fp32, so auto resolves to cuda on jp5.11 (measured
+    # 4.4x faster than 2-thread CPU).
+    hw_provider: auto
 
   vop:
     enabled: true

--- a/perception/config.yaml
+++ b/perception/config.yaml
@@ -8,9 +8,9 @@ plugins:
     # auto | cuda | cpu — auto picks cuda only when the image installed the CUDA
     # sherpa-onnx wheel (jetson jp5.11) AND the model's weights are fp32. Every
     # ASR/KWS bundle here is int8, and ONNX Runtime's CUDA provider has no int8
-    # kernels — it falls back per node, which measured 3.3x SLOWER than CPU at the
-    # same num_threads on an Orin NX. So this resolves to cpu today. Numbers and
-    # method in utils/onnx_provider.py.
+    # kernels — it falls back per node, measured 1.25x-3.3x SLOWER than CPU at
+    # the same num_threads on an Orin NX. So this resolves to cpu today. Numbers
+    # and method in utils/onnx_provider.py.
     hw_provider: auto
     num_threads: 2
     language: zh-CN

--- a/perception/config.yaml
+++ b/perception/config.yaml
@@ -8,8 +8,9 @@ plugins:
     # auto | cuda | cpu — auto picks cuda only when the image installed the CUDA
     # sherpa-onnx wheel (jetson jp5.11) AND the model's weights are fp32. Every
     # ASR/KWS bundle here is int8, and ONNX Runtime's CUDA provider has no int8
-    # kernels — it falls back per node and measured 2-3x SLOWER than 2-thread CPU
-    # on an Orin NX. So this resolves to cpu today. See utils/onnx_provider.py.
+    # kernels — it falls back per node, which measured 3.3x SLOWER than CPU at the
+    # same num_threads on an Orin NX. So this resolves to cpu today. Numbers and
+    # method in utils/onnx_provider.py.
     hw_provider: auto
     num_threads: 2
     language: zh-CN
@@ -35,7 +36,7 @@ plugins:
     max_chunk_tokens: 256
     # sherpa_onnx engine only — vits2_trt runs on TensorRT and ignores this.
     # Matcha's weights are fp32, so auto resolves to cuda on jp5.11 (measured
-    # 4.4x faster than 2-thread CPU).
+    # 4.3x faster than CPU at num_threads=2, 2.8x at each side's best).
     hw_provider: auto
 
   vop:

--- a/perception/plugins/asr.py
+++ b/perception/plugins/asr.py
@@ -300,8 +300,9 @@ TOOLS = [
                 # test_asr_device_registry.py asserts they match.
                 "device":        {"type": "string", "enum": ["cpu", "gpu"],
                                   "description": "Inference device. gpu loads non-quantised weights "
-                                                 "(SenseVoice fp16 ~5.8x, streaming paraformer fp32 ~1.8x "
-                                                 "vs int8-on-cpu) and needs the CUDA sherpa-onnx wheel",
+                                                 "(~2.5x faster per utterance) but costs ~2 GB RAM "
+                                                 "vs ~0.5 GB on cpu, ~1.4 GB of which a CUDA context "
+                                                 "never gives back — check headroom before enabling",
                                   "default": "cpu", "scope": "shared",
                                   "x-show-when": {"asr_model": ["paraformer-zh-en", "sensevoice-small"]}},
                 "trigger_mode":  {"type": "string", "enum": ["vad", "kws", "asr_kws"], "description": "Trigger mode (vad = always listen, kws = KWS model, asr_kws = ASR + phoneme matching)", "default": "kws", "scope": "shared"},
@@ -704,7 +705,45 @@ def _build_asr_adapter(cfg: dict) -> Optional[ASRAdapter]:
         ensure_model(spec["download"], model_dir)
 
     num_threads = int(cfg.get('num_threads', 2))
-    return model_info["adapter"](model_dir, device, num_threads)
+    adapter = model_info["adapter"](model_dir, device, num_threads)
+    if cfg.get('warmup', True):
+        _warmup_adapter(adapter, model_name, device)
+    return adapter
+
+
+def _silence_wav(seconds: float = 1.0) -> bytes:
+    import io
+    buf = io.BytesIO()
+    with wave.open(buf, 'wb') as w:
+        w.setnchannels(1)
+        w.setsampwidth(2)
+        w.setframerate(SAMPLE_RATE)
+        w.writeframes(b'\x00\x00' * int(SAMPLE_RATE * seconds))
+    return buf.getvalue()
+
+
+def _warmup_adapter(adapter: ASRAdapter, model_name: str, device: str) -> None:
+    """Decode one second of silence so the first real utterance is not the one
+    that pays initialisation.
+
+    On CUDA the first inference measured 1777 ms against a 77 ms steady state —
+    lazy kernel loading, cuDNN autotuning and the memory pool all land on it. That
+    is precisely the utterance an operator notices, because it arrives right after
+    the model finished loading. Warming up here moves the cost inside the `loading`
+    window the dashboard is already showing.
+
+    Best-effort: a model that cannot decode silence is not necessarily broken (and
+    would fail loudly on the first real utterance anyway), so a failure here is
+    logged and does not stop the plugin from coming up.
+    """
+    t0 = time.monotonic()
+    try:
+        adapter.transcribe(_silence_wav(), 'zh-CN')
+    except Exception as error:  # noqa: BLE001
+        log.warning("[asr] warmup of %s on %s failed: %s", model_name, device, error)
+        return
+    log.info("[asr] warmup: %s on %s took %.0f ms", model_name, device,
+             (time.monotonic() - t0) * 1000)
 
 
 # ── VAD Worker Process ────────────────────────────────────────────────────────

--- a/perception/plugins/asr.py
+++ b/perception/plugins/asr.py
@@ -143,40 +143,98 @@ def _phonemize_safe(text: str, lang: str) -> str:
 
 
 
-def _text_to_ipa(text: str) -> list:
-    """Convert text to IPA phoneme sequence using persistent espeak-ng backend.
-    Returns a list of IPA phoneme strings (one per word/character).
-    """
-    # Separate Chinese and non-Chinese segments
-    segments = []
-    current = ''
-    current_is_cjk = None
-    for char in text:
-        is_cjk = '\u4e00' <= char <= '\u9fff'
-        if current_is_cjk is None:
-            current_is_cjk = is_cjk
-        if is_cjk != current_is_cjk:
-            if current.strip():
-                segments.append((current.strip(), current_is_cjk))
-            current = ''
-            current_is_cjk = is_cjk
-        current += char
-    if current.strip():
-        segments.append((current.strip(), current_is_cjk))
+def _text_segments(text: str):
+    """Runs of CJK / non-CJK as `(start, end, is_cjk)` offsets into `text`.
 
+    Offsets rather than substrings because a phoneme index has to be mapped back to
+    a character index, and the previous code `strip()`ed each run before handing it
+    on, which silently broke that correspondence.
+    """
+    spans = []
+    run_start = None
+    run_is_cjk = None
+    for i, char in enumerate(text):
+        is_cjk = '\u4e00' <= char <= '\u9fff'
+        if run_is_cjk is None:
+            run_start, run_is_cjk = i, is_cjk
+        elif is_cjk != run_is_cjk:
+            spans.append((run_start, i, run_is_cjk))
+            run_start, run_is_cjk = i, is_cjk
+    if run_is_cjk is not None:
+        spans.append((run_start, len(text), run_is_cjk))
+
+    trimmed = []
+    for seg_start, seg_end, is_cjk in spans:
+        while seg_start < seg_end and text[seg_start].isspace():
+            seg_start += 1
+        while seg_end > seg_start and text[seg_end - 1].isspace():
+            seg_end -= 1
+        if seg_start < seg_end:
+            trimmed.append((seg_start, seg_end, is_cjk))
+    return trimmed
+
+
+def _segment_phones(seg_text: str, lang: str):
+    """``(phones, phonemized)``; phonemized is False on the character fallback."""
+    try:
+        ipa = _phonemize_safe(seg_text, lang)
+        # Remove tone numbers and diacritics for fuzzy matching
+        ipa = _re.sub(r'[0-9\u02e5\u02e6\u02e7\u02e8\u02e9\xb9\xb2\xb3\u2074\u2075]', '', ipa)
+        return [p for p in ipa.split() if p], True
+    except Exception:
+        return list(seg_text), False
+
+
+def _phone_char_ends(text: str, start: int, end: int, lang: str,
+                     phones: list, phonemized: bool) -> list:
+    """For one segment, the character offset each of its phonemes ends at.
+
+    Counted from growing prefixes of the segment, phonemized with the same function
+    that produced ``phones``, so the mapping is exact. The previous code
+    extrapolated it from a phonemes-per-character ratio, which ate a character
+    whenever that ratio was not uniform: for '\u5c0f\u6f58\u5c0f\u6f58\uff0c\u73b0\u5728\u53d1\u751f\u4ec0\u4e48\u4e86\uff1f' with end_pos=12 it
+    computed round(12 * 11 / 29) = 5 and cut five characters, dropping \u73b0 from the
+    result. It also measured that ratio over a *different* segmentation, since it
+    skipped punctuation where _text_to_ipa splits on it.
+    """
+    if not phonemized:
+        # One "phoneme" per character, so the mapping is the identity.
+        return list(range(start + 1, end + 1))
+    ends = []
+    for i in range(start + 1, end + 1):
+        prefix_phones, ok = _segment_phones(text[start:i], lang)
+        if not ok:
+            break
+        target = min(len(prefix_phones), len(phones))
+        while len(ends) < target:
+            ends.append(i)
+    # Phonemizing the whole segment can yield more phonemes than any prefix did —
+    # espeak is context-sensitive and warns about word-count mismatches on Chinese.
+    # Attribute the remainder to the segment's last character.
+    while len(ends) < len(phones):
+        ends.append(end)
+    return ends
+
+
+def _text_to_ipa(text: str, with_positions: bool = False):
+    """Convert text to an IPA phoneme sequence using the persistent espeak backend.
+
+    Returns the phoneme list, or ``(phones, char_ends)`` when ``with_positions`` is
+    set, where ``char_ends[i]`` is the offset in ``text`` just past the last
+    character that produced ``phones[i]``. Positions cost one phonemize call per
+    character, so they are opt-in — only asr_kws needs them, to find where the wake
+    word ends.
+    """
     ipa_seq = []
-    for seg_text, is_cjk in segments:
+    char_ends = []
+    for seg_start, seg_end, is_cjk in _text_segments(text):
         lang = 'cmn' if is_cjk else 'en-us'
-        try:
-            ipa = _phonemize_safe(seg_text, lang)
-            # Remove tone numbers and diacritics for fuzzy matching
-            ipa = _re.sub(r'[0-9˥˦˧˨˩¹²³⁴⁵]', '', ipa)
-            phones = [p for p in ipa.split() if p]
-            ipa_seq.extend(phones)
-        except Exception:
-            # Fallback: use characters as-is
-            ipa_seq.extend(list(seg_text))
-    return ipa_seq
+        phones, phonemized = _segment_phones(text[seg_start:seg_end], lang)
+        if with_positions:
+            char_ends.extend(_phone_char_ends(text, seg_start, seg_end, lang,
+                                              phones, phonemized))
+        ipa_seq.extend(phones)
+    return (ipa_seq, char_ends) if with_positions else ipa_seq
 
 
 def _phoneme_edit_distance(seq1: list, seq2: list) -> float:
@@ -255,70 +313,20 @@ def _find_keyword_in_ipa(text_ipa: list, keyword_ipa: list, threshold: float):
     return best_dist <= threshold, best_end
 
 
-def _extract_after_keyword(text: str, keyword_text: str, end_pos: int) -> str:
-    """Extract text after the matched keyword using IPA end_pos to locate cut point.
+def _text_after_phoneme(text: str, char_ends: list, end_pos: int) -> str:
+    """The text following the phoneme at ``end_pos - 1``, by exact character offset.
 
-    end_pos is the IPA phoneme index where the keyword match ends.
-    We map this back to the original text by counting phoneme-producing
-    characters and their IPA token counts per segment.
+    ``char_ends`` comes from ``_text_to_ipa(text, with_positions=True)``, so this is
+    a lookup rather than the estimate it replaces — and it needs no second
+    phonemization pass, which used to redo the work with a *different* segmentation
+    (it skipped punctuation where _text_to_ipa splits on it) and therefore could not
+    have agreed with the index it was given.
     """
-    # Build segments of phoneme-producing characters
-    segments = []
-    current = ''
-    current_is_cjk = None
-    for char in text:
-        is_cjk = '\u4e00' <= char <= '\u9fff'
-        is_alpha = char.isalpha()
-        if not is_cjk and not is_alpha:
-            continue
-        if current_is_cjk is None:
-            current_is_cjk = is_cjk
-        if is_cjk != current_is_cjk:
-            if current.strip():
-                segments.append((current.strip(), current_is_cjk))
-            current = ''
-            current_is_cjk = is_cjk
-        current += char
-    if current.strip():
-        segments.append((current.strip(), current_is_cjk))
+    if end_pos <= 0 or not char_ends:
+        return ''
+    cut = char_ends[min(end_pos, len(char_ends)) - 1]
+    return text[cut:].lstrip('\uff0c\u3002\uff01\uff1f\u3001\uff1b\uff1a,.!?;: ')
 
-    # Count IPA tokens per segment to find the text position for end_pos
-    ipa_idx = 0
-    phoneme_char_pos = 0
-
-    for seg_text, is_cjk in segments:
-        lang = 'cmn' if is_cjk else 'en-us'
-        try:
-            ipa = _phonemize_safe(seg_text, lang)
-            ipa = _re.sub(r'[0-9˥˦˧˨˩¹²³⁴⁵]', '', ipa)
-            phones = [p for p in ipa.split() if p]
-        except Exception:
-            phones = list(seg_text)
-
-        seg_ipa_count = len(phones)
-        if ipa_idx + seg_ipa_count >= end_pos:
-            offset_in_seg = end_pos - ipa_idx
-            chars_in_seg = len(seg_text)
-            if seg_ipa_count > 0:
-                cut_chars = round(offset_in_seg * chars_in_seg / seg_ipa_count)
-            else:
-                cut_chars = chars_in_seg
-            cut_chars = min(cut_chars, chars_in_seg)
-
-            found = 0
-            for i, c in enumerate(text):
-                if '\u4e00' <= c <= '\u9fff' or c.isalpha():
-                    found += 1
-                if found >= phoneme_char_pos + cut_chars:
-                    cut_idx = i + 1
-                    remaining = text[cut_idx:]
-                    remaining = remaining.lstrip('，。！？、；：,.!?;: ')
-                    return remaining
-            return ''
-        ipa_idx += seg_ipa_count
-        phoneme_char_pos += len(seg_text)
-
-    return ''
 
 _ASR_PUB_QOS = QoSProfile(
     reliability=ReliabilityPolicy.BEST_EFFORT,
@@ -1470,7 +1478,8 @@ class _ASRNode(Node):
                 # ASR-based keyword spotting
                 if trigger_mode == 'asr_kws' and keyword_ipa:
                     _t1 = time.time()
-                    text_ipa = _text_to_ipa(text)
+                    text_ipa, text_char_ends = _text_to_ipa(
+                        text, with_positions=True)
                     _spans.append({"span": "kws_phonemize", "component": "perception",
                                    "start_ts": _t1, "end_ts": time.time(),
                                    "meta": {"text": text[:20]}})
@@ -1485,7 +1494,7 @@ class _ASRNode(Node):
                     if not matched:
                         continue
                     # Extract text after keyword
-                    remaining = _extract_after_keyword(text, kw_text, end_pos)
+                    remaining = _text_after_phoneme(text, text_char_ends, end_pos)
                     log.info(f"[asr] asr_kws TRIGGERED: '{text}' → '{remaining}'")
                     _kws_triggered = True
                     if not remaining.strip():

--- a/perception/plugins/asr.py
+++ b/perception/plugins/asr.py
@@ -333,8 +333,9 @@ class ASRAdapter(ABC):
 class SherpaOnnxASRAdapter(ASRAdapter):
     """On-device streaming ASR using sherpa-onnx paraformer (no network required)."""
 
-    def __init__(self, model_dir: str, hw_provider: str = "cuda", num_threads: int = 2):
+    def __init__(self, model_dir: str, hw_provider: str = "auto", num_threads: int = 2):
         from utils.model_downloader import ensure_model
+        from utils.onnx_provider import resolve_provider
         ensure_model("asr", model_dir)
 
         import sherpa_onnx
@@ -346,6 +347,7 @@ class SherpaOnnxASRAdapter(ASRAdapter):
         if not os.path.exists(decoder_path):
             decoder_path = os.path.join(model_dir, "decoder.onnx")
         tokens_path = os.path.join(model_dir, "tokens.txt")
+        hw_provider = resolve_provider(hw_provider, (encoder_path, decoder_path))
 
         self._recognizer = sherpa_onnx.OnlineRecognizer.from_paraformer(
             encoder=encoder_path,
@@ -382,8 +384,9 @@ class SherpaOnnxASRAdapter(ASRAdapter):
 class SherpaOnnxZipformerAdapter(ASRAdapter):
     """On-device streaming ASR using sherpa-onnx zipformer transducer (English)."""
 
-    def __init__(self, model_dir: str, hw_provider: str = "cuda", num_threads: int = 2):
+    def __init__(self, model_dir: str, hw_provider: str = "auto", num_threads: int = 2):
         from utils.model_downloader import ensure_model
+        from utils.onnx_provider import resolve_provider
         ensure_model("asr_en", model_dir)
 
         import sherpa_onnx
@@ -415,6 +418,8 @@ class SherpaOnnxZipformerAdapter(ASRAdapter):
         if not all([encoder_path, decoder_path, joiner_path]):
             raise RuntimeError(f"[asr] zipformer model files not found in {model_dir}")
 
+        hw_provider = resolve_provider(hw_provider,
+                                       (encoder_path, decoder_path, joiner_path))
         self._recognizer = sherpa_onnx.OnlineRecognizer.from_transducer(
             encoder=encoder_path,
             decoder=decoder_path,
@@ -453,8 +458,9 @@ class SherpaOnnxSenseVoiceAdapter(ASRAdapter):
     code-switching scenarios. Uses sherpa_onnx.OfflineRecognizer.
     """
 
-    def __init__(self, model_dir: str, hw_provider: str = "cuda", num_threads: int = 2):
+    def __init__(self, model_dir: str, hw_provider: str = "auto", num_threads: int = 2):
         from utils.model_downloader import ensure_model
+        from utils.onnx_provider import resolve_provider
         ensure_model("asr_sensevoice", model_dir)
 
         import sherpa_onnx
@@ -462,6 +468,7 @@ class SherpaOnnxSenseVoiceAdapter(ASRAdapter):
         if not os.path.exists(model_path):
             model_path = os.path.join(model_dir, "model.onnx")
         tokens_path = os.path.join(model_dir, "tokens.txt")
+        hw_provider = resolve_provider(hw_provider, (model_path,))
 
         self._recognizer = sherpa_onnx.OfflineRecognizer.from_sense_voice(
             model=model_path,
@@ -497,8 +504,9 @@ class SherpaOnnxOfflineParaformerAdapter(ASRAdapter):
     Uses sherpa_onnx.OfflineRecognizer.from_paraformer.
     """
 
-    def __init__(self, model_dir: str, hw_provider: str = "cuda", num_threads: int = 2):
+    def __init__(self, model_dir: str, hw_provider: str = "auto", num_threads: int = 2):
         from utils.model_downloader import ensure_model
+        from utils.onnx_provider import resolve_provider
         ensure_model("asr_paraformer_offline", model_dir)
 
         import sherpa_onnx
@@ -506,6 +514,7 @@ class SherpaOnnxOfflineParaformerAdapter(ASRAdapter):
         if not os.path.exists(model_path):
             model_path = os.path.join(model_dir, "model.onnx")
         tokens_path = os.path.join(model_dir, "tokens.txt")
+        hw_provider = resolve_provider(hw_provider, (model_path,))
 
         self._recognizer = sherpa_onnx.OfflineRecognizer.from_paraformer(
             paraformer=model_path,
@@ -535,7 +544,7 @@ class SherpaOnnxOfflineParaformerAdapter(ASRAdapter):
 class SherpaOnnxXASRAdapter(ASRAdapter):
     """Offline X-ASR transducer with general robot-domain hotword biasing."""
 
-    def __init__(self, model_dir: str, hw_provider: str = "cpu", num_threads: int = 2):
+    def __init__(self, model_dir: str, hw_provider: str = "auto", num_threads: int = 2):
         from utils.model_downloader import ensure_model
         from plugins.x_asr import XASRAdapter
 
@@ -590,7 +599,7 @@ def _build_asr_adapter(cfg: dict) -> Optional[ASRAdapter]:
     if model_dir in other_defaults:
         model_dir = model_info["default_model_dir"]
 
-    hw_provider = cfg.get('hw_provider', 'cpu')
+    hw_provider = cfg.get('hw_provider', 'auto')
     num_threads = int(cfg.get('num_threads', 2))
     return model_info["adapter"](model_dir, hw_provider, num_threads)
 
@@ -629,6 +638,7 @@ def _vad_worker(pcm_q: multiprocessing.Queue, result_q: multiprocessing.Queue,
     # ── Initialize VAD ──
     import sherpa_onnx
     from utils.model_downloader import ensure_model
+    from utils.onnx_provider import resolve_provider
 
     vad_model_dir = '/models/sherpa-onnx/vad'
     ensure_model("vad", vad_model_dir)
@@ -645,6 +655,12 @@ def _vad_worker(pcm_q: multiprocessing.Queue, result_q: multiprocessing.Queue,
         ),
         sample_rate=SAMPLE_RATE,
         num_threads=1,
+        # CPU on purpose, even when the image has the CUDA-enabled wheel and ASR
+        # runs on the GPU: silero VAD infers one 512-sample window at a time, so
+        # a CUDA session pays a kernel launch plus a H2D/D2H copy per 32 ms of
+        # audio for a model small enough to finish on one core. It would also
+        # hold a second CUDA context in this child process. Only ASR, KWS and
+        # sherpa TTS follow hw_provider.
         provider="cpu",
     )
     vad = sherpa_onnx.VoiceActivityDetector(vad_config, buffer_size_in_seconds=30)
@@ -710,7 +726,8 @@ def _vad_worker(pcm_q: multiprocessing.Queue, result_q: multiprocessing.Queue,
                     joiner=joiner,
                     keywords_file=kws_keywords_file,
                     num_threads=1,
-                    provider="cpu",
+                    provider=resolve_provider(kws_cfg.get('hw_provider'),
+                                              (encoder, decoder, joiner)),
                     keywords_score=1.5,
                     keywords_threshold=0.1,
                 )
@@ -1312,6 +1329,10 @@ class ASRPlugin:
         self._vad_threshold = float(vad_cfg.get('threshold', SPEECH_THRESH))
         self._vad_silence_ms = int(vad_cfg.get('silence_ms', 400))
         self._kws_cfg      = plugin_cfg.get('kws', {})
+        # KWS is built inside the VAD child process, which only receives kws_cfg
+        # (see _vad_worker), so the plugin-level hw_provider has to ride along in
+        # it. setdefault so an explicit kws.hw_provider can still override.
+        self._kws_cfg.setdefault('hw_provider', plugin_cfg.get('hw_provider', 'auto'))
         # On by default: the saved segments are the only way to audit what the VAD
         # actually handed the recogniser when a transcription looks wrong. Bounded
         # by _max_saved_segments — see _enforce_retention(), which unlike the
@@ -1685,6 +1706,8 @@ def _vad_segment_sync(audio_bytes: bytes, model: str = 'silero',
                 ),
                 sample_rate=SAMPLE_RATE,
                 num_threads=1,
+                # CPU on purpose — same reasoning as the _vad_worker VAD above:
+                # per-window inference is too small to amortise a CUDA session.
                 provider="cpu",
             ),
             buffer_size_in_seconds=30,

--- a/perception/plugins/asr.py
+++ b/perception/plugins/asr.py
@@ -293,6 +293,17 @@ TOOLS = [
             "type": "object",
             "properties": {
                 "asr_model":     {"type": "string", "enum": ["x-asr-zh-en", "paraformer-zh-en", "paraformer-offline", "zipformer-en", "sensevoice-small"], "description": "ASR model (x-asr-zh-en = bilingual offline transducer with hotwords, paraformer-zh-en = bilingual streaming, paraformer-offline = bilingual offline, zipformer-en = English streaming, sensevoice-small = multilingual offline)", "default": "sensevoice-small", "scope": "shared"},
+                # Which weights each device loads is in ASR_MODELS; only models
+                # with a verified gpu entry list one, so x-show-when hides this
+                # field for the rest rather than offering a choice that would be
+                # rejected. Keep the list in sync with ASR_MODELS — the unit test
+                # test_asr_device_registry.py asserts they match.
+                "device":        {"type": "string", "enum": ["cpu", "gpu"],
+                                  "description": "Inference device. gpu loads non-quantised weights "
+                                                 "(SenseVoice fp16 ~5.8x, streaming paraformer fp32 ~1.8x "
+                                                 "vs int8-on-cpu) and needs the CUDA sherpa-onnx wheel",
+                                  "default": "cpu", "scope": "shared",
+                                  "x-show-when": {"asr_model": ["paraformer-zh-en", "sensevoice-small"]}},
                 "trigger_mode":  {"type": "string", "enum": ["vad", "kws", "asr_kws"], "description": "Trigger mode (vad = always listen, kws = KWS model, asr_kws = ASR + phoneme matching)", "default": "kws", "scope": "shared"},
                 "kws_model":     {"type": "string", "enum": ["zh", "en", "zh-en"], "description": "KWS 模型 (zh=纯中文, en=纯英文, zh-en=双语)", "default": "zh", "scope": "shared", "x-show-when": {"trigger_mode": "kws"}},
                 "kws_keywords":  {"type": "string", "description": "Wake word (zh: 'f àn sh ì x iǎo g ǒu @范式小狗', en: '▁FA N C Y ▁RO B O T @FANCY_ROBOT')", "scope": "shared", "x-show-when": {"trigger_mode": "kws"}},
@@ -333,32 +344,33 @@ class ASRAdapter(ABC):
 class SherpaOnnxASRAdapter(ASRAdapter):
     """On-device streaming ASR using sherpa-onnx paraformer (no network required)."""
 
-    def __init__(self, model_dir: str, hw_provider: str = "auto", num_threads: int = 2):
-        from utils.model_downloader import ensure_model
-        from utils.onnx_provider import resolve_provider
-        ensure_model("asr", model_dir)
+    def __init__(self, model_dir: str, device: str = "cpu", num_threads: int = 2):
+        from utils.onnx_provider import pick_weights, provider_for_device
 
         import sherpa_onnx
-        # Streaming paraformer uses encoder + decoder (not a single model file)
-        encoder_path = os.path.join(model_dir, "encoder.int8.onnx")
-        if not os.path.exists(encoder_path):
-            encoder_path = os.path.join(model_dir, "encoder.onnx")
-        decoder_path = os.path.join(model_dir, "decoder.int8.onnx")
-        if not os.path.exists(decoder_path):
-            decoder_path = os.path.join(model_dir, "decoder.onnx")
+        # Streaming paraformer uses encoder + decoder (not a single model file).
+        # Candidate order flips with the device: a gpu bundle holds fp32 weights,
+        # a cpu bundle holds int8. See utils/onnx_provider.py for why.
+        enc = ("encoder.onnx", "encoder.int8.onnx") if device == "gpu" else \
+              ("encoder.int8.onnx", "encoder.onnx")
+        dec = ("decoder.onnx", "decoder.int8.onnx") if device == "gpu" else \
+              ("decoder.int8.onnx", "decoder.onnx")
+        encoder_path = pick_weights(model_dir, *enc)
+        decoder_path = pick_weights(model_dir, *dec)
         tokens_path = os.path.join(model_dir, "tokens.txt")
-        hw_provider = resolve_provider(hw_provider, (encoder_path, decoder_path))
+        provider = provider_for_device(device, (encoder_path, decoder_path))
 
         self._recognizer = sherpa_onnx.OnlineRecognizer.from_paraformer(
             encoder=encoder_path,
             decoder=decoder_path,
             tokens=tokens_path,
             num_threads=num_threads,
-            provider=hw_provider,
+            provider=provider,
             sample_rate=SAMPLE_RATE,
             decoding_method="greedy_search",
         )
-        log.info(f"[asr] sherpa-onnx paraformer adapter loaded: encoder={encoder_path}, provider={hw_provider}")
+        log.info(f"[asr] sherpa-onnx paraformer adapter loaded: encoder={encoder_path}, "
+                 f"device={device}, provider={provider}")
 
     def transcribe(self, wav_bytes: bytes, language: str) -> str:
         import io as _io, wave as _wave
@@ -384,15 +396,16 @@ class SherpaOnnxASRAdapter(ASRAdapter):
 class SherpaOnnxZipformerAdapter(ASRAdapter):
     """On-device streaming ASR using sherpa-onnx zipformer transducer (English)."""
 
-    def __init__(self, model_dir: str, hw_provider: str = "auto", num_threads: int = 2):
-        from utils.model_downloader import ensure_model
-        from utils.onnx_provider import resolve_provider
-        ensure_model("asr_en", model_dir)
+    def __init__(self, model_dir: str, device: str = "cpu", num_threads: int = 2):
+        from utils.onnx_provider import provider_for_device
 
         import sherpa_onnx
         import glob as _glob
 
-        # Find encoder/decoder/joiner (prefer int8 + chunk-16)
+        # Find encoder/decoder/joiner (prefer chunk-16; dtype follows the device —
+        # int8 for cpu, non-int8 for gpu, see utils/onnx_provider.py)
+        prefer_int8 = device != "gpu"
+
         def _find(prefix, prefer_int8=True):
             pattern = os.path.join(model_dir, f"{prefix}-*.onnx")
             files = _glob.glob(pattern)
@@ -410,27 +423,29 @@ class SherpaOnnxZipformerAdapter(ASRAdapter):
                     return fp32f[0]
             return cands[0]
 
-        encoder_path = _find("encoder", prefer_int8=True)
+        encoder_path = _find("encoder", prefer_int8=prefer_int8)
+        # The decoder is tiny, so the fp32 copy is preferred on both devices.
         decoder_path = _find("decoder", prefer_int8=False)
-        joiner_path = _find("joiner", prefer_int8=True)
+        joiner_path = _find("joiner", prefer_int8=prefer_int8)
         tokens_path = os.path.join(model_dir, "tokens.txt")
 
         if not all([encoder_path, decoder_path, joiner_path]):
             raise RuntimeError(f"[asr] zipformer model files not found in {model_dir}")
 
-        hw_provider = resolve_provider(hw_provider,
-                                       (encoder_path, decoder_path, joiner_path))
+        provider = provider_for_device(
+            device, (encoder_path, decoder_path, joiner_path))
         self._recognizer = sherpa_onnx.OnlineRecognizer.from_transducer(
             encoder=encoder_path,
             decoder=decoder_path,
             joiner=joiner_path,
             tokens=tokens_path,
             num_threads=num_threads,
-            provider=hw_provider,
+            provider=provider,
             sample_rate=SAMPLE_RATE,
             decoding_method="greedy_search",
         )
-        log.info(f"[asr] sherpa-onnx zipformer adapter loaded: encoder={encoder_path}, provider={hw_provider}")
+        log.info(f"[asr] sherpa-onnx zipformer adapter loaded: encoder={encoder_path}, "
+                 f"device={device}, provider={provider}")
 
     def transcribe(self, wav_bytes: bytes, language: str) -> str:
         import io as _io, wave as _wave
@@ -458,27 +473,30 @@ class SherpaOnnxSenseVoiceAdapter(ASRAdapter):
     code-switching scenarios. Uses sherpa_onnx.OfflineRecognizer.
     """
 
-    def __init__(self, model_dir: str, hw_provider: str = "auto", num_threads: int = 2):
-        from utils.model_downloader import ensure_model
-        from utils.onnx_provider import resolve_provider
-        ensure_model("asr_sensevoice", model_dir)
+    def __init__(self, model_dir: str, device: str = "cpu", num_threads: int = 2):
+        from utils.onnx_provider import pick_weights, provider_for_device
 
         import sherpa_onnx
-        model_path = os.path.join(model_dir, "model.int8.onnx")
-        if not os.path.exists(model_path):
-            model_path = os.path.join(model_dir, "model.onnx")
+        # The gpu bundle ships fp16 (fastest here and transcript-identical to
+        # fp32); the cpu bundle ships int8. fp32 is listed as a middle fallback
+        # for a hand-assembled directory.
+        names = ("model.fp16.onnx", "model.onnx", "model.int8.onnx") \
+            if device == "gpu" else \
+            ("model.int8.onnx", "model.onnx")
+        model_path = pick_weights(model_dir, *names)
         tokens_path = os.path.join(model_dir, "tokens.txt")
-        hw_provider = resolve_provider(hw_provider, (model_path,))
+        provider = provider_for_device(device, (model_path,))
 
         self._recognizer = sherpa_onnx.OfflineRecognizer.from_sense_voice(
             model=model_path,
             tokens=tokens_path,
             num_threads=num_threads,
-            provider=hw_provider,
+            provider=provider,
             use_itn=True,
             language="auto",
         )
-        log.info(f"[asr] sherpa-onnx sensevoice adapter loaded: model={model_path}, provider={hw_provider}")
+        log.info(f"[asr] sherpa-onnx sensevoice adapter loaded: model={model_path}, "
+                 f"device={device}, provider={provider}")
 
     def transcribe(self, wav_bytes: bytes, language: str) -> str:
         import io as _io, wave as _wave
@@ -504,27 +522,27 @@ class SherpaOnnxOfflineParaformerAdapter(ASRAdapter):
     Uses sherpa_onnx.OfflineRecognizer.from_paraformer.
     """
 
-    def __init__(self, model_dir: str, hw_provider: str = "auto", num_threads: int = 2):
-        from utils.model_downloader import ensure_model
-        from utils.onnx_provider import resolve_provider
-        ensure_model("asr_paraformer_offline", model_dir)
+    def __init__(self, model_dir: str, device: str = "cpu", num_threads: int = 2):
+        from utils.onnx_provider import pick_weights, provider_for_device
 
         import sherpa_onnx
-        model_path = os.path.join(model_dir, "model.int8.onnx")
-        if not os.path.exists(model_path):
-            model_path = os.path.join(model_dir, "model.onnx")
+        names = ("model.fp16.onnx", "model.onnx", "model.int8.onnx") \
+            if device == "gpu" else \
+            ("model.int8.onnx", "model.onnx")
+        model_path = pick_weights(model_dir, *names)
         tokens_path = os.path.join(model_dir, "tokens.txt")
-        hw_provider = resolve_provider(hw_provider, (model_path,))
+        provider = provider_for_device(device, (model_path,))
 
         self._recognizer = sherpa_onnx.OfflineRecognizer.from_paraformer(
             paraformer=model_path,
             tokens=tokens_path,
             num_threads=num_threads,
-            provider=hw_provider,
+            provider=provider,
             sample_rate=SAMPLE_RATE,
             decoding_method="greedy_search",
         )
-        log.info(f"[asr] sherpa-onnx offline paraformer adapter loaded: model={model_path}, provider={hw_provider}")
+        log.info(f"[asr] sherpa-onnx offline paraformer adapter loaded: "
+                 f"model={model_path}, device={device}, provider={provider}")
 
     def transcribe(self, wav_bytes: bytes, language: str) -> str:
         import io as _io, wave as _wave
@@ -544,64 +562,149 @@ class SherpaOnnxOfflineParaformerAdapter(ASRAdapter):
 class SherpaOnnxXASRAdapter(ASRAdapter):
     """Offline X-ASR transducer with general robot-domain hotword biasing."""
 
-    def __init__(self, model_dir: str, hw_provider: str = "auto", num_threads: int = 2):
-        from utils.model_downloader import ensure_model
+    def __init__(self, model_dir: str, device: str = "cpu", num_threads: int = 2):
         from plugins.x_asr import XASRAdapter
 
-        ensure_model("asr_x_asr", model_dir)
-        self._delegate = XASRAdapter(model_dir, hw_provider, num_threads)
+        self._delegate = XASRAdapter(model_dir, device, num_threads)
 
     def transcribe(self, wav_bytes: bytes, language: str) -> str:
         return self._delegate.transcribe(wav_bytes, language)
 
 
-# ASR model registry
+# ASR model registry.
+#
+# `devices` maps the config's `device` value to the weights that device loads.
+# Quantised weights are the right choice on the CPU and the wrong one on the GPU
+# (ONNX Runtime's CUDA provider has no int8 kernels and falls back per node), so
+# the two devices generally want different files — which is the whole reason this
+# is a table rather than one directory per model. `download` is the
+# model_downloader key; `gpu` entries are size/SHA256-pinned bundles fetched with
+# ensure_gpu_model, `cpu` entries are the legacy archives fetched with ensure_model.
+#
+# A `gpu` entry is only listed after that (model, device) pair was benchmarked AND
+# its transcripts were read. Speed and self-consistency are not sufficient
+# evidence: streaming paraformer fp16 on CUDA was fast, identical across thread
+# counts, and emitted nothing but `</s>`. See utils/onnx_provider.py for the
+# measurements and perception/README.md for the admission checklist.
 ASR_MODELS = {
     "x-asr-zh-en": {
         "label": "X-ASR Bilingual (zh+en, offline transducer)",
         "adapter": SherpaOnnxXASRAdapter,
-        "default_model_dir": "/models/sherpa-onnx/x-asr-zh-en",
+        "devices": {
+            # No gpu entry: measured 0.80x on CUDA at matched threads. Its bundle
+            # is mixed precision (int8 encoder+joiner, fp32 decoder) and the int8
+            # parts are enough to make the GPU lose.
+            "cpu": {"download": "asr_x_asr", "dtype": "int8",
+                    "dir": "/models/sherpa-onnx/x-asr-zh-en"},
+        },
     },
     "paraformer-zh-en": {
         "label": "Paraformer Bilingual (zh+en, streaming)",
         "adapter": SherpaOnnxASRAdapter,
-        "default_model_dir": "/models/sherpa-onnx/asr",
+        "devices": {
+            "cpu": {"download": "asr", "dtype": "int8",
+                    "dir": "/models/sherpa-onnx/asr"},
+            # fp32, not fp16: fp16 on CUDA emits only `</s>` for this model, and
+            # is slower than fp32 anyway (2077 ms vs 1859 ms).
+            "gpu": {"download": "asr_gpu", "dtype": "fp32",
+                    "dir": "/models/sherpa-onnx/asr-gpu"},
+        },
     },
     "paraformer-offline": {
         "label": "Paraformer Offline (zh+en, small)",
         "adapter": SherpaOnnxOfflineParaformerAdapter,
-        "default_model_dir": "/models/sherpa-onnx/asr-paraformer-offline",
+        "devices": {
+            # No gpu entry: no non-quantised variant has been built or measured.
+            "cpu": {"download": "asr_paraformer_offline", "dtype": "int8",
+                    "dir": "/models/sherpa-onnx/asr-paraformer-offline"},
+        },
     },
     "zipformer-en": {
         "label": "Zipformer English (streaming)",
         "adapter": SherpaOnnxZipformerAdapter,
-        "default_model_dir": "/models/sherpa-onnx/asr-en",
+        "devices": {
+            # No gpu entry: not measured.
+            "cpu": {"download": "asr_en", "dtype": "int8",
+                    "dir": "/models/sherpa-onnx/asr-en"},
+        },
     },
     "sensevoice-small": {
         "label": "SenseVoice Small (zh+en+ja+ko+yue)",
         "adapter": SherpaOnnxSenseVoiceAdapter,
-        "default_model_dir": "/models/sherpa-onnx/sensevoice",
+        "devices": {
+            "cpu": {"download": "asr_sensevoice", "dtype": "int8",
+                    "dir": "/models/sherpa-onnx/sensevoice"},
+            # fp16: 344 ms vs 416 ms for fp32 on CUDA, half the size, and
+            # transcript-identical to fp32 on both providers.
+            "gpu": {"download": "asr_sensevoice_gpu", "dtype": "fp16",
+                    "dir": "/models/sherpa-onnx/sensevoice-gpu"},
+        },
     },
 }
 
+DEFAULT_ASR_MODEL = "sensevoice-small"
+
+
+def asr_models_supporting(device: str) -> list[str]:
+    """Model names whose registry entry has weights for this device."""
+    return sorted(name for name, info in ASR_MODELS.items()
+                  if device in info["devices"])
+
+
+_REGISTRY_DIRS = {spec["dir"]
+                  for info in ASR_MODELS.values()
+                  for spec in info["devices"].values()}
+
+
+def _model_dir_for(cfg: dict, spec: dict) -> str:
+    """Honour an explicit `model_dir`, unless it is another entry's default.
+
+    config.yaml ships a `model_dir` for the one bundle it was written for. Carrying
+    that path over to a different model — or to the same model's other device —
+    would download the wrong weights into it. Same intent as the pre-`device`
+    guard, extended across devices.
+    """
+    requested = cfg.get('model_dir')
+    if not requested or (requested in _REGISTRY_DIRS and requested != spec["dir"]):
+        return spec["dir"]
+    return requested
+
 
 def _build_asr_adapter(cfg: dict) -> Optional[ASRAdapter]:
-    model_name = cfg.get('asr_model', 'paraformer-zh-en')
+    from utils.onnx_provider import normalize_device
+
+    model_name = cfg.get('asr_model', DEFAULT_ASR_MODEL)
     model_info = ASR_MODELS.get(model_name)
     if not model_info:
-        log.warning(f"[asr] unknown model '{model_name}', falling back to paraformer-zh-en")
-        model_info = ASR_MODELS["paraformer-zh-en"]
-        model_name = "paraformer-zh-en"
+        log.warning(f"[asr] unknown model '{model_name}', falling back to "
+                    f"{DEFAULT_ASR_MODEL}")
+        model_name = DEFAULT_ASR_MODEL
+        model_info = ASR_MODELS[model_name]
 
-    model_dir = cfg.get('model_dir', model_info["default_model_dir"])
-    # If model_dir points to another model's default, use correct default
-    other_defaults = [v["default_model_dir"] for k, v in ASR_MODELS.items() if k != model_name]
-    if model_dir in other_defaults:
-        model_dir = model_info["default_model_dir"]
+    device = normalize_device(cfg.get('device'), cfg.get('hw_provider'))
+    if device not in model_info["devices"]:
+        # Degrade rather than refuse to boot: a baked config.yaml asking for a
+        # device this model has no verified weights for should still come up on
+        # CPU. The `config` action validates up front and reports the error there,
+        # where someone is watching.
+        log.warning("[asr] model '%s' has no '%s' weights — it was either measured "
+                    "slower there or never verified. Using cpu. Models with %s "
+                    "support: %s", model_name, device, device,
+                    ", ".join(asr_models_supporting(device)) or "(none)")
+        device = "cpu"
+    spec = model_info["devices"][device]
 
-    hw_provider = cfg.get('hw_provider', 'auto')
+    model_dir = _model_dir_for(cfg, spec)
+    if device == "gpu":
+        # Size/SHA256-pinned: these are the largest downloads in the stack.
+        from utils.model_downloader import ensure_gpu_model
+        ensure_gpu_model(spec["download"], model_dir)
+    else:
+        from utils.model_downloader import ensure_model
+        ensure_model(spec["download"], model_dir)
+
     num_threads = int(cfg.get('num_threads', 2))
-    return model_info["adapter"](model_dir, hw_provider, num_threads)
+    return model_info["adapter"](model_dir, device, num_threads)
 
 
 # ── VAD Worker Process ────────────────────────────────────────────────────────
@@ -638,7 +741,6 @@ def _vad_worker(pcm_q: multiprocessing.Queue, result_q: multiprocessing.Queue,
     # ── Initialize VAD ──
     import sherpa_onnx
     from utils.model_downloader import ensure_model
-    from utils.onnx_provider import resolve_provider
 
     vad_model_dir = '/models/sherpa-onnx/vad'
     ensure_model("vad", vad_model_dir)
@@ -660,7 +762,8 @@ def _vad_worker(pcm_q: multiprocessing.Queue, result_q: multiprocessing.Queue,
         # a CUDA session pays a kernel launch plus a H2D/D2H copy per 32 ms of
         # audio for a model small enough to finish on one core. It would also
         # hold a second CUDA context in this child process. Only ASR, KWS and
-        # sherpa TTS follow hw_provider.
+        # hold a second CUDA context in this child process. Only ASR and the
+        # sherpa TTS engine follow `device`.
         provider="cpu",
     )
     vad = sherpa_onnx.VoiceActivityDetector(vad_config, buffer_size_in_seconds=30)
@@ -726,8 +829,11 @@ def _vad_worker(pcm_q: multiprocessing.Queue, result_q: multiprocessing.Queue,
                     joiner=joiner,
                     keywords_file=kws_keywords_file,
                     num_threads=1,
-                    provider=resolve_provider(kws_cfg.get('hw_provider'),
-                                              (encoder, decoder, joiner)),
+                    # KWS is pinned to CPU. Its zipformer bundle ships int8 only,
+                    # and int8 on CUDA measured slower than CPU on every model
+                    # tried — so there is nothing to gain and the `device` setting
+                    # deliberately does not reach here. See utils/onnx_provider.py.
+                    provider="cpu",
                     keywords_score=1.5,
                     keywords_threshold=0.1,
                 )
@@ -1318,8 +1424,16 @@ class ASRPlugin:
     PREFIX = "asr"
 
     def __init__(self, plugin_cfg: dict, executor):
+        from utils.onnx_provider import normalize_device
         self._language     = plugin_cfg.get('language', 'zh-CN')
-        self._asr_model    = plugin_cfg.get('asr_model', 'paraformer-zh-en')
+        self._asr_model    = plugin_cfg.get('asr_model', DEFAULT_ASR_MODEL)
+        # Mirrors what _build_asr_adapter resolved, including its fall back to cpu
+        # for a model with no weights for the requested device, so `info` and the
+        # next `config` comparison report what is actually loaded.
+        self._device       = normalize_device(plugin_cfg.get('device'),
+                                             plugin_cfg.get('hw_provider'))
+        if self._device not in ASR_MODELS.get(self._asr_model, {}).get("devices", {}):
+            self._device = "cpu"
         self._plugin_cfg   = plugin_cfg
         self._loading      = False
         self._load_error   = None
@@ -1329,10 +1443,6 @@ class ASRPlugin:
         self._vad_threshold = float(vad_cfg.get('threshold', SPEECH_THRESH))
         self._vad_silence_ms = int(vad_cfg.get('silence_ms', 400))
         self._kws_cfg      = plugin_cfg.get('kws', {})
-        # KWS is built inside the VAD child process, which only receives kws_cfg
-        # (see _vad_worker), so the plugin-level hw_provider has to ride along in
-        # it. setdefault so an explicit kws.hw_provider can still override.
-        self._kws_cfg.setdefault('hw_provider', plugin_cfg.get('hw_provider', 'auto'))
         # On by default: the saved segments are the only way to audit what the VAD
         # actually handed the recogniser when a transcription looks wrong. Bounded
         # by _max_saved_segments — see _enforce_retention(), which unlike the
@@ -1348,7 +1458,8 @@ class ASRPlugin:
         # cancel it. See perception/README.md § Plugin Concurrency.
         self._nodes_lock = threading.RLock()
         self._executor = executor
-        log.info(f"[asr] plugin init: model={self._asr_model}, vad={self._vad_backend}, threshold={self._vad_threshold}, "
+        log.info(f"[asr] plugin init: model={self._asr_model}, device={self._device}, "
+                 f"vad={self._vad_backend}, threshold={self._vad_threshold}, "
                  f"silence_ms={self._vad_silence_ms}, pre_roll_ms={self._vad_pre_roll_ms}, "
                  f"kws_enabled={self._kws_cfg.get('enabled', False)}")
 
@@ -1583,8 +1694,32 @@ class ASRPlugin:
                 self._max_saved_segments = int(cfg['max_saved_segments'])
             if 'vad_pre_roll_ms' in cfg:
                 self._vad_pre_roll_ms = int(cfg['vad_pre_roll_ms'])
-            # ASR model switch — load in background if changed
-            if 'asr_model' in cfg and cfg['asr_model'] != self._asr_model:
+            # Model or device switch — either one changes which weights are loaded,
+            # so both go through the same background reload. Validated together
+            # because a request can change both at once, and whether a device is
+            # allowed depends on the model.
+            from utils.onnx_provider import normalize_device
+            new_model = cfg.get('asr_model', self._asr_model)
+            new_device = (normalize_device(cfg['device']) if 'device' in cfg
+                          else self._device)
+            if new_model not in ASR_MODELS:
+                return {"status": "error", "asr_model": self._asr_model,
+                        "message": f"Unknown asr_model '{new_model}'; "
+                                   f"available: {', '.join(sorted(ASR_MODELS))}"}
+            if new_device not in ASR_MODELS[new_model]["devices"]:
+                # Reject rather than silently degrade: someone is looking at the
+                # result of this call, and a request for gpu that quietly runs on
+                # cpu is how a "GPU is not faster" bug report gets written.
+                supported = asr_models_supporting(new_device)
+                return {"status": "error",
+                        "asr_model": self._asr_model, "device": self._device,
+                        "message": (
+                            f"Model '{new_model}' has no '{new_device}' weights — it "
+                            f"was either measured slower there or never verified. "
+                            f"Models with {new_device} support: "
+                            f"{', '.join(supported) or '(none)'}")}
+
+            if (new_model, new_device) != (self._asr_model, self._device):
                 # Stop all running nodes first
                 with self._nodes_lock:
                     nodes = [(k, self._nodes.pop(k)) for k in list(self._nodes.keys())]
@@ -1592,10 +1727,14 @@ class ASRPlugin:
                     node.request_stop()
                 for key, node in nodes:
                     self._dispose_node(node, key)
-                self._asr_model = cfg['asr_model']
+                self._asr_model = new_model
+                self._device = new_device
+                self._plugin_cfg['device'] = new_device
                 self._load_model_async(self._asr_model)
                 return {"status": "loading", "asr_model": self._asr_model,
-                        "message": f"Switching to model '{self._asr_model}', downloading..."}
+                        "device": self._device,
+                        "message": f"Switching to model '{self._asr_model}' on "
+                                   f"{self._device}, downloading..."}
             # Hot-reload: stop running nodes, apply new config, restart automatically
             with self._nodes_lock:
                 was_running = [(key, node) for key, node in self._nodes.items()

--- a/perception/plugins/asr.py
+++ b/perception/plugins/asr.py
@@ -57,13 +57,55 @@ _LOW_LAT_QOS = QoSProfile(
 import re as _re
 
 # ── Persistent EspeakBackend instances (avoid 70ms+ re-init per call) ─────────
+#
+# The espeak library has to be pointed at explicitly. phonemizer locates it with
+# ctypes.util.find_library('espeak-ng'), which on Linux shells out to `ldconfig -p`
+# — and libespeak-ng is absent from the ld cache in the jetson image, because
+# Dockerfile.jetson stubs ldconfig out during apt installs to survive qemu and the
+# cache is never rebuilt. So find_library returns None, EspeakBackend raises
+# "espeak not installed", and phonemization silently degrades to matching raw
+# characters.
+#
+# That cost 5.2 s per utterance in production, measured from the plugin's own
+# kws_phonemize span. _text_to_ipa splits an utterance into CJK/non-CJK segments
+# (4 for '小范小范，你好。', since fullwidth punctuation is not in the CJK range),
+# _phonemize_safe used to retry each failure once, and every attempt forked
+# `ldconfig` from a 3.6 GB multi-threaded process. Eight subprocess spawns per
+# utterance. Out of process the same call took 320 ms, which is why this only ever
+# showed up in the span data.
 _ESPEAK_BACKENDS = {}  # lang -> EspeakBackend instance
 _ESPEAK_SEP = None
+_ESPEAK_UNAVAILABLE = None   # str reason once probing has failed; see below
+_ESPEAK_LIB_CANDIDATES = (
+    "/usr/lib/aarch64-linux-gnu/libespeak-ng.so.1",
+    "/usr/lib/x86_64-linux-gnu/libespeak-ng.so.1",
+    "/usr/lib/libespeak-ng.so.1",
+    "/usr/local/lib/libespeak-ng.so.1",
+)
+
+
+def _point_phonemizer_at_espeak() -> None:
+    """Tell phonemizer where libespeak-ng is, since the ld cache will not.
+
+    PHONEMIZER_ESPEAK_LIBRARY wins if the deployment already set it. Otherwise the
+    first candidate that exists is used — cheap `os.path.exists` checks rather than
+    find_library's subprocess.
+    """
+    if os.environ.get("PHONEMIZER_ESPEAK_LIBRARY"):
+        return
+    for path in _ESPEAK_LIB_CANDIDATES:
+        if os.path.exists(path):
+            os.environ["PHONEMIZER_ESPEAK_LIBRARY"] = path
+            log.info("[asr] phonemizer: using espeak library at %s", path)
+            return
+    log.warning("[asr] phonemizer: no libespeak-ng found in %s",
+                ", ".join(_ESPEAK_LIB_CANDIDATES))
 
 
 def _get_espeak_backend(lang):
     global _ESPEAK_SEP
     if _ESPEAK_SEP is None:
+        _point_phonemizer_at_espeak()
         from phonemizer.separator import Separator
         _ESPEAK_SEP = Separator(phone=' ', word='  ', syllable='')
     if lang not in _ESPEAK_BACKENDS:
@@ -73,15 +115,32 @@ def _get_espeak_backend(lang):
 
 
 def _phonemize_safe(text: str, lang: str) -> str:
-    """Phonemize with persistent backend; auto-rebuild on failure."""
-    backend = _get_espeak_backend(lang)
+    """Phonemize with a persistent backend, rebuilding once if espeak crashed.
+
+    A construction failure is remembered and never retried: espeak either resolves
+    or it does not, and retrying it per segment per utterance is what turned a
+    misconfiguration into 5.2 s of latency. `_text_to_ipa` still falls back to
+    characters, so a genuinely missing espeak degrades in quality, not in speed.
+    """
+    global _ESPEAK_UNAVAILABLE
+    if _ESPEAK_UNAVAILABLE is not None:
+        raise RuntimeError(_ESPEAK_UNAVAILABLE)
+    try:
+        backend = _get_espeak_backend(lang)
+    except Exception as error:  # noqa: BLE001 - espeak absent or unloadable
+        _ESPEAK_UNAVAILABLE = f"espeak unavailable: {error}"
+        log.error("[asr] phonemizer unusable, asr_kws will match on characters "
+                  "instead of phonemes: %s", error)
+        raise
     try:
         return backend.phonemize([text], separator=_ESPEAK_SEP, strip=True)[0]
     except Exception:
-        # espeak-ng may have crashed — rebuild backend and retry once
+        # espeak-ng may have crashed mid-run — rebuild the backend and retry once.
+        # Only reachable when construction previously succeeded.
         _ESPEAK_BACKENDS.pop(lang, None)
         backend = _get_espeak_backend(lang)
         return backend.phonemize([text], separator=_ESPEAK_SEP, strip=True)[0]
+
 
 
 def _text_to_ipa(text: str) -> list:

--- a/perception/plugins/tts.py
+++ b/perception/plugins/tts.py
@@ -11,6 +11,7 @@ import json
 import logging
 import queue
 import threading
+import time
 from abc import ABC, abstractmethod
 from typing import Optional
 
@@ -750,6 +751,13 @@ ENGINE_MODEL_DIRS = {
     "vits2_trt": "/models/vits2",
     "sherpa_onnx": "/models/sherpa-onnx/tts",
 }
+# How long an `action=config` engine switch waits for the new engine before
+# answering `loading`. Sized so the bounded part of a build finishes inside it
+# (constructing the sherpa session measured ~2 s on cpu, ~5 s on gpu) while a cold
+# model download does not — that one genuinely has to go async. Also under the 30 s
+# the LLM path allows a tools/call (agent-core/src/mcp_client.py), in case a config
+# ever arrives from there rather than from the dashboard.
+ENGINE_SWITCH_WAIT_S = 20
 
 
 class TTSPlugin:
@@ -758,9 +766,17 @@ class TTSPlugin:
     A facade rather than a `__new__` switch: the engine is a configSchema field,
     so it can change at runtime (`action=config`, `tts_engine=...`) and not only
     at process start. Switching disposes the previous engine's nodes and builds
-    the new one in the background — sherpa-onnx downloads its Matcha model in
-    its constructor, which would otherwise blow through the 60 s Agent Core
-    allows a processor call.
+    the new one on a background thread, because sherpa-onnx downloads its Matcha
+    model in its constructor and that is open-ended.
+
+    `action=config` then waits up to ENGINE_SWITCH_WAIT_S for that build and only
+    answers `loading` if it is still going, so the bounded part — constructing the
+    session, ~2 s on cpu and ~5 s on gpu — is not something callers have to poll
+    for. It can afford to wait: the dashboard's start-project path
+    (agent-core/src/api/mcp_manage.py mcp_call_tool) sets no client timeout at all,
+    and its loading watcher polls for up to 900 s. The 60 s figure that used to be
+    cited here belongs to the *LLM* tool path (agent-core/src/mcp_client.py), which
+    does not send config.
     """
 
     PREFIX = "tts"
@@ -947,6 +963,30 @@ class TTSPlugin:
                     "message": f"TTS engine {building} is initializing, retry shortly"}
         return {"state": "error", "message": f"TTS engine {engine} failed: {error}"}
 
+    def _await_build(self, engine: str, timeout_s: float) -> tuple[bool, str | None]:
+        """Wait for an in-flight build. Returns (ready, error).
+
+        `ready` false with no error means it is still going, which is the caller's
+        cue to answer `loading` and let the deferred-start machinery finish the job.
+        Another switch superseding this one also reads as not-ready: this build's
+        result is about to be discarded, so claiming success would be wrong.
+        """
+        deadline = time.monotonic() + timeout_s
+        while True:
+            with self._lock:
+                if self._engine != engine:
+                    return False, None          # superseded by a newer switch
+                if self._impl is not None and self._impl_engine == engine:
+                    return True, None
+                if self._build_error:
+                    return False, self._build_error
+                if not self._building:
+                    # Neither resident nor building nor failed: nothing to wait on.
+                    return False, None
+            if time.monotonic() >= deadline:
+                return False, None
+            time.sleep(0.2)
+
     def _config(self, name: str, args: dict) -> dict:
         """Apply shared config, switching engines when tts_engine changes."""
         requested = args.get("tts_engine") or args.get("engine")
@@ -975,6 +1015,20 @@ class TTSPlugin:
                     _dispose_impl(outgoing)
                 self._build_async(engine)
                 log.info("[tts] switching engine to %s", engine)
+                # Wait for it, up to a bound. Only part of a build is open-ended
+                # (downloading a model); constructing the session afterwards took
+                # ~2 s on cpu and ~5 s on gpu, and answering `loading` for that is
+                # what made the dashboard send a start the engine could not honour.
+                # A time bound rather than "does it need to download" because the
+                # download is not the only slow phase — the gpu paraformer encoder
+                # is 636 MB and reading it cold takes seconds on its own.
+                ready, error = self._await_build(engine, ENGINE_SWITCH_WAIT_S)
+                if error:
+                    return {"status": "error", "engine": engine,
+                            "state": "error", "message": error}
+                if ready:
+                    log.info("[tts] engine %s ready", engine)
+                    return {"status": "configured", "engine": engine}
                 return {"status": "configured", "state": "loading",
                         "engine": engine,
                         "message": f"loading the {engine} engine"}

--- a/perception/plugins/tts.py
+++ b/perception/plugins/tts.py
@@ -129,7 +129,7 @@ class SherpaOnnxTTSAdapter(TTSAdapter):
         if not os.path.isdir(data_dir):
             data_dir = ""
         # Both weights are fp32, so auto lands on cuda where the wheel supports
-        # it — measured 4.4x faster than 2-thread CPU on an Orin NX.
+        # it — measured 4.3x faster than CPU at num_threads=2 on an Orin NX.
         provider = resolve_provider(hw_provider, (acoustic_model, vocoder))
 
         # Gather rule FSTs

--- a/perception/plugins/tts.py
+++ b/perception/plugins/tts.py
@@ -77,8 +77,15 @@ TOOLS = [
                 # without rebuilding the image. Mirrors asr_model in asr.py.
                 "tts_engine": {"type": "string", "enum": ["vits2_trt", "sherpa_onnx"],
                                "description": "TTS engine (vits2_trt = VITS2 TensorRT on Jetson, "
-                                              "sherpa_onnx = sherpa-onnx Matcha on CPU)",
+                                              "sherpa_onnx = sherpa-onnx Matcha)",
                                "default": "vits2_trt", "scope": "shared"},
+                # sherpa_onnx only — vits2_trt is a TensorRT engine and never
+                # touches ONNX Runtime, so this field does nothing for it.
+                "hw_provider": {"type": "string", "enum": ["auto", "cuda", "cpu"],
+                                "description": "ONNX Runtime provider for the sherpa_onnx engine "
+                                               "(auto = cuda on images with the CUDA wheel, since "
+                                               "Matcha's weights are fp32)",
+                                "default": "auto", "scope": "shared"},
                 "speaker_id": {"type": "integer", "description": "Speaker ID (VITS2 supports 0 only)", "default": 0, "scope": "shared"},
                 "speed":      {"type": "number", "description": "Speech speed (1.0 = normal)", "default": 1.0, "scope": "shared"},
             },
@@ -104,9 +111,11 @@ class TTSAdapter(ABC):
 class SherpaOnnxTTSAdapter(TTSAdapter):
     """On-device TTS using sherpa-onnx Matcha (flow-matching, fast non-autoregressive)."""
 
-    def __init__(self, model_dir: str, speaker_id: int = 0, speed: float = 1.0):
+    def __init__(self, model_dir: str, speaker_id: int = 0, speed: float = 1.0,
+                 hw_provider: str = "auto"):
         import os
         from utils.model_downloader import ensure_model
+        from utils.onnx_provider import resolve_provider
         ensure_model("tts", model_dir)
         ensure_model("tts_vocoder", model_dir)
 
@@ -119,6 +128,9 @@ class SherpaOnnxTTSAdapter(TTSAdapter):
         data_dir = os.path.join(model_dir, "espeak-ng-data")
         if not os.path.isdir(data_dir):
             data_dir = ""
+        # Both weights are fp32, so auto lands on cuda where the wheel supports
+        # it — measured 4.4x faster than 2-thread CPU on an Orin NX.
+        provider = resolve_provider(hw_provider, (acoustic_model, vocoder))
 
         # Gather rule FSTs
         rule_fsts = []
@@ -138,7 +150,7 @@ class SherpaOnnxTTSAdapter(TTSAdapter):
                     length_scale=1.0 / speed if speed else 1.0,
                 ),
                 num_threads=2,
-                provider="cpu",
+                provider=provider,
             ),
             rule_fsts=",".join(rule_fsts) if rule_fsts else "",
         )
@@ -146,7 +158,7 @@ class SherpaOnnxTTSAdapter(TTSAdapter):
         self._sid = speaker_id
         self._speed = speed
         log.info(f"[tts] sherpa-onnx Matcha loaded: model_dir={model_dir}, "
-                 f"speaker_id={speaker_id}, speed={speed}")
+                 f"speaker_id={speaker_id}, speed={speed}, provider={provider}")
 
     def synthesize(self, text: str) -> bytes:
         return b''.join(self.synthesize_stream(text))
@@ -169,7 +181,8 @@ def _build_tts_adapter(cfg: dict) -> TTSAdapter:
     model_dir = cfg.get('model_dir', '/models/sherpa-onnx/tts')
     speaker_id = int(cfg.get('speaker_id', 0))
     speed = float(cfg.get('speed', 1.0))
-    return SherpaOnnxTTSAdapter(model_dir, speaker_id, speed)
+    return SherpaOnnxTTSAdapter(model_dir, speaker_id, speed,
+                                cfg.get('hw_provider', 'auto'))
 
 
 # ── ROS2 Node ─────────────────────────────────────────────────────────────────
@@ -692,6 +705,8 @@ class SherpaOnnxTTSPlugin:
                 self._cfg['speaker_id'] = int(cfg['speaker_id'])
             if 'speed' in cfg:
                 self._cfg['speed'] = float(cfg['speed'])
+            if 'hw_provider' in cfg:
+                self._cfg['hw_provider'] = cfg['hw_provider']
             self._adapter = _build_tts_adapter(self._cfg)
             # Stop all nodes (they'll use new adapter on next start)
             with self._nodes_lock:
@@ -883,7 +898,7 @@ class TTSPlugin:
         requested = args.get("tts_engine") or args.get("engine")
         forwarded = {k: v for k, v in args.items()
                      if k not in ("tts_engine", "engine")}
-        for key in ("speaker_id", "speed"):
+        for key in ("speaker_id", "speed", "hw_provider"):
             if key in args:
                 self._cfg[key] = args[key]
 

--- a/perception/plugins/tts.py
+++ b/perception/plugins/tts.py
@@ -80,12 +80,14 @@ TOOLS = [
                                               "sherpa_onnx = sherpa-onnx Matcha)",
                                "default": "vits2_trt", "scope": "shared"},
                 # sherpa_onnx only — vits2_trt is a TensorRT engine and never
-                # touches ONNX Runtime, so this field does nothing for it.
-                "hw_provider": {"type": "string", "enum": ["auto", "cuda", "cpu"],
-                                "description": "ONNX Runtime provider for the sherpa_onnx engine "
-                                               "(auto = cuda on images with the CUDA wheel, since "
-                                               "Matcha's weights are fp32)",
-                                "default": "auto", "scope": "shared"},
+                # touches ONNX Runtime, so this field does nothing for it. Matcha's
+                # weights are fp32, so both devices load the same files and only
+                # the provider changes; measured 4.3x faster on gpu.
+                "device":      {"type": "string", "enum": ["cpu", "gpu"],
+                                "description": "Inference device for the sherpa_onnx engine "
+                                               "(gpu needs the CUDA sherpa-onnx wheel; ~4.3x faster)",
+                                "default": "cpu", "scope": "shared",
+                                "x-show-when": {"tts_engine": "sherpa_onnx"}},
                 "speaker_id": {"type": "integer", "description": "Speaker ID (VITS2 supports 0 only)", "default": 0, "scope": "shared"},
                 "speed":      {"type": "number", "description": "Speech speed (1.0 = normal)", "default": 1.0, "scope": "shared"},
             },
@@ -112,10 +114,10 @@ class SherpaOnnxTTSAdapter(TTSAdapter):
     """On-device TTS using sherpa-onnx Matcha (flow-matching, fast non-autoregressive)."""
 
     def __init__(self, model_dir: str, speaker_id: int = 0, speed: float = 1.0,
-                 hw_provider: str = "auto"):
+                 device: str = "cpu"):
         import os
         from utils.model_downloader import ensure_model
-        from utils.onnx_provider import resolve_provider
+        from utils.onnx_provider import provider_for_device
         ensure_model("tts", model_dir)
         ensure_model("tts_vocoder", model_dir)
 
@@ -128,9 +130,9 @@ class SherpaOnnxTTSAdapter(TTSAdapter):
         data_dir = os.path.join(model_dir, "espeak-ng-data")
         if not os.path.isdir(data_dir):
             data_dir = ""
-        # Both weights are fp32, so auto lands on cuda where the wheel supports
-        # it — measured 4.3x faster than CPU at num_threads=2 on an Orin NX.
-        provider = resolve_provider(hw_provider, (acoustic_model, vocoder))
+        # Both weights are fp32, so there is only one file set and device just
+        # picks the provider — measured 4.3x faster on gpu at num_threads=2.
+        provider = provider_for_device(device, (acoustic_model, vocoder))
 
         # Gather rule FSTs
         rule_fsts = []
@@ -158,7 +160,8 @@ class SherpaOnnxTTSAdapter(TTSAdapter):
         self._sid = speaker_id
         self._speed = speed
         log.info(f"[tts] sherpa-onnx Matcha loaded: model_dir={model_dir}, "
-                 f"speaker_id={speaker_id}, speed={speed}, provider={provider}")
+                 f"speaker_id={speaker_id}, speed={speed}, "
+                 f"device={device}, provider={provider}")
 
     def synthesize(self, text: str) -> bytes:
         return b''.join(self.synthesize_stream(text))
@@ -178,11 +181,12 @@ class SherpaOnnxTTSAdapter(TTSAdapter):
 
 def _build_tts_adapter(cfg: dict) -> TTSAdapter:
     import os
+    from utils.onnx_provider import normalize_device
     model_dir = cfg.get('model_dir', '/models/sherpa-onnx/tts')
     speaker_id = int(cfg.get('speaker_id', 0))
     speed = float(cfg.get('speed', 1.0))
-    return SherpaOnnxTTSAdapter(model_dir, speaker_id, speed,
-                                cfg.get('hw_provider', 'auto'))
+    device = normalize_device(cfg.get('device'), cfg.get('hw_provider'))
+    return SherpaOnnxTTSAdapter(model_dir, speaker_id, speed, device)
 
 
 # ── ROS2 Node ─────────────────────────────────────────────────────────────────
@@ -705,8 +709,8 @@ class SherpaOnnxTTSPlugin:
                 self._cfg['speaker_id'] = int(cfg['speaker_id'])
             if 'speed' in cfg:
                 self._cfg['speed'] = float(cfg['speed'])
-            if 'hw_provider' in cfg:
-                self._cfg['hw_provider'] = cfg['hw_provider']
+            if 'device' in cfg:
+                self._cfg['device'] = cfg['device']
             self._adapter = _build_tts_adapter(self._cfg)
             # Stop all nodes (they'll use new adapter on next start)
             with self._nodes_lock:
@@ -898,7 +902,7 @@ class TTSPlugin:
         requested = args.get("tts_engine") or args.get("engine")
         forwarded = {k: v for k, v in args.items()
                      if k not in ("tts_engine", "engine")}
-        for key in ("speaker_id", "speed", "hw_provider"):
+        for key in ("speaker_id", "speed", "device"):
             if key in args:
                 self._cfg[key] = args[key]
 

--- a/perception/plugins/tts.py
+++ b/perception/plugins/tts.py
@@ -773,6 +773,16 @@ class TTSPlugin:
         self._impl_engine = ""
         self._building = ""          # engine name while a build is in flight
         self._build_error = None
+        # `start` calls that arrived while a build was in flight, keyed by
+        # instance_id, replayed against the new engine once it is resident. Agent
+        # Core's contract for a start that answers `state: loading` is that the
+        # tool will reach `running` on its own — it polls `info` and reports
+        # "启动已取消" if it ever sees `idle` (see agent-core api/config.py
+        # _settle_loading_item). Dropping the start satisfied the letter of
+        # "never block" and broke that contract: switching engine and starting in
+        # the same batch, which is exactly what the dashboard does, left the card
+        # cancelled even though the engine had loaded fine.
+        self._pending_starts: dict[str, dict] = {}
         engine = self._select_engine(self._cfg.get("engine")
                                      or self._cfg.get("tts_engine"))
         self._engine = engine
@@ -845,6 +855,7 @@ class TTSPlugin:
                         self._build_error = str(error)
                 return
             stale = None
+            replay = []
             with self._lock:
                 if self._building != engine:
                     stale = impl          # another switch superseded this one
@@ -853,8 +864,24 @@ class TTSPlugin:
                     self._impl_engine = engine
                     self._building = ""
                     self._build_error = None
+                    replay = list(self._pending_starts.values())
+                    self._pending_starts.clear()
             if stale is not None:
                 _dispose_impl(stale)
+                return
+
+            # Honour the starts that arrived mid-build. Without this the engine
+            # comes up idle, and Agent Core — which polls `info` after a start
+            # answered `loading` — reports the card as "启动已取消".
+            for start_args in replay:
+                try:
+                    log.info("[tts] replaying start deferred during the %s build: %s",
+                             engine, start_args.get("instance_id") or
+                             start_args.get("input_topic"))
+                    impl.dispatch("tts", start_args)
+                except Exception:
+                    log.error("[tts] deferred start failed after the %s build",
+                              engine, exc_info=True)
 
         threading.Thread(target=_run, name=f"tts-engine-{engine}", daemon=True).start()
 
@@ -893,6 +920,29 @@ class TTSPlugin:
                 result["error"] = error
             return result
         if building:
+            if action == "start":
+                # Defer, do not drop. The dashboard sends config (which triggers
+                # the switch) and start back to back, so this is the normal path,
+                # not a rare race — and _build_async replays it.
+                with self._lock:
+                    if self._building:
+                        key = args.get("instance_id") or args.get("input_topic") or ""
+                        self._pending_starts[key] = dict(args)
+                        deferred = True
+                    else:
+                        deferred = False   # build finished while we waited on the lock
+                if not deferred:
+                    return self.dispatch(name, args)
+            elif action == "stop":
+                # Cancel a deferred start rather than letting it revive the node
+                # after the operator asked for it to stop.
+                with self._lock:
+                    key = args.get("instance_id") or args.get("input_topic") or ""
+                    if key in self._pending_starts:
+                        self._pending_starts.pop(key, None)
+                    elif not key:
+                        self._pending_starts.clear()
+                return {"state": "idle"}
             return {"state": "loading",
                     "message": f"TTS engine {building} is initializing, retry shortly"}
         return {"state": "error", "message": f"TTS engine {engine} failed: {error}"}

--- a/perception/plugins/vits2_tts_trt/plugin.py
+++ b/perception/plugins/vits2_tts_trt/plugin.py
@@ -463,9 +463,11 @@ class TTSPlugin:
     """VITS2 TensorRT implementation behind the standard ``tts`` tool.
 
     Lifecycle mirrors plugins/ocr.py, for the same reason: the slow work (a
-    60 MB release download, three TensorRT engines, a warmup pass) takes far
-    longer than the 60 s Agent Core allows a processor tools/call
-    (agent-core/src/mcp_client.py), so it must not run on the request thread.
+    60 MB release download, three TensorRT engines, a warmup pass) is open-ended,
+    so it must not run on the request thread. The bound it would blow through is
+    the 60 s the *LLM* tool path allows a processor tools/call
+    (agent-core/src/mcp_client.py); the dashboard's start-project path sets no
+    client timeout, but a download still has no upper bound worth blocking on.
 
         idle --start--> loading --ok--> ready/running
                           |               ^

--- a/perception/plugins/x_asr.py
+++ b/perception/plugins/x_asr.py
@@ -77,9 +77,11 @@ class XASRAdapter:
     def __init__(
         self,
         model_dir: str,
-        hw_provider: str = "cpu",
+        hw_provider: str = "auto",
         num_threads: int = 2,
     ):
+        from utils.onnx_provider import resolve_provider
+
         root = Path(model_dir)
         encoder = root / "encoder-epoch-99-avg-1.int8.onnx"
         decoder = root / "decoder-epoch-99-avg-1.onnx"
@@ -105,6 +107,8 @@ class XASRAdapter:
 
         import sherpa_onnx
 
+        hw_provider = resolve_provider(hw_provider,
+                                       (str(encoder), str(decoder), str(joiner)))
         encoded_hotwords = _prepare_hotwords_file(hotwords)
         self._recognizer = sherpa_onnx.OfflineRecognizer.from_transducer(
             encoder=str(encoder),

--- a/perception/plugins/x_asr.py
+++ b/perception/plugins/x_asr.py
@@ -77,10 +77,10 @@ class XASRAdapter:
     def __init__(
         self,
         model_dir: str,
-        hw_provider: str = "auto",
+        device: str = "cpu",
         num_threads: int = 2,
     ):
-        from utils.onnx_provider import resolve_provider
+        from utils.onnx_provider import provider_for_device
 
         root = Path(model_dir)
         encoder = root / "encoder-epoch-99-avg-1.int8.onnx"
@@ -107,7 +107,10 @@ class XASRAdapter:
 
         import sherpa_onnx
 
-        hw_provider = resolve_provider(hw_provider,
+        # This bundle only exists in mixed int8/fp32 form, so ASR_MODELS lists no
+        # gpu entry for it and device is effectively always cpu. The call stays so
+        # a forced device=gpu is reported rather than silently honoured.
+        provider = provider_for_device(device,
                                        (str(encoder), str(decoder), str(joiner)))
         encoded_hotwords = _prepare_hotwords_file(hotwords)
         self._recognizer = sherpa_onnx.OfflineRecognizer.from_transducer(
@@ -116,7 +119,7 @@ class XASRAdapter:
             joiner=str(joiner),
             tokens=str(tokens),
             num_threads=int(num_threads),
-            provider=hw_provider,
+            provider=provider,
             sample_rate=SAMPLE_RATE,
             feature_dim=80,
             decoding_method="modified_beam_search",
@@ -128,10 +131,11 @@ class XASRAdapter:
         )
         self._decode_lock = threading.Lock()
         log.info(
-            "[asr] X-ASR adapter loaded: encoder=%s, provider=%s, "
+            "[asr] X-ASR adapter loaded: encoder=%s, device=%s, provider=%s, "
             "max_active_paths=%d, hotwords_score=%.1f",
             encoder,
-            hw_provider,
+            device,
+            provider,
             MAX_ACTIVE_PATHS,
             HOTWORDS_SCORE,
         )

--- a/perception/tests/test_asr_device_registry.py
+++ b/perception/tests/test_asr_device_registry.py
@@ -11,7 +11,7 @@ expensive to notice:
 - pointing a `gpu` entry at int8 weights, which runs 1.25x-3.3x *slower* than the
   CPU because ONNX Runtime's CUDA provider has no int8 kernels, and
 - pointing a `cpu` entry at fp16 weights, which measured 42890 ms against int8's
-  3383 ms because ONNX Runtime has no fp16 CPU kernels.
+  3295 ms because ONNX Runtime has no fp16 CPU kernels.
 
 Neither raises; both just make the product slow. Also asserted: the configSchema's
 `device` visibility list matches the models that actually have gpu weights, so the
@@ -76,7 +76,7 @@ def test_gpu_entries_are_never_int8():
 
 def test_cpu_entries_are_never_fp16():
     """ONNX Runtime has no fp16 CPU kernels and casts everything: 42890 ms where
-    int8 took 3383 ms on the same audio."""
+    int8 took 3295 ms on the same audio."""
     for model, device, spec in _device_specs():
         if device == "cpu":
             assert spec["dtype"] != "fp16", \
@@ -150,3 +150,61 @@ def test_model_dir_from_another_entry_is_ignored():
     spec = asr.ASR_MODELS["sensevoice-small"]["devices"]["gpu"]
     other = asr.ASR_MODELS["paraformer-zh-en"]["devices"]["cpu"]["dir"]
     assert asr._model_dir_for({"model_dir": other}, spec) == spec["dir"]
+
+
+# ── warmup ───────────────────────────────────────────────────────────────────
+#
+# The first CUDA inference cost 1777 ms against a 77 ms steady state (lazy kernel
+# loading, cuDNN autotuning, memory pool). Untouched, that lands on the operator's
+# first utterance, right after the model finished loading.
+
+def test_silence_wav_is_a_decodable_16k_mono_wav():
+    import io
+    import wave
+    data = asr._silence_wav(0.5)
+    with wave.open(io.BytesIO(data)) as wf:
+        assert wf.getnchannels() == 1
+        assert wf.getsampwidth() == 2
+        assert wf.getframerate() == asr.SAMPLE_RATE
+        assert wf.getnframes() == int(asr.SAMPLE_RATE * 0.5)
+
+
+def test_warmup_decodes_one_clip():
+    calls = []
+
+    class _Adapter:
+        def transcribe(self, wav_bytes, language):
+            calls.append((len(wav_bytes), language))
+            return ""
+
+    asr._warmup_adapter(_Adapter(), "sensevoice-small", "gpu")
+    assert len(calls) == 1
+    assert calls[0][0] > 0
+
+
+@pytest.mark.parametrize("cfg, expect_warm", [
+    ({}, True),                      # on by default — the gpu first-call cost
+    ({"warmup": True}, True),
+    ({"warmup": False}, False),      # opt out
+])
+def test_build_warms_up_unless_disabled(monkeypatch, cfg, expect_warm):
+    warmed = []
+    monkeypatch.setattr(asr, "_warmup_adapter",
+                        lambda adapter, model, device: warmed.append((model, device)))
+    monkeypatch.setattr("utils.model_downloader.ensure_model",
+                        lambda *a, **k: None)
+    monkeypatch.setitem(asr.ASR_MODELS["sensevoice-small"], "adapter",
+                        lambda model_dir, device, num_threads: object())
+
+    asr._build_asr_adapter({"asr_model": "sensevoice-small", "device": "cpu", **cfg})
+    assert bool(warmed) is expect_warm
+
+
+def test_warmup_failure_does_not_propagate():
+    """A model that cannot decode silence still fails loudly on real audio; it must
+    not stop the plugin from coming up."""
+    class _Broken:
+        def transcribe(self, wav_bytes, language):
+            raise RuntimeError("no session")
+
+    asr._warmup_adapter(_Broken(), "sensevoice-small", "gpu")  # must not raise

--- a/perception/tests/test_asr_device_registry.py
+++ b/perception/tests/test_asr_device_registry.py
@@ -1,0 +1,152 @@
+"""
+Invariants for the ASR (model, device) registry — no hardware or models needed.
+
+Run from the repo root:
+    python -m pytest perception/tests -q
+
+These exist because the registry encodes measurements, and a plausible-looking
+edit can silently undo them. Two mistakes in particular are cheap to make and
+expensive to notice:
+
+- pointing a `gpu` entry at int8 weights, which runs 1.25x-3.3x *slower* than the
+  CPU because ONNX Runtime's CUDA provider has no int8 kernels, and
+- pointing a `cpu` entry at fp16 weights, which measured 42890 ms against int8's
+  3383 ms because ONNX Runtime has no fp16 CPU kernels.
+
+Neither raises; both just make the product slow. Also asserted: the configSchema's
+`device` visibility list matches the models that actually have gpu weights, so the
+dashboard never offers a choice the plugin would reject.
+
+sherpa_onnx is stubbed out because importing plugins.asr pulls it in transitively.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+PERCEPTION_ROOT = Path(__file__).resolve().parents[1]
+if str(PERCEPTION_ROOT) not in sys.path:
+    sys.path.insert(0, str(PERCEPTION_ROOT))
+
+sys.modules.setdefault("sherpa_onnx", types.ModuleType("sherpa_onnx"))
+
+from plugins import asr  # noqa: E402
+from utils import model_downloader  # noqa: E402
+
+VALID_DTYPES = {"int8", "fp32", "fp16"}
+
+
+def _device_specs():
+    for model, info in asr.ASR_MODELS.items():
+        for device, spec in info["devices"].items():
+            yield model, device, spec
+
+
+def test_every_model_has_a_cpu_entry():
+    """cpu is the fallback for an unsupported device request, so it must exist."""
+    for model, info in asr.ASR_MODELS.items():
+        assert "cpu" in info["devices"], f"{model} has no cpu weights"
+
+
+def test_device_keys_are_known():
+    for model, device, _ in _device_specs():
+        assert device in ("cpu", "gpu"), f"{model} declares unknown device {device!r}"
+
+
+def test_dtypes_are_declared_and_known():
+    for model, device, spec in _device_specs():
+        assert spec.get("dtype") in VALID_DTYPES, \
+            f"{model}/{device} has dtype {spec.get('dtype')!r}"
+
+
+def test_gpu_entries_are_never_int8():
+    """ONNX Runtime's CUDA provider has no int8 kernels: it partitions the graph,
+    falls back to CPU node by node, and adds a copy at every boundary. Measured
+    1.25x-3.3x slower than the CPU, and it also perturbs the output (3 of 4
+    SenseVoice transcripts changed versus the same model on CPU)."""
+    for model, device, spec in _device_specs():
+        if device == "gpu":
+            assert spec["dtype"] != "int8", \
+                f"{model}/gpu points at int8 weights, which is slower than cpu"
+
+
+def test_cpu_entries_are_never_fp16():
+    """ONNX Runtime has no fp16 CPU kernels and casts everything: 42890 ms where
+    int8 took 3383 ms on the same audio."""
+    for model, device, spec in _device_specs():
+        if device == "cpu":
+            assert spec["dtype"] != "fp16", \
+                f"{model}/cpu points at fp16 weights, which is ~10x slower than int8"
+
+
+def test_download_keys_resolve():
+    """A gpu entry must name a pinned bundle; a cpu entry a legacy archive."""
+    for model, device, spec in _device_specs():
+        key = spec["download"]
+        if device == "gpu":
+            assert key in model_downloader.SHERPA_GPU_BUNDLES, \
+                f"{model}/gpu download key {key!r} is not a SHERPA_GPU_BUNDLES entry"
+        else:
+            assert key in model_downloader.MODELS, \
+                f"{model}/cpu download key {key!r} is not a MODELS entry"
+
+
+def test_model_dirs_are_unique():
+    """Two entries sharing a directory would download over each other's weights."""
+    dirs = [spec["dir"] for _, _, spec in _device_specs()]
+    assert len(dirs) == len(set(dirs)), "duplicate model_dir in ASR_MODELS"
+
+
+def test_default_model_exists_and_is_the_schema_default():
+    assert asr.DEFAULT_ASR_MODEL in asr.ASR_MODELS
+    schema = asr.TOOLS[0]["configSchema"]["properties"]
+    assert schema["asr_model"]["default"] == asr.DEFAULT_ASR_MODEL
+
+
+def test_schema_enum_matches_the_registry():
+    schema = asr.TOOLS[0]["configSchema"]["properties"]
+    assert sorted(schema["asr_model"]["enum"]) == sorted(asr.ASR_MODELS)
+
+
+def test_device_field_is_shown_exactly_for_models_with_gpu_weights():
+    """Otherwise the dashboard offers gpu on a model whose config action rejects
+    it, or hides it on a model that supports it."""
+    schema = asr.TOOLS[0]["configSchema"]["properties"]
+    shown_for = schema["device"]["x-show-when"]["asr_model"]
+    assert sorted(shown_for) == asr.asr_models_supporting("gpu")
+
+
+def test_device_schema_default_is_cpu():
+    schema = asr.TOOLS[0]["configSchema"]["properties"]
+    assert schema["device"]["default"] == "cpu"
+    assert sorted(schema["device"]["enum"]) == ["cpu", "gpu"]
+
+
+def test_asr_models_supporting():
+    assert "sensevoice-small" in asr.asr_models_supporting("gpu")
+    assert "paraformer-zh-en" in asr.asr_models_supporting("gpu")
+    # Measured 0.80x on CUDA — deliberately absent.
+    assert "x-asr-zh-en" not in asr.asr_models_supporting("gpu")
+    assert asr.asr_models_supporting("cpu") == sorted(asr.ASR_MODELS)
+
+
+@pytest.mark.parametrize("cfg, expected_dir", [
+    ({}, None),                                        # registry default
+    ({"model_dir": "/custom/place"}, "/custom/place"),  # honoured
+])
+def test_model_dir_override(cfg, expected_dir):
+    spec = asr.ASR_MODELS["sensevoice-small"]["devices"]["cpu"]
+    got = asr._model_dir_for(cfg, spec)
+    assert got == (expected_dir or spec["dir"])
+
+
+def test_model_dir_from_another_entry_is_ignored():
+    """config.yaml ships a model_dir for one bundle; reusing it for a different
+    model or device would download the wrong weights into it."""
+    spec = asr.ASR_MODELS["sensevoice-small"]["devices"]["gpu"]
+    other = asr.ASR_MODELS["paraformer-zh-en"]["devices"]["cpu"]["dir"]
+    assert asr._model_dir_for({"model_dir": other}, spec) == spec["dir"]

--- a/perception/tests/test_asr_phonemize.py
+++ b/perception/tests/test_asr_phonemize.py
@@ -167,3 +167,105 @@ def test_mixed_language_text_builds_one_backend_per_language(monkeypatch):
     asr._text_to_ipa("小范小范，jump forward.")
     assert sorted(set(builds)) == ["cmn", "en-us"]
     assert len(builds) == 2, f"built {len(builds)} backends for two languages"
+
+
+# ── mapping a phoneme index back to a character offset ───────────────────────
+#
+# The reported symptom: 小潘小潘，现在发生什么了？ triggered on the wake word and the
+# remainder came back as 在发生什么了？ — 现 was eaten. end_pos was right; the mapping
+# was a phonemes-per-character extrapolation, round(12 * 11 / 29) = 5, measured over
+# a segmentation that skipped punctuation where _text_to_ipa splits on it.
+
+def _fake_cmn_phonemizer(monkeypatch, per_char=3):
+    """espeak stand-in: `per_char` phonemes per CJK character, one per latin char.
+
+    Deliberately non-uniform across languages, which is what broke the ratio
+    estimate; a uniform stub would pass either implementation.
+    """
+    class _Backend:
+        def __init__(self, lang, with_stress=False):
+            self.lang = lang
+
+        def phonemize(self, texts, separator=None, strip=False):
+            t = texts[0]
+            if self.lang == "cmn":
+                return [" ".join("p%d" % i for i in range(len(t) * per_char))]
+            return [" ".join(list(t))]
+
+    backend_mod = types.ModuleType("phonemizer.backend")
+    backend_mod.EspeakBackend = _Backend
+    sep_mod = types.ModuleType("phonemizer.separator")
+    sep_mod.Separator = lambda **kw: object()
+    monkeypatch.setitem(sys.modules, "phonemizer", types.ModuleType("phonemizer"))
+    monkeypatch.setitem(sys.modules, "phonemizer.backend", backend_mod)
+    monkeypatch.setitem(sys.modules, "phonemizer.separator", sep_mod)
+
+
+def test_segments_are_offsets_into_the_original_text():
+    text = "小范小范，你好。"
+    spans = asr._text_segments(text)
+    assert [text[s:e] for s, e, _ in spans] == ["小范小范", "，", "你好", "。"]
+    assert [cjk for _, _, cjk in spans] == [True, False, True, False]
+
+
+def test_the_reported_case_keeps_every_character_after_the_wake_word(monkeypatch):
+    _fake_cmn_phonemizer(monkeypatch)
+    text = "小潘小潘，现在发生什么了？"
+    phones, char_ends = asr._text_to_ipa(text, with_positions=True)
+    assert len(char_ends) == len(phones)
+    # 4 CJK chars x 3 phonemes = the wake word ends at phoneme 12
+    assert asr._text_after_phoneme(text, char_ends, 12) == "现在发生什么了？"
+
+
+@pytest.mark.parametrize("end_pos, expected", [
+    (3,  "潘小潘，现在发生什么了？"),   # after the first character
+    (6,  "小潘，现在发生什么了？"),
+    (12, "现在发生什么了？"),          # after the wake word
+    (15, "在发生什么了？"),
+])
+def test_cut_points_are_exact_not_estimated(monkeypatch, end_pos, expected):
+    _fake_cmn_phonemizer(monkeypatch)
+    text = "小潘小潘，现在发生什么了？"
+    _, char_ends = asr._text_to_ipa(text, with_positions=True)
+    assert asr._text_after_phoneme(text, char_ends, end_pos) == expected
+
+
+def test_mixed_script_cut(monkeypatch):
+    """The old estimate was worst here: CJK and latin have very different
+    phonemes-per-character, and it applied one ratio to a merged segment."""
+    _fake_cmn_phonemizer(monkeypatch)
+    text = "小范小范，jump forward."
+    _, char_ends = asr._text_to_ipa(text, with_positions=True)
+    assert asr._text_after_phoneme(text, char_ends, 12) == "jump forward."
+
+
+def test_char_ends_are_monotonic(monkeypatch):
+    _fake_cmn_phonemizer(monkeypatch)
+    _, char_ends = asr._text_to_ipa("小范小范，你好啊。", with_positions=True)
+    assert char_ends == sorted(char_ends)
+
+
+def test_positions_work_on_the_character_fallback(monkeypatch):
+    """Without espeak each character is its own phoneme, so the cut is direct."""
+    monkeypatch.setattr(asr, "_get_espeak_backend",
+                        lambda lang: (_ for _ in ()).throw(RuntimeError("nope")))
+    text = "小范小范，你好。"
+    phones, char_ends = asr._text_to_ipa(text, with_positions=True)
+    assert len(char_ends) == len(phones)
+    assert asr._text_after_phoneme(text, char_ends, 4) == "你好。"
+
+
+def test_out_of_range_end_pos_is_safe(monkeypatch):
+    _fake_cmn_phonemizer(monkeypatch)
+    text = "小范小范"
+    _, char_ends = asr._text_to_ipa(text, with_positions=True)
+    assert asr._text_after_phoneme(text, char_ends, 0) == ""
+    assert asr._text_after_phoneme(text, char_ends, 9999) == ""
+    assert asr._text_after_phoneme(text, [], 5) == ""
+
+
+def test_positions_are_opt_in(monkeypatch):
+    """Callers that only match still get a plain list, and pay no prefix passes."""
+    _fake_cmn_phonemizer(monkeypatch)
+    out = asr._text_to_ipa("小范小范")
+    assert isinstance(out, list) and out and isinstance(out[0], str)

--- a/perception/tests/test_asr_phonemize.py
+++ b/perception/tests/test_asr_phonemize.py
@@ -1,0 +1,169 @@
+"""
+Phonemizer plumbing for asr_kws — no espeak or models required.
+
+These pin the two things that made a misconfiguration cost 5.2 s per utterance in
+production, measured from the plugin's own `kws_phonemize` span:
+
+- phonemizer could not find libespeak-ng, because it looks it up with
+  ctypes.util.find_library, which shells out to `ldconfig -p`, and the jetson image
+  stubs ldconfig out during apt installs to survive qemu. So the library is
+  installed and the cache does not know about it.
+- every failure was retried, and `_text_to_ipa` splits an utterance into CJK /
+  non-CJK segments — four for '小范小范，你好。', since fullwidth punctuation is
+  outside the CJK range. Eight fork+exec of `ldconfig` per utterance from a 3.6 GB
+  multi-threaded process.
+
+Out of process the same call took 320 ms, so neither showed up until the spans were
+read. That is why these are unit tests now.
+
+Run: python -m pytest perception/tests -q
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+PERCEPTION_ROOT = Path(__file__).resolve().parents[1]
+if str(PERCEPTION_ROOT) not in sys.path:
+    sys.path.insert(0, str(PERCEPTION_ROOT))
+
+sys.modules.setdefault("sherpa_onnx", types.ModuleType("sherpa_onnx"))
+
+from plugins import asr  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _reset_espeak(monkeypatch):
+    """Module-level caches, so every test starts from a cold probe."""
+    monkeypatch.setattr(asr, "_ESPEAK_BACKENDS", {})
+    monkeypatch.setattr(asr, "_ESPEAK_SEP", None)
+    monkeypatch.setattr(asr, "_ESPEAK_UNAVAILABLE", None)
+    monkeypatch.delenv("PHONEMIZER_ESPEAK_LIBRARY", raising=False)
+    yield
+
+
+# ── locating the library ─────────────────────────────────────────────────────
+
+def test_probe_points_phonemizer_at_the_first_existing_candidate(monkeypatch, tmp_path):
+    lib = tmp_path / "libespeak-ng.so.1"
+    lib.write_bytes(b"")
+    monkeypatch.setattr(asr, "_ESPEAK_LIB_CANDIDATES",
+                        ("/nonexistent/libespeak-ng.so.1", str(lib)))
+    asr._point_phonemizer_at_espeak()
+    assert asr.os.environ["PHONEMIZER_ESPEAK_LIBRARY"] == str(lib)
+
+
+def test_probe_respects_a_preset_library(monkeypatch, tmp_path):
+    """A deployment that already points somewhere must not be overridden."""
+    lib = tmp_path / "libespeak-ng.so.1"
+    lib.write_bytes(b"")
+    monkeypatch.setenv("PHONEMIZER_ESPEAK_LIBRARY", "/operator/choice.so")
+    monkeypatch.setattr(asr, "_ESPEAK_LIB_CANDIDATES", (str(lib),))
+    asr._point_phonemizer_at_espeak()
+    assert asr.os.environ["PHONEMIZER_ESPEAK_LIBRARY"] == "/operator/choice.so"
+
+
+def test_probe_leaves_the_env_alone_when_nothing_exists(monkeypatch):
+    monkeypatch.setattr(asr, "_ESPEAK_LIB_CANDIDATES",
+                        ("/nonexistent/a.so", "/nonexistent/b.so"))
+    asr._point_phonemizer_at_espeak()
+    assert "PHONEMIZER_ESPEAK_LIBRARY" not in asr.os.environ
+
+
+# ── not retrying a failure ───────────────────────────────────────────────────
+
+def test_a_construction_failure_is_probed_once_and_then_remembered(monkeypatch):
+    """The whole 5.2 s was retrying this. espeak either resolves or it does not."""
+    attempts = []
+
+    def _boom(lang):
+        attempts.append(lang)
+        raise RuntimeError("espeak not installed on your system")
+
+    monkeypatch.setattr(asr, "_get_espeak_backend", _boom)
+
+    for _ in range(5):
+        with pytest.raises(Exception):
+            asr._phonemize_safe("小范小范", "cmn")
+    assert len(attempts) == 1, f"probed {len(attempts)} times, must be 1"
+
+
+def test_text_to_ipa_falls_back_to_characters_without_espeak(monkeypatch):
+    monkeypatch.setattr(asr, "_get_espeak_backend",
+                        lambda lang: (_ for _ in ()).throw(RuntimeError("nope")))
+    ipa = asr._text_to_ipa("小范小范，你好。")
+    # Degraded but usable: characters, not an exception and not an empty list.
+    assert ipa[:4] == ["小", "范", "小", "范"]
+
+
+def test_text_to_ipa_probes_once_across_all_segments(monkeypatch):
+    """'小范小范，你好。' is four CJK/non-CJK segments; a per-segment retry is what
+    multiplied one failure into eight subprocess spawns."""
+    attempts = []
+
+    def _boom(lang):
+        attempts.append(lang)
+        raise RuntimeError("nope")
+
+    monkeypatch.setattr(asr, "_get_espeak_backend", _boom)
+    asr._text_to_ipa("小范小范，你好。")
+    assert len(attempts) == 1
+
+
+# ── the happy path keeps its persistent backend ──────────────────────────────
+
+def test_a_working_backend_is_built_once_and_reused(monkeypatch):
+    """The cache was always empty before, because construction never succeeded, so
+    every segment rebuilt. Reuse is the difference between 0.3 ms and 500 ms."""
+    builds = []
+
+    class _Backend:
+        def __init__(self, lang, with_stress=False):
+            builds.append(lang)
+
+        def phonemize(self, texts, separator=None, strip=False):
+            return ["ɕ j ɑu  f a n"]
+
+    # Stub the two phonemizer modules _get_espeak_backend imports lazily.
+    backend_mod = types.ModuleType("phonemizer.backend")
+    backend_mod.EspeakBackend = _Backend
+    sep_mod = types.ModuleType("phonemizer.separator")
+    sep_mod.Separator = lambda **kw: object()
+    pkg = types.ModuleType("phonemizer")
+    monkeypatch.setitem(sys.modules, "phonemizer", pkg)
+    monkeypatch.setitem(sys.modules, "phonemizer.backend", backend_mod)
+    monkeypatch.setitem(sys.modules, "phonemizer.separator", sep_mod)
+
+    for _ in range(4):
+        assert asr._phonemize_safe("小范小范", "cmn") == "ɕ j ɑu  f a n"
+    assert builds == ["cmn"], f"built the backend {len(builds)} times, must be once"
+
+
+def test_mixed_language_text_builds_one_backend_per_language(monkeypatch):
+    """'小范小范，jump forward.' needs cmn and en-us — two backends, not two per
+    segment."""
+    builds = []
+
+    class _Backend:
+        def __init__(self, lang, with_stress=False):
+            builds.append(lang)
+
+        def phonemize(self, texts, separator=None, strip=False):
+            return ["p h"]
+
+    backend_mod = types.ModuleType("phonemizer.backend")
+    backend_mod.EspeakBackend = _Backend
+    sep_mod = types.ModuleType("phonemizer.separator")
+    sep_mod.Separator = lambda **kw: object()
+    monkeypatch.setitem(sys.modules, "phonemizer", types.ModuleType("phonemizer"))
+    monkeypatch.setitem(sys.modules, "phonemizer.backend", backend_mod)
+    monkeypatch.setitem(sys.modules, "phonemizer.separator", sep_mod)
+
+    asr._text_to_ipa("小范小范，jump forward.")
+    asr._text_to_ipa("小范小范，jump forward.")
+    assert sorted(set(builds)) == ["cmn", "en-us"]
+    assert len(builds) == 2, f"built {len(builds)} backends for two languages"

--- a/perception/tests/test_onnx_provider.py
+++ b/perception/tests/test_onnx_provider.py
@@ -23,7 +23,8 @@ if str(PERCEPTION_ROOT) not in sys.path:
 from utils import onnx_provider  # noqa: E402
 
 INT8 = "/models/asr/encoder.int8.onnx"
-FP32 = "/models/tts/model-steps-3.onnx"
+FP32 = "/models/asr/encoder.onnx"
+FP16 = "/models/asr/model.fp16.onnx"
 
 
 @pytest.fixture(autouse=True)
@@ -71,11 +72,12 @@ def test_cuda_available_false_when_sherpa_missing(monkeypatch):
     assert onnx_provider.cuda_available() is False
 
 
-# ── is_quantised ─────────────────────────────────────────────────────────────
+# ── dtype detection ──────────────────────────────────────────────────────────
 
 @pytest.mark.parametrize("paths, expected", [
     ((INT8,), True),
     ((FP32,), False),
+    ((FP16,), False),
     ((INT8, FP32), True),                       # any int8 file poisons the set
     (("/m/decoder-epoch-99-avg-1.onnx", "/m/joiner-epoch-99-avg-1.int8.onnx"), True),
     ((), False),
@@ -85,47 +87,118 @@ def test_is_quantised(paths, expected):
     assert onnx_provider.is_quantised(paths) is expected
 
 
-# ── resolve_provider ─────────────────────────────────────────────────────────
+@pytest.mark.parametrize("paths, expected", [
+    ((FP16,), True),
+    ((FP32,), False),
+    ((INT8,), False),
+    ((FP32, FP16), True),
+    ((), False),
+])
+def test_is_fp16(paths, expected):
+    assert onnx_provider.is_fp16(paths) is expected
 
-def test_auto_picks_cuda_for_fp32_on_gpu_wheel(monkeypatch, tmp_path):
+
+# ── normalize_device ─────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("value, expected", [
+    ("cpu", "cpu"),
+    ("gpu", "gpu"),
+    ("GPU", "gpu"),
+    (" gpu ", "gpu"),
+    ("cuda", "gpu"),        # provider name accepted as an alias
+    ("nvidia", "gpu"),
+    (None, "cpu"),
+    ("", "cpu"),
+    ("tpu", "cpu"),         # unknown falls back rather than raising
+])
+def test_normalize_device(value, expected):
+    assert onnx_provider.normalize_device(value) == expected
+
+
+@pytest.mark.parametrize("legacy, expected", [
+    ("cuda", "gpu"),
+    ("gpu", "gpu"),
+    ("cpu", "cpu"),
+    ("auto", "cpu"),        # the old `auto` has no device meaning; default applies
+])
+def test_normalize_device_accepts_legacy_hw_provider(legacy, expected):
+    """A deployment mounting its own pre-`device` config.yaml keeps working."""
+    assert onnx_provider.normalize_device(None, legacy) == expected
+
+
+def test_explicit_device_wins_over_legacy_key(monkeypatch):
+    assert onnx_provider.normalize_device("cpu", "cuda") == "cpu"
+
+
+# ── provider_for_device ──────────────────────────────────────────────────────
+
+def test_gpu_with_fp16_weights_uses_cuda(monkeypatch, tmp_path):
     _install_fake_sherpa(monkeypatch, tmp_path, with_cuda=True)
-    assert onnx_provider.resolve_provider("auto", (FP32,)) == "cuda"
+    assert onnx_provider.provider_for_device("gpu", (FP16,)) == "cuda"
 
 
-def test_auto_picks_cpu_for_int8_even_on_gpu_wheel(monkeypatch, tmp_path):
-    """The measured reason: ONNX Runtime's CUDA EP has no int8 kernels and falls
-    back per node, which came out 3.3x slower than CPU at the same num_threads on
-    an Orin NX (streaming paraformer)."""
+def test_gpu_with_fp32_weights_uses_cuda(monkeypatch, tmp_path):
     _install_fake_sherpa(monkeypatch, tmp_path, with_cuda=True)
-    assert onnx_provider.resolve_provider("auto", (INT8,)) == "cpu"
+    assert onnx_provider.provider_for_device("gpu", (FP32,)) == "cuda"
 
 
-def test_auto_with_no_paths_assumes_fp32(monkeypatch, tmp_path):
-    """A caller that forgets model_paths errs toward the GPU, not toward a silent
-    CPU pin — an unexpectedly slow ASR is harder to notice than a fast one."""
+def test_gpu_with_int8_weights_falls_back_to_cpu(monkeypatch, tmp_path):
+    """A registry bug, and the measured reason to catch it: ONNX Runtime's CUDA EP
+    has no int8 kernels, falls back per node, and ran 1.25x-3.3x slower than CPU."""
     _install_fake_sherpa(monkeypatch, tmp_path, with_cuda=True)
-    assert onnx_provider.resolve_provider("auto") == "cuda"
+    assert onnx_provider.provider_for_device("gpu", (INT8,)) == "cpu"
 
 
-@pytest.mark.parametrize("value", ["auto", "AUTO", " auto ", "", None])
-def test_auto_and_unset_fall_back_to_cpu_on_cpu_wheel(monkeypatch, tmp_path, value):
+def test_gpu_on_cpu_only_wheel_falls_back(monkeypatch, tmp_path):
+    """jp6.1 and x86 install the PyPI CPU wheel; ASR must still come up."""
     _install_fake_sherpa(monkeypatch, tmp_path, with_cuda=False)
-    assert onnx_provider.resolve_provider(value, (FP32,)) == "cpu"
+    assert onnx_provider.provider_for_device("gpu", (FP16,)) == "cpu"
 
 
-@pytest.mark.parametrize("value", ["cuda", "CUDA", " cuda "])
-def test_explicit_cuda_passes_through_on_int8_and_cpu_wheel(monkeypatch, tmp_path, value):
-    """A pinned provider is not second-guessed: either it is a deliberate choice
-    or a misconfigured deployment, and both should stay visible."""
-    _install_fake_sherpa(monkeypatch, tmp_path, with_cuda=False)
-    assert onnx_provider.resolve_provider(value, (INT8,)) == "cuda"
-
-
-def test_explicit_cpu_passes_through_for_fp32_on_gpu_wheel(monkeypatch, tmp_path):
+def test_cpu_stays_cpu_for_every_dtype(monkeypatch, tmp_path):
     _install_fake_sherpa(monkeypatch, tmp_path, with_cuda=True)
-    assert onnx_provider.resolve_provider("cpu", (FP32,)) == "cpu"
+    for path in (INT8, FP32, FP16):
+        assert onnx_provider.provider_for_device("cpu", (path,)) == "cpu"
 
 
-def test_unknown_value_falls_back_to_cpu(monkeypatch, tmp_path):
+def test_cpu_with_fp16_logs_an_error(monkeypatch, tmp_path, caplog):
+    """fp16 on CPU measured 42890 ms against int8's 3383 ms — ONNX Runtime has no
+    fp16 CPU kernels. It still runs, but the registry is wrong and should say so."""
     _install_fake_sherpa(monkeypatch, tmp_path, with_cuda=True)
-    assert onnx_provider.resolve_provider("trt", (FP32,)) == "cpu"
+    with caplog.at_level("ERROR"):
+        assert onnx_provider.provider_for_device("cpu", (FP16,)) == "cpu"
+    assert any("fp16" in r.message.lower() or "fp16" in r.getMessage().lower()
+               for r in caplog.records)
+
+
+def test_unknown_device_is_treated_as_cpu(monkeypatch, tmp_path):
+    _install_fake_sherpa(monkeypatch, tmp_path, with_cuda=True)
+    assert onnx_provider.provider_for_device("tpu", (FP32,)) == "cpu"
+
+
+# ── pick_weights ─────────────────────────────────────────────────────────────
+
+def test_pick_weights_returns_first_existing(tmp_path):
+    (tmp_path / "model.onnx").write_bytes(b"")
+    picked = onnx_provider.pick_weights(str(tmp_path), "model.fp16.onnx",
+                                        "model.onnx", "model.int8.onnx")
+    assert picked == str(tmp_path / "model.onnx")
+
+
+def test_pick_weights_respects_candidate_order(tmp_path):
+    (tmp_path / "model.onnx").write_bytes(b"")
+    (tmp_path / "model.int8.onnx").write_bytes(b"")
+    assert onnx_provider.pick_weights(str(tmp_path), "model.int8.onnx",
+                                      "model.onnx") == str(tmp_path / "model.int8.onnx")
+    assert onnx_provider.pick_weights(str(tmp_path), "model.onnx",
+                                      "model.int8.onnx") == str(tmp_path / "model.onnx")
+
+
+def test_pick_weights_falls_back_to_last_candidate(tmp_path):
+    """So the caller's own "not found" error names the file it wanted."""
+    assert onnx_provider.pick_weights(str(tmp_path), "a.onnx", "b.onnx") == \
+        str(tmp_path / "b.onnx")
+
+
+def test_pick_weights_with_no_candidates(tmp_path):
+    assert onnx_provider.pick_weights(str(tmp_path)) == ""

--- a/perception/tests/test_onnx_provider.py
+++ b/perception/tests/test_onnx_provider.py
@@ -94,7 +94,8 @@ def test_auto_picks_cuda_for_fp32_on_gpu_wheel(monkeypatch, tmp_path):
 
 def test_auto_picks_cpu_for_int8_even_on_gpu_wheel(monkeypatch, tmp_path):
     """The measured reason: ONNX Runtime's CUDA EP has no int8 kernels and falls
-    back per node, which came out 2-3x slower than 2-thread CPU on an Orin NX."""
+    back per node, which came out 3.3x slower than CPU at the same num_threads on
+    an Orin NX (streaming paraformer)."""
     _install_fake_sherpa(monkeypatch, tmp_path, with_cuda=True)
     assert onnx_provider.resolve_provider("auto", (INT8,)) == "cpu"
 

--- a/perception/tests/test_onnx_provider.py
+++ b/perception/tests/test_onnx_provider.py
@@ -162,7 +162,7 @@ def test_cpu_stays_cpu_for_every_dtype(monkeypatch, tmp_path):
 
 
 def test_cpu_with_fp16_logs_an_error(monkeypatch, tmp_path, caplog):
-    """fp16 on CPU measured 42890 ms against int8's 3383 ms — ONNX Runtime has no
+    """fp16 on CPU measured 42890 ms against int8's 3295 ms — ONNX Runtime has no
     fp16 CPU kernels. It still runs, but the registry is wrong and should say so."""
     _install_fake_sherpa(monkeypatch, tmp_path, with_cuda=True)
     with caplog.at_level("ERROR"):

--- a/perception/tests/test_onnx_provider.py
+++ b/perception/tests/test_onnx_provider.py
@@ -1,0 +1,130 @@
+"""
+Host-side unit tests for utils/onnx_provider (no sherpa-onnx install required).
+
+Run from the repo root:
+    python -m pytest perception/tests -q
+
+`sherpa_onnx` is replaced by a stub module whose __file__ points into a tmp_path
+tree, so the CUDA-wheel marker can be made present or absent at will.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+PERCEPTION_ROOT = Path(__file__).resolve().parents[1]
+if str(PERCEPTION_ROOT) not in sys.path:
+    sys.path.insert(0, str(PERCEPTION_ROOT))
+
+from utils import onnx_provider  # noqa: E402
+
+INT8 = "/models/asr/encoder.int8.onnx"
+FP32 = "/models/tts/model-steps-3.onnx"
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    """cuda_available is lru_cached for the process lifetime."""
+    onnx_provider.cuda_available.cache_clear()
+    yield
+    onnx_provider.cuda_available.cache_clear()
+
+
+def _install_fake_sherpa(monkeypatch, tmp_path, *, with_cuda: bool):
+    pkg_dir = tmp_path / "sherpa_onnx"
+    (pkg_dir / "lib").mkdir(parents=True)
+    (pkg_dir / "__init__.py").write_text("")
+    if with_cuda:
+        (pkg_dir / "lib" / "libonnxruntime_providers_cuda.so").write_bytes(b"")
+    module = types.ModuleType("sherpa_onnx")
+    module.__file__ = str(pkg_dir / "__init__.py")
+    monkeypatch.setitem(sys.modules, "sherpa_onnx", module)
+
+
+# ── cuda_available ───────────────────────────────────────────────────────────
+
+def test_cuda_available_true_when_marker_present(monkeypatch, tmp_path):
+    _install_fake_sherpa(monkeypatch, tmp_path, with_cuda=True)
+    assert onnx_provider.cuda_available() is True
+
+
+def test_cuda_available_false_on_cpu_wheel(monkeypatch, tmp_path):
+    _install_fake_sherpa(monkeypatch, tmp_path, with_cuda=False)
+    assert onnx_provider.cuda_available() is False
+
+
+def test_cuda_available_false_when_sherpa_missing(monkeypatch):
+    """x86 dev hosts and the unit-test environment have no sherpa-onnx at all."""
+    real_import = __import__
+
+    def _fail(name, *args, **kwargs):
+        if name == "sherpa_onnx":
+            raise ImportError("no sherpa_onnx")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.delitem(sys.modules, "sherpa_onnx", raising=False)
+    monkeypatch.setattr("builtins.__import__", _fail)
+    assert onnx_provider.cuda_available() is False
+
+
+# ── is_quantised ─────────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("paths, expected", [
+    ((INT8,), True),
+    ((FP32,), False),
+    ((INT8, FP32), True),                       # any int8 file poisons the set
+    (("/m/decoder-epoch-99-avg-1.onnx", "/m/joiner-epoch-99-avg-1.int8.onnx"), True),
+    ((), False),
+    ((None, ""), False),                        # unset paths are not int8 evidence
+])
+def test_is_quantised(paths, expected):
+    assert onnx_provider.is_quantised(paths) is expected
+
+
+# ── resolve_provider ─────────────────────────────────────────────────────────
+
+def test_auto_picks_cuda_for_fp32_on_gpu_wheel(monkeypatch, tmp_path):
+    _install_fake_sherpa(monkeypatch, tmp_path, with_cuda=True)
+    assert onnx_provider.resolve_provider("auto", (FP32,)) == "cuda"
+
+
+def test_auto_picks_cpu_for_int8_even_on_gpu_wheel(monkeypatch, tmp_path):
+    """The measured reason: ONNX Runtime's CUDA EP has no int8 kernels and falls
+    back per node, which came out 2-3x slower than 2-thread CPU on an Orin NX."""
+    _install_fake_sherpa(monkeypatch, tmp_path, with_cuda=True)
+    assert onnx_provider.resolve_provider("auto", (INT8,)) == "cpu"
+
+
+def test_auto_with_no_paths_assumes_fp32(monkeypatch, tmp_path):
+    """A caller that forgets model_paths errs toward the GPU, not toward a silent
+    CPU pin — an unexpectedly slow ASR is harder to notice than a fast one."""
+    _install_fake_sherpa(monkeypatch, tmp_path, with_cuda=True)
+    assert onnx_provider.resolve_provider("auto") == "cuda"
+
+
+@pytest.mark.parametrize("value", ["auto", "AUTO", " auto ", "", None])
+def test_auto_and_unset_fall_back_to_cpu_on_cpu_wheel(monkeypatch, tmp_path, value):
+    _install_fake_sherpa(monkeypatch, tmp_path, with_cuda=False)
+    assert onnx_provider.resolve_provider(value, (FP32,)) == "cpu"
+
+
+@pytest.mark.parametrize("value", ["cuda", "CUDA", " cuda "])
+def test_explicit_cuda_passes_through_on_int8_and_cpu_wheel(monkeypatch, tmp_path, value):
+    """A pinned provider is not second-guessed: either it is a deliberate choice
+    or a misconfigured deployment, and both should stay visible."""
+    _install_fake_sherpa(monkeypatch, tmp_path, with_cuda=False)
+    assert onnx_provider.resolve_provider(value, (INT8,)) == "cuda"
+
+
+def test_explicit_cpu_passes_through_for_fp32_on_gpu_wheel(monkeypatch, tmp_path):
+    _install_fake_sherpa(monkeypatch, tmp_path, with_cuda=True)
+    assert onnx_provider.resolve_provider("cpu", (FP32,)) == "cpu"
+
+
+def test_unknown_value_falls_back_to_cpu(monkeypatch, tmp_path):
+    _install_fake_sherpa(monkeypatch, tmp_path, with_cuda=True)
+    assert onnx_provider.resolve_provider("trt", (FP32,)) == "cpu"

--- a/perception/tests/test_tts_engine_switch.py
+++ b/perception/tests/test_tts_engine_switch.py
@@ -124,29 +124,56 @@ def test_actions_are_forwarded_to_the_active_engine(_fake_engines):
     assert _fake_engines["vits2_trt"].calls[-1]["input_topic"] == "/say"
 
 
-def test_switch_stops_the_old_engine_and_never_blocks(_fake_engines):
+def test_switch_stops_the_old_engine_and_waits_for_the_new_one(_fake_engines):
+    """config waits for the bounded part of a build instead of making the caller
+    poll. Answering `loading` for a 5 s session construction is what made the
+    dashboard send a start the engine could not honour — see the deferred-start
+    tests at the bottom for the case where waiting is not enough."""
     plugin = _plugin()
     outgoing = _fake_engines["vits2_trt"]
 
-    began = time.monotonic()
     result = plugin.dispatch("tts", {"action": "config", "tts_engine": "sherpa_onnx"})
-    elapsed = time.monotonic() - began
 
     assert result["status"] == "configured"
-    assert result["state"] == "loading"
-    # sherpa-onnx downloads its model in the constructor; the config call must
-    # not wait for that (Agent Core gives a processor call 60 s).
-    assert elapsed < 0.2, f"config blocked for {elapsed:.2f}s"
+    assert "state" not in result, "a completed switch must not report loading"
+    assert result["engine"] == "sherpa_onnx"
     # The outgoing engine is stopped before the new one can publish.
     assert outgoing.stopped is True
-
-    assert _wait_until(
-        lambda: plugin.dispatch("tts", {"action": "info"}).get("model") == "sherpa_onnx"
-    )
+    # And the engine is live *now*, so the start that follows lands on it.
     assert plugin.dispatch("tts", {"action": "info"})["engine"] == "sherpa_onnx"
+    assert plugin.dispatch("tts", {"action": "start",
+                                   "input_topic": "/say"})["state"] == "running"
 
 
-def test_info_reports_loading_while_the_new_engine_builds(_fake_engines):
+def test_config_gives_up_waiting_and_reports_loading(monkeypatch, _fake_engines):
+    """A build slower than the bound — a cold model download — still goes async."""
+    monkeypatch.setattr(tts, "ENGINE_SWITCH_WAIT_S", 0.05)
+    result = _plugin().dispatch("tts", {"action": "config",
+                                        "tts_engine": "sherpa_onnx"})
+    assert result["status"] == "configured"
+    assert result["state"] == "loading"
+
+
+def test_config_reports_a_build_failure_instead_of_loading(monkeypatch):
+    class _Boom:
+        def __init__(self, cfg, executor):
+            raise RuntimeError("Protobuf parsing failed")
+
+    monkeypatch.setattr(tts, "SherpaOnnxTTSPlugin", _Boom)
+    monkeypatch.setattr(
+        tts.TTSPlugin, "_build_vits2",
+        lambda self, cfg: _FakeEngine("vits2_trt", cfg, self._executor, lambda i: None),
+    )
+    plugin = tts.TTSPlugin({"engine": "vits2_trt"}, _FakeExecutor())
+    result = plugin.dispatch("tts", {"action": "config", "tts_engine": "sherpa_onnx"})
+    assert result["status"] == "error"
+    assert "Protobuf parsing failed" in result["message"]
+
+
+def test_info_reports_loading_while_the_new_engine_builds(monkeypatch, _fake_engines):
+    """Only reachable once config has stopped waiting; until then there is no
+    window in which the facade has no engine."""
+    monkeypatch.setattr(tts, "ENGINE_SWITCH_WAIT_S", 0.05)
     plugin = _plugin()
     plugin.dispatch("tts", {"action": "config", "tts_engine": "sherpa_onnx"})
 
@@ -154,7 +181,7 @@ def test_info_reports_loading_while_the_new_engine_builds(_fake_engines):
     assert info["state"] == "loading"
     assert "sherpa_onnx" in info["desc"]
     # Other actions answer loading too, rather than hanging or lying.
-    assert plugin.dispatch("tts", {"action": "start"})["state"] == "loading"
+    assert plugin.dispatch("tts", {"action": "speak", "text": "hi"})["state"] == "loading"
 
 
 def test_switching_back_and_forth_keeps_one_engine_live(_fake_engines):
@@ -316,7 +343,8 @@ def test_engine_that_reports_error_after_construction_is_not_installed(monkeypat
 # Agent Core — which polls `info` after a loading start and reports "启动已取消"
 # if it ever sees idle — cancelled the card even though the engine loaded fine.
 
-def test_start_during_a_switch_is_replayed_once_the_engine_is_up(_fake_engines):
+def test_start_during_a_switch_is_replayed_once_the_engine_is_up(monkeypatch, _fake_engines):
+    monkeypatch.setattr(tts, "ENGINE_SWITCH_WAIT_S", 0.05)
     plugin = _plugin()
     plugin.dispatch("tts", {"action": "config", "tts_engine": "sherpa_onnx"})
 
@@ -336,8 +364,9 @@ def test_start_during_a_switch_is_replayed_once_the_engine_is_up(_fake_engines):
     assert started[0]["instance_id"] == "card-1"
 
 
-def test_a_stop_during_a_switch_cancels_the_deferred_start(_fake_engines):
+def test_a_stop_during_a_switch_cancels_the_deferred_start(monkeypatch, _fake_engines):
     """Otherwise the node reappears after the operator asked for it to stop."""
+    monkeypatch.setattr(tts, "ENGINE_SWITCH_WAIT_S", 0.05)
     plugin = _plugin()
     plugin.dispatch("tts", {"action": "config", "tts_engine": "sherpa_onnx"})
     plugin.dispatch("tts", {"action": "start", "instance_id": "card-1",
@@ -351,7 +380,8 @@ def test_a_stop_during_a_switch_cancels_the_deferred_start(_fake_engines):
     assert not [c for c in incoming.calls if c.get("action") == "start"]
 
 
-def test_deferred_starts_are_per_instance(_fake_engines):
+def test_deferred_starts_are_per_instance(monkeypatch, _fake_engines):
+    monkeypatch.setattr(tts, "ENGINE_SWITCH_WAIT_S", 0.05)
     plugin = _plugin()
     plugin.dispatch("tts", {"action": "config", "tts_engine": "sherpa_onnx"})
     for card, topic in (("card-1", "/say/a"), ("card-2", "/say/b")):

--- a/perception/tests/test_tts_engine_switch.py
+++ b/perception/tests/test_tts_engine_switch.py
@@ -306,3 +306,75 @@ def test_engine_that_reports_error_after_construction_is_not_installed(monkeypat
     # And no action may claim success against it.
     assert plugin.dispatch("tts", {"action": "start"})["state"] == "error"
     assert plugin.dispatch("tts", {"action": "speak", "text": "hi"})["state"] == "error"
+
+
+# ── starts that arrive mid-build ─────────────────────────────────────────────
+#
+# The dashboard sends config (which triggers the switch) and start back to back,
+# so a start during a build is the normal path, not a rare race. Answering
+# `state: loading` and dropping it left the engine idle once it finished, and
+# Agent Core — which polls `info` after a loading start and reports "启动已取消"
+# if it ever sees idle — cancelled the card even though the engine loaded fine.
+
+def test_start_during_a_switch_is_replayed_once_the_engine_is_up(_fake_engines):
+    plugin = _plugin()
+    plugin.dispatch("tts", {"action": "config", "tts_engine": "sherpa_onnx"})
+
+    # The build is still in flight, so the call cannot start anything yet.
+    result = plugin.dispatch("tts", {"action": "start",
+                                     "instance_id": "card-1",
+                                     "input_topic": "/say"})
+    assert result["state"] == "loading"
+
+    _wait_until(lambda: "sherpa_onnx" in _fake_engines)
+    incoming = _fake_engines["sherpa_onnx"]
+    _wait_until(lambda: any(c.get("action") == "start" for c in incoming.calls))
+
+    started = [c for c in incoming.calls if c.get("action") == "start"]
+    assert len(started) == 1, "the deferred start must be replayed exactly once"
+    assert started[0]["input_topic"] == "/say"
+    assert started[0]["instance_id"] == "card-1"
+
+
+def test_a_stop_during_a_switch_cancels_the_deferred_start(_fake_engines):
+    """Otherwise the node reappears after the operator asked for it to stop."""
+    plugin = _plugin()
+    plugin.dispatch("tts", {"action": "config", "tts_engine": "sherpa_onnx"})
+    plugin.dispatch("tts", {"action": "start", "instance_id": "card-1",
+                            "input_topic": "/say"})
+    assert plugin.dispatch("tts", {"action": "stop",
+                                   "instance_id": "card-1"})["state"] == "idle"
+
+    _wait_until(lambda: "sherpa_onnx" in _fake_engines)
+    incoming = _fake_engines["sherpa_onnx"]
+    time.sleep(0.4)   # past the fake build delay, so a replay would have landed
+    assert not [c for c in incoming.calls if c.get("action") == "start"]
+
+
+def test_deferred_starts_are_per_instance(_fake_engines):
+    plugin = _plugin()
+    plugin.dispatch("tts", {"action": "config", "tts_engine": "sherpa_onnx"})
+    for card, topic in (("card-1", "/say/a"), ("card-2", "/say/b")):
+        plugin.dispatch("tts", {"action": "start", "instance_id": card,
+                                "input_topic": topic})
+
+    _wait_until(lambda: "sherpa_onnx" in _fake_engines)
+    incoming = _fake_engines["sherpa_onnx"]
+    _wait_until(lambda: len([c for c in incoming.calls
+                             if c.get("action") == "start"]) == 2)
+    topics = sorted(c["input_topic"] for c in incoming.calls
+                    if c.get("action") == "start")
+    assert topics == ["/say/a", "/say/b"]
+
+
+def test_start_after_the_build_finishes_is_not_replayed_twice(_fake_engines):
+    """A start that the live engine already handled must not also be queued."""
+    plugin = _plugin()
+    plugin.dispatch("tts", {"action": "config", "tts_engine": "sherpa_onnx"})
+    _wait_until(lambda: plugin.dispatch("tts", {"action": "info"})["state"] != "loading")
+
+    plugin.dispatch("tts", {"action": "start", "instance_id": "card-1",
+                            "input_topic": "/say"})
+    time.sleep(0.2)
+    incoming = _fake_engines["sherpa_onnx"]
+    assert len([c for c in incoming.calls if c.get("action") == "start"]) == 1

--- a/perception/tools/convert_onnx_fp16.py
+++ b/perception/tools/convert_onnx_fp16.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""
+tools/convert_onnx_fp16.py — Convert sherpa-onnx fp32 weights to fp16.
+
+The `device: gpu` bundles are ours, not upstream's, so the recipe has to live in
+the repo rather than only in whatever produced the blob on COS.
+
+    python3 tools/convert_onnx_fp16.py model.onnx --out model.fp16.onnx
+
+Requires `onnx` and `onnxconverter-common`, which are NOT in the perception image:
+
+    pip3 install onnx==1.14.1 onnxconverter-common==1.14.0
+
+Two flags are load-bearing and both were learned the hard way:
+
+- `keep_io_types=True`. sherpa-onnx hands the session fp32 features, so the graph's
+  inputs and outputs must stay fp32 with only the interior in fp16. Without it the
+  session rejects sherpa's tensors.
+
+- `disable_shape_infer=False` (i.e. leave shape inference ON). Ops that cannot take
+  fp16 — `Range` above all — are already in onnxconverter-common's default
+  op_block_list, and the converter fences them with Cast nodes. Placing those Casts
+  needs shape inference. Turn it off to save 30 seconds and you get a file that
+  saves fine and then fails at session creation with:
+
+      Type 'tensor(float16)' of input parameter
+      (/encoder/embed/Constant_10_output_0) of operator (Range) in node
+      (/encoder/embed/Range_1) is invalid
+
+**Converting successfully is not the same as converting correctly, and this script
+cannot tell you the difference.** `--check-session` proves ONNX Runtime will load
+the result; it says nothing about whether the model still transcribes. Streaming
+paraformer fp16 loaded, ran 20x faster than fp16-on-CPU, gave byte-identical
+results across three thread counts on CUDA — and emitted nothing but `</s>`. The
+same file on CPU was fine. So before adding any (model, device) pair to
+ASR_MODELS, decode real audio on the target device and *read the text*. See
+perception/README.md § sherpa-onnx Device Selection.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import time
+
+
+def convert(src: str, dst: str, extra_block: tuple[str, ...] = ()) -> None:
+    import onnx
+    from onnxconverter_common import float16
+
+    block = set(getattr(float16, "DEFAULT_OP_BLOCK_LIST", ()))
+    block |= set(extra_block)
+
+    print(f"loading {src} ({os.path.getsize(src) / 1048576:.1f} MB)")
+    t0 = time.perf_counter()
+    model = onnx.load(src)
+    print(f"  loaded in {time.perf_counter() - t0:.1f}s")
+
+    print(f"converting to fp16 (op_block_list: {len(block)} ops)")
+    t0 = time.perf_counter()
+    converted = float16.convert_float_to_float16(
+        model,
+        keep_io_types=True,        # sherpa feeds fp32 features
+        disable_shape_infer=False,  # required for correct Cast fencing — see docstring
+        op_block_list=sorted(block),
+    )
+    print(f"  converted in {time.perf_counter() - t0:.1f}s")
+
+    del model
+    onnx.save(converted, dst)
+    print(f"saved {dst} ({os.path.getsize(dst) / 1048576:.1f} MB)")
+
+
+def check_session(paths: dict, kind: str, tokens: str, provider: str) -> None:
+    """Create a real ONNX Runtime session. Necessary, nowhere near sufficient."""
+    import sherpa_onnx
+
+    print(f"\ncreating a {kind} session on {provider} ...")
+    if kind == "sense_voice":
+        sherpa_onnx.OfflineRecognizer.from_sense_voice(
+            model=paths["model"], tokens=tokens, num_threads=2,
+            provider=provider, use_itn=True)
+    elif kind == "streaming_paraformer":
+        sherpa_onnx.OnlineRecognizer.from_paraformer(
+            encoder=paths["encoder"], decoder=paths["decoder"], tokens=tokens,
+            num_threads=2, provider=provider, sample_rate=16000,
+            decoding_method="greedy_search")
+    else:
+        raise SystemExit(f"unknown --check-session kind: {kind}")
+    print("  session created OK")
+    print("  NOTE: this does not prove the model transcribes. Decode real audio on "
+          "the target device and read the text before shipping it.")
+
+
+def main(argv: list[str]) -> int:
+    p = argparse.ArgumentParser(
+        description="Convert sherpa-onnx fp32 weights to fp16.",
+        epilog="Loading successfully is not correctness — read the transcripts.")
+    p.add_argument("src", help="fp32 .onnx file")
+    p.add_argument("--out", help="output path (default: <src stem>.fp16.onnx)")
+    p.add_argument("--block-op", action="append", default=[],
+                   metavar="OP",
+                   help="extra op to keep in fp32, on top of the library default")
+    p.add_argument("--check-session", choices=("sense_voice", "streaming_paraformer"),
+                   help="after converting, build an ONNX Runtime session")
+    p.add_argument("--tokens", help="tokens.txt, required by --check-session")
+    p.add_argument("--check-provider", default="cpu", choices=("cpu", "cuda"),
+                   help="provider for --check-session (default cpu)")
+    p.add_argument("--decoder", help="decoder .onnx, for --check-session "
+                                     "streaming_paraformer")
+    args = p.parse_args(argv)
+
+    if not os.path.isfile(args.src):
+        p.error(f"no such file: {args.src}")
+    dst = args.out or args.src.replace(".onnx", "") + ".fp16.onnx"
+    if os.path.exists(dst):
+        p.error(f"refusing to overwrite {dst}")
+
+    convert(args.src, dst, tuple(args.block_op))
+
+    if args.check_session:
+        if not args.tokens:
+            p.error("--check-session needs --tokens")
+        if args.check_session == "streaming_paraformer" and not args.decoder:
+            p.error("--check-session streaming_paraformer needs --decoder")
+        check_session({"model": dst, "encoder": dst, "decoder": args.decoder},
+                      args.check_session, args.tokens, args.check_provider)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/perception/utils/model_downloader.py
+++ b/perception/utils/model_downloader.py
@@ -467,6 +467,78 @@ def _download_verified_bundle(
 
 
 
+# ── sherpa-onnx GPU weight variants (device: gpu) ──────────────────────────
+# The bundles in MODELS above are all int8, which is the right choice for the CPU
+# and the wrong one for the GPU: ONNX Runtime's CUDA provider has no int8 kernels,
+# falls back to CPU node by node, and measured 1.25x-3.3x *slower* than the CPU on
+# the same audio. These are the non-quantised variants that `device: gpu` loads —
+# which weights belong to which model is declared in plugins/asr.py ASR_MODELS.
+#
+# These use ensure_verified_bundle rather than ensure_model because they are the
+# largest downloads in the stack (the paraformer encoder alone is 636 MB) and
+# ensure_model's only integrity check is "does check_file exist in the archive".
+# A truncated 780 MB transfer passes that and then fails at session creation in a
+# way nobody can diagnose. Here every file is pinned by size and SHA256.
+#
+# Provenance: derived from pengzhendong's ModelScope mirrors of the k2-fsa model
+# zoo, accepted only after that mirror's int8 weights were confirmed byte-identical
+# to the copies we already deploy from COS. The fp16 files are converted from the
+# mirror's fp32 with tools/convert_onnx_fp16.py.
+SHERPA_GPU_MODEL_BASE = os.environ.get(
+    "SHERPA_GPU_MODEL_BASE_URL", f"{COS_BASE}/sherpa-onnx-gpu"
+)
+SHERPA_GPU_BUNDLES = {
+    # Streaming paraformer, fp32. fp16 exists but is NOT used here: on CUDA it
+    # emits nothing but </s> (correct on CPU, so the conversion is fine and the
+    # CUDA+fp16+streaming combination is not), and it is slower than fp32 anyway
+    # (2077 ms vs 1859 ms).
+    "asr_gpu": {
+        "base_url": f"{SHERPA_GPU_MODEL_BASE}/streaming-paraformer-bilingual-zh-en-fp32",
+        "files": {
+            "encoder.onnx": {
+                "size": 636348877,
+                "sha256": "832c8e8d3f758f4ab0fcfc011eec91154ecd129b7305564a7b461b20064ebcc6",
+            },
+            "decoder.onnx": {
+                "size": 228464044,
+                "sha256": "e178f5a7dd4efbf5905a797807006d773b12116eb39fed3d16758e68f9f50921",
+            },
+            "tokens.txt": {
+                "size": 75756,
+                "sha256": "59aba8873a2ed1e122c25fee421e25f283b63290efbde85c1f01a853d83cb6e6",
+            },
+        },
+    },
+    # Offline SenseVoice, fp16 — faster than fp32 on CUDA (344 ms vs 416 ms), half
+    # the size, and transcript-identical to fp32 on both providers.
+    "asr_sensevoice_gpu": {
+        "base_url": f"{SHERPA_GPU_MODEL_BASE}/sense-voice-zh-en-ja-ko-yue-2024-07-17-fp16",
+        "files": {
+            "model.fp16.onnx": {
+                "size": 470225401,
+                "sha256": "b6b71a306afa7ccb48d2319b91567dfeefeb51f0f4eed9c88ec139cb10c14e09",
+            },
+            "tokens.txt": {
+                "size": 315894,
+                "sha256": "f449eb28dc567533d7fa59be34e2abca8784f771850c78a47fb731a31429a1dc",
+            },
+        },
+    },
+}
+
+
+def ensure_gpu_model(name: str, model_dir: str) -> dict[str, str]:
+    """Ensure a `device: gpu` weight bundle is present and SHA256-verified."""
+    bundle = SHERPA_GPU_BUNDLES.get(name)
+    if bundle is None:
+        raise KeyError(
+            f"No GPU weight bundle named {name!r}; "
+            f"available: {sorted(SHERPA_GPU_BUNDLES)}"
+        )
+    return ensure_verified_bundle(name, model_dir, bundle["base_url"],
+                                  bundle["files"])
+
+
 # ── OCR (PP-OCRv6 small, TensorRT engines; one bundle per JetPack family) ──
 # The engines are built per TensorRT major and are not portable, so the
 # bundle is chosen from the TensorRT that is importable at runtime. Only the

--- a/perception/utils/onnx_provider.py
+++ b/perception/utils/onnx_provider.py
@@ -1,0 +1,105 @@
+"""
+utils/onnx_provider.py — Resolve the sherpa-onnx execution provider per model.
+
+Two independent facts decide this, and both were measured on orin5 (Orin NX,
+JetPack 5.11, CUDA 11.4, 6 CPU cores) against sherpa-onnx 1.13.6+cuda:
+
+1. **Not every image can use the GPU at all.** jetson jp5.11 installs a
+   CUDA-enabled wheel (onnxruntime-gpu 1.16.0); jp6.1 is CUDA 12.6 and that
+   wheel's `libcudart.so.11.0` does not satisfy it, so it keeps the CPU wheel
+   from PyPI, as do x86 dev hosts. See `Dockerfile.jetson`.
+
+2. **The GPU only wins on fp32 weights.** ONNX Runtime's CUDA execution provider
+   has no kernels for the quantised ops in an int8 model, so it partitions the
+   graph and falls back to CPU node by node, adding a H2D/D2H copy at every
+   boundary. Measured, same audio, steady-state median:
+
+   | model                                   | CPU (2 thr) | CUDA    |         |
+   |-----------------------------------------|-------------|---------|---------|
+   | streaming paraformer `encoder.int8.onnx`| 3412 ms     | 10804 ms| 0.32x   |
+   | offline SenseVoice `model.int8.onnx`    | 2021 ms     | 3787 ms | 0.53x   |
+   | Matcha TTS fp32 (`model-steps-3.onnx`)  | 1751 ms     |  400 ms | 4.38x   |
+
+So `hw_provider: auto` means "cuda when the wheel supports it *and* this model's
+weights are fp32". Every ASR and KWS bundle deployed today ships int8 weights, so
+auto keeps them on CPU; Matcha TTS is fp32 and gets the GPU.
+
+Caveat worth knowing: the int8 rule is what the measurements support. A
+*streaming* fp32 model is untested — the streaming penalty above (0.32x vs 0.53x
+for the same dtype) shows sherpa's per-chunk decode adds its own GPU overhead, so
+a streaming fp32 model might not reach anything like Matcha's 4.4x. Pin
+`hw_provider: cpu` explicitly if you deploy one and it disappoints.
+"""
+
+from __future__ import annotations
+
+import logging
+from functools import lru_cache
+from pathlib import Path
+from typing import Iterable
+
+log = logging.getLogger(__name__)
+
+VALID_PROVIDERS = ("auto", "cuda", "cpu")
+
+
+@lru_cache(maxsize=1)
+def cuda_available() -> bool:
+    """True when the installed sherpa_onnx wheel bundles the CUDA provider.
+
+    The marker is `sherpa_onnx/lib/libonnxruntime_providers_cuda.so`, which only
+    a `-DSHERPA_ONNX_ENABLE_GPU=ON` build ships. This deliberately does not probe
+    the driver or create a session: on Jetson the wheel is built for the same L4T
+    release it is deployed on, and a probe would cost a full ONNX Runtime session
+    at import time.
+    """
+    try:
+        import sherpa_onnx
+    except ImportError:
+        return False
+    marker = Path(sherpa_onnx.__file__).resolve().parent / "lib" / "libonnxruntime_providers_cuda.so"
+    return marker.is_file()
+
+
+def is_quantised(model_paths: Iterable[str]) -> bool:
+    """True when any of these model files carries int8 weights.
+
+    Filename, not graph inspection: `.int8.onnx` is the naming every sherpa-onnx
+    bundle uses, and it is already what `asr.py` and `x_asr.py` match on to
+    *prefer* the quantised file. Parsing the ONNX protobuf for QuantizeLinear
+    nodes would be more precise but costs a read of a 165 MB file at startup.
+    """
+    return any("int8" in Path(p).name.lower() for p in model_paths if p)
+
+
+def resolve_provider(value: str | None, model_paths: Iterable[str] = ()) -> str:
+    """Map a configured `hw_provider` to a provider sherpa-onnx will accept.
+
+    An explicit `cuda`/`cpu` is passed through unchanged — if someone pins cuda
+    on an int8 model or a CPU wheel, that is a deliberate choice (or a
+    misconfigured deployment that should stay visible), and silently rewriting it
+    would hide either one.
+
+    `model_paths` are the weight files the caller is about to load. Omitting them
+    means "assume fp32", so a caller that forgets them errs toward the GPU rather
+    than silently pinning CPU.
+    """
+    provider = (value or "auto").strip().lower()
+    if provider != "auto":
+        if provider not in VALID_PROVIDERS:
+            log.warning("[onnx_provider] unknown hw_provider %r, using cpu", value)
+            return "cpu"
+        return provider
+
+    paths = [p for p in model_paths if p]
+    if not cuda_available():
+        reason = "the installed sherpa_onnx wheel has no CUDA provider"
+    elif is_quantised(paths):
+        reason = ("int8 weights — ONNX Runtime's CUDA provider falls back to CPU "
+                  "per node on quantised ops, which measured 2-3x slower")
+    else:
+        log.info("[onnx_provider] hw_provider=auto -> cuda (fp32 weights, CUDA wheel installed)")
+        return "cuda"
+
+    log.info("[onnx_provider] hw_provider=auto -> cpu (%s)", reason)
+    return "cpu"

--- a/perception/utils/onnx_provider.py
+++ b/perception/utils/onnx_provider.py
@@ -61,7 +61,7 @@ CUDA it does not give that back. On a 7.4 GB Orin already running vop (YOLO), OC
 perception restarted in a loop. So `cpu` stays the default even on images that
 *can* use the GPU — gpu is a deliberate choice for a box with headroom.
 
-**And the first gpu inference is the expensive one.** 1777 ms against a 77 ms
+**And the first gpu inference is the expensive one.** 1659 ms against a 58 ms
 steady state: lazy kernel loading, cuDNN autotuning and the memory pool all land
 on it. plugins/asr.py warms the adapter up with one second of silence after
 building so an operator never pays that on a real utterance.

--- a/perception/utils/onnx_provider.py
+++ b/perception/utils/onnx_provider.py
@@ -12,45 +12,52 @@ JetPack 5.11, CUDA 11.4, 6 CPU cores) against sherpa-onnx 1.13.6+cuda:
 2. **The GPU only wins on fp32 weights.** ONNX Runtime's CUDA execution provider
    has no kernels for the quantised ops in an int8 model, so it partitions the
    graph and falls back to CPU node by node, adding a H2D/D2H copy at every
-   boundary. Measured, same audio, steady-state median, every provider swept
-   across 1/2/4 `num_threads` (the ratio changes a lot with thread count, so a
+   boundary. Measured on an idle box (services stopped, idle GR3D verified 0%),
+   same audio, steady-state median, every provider swept across 1/2/4
+   `num_threads` (the ratio changes a lot with thread count, so a
    single-thread-count comparison is misleading):
 
    | model                                    | dtype       | CPU t=2 | CUDA t=2 | ratio  |
    |------------------------------------------|-------------|---------|----------|--------|
    | streaming paraformer `encoder.int8.onnx` | int8        | 3383 ms | 11125 ms |  0.30x |
-   | X-ASR offline transducer, beam search    | int8 + fp32 | 2832 ms |  5707 ms |  0.50x |
-   | offline SenseVoice `model.int8.onnx`     | int8        | 2086 ms |  2332 ms |  0.89x |
-   | offline SenseVoice `model.onnx`          | fp32        | 4905 ms |   426 ms | 11.52x |
+   | X-ASR offline transducer, beam search    | int8 + fp32 | 2645 ms |  3294 ms |  0.80x |
+   | offline SenseVoice `model.int8.onnx`     | int8        | 1996 ms |  2753 ms |  0.73x |
+   | offline SenseVoice `model.onnx`          | fp32        | 4792 ms |   416 ms | 11.52x |
+   | offline SenseVoice `model.fp16.onnx`     | fp16        | 8117 ms |   344 ms | 23.60x |
    | Matcha TTS `model-steps-3.onnx` + vocos  | fp32        | 1784 ms |   416 ms |  4.28x |
 
-   The two SenseVoice rows are the same model in both dtypes, so this is a dtype
-   result and not a per-model coincidence. X-ASR is why `is_quantised` disqualifies
-   a bundle on *any* int8 file: it is mixed precision (int8 encoder and joiner,
-   fp32 decoder) and CUDA still lost by 2x.
+   The three SenseVoice rows are the same model in three dtypes, so this is a
+   dtype result and not a per-model coincidence. X-ASR is why `is_quantised`
+   disqualifies a bundle on *any* int8 file: it is mixed precision (int8 encoder
+   and joiner, fp32 decoder) and CUDA still lost.
 
-   Mechanism confirmed two ways. fp32-CUDA is completely insensitive to thread
-   count (433/426/431 ms at 1/2/4) with GR3D pinned at 97% — the graph really is
-   on the GPU. int8-CUDA instead scales with *CPU* threads (3314 -> 2332 -> 1797
-   for SenseVoice, 17861 -> 11125 -> 10524 for streaming paraformer), which only
-   makes sense if much of it is not. GPU contention is not the explanation: the
-   idle GR3D baseline was 0%.
+   Mechanism confirmed two ways. fp32-CUDA and fp16-CUDA are completely
+   insensitive to thread count (417/416/415 and 343/344/346 ms at 1/2/4) with GR3D
+   pinned at 95-97% — the graph really is on the GPU. int8-CUDA instead scales with
+   *CPU* threads (3793 -> 2753 -> 1905 for SenseVoice, 17861 -> 11125 -> 10524 for
+   streaming paraformer), which only makes sense if much of it is not.
 
    int8 on CUDA is also numerically noisier, because every int8<->fp32 partition
    boundary requantises. Same model and audio at num_threads=2, CPU vs CUDA:
    SenseVoice int8 differed on 3 of 4 clips (including `不然` -> `主然`, a real
-   word error); SenseVoice fp32 differed on 0 of 4. So keeping int8 on CPU buys
-   output stability as well as speed.
+   word error); SenseVoice fp32 and fp16 differed on 0 of 4, and fp16 matched fp32
+   exactly. So keeping int8 on CPU buys output stability as well as speed.
 
 So `hw_provider: auto` means "cuda when the wheel supports it *and* this model's
 weights are fp32". Every ASR and KWS bundle deployed today ships int8 weights, so
 auto keeps them on CPU; Matcha TTS is fp32 and gets the GPU.
 
-Putting ASR on the GPU is a *model* change, not a config one: ship the fp32 bundle
-and auto routes it to CUDA by itself (426 ms vs the 2086 ms the deployed int8-on-CPU
-takes). The trade-offs — 894 MB vs 228 MB, accuracy that differs in both directions
-and needs a labelled set to judge, streaming still unmeasured at fp32, and fp16 as
-the likely better target — are written up in perception/README.md.
+Putting ASR on the GPU is a *model* change, not a config one: ship non-int8 weights
+and auto routes them to CUDA by itself. Against the deployed int8-on-CPU (1996 ms),
+fp32-CUDA is 4.80x and fp16-CUDA is 5.81x at half fp32's size — the trade-offs, the
+fp16 conversion recipe, and what is still unmeasured (streaming) are written up in
+perception/README.md.
+
+KNOWN GAP: `is_quantised` only recognises int8. An fp16 model resolves to `cuda`,
+which is right on a GPU wheel — but it would also resolve to `cuda` on a CPU-only
+wheel, and fp16 on CPU is catastrophic (13051 ms vs int8's 3292 at one thread,
+because ONNX Runtime has no fp16 CPU kernels and casts everything). Nothing ships
+fp16 today; if that changes, this needs a guard that refuses fp16 without CUDA.
 
 `int16` is not a middle ground worth trying: ONNX Runtime's int16 quantisation is
 newer than int8, the CUDA provider has no kernels for it either, and the CPU side
@@ -91,8 +98,8 @@ def is_quantised(model_paths: Iterable[str]) -> bool:
     """True when any of these model files carries int8 weights.
 
     *Any*, not all: X-ASR ships an int8 encoder and joiner beside an fp32 decoder,
-    and CUDA still lost by 2x on it, so one quantised file is enough to disqualify
-    the bundle.
+    and CUDA still lost on it, so one quantised file is enough to disqualify the
+    bundle.
 
     Filename, not graph inspection: `.int8.onnx` is the naming every sherpa-onnx
     bundle uses, and it is already what `asr.py` and `x_asr.py` match on to
@@ -126,7 +133,7 @@ def resolve_provider(value: str | None, model_paths: Iterable[str] = ()) -> str:
         reason = "the installed sherpa_onnx wheel has no CUDA provider"
     elif is_quantised(paths):
         reason = ("int8 weights — ONNX Runtime's CUDA provider falls back to CPU "
-                  "per node on quantised ops, measured up to 3x slower")
+                  "per node on quantised ops; measured 1.25x-3.3x slower")
     else:
         log.info("[onnx_provider] hw_provider=auto -> cuda (fp32 weights, CUDA wheel installed)")
         return "cuda"

--- a/perception/utils/onnx_provider.py
+++ b/perception/utils/onnx_provider.py
@@ -13,7 +13,7 @@ idle box (services stopped, idle GR3D verified 0%), swept across 1/2/4
 
 | model                                 | dtype | CPU t=2 | CUDA t=2 | ratio  |
 |---------------------------------------|-------|---------|----------|--------|
-| streaming paraformer (30.7 s audio)   | int8  | 3383 ms | 11125 ms |  0.30x |
+| streaming paraformer (30.7 s audio)   | int8  | 3295 ms |  8394 ms |  0.39x |
 | streaming paraformer                  | fp32  | 8702 ms |  1859 ms |  4.68x |
 | streaming paraformer                  | fp16  |42890 ms |  2077 ms | 20.65x |
 | X-ASR beam search (28.7 s audio)      | int8  | 2645 ms |  3294 ms |  0.80x |
@@ -29,12 +29,12 @@ Three things follow, and they are the three rules below:
    node, adding a host<->device copy at every boundary. Confirmed two ways: fp32
    and fp16 on CUDA are completely insensitive to CPU thread count (417/416/415
    and 343/344/346 ms) with GR3D pinned at 95-97%, while int8 on CUDA scales with
-   CPU threads (3793 -> 2753 -> 1905). int8 on CUDA is also numerically noisier —
+   CPU threads (3793 -> 2753 -> 1905 for SenseVoice). int8 on CUDA is also numerically noisier —
    requantising at every partition boundary changed 3 of 4 SenseVoice transcripts
    versus the same model on CPU, including `不然` -> `主然`.
 
 2. **fp16 loses on the CPU, catastrophically.** ONNX Runtime has no fp16 CPU
-   kernels and casts everything: 42890 ms where int8 took 3383 ms.
+   kernels and casts everything: 42890 ms where int8 took 3295 ms.
 
 3. **Neither speed nor self-consistency proves a pair works.** Streaming
    paraformer fp16 on CUDA was fast (2077 ms), identical across all three thread
@@ -48,6 +48,23 @@ Three things follow, and they are the three rules below:
 `int16` is not a middle ground worth trying: ONNX Runtime's int16 quantisation is
 newer than int8, the CUDA provider has no kernels for it either, and the CPU side
 lacks the dot-product paths that make int8 fast.
+
+**gpu costs memory, and most of it is unreturnable.** Measured on the same box with
+only ASR resident, SenseVoice:
+
+    cpu (int8)  build +542 MB, back to  129 MB after the adapter is dropped
+    gpu (fp16)  build +1968 MB, still  1516 MB after the adapter is dropped
+
+The residue is the CUDA context and its memory pool: once a process has touched
+CUDA it does not give that back. On a 7.4 GB Orin already running vop (YOLO), OCR
+(TensorRT) and TTS, enabling gpu ASR was enough to exhaust memory and get
+perception restarted in a loop. So `cpu` stays the default even on images that
+*can* use the GPU — gpu is a deliberate choice for a box with headroom.
+
+**And the first gpu inference is the expensive one.** 1777 ms against a 77 ms
+steady state: lazy kernel loading, cuDNN autotuning and the memory pool all land
+on it. plugins/asr.py warms the adapter up with one second of silence after
+building so an operator never pays that on a real utterance.
 """
 
 from __future__ import annotations
@@ -152,7 +169,7 @@ def provider_for_device(device: str, model_paths: Sequence[str] = ()) -> str:
 
     if is_fp16(paths):
         # Registry bug in the other direction, and a much worse one: 42890 ms vs
-        # 3383 ms for int8 on the streaming model.
+        # 3295 ms for int8 on the streaming model.
         log.error("[onnx_provider] device=cpu selected fp16 weights (%s) — "
                   "ONNX Runtime has no fp16 CPU kernels and casts everything, "
                   "measured over 10x slower than int8. Fix the ASR_MODELS entry.",

--- a/perception/utils/onnx_provider.py
+++ b/perception/utils/onnx_provider.py
@@ -16,35 +16,45 @@ JetPack 5.11, CUDA 11.4, 6 CPU cores) against sherpa-onnx 1.13.6+cuda:
    across 1/2/4 `num_threads` (the ratio changes a lot with thread count, so a
    single-thread-count comparison is misleading):
 
-   | model                                    | dtype       | CPU t=2 | CUDA t=2 | ratio | best CPU    | best CUDA  | ratio |
-   |------------------------------------------|-------------|---------|----------|-------|-------------|------------|-------|
-   | streaming paraformer `encoder.int8.onnx` | int8        | 3383 ms | 11125 ms | 0.30x | 3097 (t=4)  | 10524 (t=4)| 0.29x |
-   | X-ASR offline transducer, beam search    | int8 + fp32 | 2832 ms |  5707 ms | 0.50x | 2503 (t=4)  |  5707 (t=2)| 0.44x |
-   | offline SenseVoice `model.int8.onnx`     | int8        | 2022 ms |  2341 ms | 0.86x | 1354 (t=4)  |  1694 (t=4)| 0.80x |
-   | Matcha TTS `model-steps-3.onnx` + vocos  | fp32        | 1784 ms |   416 ms | 4.28x | 1175 (t=4)  |   416 (t=1)| 2.83x |
+   | model                                    | dtype       | CPU t=2 | CUDA t=2 | ratio  |
+   |------------------------------------------|-------------|---------|----------|--------|
+   | streaming paraformer `encoder.int8.onnx` | int8        | 3383 ms | 11125 ms |  0.30x |
+   | X-ASR offline transducer, beam search    | int8 + fp32 | 2832 ms |  5707 ms |  0.50x |
+   | offline SenseVoice `model.int8.onnx`     | int8        | 2086 ms |  2332 ms |  0.89x |
+   | offline SenseVoice `model.onnx`          | fp32        | 4905 ms |   426 ms | 11.52x |
+   | Matcha TTS `model-steps-3.onnx` + vocos  | fp32        | 1784 ms |   416 ms |  4.28x |
 
-   X-ASR is the case that justifies `is_quantised` treating *any* int8 file as
-   disqualifying: its bundle is mixed precision (int8 encoder and joiner, fp32
-   decoder) and CUDA still lost by 2x.
+   The two SenseVoice rows are the same model in both dtypes, so this is a dtype
+   result and not a per-model coincidence. X-ASR is why `is_quantised` disqualifies
+   a bundle on *any* int8 file: it is mixed precision (int8 encoder and joiner,
+   fp32 decoder) and CUDA still lost by 2x.
 
-   The per-node fallback is not just an inference from that contrast: on the
-   streaming int8 model the *CUDA* path speeds up 1.7x when given more **CPU**
-   threads (17861 -> 11125 -> 10524 ms for 1/2/4). Thread count would barely
-   matter if the graph were executing on the GPU. GPU contention is not the
-   explanation either — the idle GR3D baseline was 0%, and GR3D sat at 88-92%
-   during the CUDA runs, so the work does reach the GPU, just slowly.
+   Mechanism confirmed two ways. fp32-CUDA is completely insensitive to thread
+   count (433/426/431 ms at 1/2/4) with GR3D pinned at 97% — the graph really is
+   on the GPU. int8-CUDA instead scales with *CPU* threads (3314 -> 2332 -> 1797
+   for SenseVoice, 17861 -> 11125 -> 10524 for streaming paraformer), which only
+   makes sense if much of it is not. GPU contention is not the explanation: the
+   idle GR3D baseline was 0%.
+
+   int8 on CUDA is also numerically noisier, because every int8<->fp32 partition
+   boundary requantises. Same model and audio at num_threads=2, CPU vs CUDA:
+   SenseVoice int8 differed on 3 of 4 clips (including `不然` -> `主然`, a real
+   word error); SenseVoice fp32 differed on 0 of 4. So keeping int8 on CPU buys
+   output stability as well as speed.
 
 So `hw_provider: auto` means "cuda when the wheel supports it *and* this model's
 weights are fp32". Every ASR and KWS bundle deployed today ships int8 weights, so
 auto keeps them on CPU; Matcha TTS is fp32 and gets the GPU.
 
-Caveat worth knowing: the int8 rule is what the measurements support, and only for
-these shapes. A *streaming* fp32 model is untested, and the streaming-vs-offline
-gap at the same dtype above is large (0.30x vs 0.86x) — sherpa's per-chunk decode
-carries substantial GPU overhead of its own, so a streaming fp32 model may land
-nowhere near Matcha's speed-up. Pin `hw_provider: cpu` explicitly if you deploy
-one and it disappoints. Note also that the deployed `num_threads` is 2; at 4
-threads the CPU closes much of Matcha's gap (2.83x rather than 4.28x).
+Putting ASR on the GPU is a *model* change, not a config one: ship the fp32 bundle
+and auto routes it to CUDA by itself (426 ms vs the 2086 ms the deployed int8-on-CPU
+takes). The trade-offs — 894 MB vs 228 MB, accuracy that differs in both directions
+and needs a labelled set to judge, streaming still unmeasured at fp32, and fp16 as
+the likely better target — are written up in perception/README.md.
+
+`int16` is not a middle ground worth trying: ONNX Runtime's int16 quantisation is
+newer than int8, the CUDA provider has no kernels for it either, and the CPU side
+lacks the dot-product paths that make int8 fast.
 """
 
 from __future__ import annotations

--- a/perception/utils/onnx_provider.py
+++ b/perception/utils/onnx_provider.py
@@ -1,63 +1,49 @@
 """
-utils/onnx_provider.py — Resolve the sherpa-onnx execution provider per model.
+utils/onnx_provider.py — Validate a device choice and pick the weights for it.
 
-Two independent facts decide this, and both were measured on orin5 (Orin NX,
-JetPack 5.11, CUDA 11.4, 6 CPU cores) against sherpa-onnx 1.13.6+cuda:
+The plugin config exposes `device: cpu | gpu`; `ASR_MODELS` in plugins/asr.py
+declares, per model, which weights each device loads. This module does not decide
+*what* to run — the registry does — it decides whether a (device, weights) pair is
+allowed to run, and helps adapters find the right file.
 
-1. **Not every image can use the GPU at all.** jetson jp5.11 installs a
-   CUDA-enabled wheel (onnxruntime-gpu 1.16.0); jp6.1 is CUDA 12.6 and that
-   wheel's `libcudart.so.11.0` does not satisfy it, so it keeps the CPU wheel
-   from PyPI, as do x86 dev hosts. See `Dockerfile.jetson`.
+Everything here encodes a measured failure mode. All numbers are from orin5
+(Orin NX, JetPack 5.11, CUDA 11.4, 6 cores) with sherpa-onnx 1.13.6+cuda, on an
+idle box (services stopped, idle GR3D verified 0%), swept across 1/2/4
+`num_threads`, reporting the steady-state median:
 
-2. **The GPU only wins on fp32 weights.** ONNX Runtime's CUDA execution provider
-   has no kernels for the quantised ops in an int8 model, so it partitions the
-   graph and falls back to CPU node by node, adding a H2D/D2H copy at every
-   boundary. Measured on an idle box (services stopped, idle GR3D verified 0%),
-   same audio, steady-state median, every provider swept across 1/2/4
-   `num_threads` (the ratio changes a lot with thread count, so a
-   single-thread-count comparison is misleading):
+| model                                 | dtype | CPU t=2 | CUDA t=2 | ratio  |
+|---------------------------------------|-------|---------|----------|--------|
+| streaming paraformer (30.7 s audio)   | int8  | 3383 ms | 11125 ms |  0.30x |
+| streaming paraformer                  | fp32  | 8702 ms |  1859 ms |  4.68x |
+| streaming paraformer                  | fp16  |42890 ms |  2077 ms | 20.65x |
+| X-ASR beam search (28.7 s audio)      | int8  | 2645 ms |  3294 ms |  0.80x |
+| offline SenseVoice (28.7 s audio)     | int8  | 1996 ms |  2753 ms |  0.73x |
+| offline SenseVoice                    | fp32  | 4792 ms |   416 ms | 11.52x |
+| offline SenseVoice                    | fp16  | 8117 ms |   344 ms | 23.60x |
+| Matcha TTS (13.3 s audio)             | fp32  | 1784 ms |   416 ms |  4.28x |
 
-   | model                                    | dtype       | CPU t=2 | CUDA t=2 | ratio  |
-   |------------------------------------------|-------------|---------|----------|--------|
-   | streaming paraformer `encoder.int8.onnx` | int8        | 3383 ms | 11125 ms |  0.30x |
-   | X-ASR offline transducer, beam search    | int8 + fp32 | 2645 ms |  3294 ms |  0.80x |
-   | offline SenseVoice `model.int8.onnx`     | int8        | 1996 ms |  2753 ms |  0.73x |
-   | offline SenseVoice `model.onnx`          | fp32        | 4792 ms |   416 ms | 11.52x |
-   | offline SenseVoice `model.fp16.onnx`     | fp16        | 8117 ms |   344 ms | 23.60x |
-   | Matcha TTS `model-steps-3.onnx` + vocos  | fp32        | 1784 ms |   416 ms |  4.28x |
+Three things follow, and they are the three rules below:
 
-   The three SenseVoice rows are the same model in three dtypes, so this is a
-   dtype result and not a per-model coincidence. X-ASR is why `is_quantised`
-   disqualifies a bundle on *any* int8 file: it is mixed precision (int8 encoder
-   and joiner, fp32 decoder) and CUDA still lost.
+1. **int8 loses on the GPU, always.** ONNX Runtime's CUDA provider has no kernels
+   for quantised ops, so it partitions the graph and falls back to CPU node by
+   node, adding a host<->device copy at every boundary. Confirmed two ways: fp32
+   and fp16 on CUDA are completely insensitive to CPU thread count (417/416/415
+   and 343/344/346 ms) with GR3D pinned at 95-97%, while int8 on CUDA scales with
+   CPU threads (3793 -> 2753 -> 1905). int8 on CUDA is also numerically noisier —
+   requantising at every partition boundary changed 3 of 4 SenseVoice transcripts
+   versus the same model on CPU, including `不然` -> `主然`.
 
-   Mechanism confirmed two ways. fp32-CUDA and fp16-CUDA are completely
-   insensitive to thread count (417/416/415 and 343/344/346 ms at 1/2/4) with GR3D
-   pinned at 95-97% — the graph really is on the GPU. int8-CUDA instead scales with
-   *CPU* threads (3793 -> 2753 -> 1905 for SenseVoice, 17861 -> 11125 -> 10524 for
-   streaming paraformer), which only makes sense if much of it is not.
+2. **fp16 loses on the CPU, catastrophically.** ONNX Runtime has no fp16 CPU
+   kernels and casts everything: 42890 ms where int8 took 3383 ms.
 
-   int8 on CUDA is also numerically noisier, because every int8<->fp32 partition
-   boundary requantises. Same model and audio at num_threads=2, CPU vs CUDA:
-   SenseVoice int8 differed on 3 of 4 clips (including `不然` -> `主然`, a real
-   word error); SenseVoice fp32 and fp16 differed on 0 of 4, and fp16 matched fp32
-   exactly. So keeping int8 on CPU buys output stability as well as speed.
-
-So `hw_provider: auto` means "cuda when the wheel supports it *and* this model's
-weights are fp32". Every ASR and KWS bundle deployed today ships int8 weights, so
-auto keeps them on CPU; Matcha TTS is fp32 and gets the GPU.
-
-Putting ASR on the GPU is a *model* change, not a config one: ship non-int8 weights
-and auto routes them to CUDA by itself. Against the deployed int8-on-CPU (1996 ms),
-fp32-CUDA is 4.80x and fp16-CUDA is 5.81x at half fp32's size — the trade-offs, the
-fp16 conversion recipe, and what is still unmeasured (streaming) are written up in
-perception/README.md.
-
-KNOWN GAP: `is_quantised` only recognises int8. An fp16 model resolves to `cuda`,
-which is right on a GPU wheel — but it would also resolve to `cuda` on a CPU-only
-wheel, and fp16 on CPU is catastrophic (13051 ms vs int8's 3292 at one thread,
-because ONNX Runtime has no fp16 CPU kernels and casts everything). Nothing ships
-fp16 today; if that changes, this needs a guard that refuses fp16 without CUDA.
+3. **Neither speed nor self-consistency proves a pair works.** Streaming
+   paraformer fp16 on CUDA was fast (2077 ms), identical across all three thread
+   counts, and created a session without complaint — while emitting nothing but
+   `</s>`. The same fp16 file on CPU transcribed correctly, so the conversion was
+   fine and the CUDA+fp16+streaming combination is not. That is why every
+   (model, device) entry in ASR_MODELS must have had its *output read* before
+   being listed, and why this module can only catch the mechanical mistakes below,
+   not that one.
 
 `int16` is not a middle ground worth trying: ONNX Runtime's int16 quantisation is
 newer than int8, the CUDA provider has no kernels for it either, and the CPU side
@@ -67,76 +53,123 @@ lacks the dot-product paths that make int8 fast.
 from __future__ import annotations
 
 import logging
+import os
 from functools import lru_cache
 from pathlib import Path
-from typing import Iterable
+from typing import Iterable, Sequence
 
 log = logging.getLogger(__name__)
 
-VALID_PROVIDERS = ("auto", "cuda", "cpu")
+VALID_DEVICES = ("cpu", "gpu")
 
 
 @lru_cache(maxsize=1)
 def cuda_available() -> bool:
     """True when the installed sherpa_onnx wheel bundles the CUDA provider.
 
-    The marker is `sherpa_onnx/lib/libonnxruntime_providers_cuda.so`, which only
-    a `-DSHERPA_ONNX_ENABLE_GPU=ON` build ships. This deliberately does not probe
-    the driver or create a session: on Jetson the wheel is built for the same L4T
-    release it is deployed on, and a probe would cost a full ONNX Runtime session
-    at import time.
+    The marker is `sherpa_onnx/lib/libonnxruntime_providers_cuda.so`, which only a
+    `-DSHERPA_ONNX_ENABLE_GPU=ON` build ships. jetson jp5.11 installs such a wheel
+    from COS; jp6.1 is CUDA 12.6 and cannot use it, and x86 dev hosts get the PyPI
+    CPU wheel — see Dockerfile.jetson. This deliberately does not probe the driver
+    or create a session: on Jetson the wheel is built for the same L4T release it
+    is deployed on, and a probe would cost a full ONNX Runtime session at import.
     """
     try:
         import sherpa_onnx
     except ImportError:
         return False
-    marker = Path(sherpa_onnx.__file__).resolve().parent / "lib" / "libonnxruntime_providers_cuda.so"
-    return marker.is_file()
+    lib = Path(sherpa_onnx.__file__).resolve().parent / "lib"
+    return (lib / "libonnxruntime_providers_cuda.so").is_file()
 
 
 def is_quantised(model_paths: Iterable[str]) -> bool:
-    """True when any of these model files carries int8 weights.
+    """True when any of these weight files is int8.
 
     *Any*, not all: X-ASR ships an int8 encoder and joiner beside an fp32 decoder,
-    and CUDA still lost on it, so one quantised file is enough to disqualify the
-    bundle.
+    and CUDA still lost on it, so one quantised file disqualifies the set.
 
     Filename, not graph inspection: `.int8.onnx` is the naming every sherpa-onnx
-    bundle uses, and it is already what `asr.py` and `x_asr.py` match on to
-    *prefer* the quantised file. Parsing the ONNX protobuf for QuantizeLinear
-    nodes would be more precise but costs a read of a 165 MB file at startup.
+    bundle uses, and it is already what asr.py and x_asr.py match on to *prefer*
+    the quantised file. Parsing the protobuf for QuantizeLinear would be more
+    precise but costs a read of a 636 MB file at startup.
     """
     return any("int8" in Path(p).name.lower() for p in model_paths if p)
 
 
-def resolve_provider(value: str | None, model_paths: Iterable[str] = ()) -> str:
-    """Map a configured `hw_provider` to a provider sherpa-onnx will accept.
+def is_fp16(model_paths: Iterable[str]) -> bool:
+    """True when any of these weight files is fp16, by the same naming convention."""
+    return any("fp16" in Path(p).name.lower() for p in model_paths if p)
 
-    An explicit `cuda`/`cpu` is passed through unchanged — if someone pins cuda
-    on an int8 model or a CPU wheel, that is a deliberate choice (or a
-    misconfigured deployment that should stay visible), and silently rewriting it
-    would hide either one.
 
-    `model_paths` are the weight files the caller is about to load. Omitting them
-    means "assume fp32", so a caller that forgets them errs toward the GPU rather
-    than silently pinning CPU.
+def normalize_device(value: str | None, legacy_hw_provider: str | None = None) -> str:
+    """Coerce a configured device to `cpu`/`gpu`.
+
+    `legacy_hw_provider` accepts the pre-`device` config key so a deployment that
+    mounts its own config.yaml keeps working; `cuda` there means `gpu`.
     """
-    provider = (value or "auto").strip().lower()
-    if provider != "auto":
-        if provider not in VALID_PROVIDERS:
-            log.warning("[onnx_provider] unknown hw_provider %r, using cpu", value)
-            return "cpu"
-        return provider
+    raw = (value or "").strip().lower()
+    if not raw and legacy_hw_provider:
+        legacy = legacy_hw_provider.strip().lower()
+        raw = "gpu" if legacy in ("gpu", "cuda") else "cpu" if legacy == "cpu" else ""
+        if raw:
+            log.info("[onnx_provider] using legacy hw_provider=%r as device=%r",
+                     legacy_hw_provider, raw)
+    if not raw:
+        return "cpu"
+    if raw in ("cuda", "nvidia"):
+        return "gpu"
+    if raw not in VALID_DEVICES:
+        log.warning("[onnx_provider] unknown device %r, using cpu", value)
+        return "cpu"
+    return raw
 
+
+def provider_for_device(device: str, model_paths: Sequence[str] = ()) -> str:
+    """Return the ONNX Runtime provider to use, refusing the known-bad pairs.
+
+    Falls back rather than raising: a wrong device in a baked config.yaml should
+    degrade to a working recogniser, not stop perception from booting. The
+    dashboard path validates separately and reports the error there, where someone
+    is watching.
+    """
+    device = normalize_device(device)
     paths = [p for p in model_paths if p]
-    if not cuda_available():
-        reason = "the installed sherpa_onnx wheel has no CUDA provider"
-    elif is_quantised(paths):
-        reason = ("int8 weights — ONNX Runtime's CUDA provider falls back to CPU "
-                  "per node on quantised ops; measured 1.25x-3.3x slower")
-    else:
-        log.info("[onnx_provider] hw_provider=auto -> cuda (fp32 weights, CUDA wheel installed)")
+
+    if device == "gpu":
+        if not cuda_available():
+            log.warning("[onnx_provider] device=gpu but the installed sherpa_onnx "
+                        "wheel has no CUDA provider — falling back to cpu")
+            return "cpu"
+        if is_quantised(paths):
+            # Registry bug: a gpu entry must not point at int8 weights.
+            log.error("[onnx_provider] device=gpu selected int8 weights (%s) — "
+                      "ONNX Runtime's CUDA provider falls back to CPU per node on "
+                      "quantised ops and measured 1.25x-3.3x slower. Using cpu; "
+                      "fix the ASR_MODELS entry.",
+                      ", ".join(os.path.basename(p) for p in paths))
+            return "cpu"
         return "cuda"
 
-    log.info("[onnx_provider] hw_provider=auto -> cpu (%s)", reason)
+    if is_fp16(paths):
+        # Registry bug in the other direction, and a much worse one: 42890 ms vs
+        # 3383 ms for int8 on the streaming model.
+        log.error("[onnx_provider] device=cpu selected fp16 weights (%s) — "
+                  "ONNX Runtime has no fp16 CPU kernels and casts everything, "
+                  "measured over 10x slower than int8. Fix the ASR_MODELS entry.",
+                  ", ".join(os.path.basename(p) for p in paths))
     return "cpu"
+
+
+def pick_weights(model_dir: str, *candidates: str) -> str:
+    """Return the first candidate filename that exists in model_dir.
+
+    Falls back to the *last* candidate when none exist, so the caller's own
+    "model files not found" error names the file it actually wanted rather than
+    an empty string. Adapters pass candidates in device-appropriate order: a gpu
+    directory holds fp16/fp32 weights, a cpu directory holds int8.
+    """
+    for name in candidates:
+        path = os.path.join(model_dir, name)
+        if os.path.exists(path):
+            return path
+    return os.path.join(model_dir, candidates[-1]) if candidates else ""

--- a/perception/utils/onnx_provider.py
+++ b/perception/utils/onnx_provider.py
@@ -12,23 +12,39 @@ JetPack 5.11, CUDA 11.4, 6 CPU cores) against sherpa-onnx 1.13.6+cuda:
 2. **The GPU only wins on fp32 weights.** ONNX Runtime's CUDA execution provider
    has no kernels for the quantised ops in an int8 model, so it partitions the
    graph and falls back to CPU node by node, adding a H2D/D2H copy at every
-   boundary. Measured, same audio, steady-state median:
+   boundary. Measured, same audio, steady-state median, every provider swept
+   across 1/2/4 `num_threads` (the ratio changes a lot with thread count, so a
+   single-thread-count comparison is misleading):
 
-   | model                                   | CPU (2 thr) | CUDA    |         |
-   |-----------------------------------------|-------------|---------|---------|
-   | streaming paraformer `encoder.int8.onnx`| 3412 ms     | 10804 ms| 0.32x   |
-   | offline SenseVoice `model.int8.onnx`    | 2021 ms     | 3787 ms | 0.53x   |
-   | Matcha TTS fp32 (`model-steps-3.onnx`)  | 1751 ms     |  400 ms | 4.38x   |
+   | model                                    | dtype       | CPU t=2 | CUDA t=2 | ratio | best CPU    | best CUDA  | ratio |
+   |------------------------------------------|-------------|---------|----------|-------|-------------|------------|-------|
+   | streaming paraformer `encoder.int8.onnx` | int8        | 3383 ms | 11125 ms | 0.30x | 3097 (t=4)  | 10524 (t=4)| 0.29x |
+   | X-ASR offline transducer, beam search    | int8 + fp32 | 2832 ms |  5707 ms | 0.50x | 2503 (t=4)  |  5707 (t=2)| 0.44x |
+   | offline SenseVoice `model.int8.onnx`     | int8        | 2022 ms |  2341 ms | 0.86x | 1354 (t=4)  |  1694 (t=4)| 0.80x |
+   | Matcha TTS `model-steps-3.onnx` + vocos  | fp32        | 1784 ms |   416 ms | 4.28x | 1175 (t=4)  |   416 (t=1)| 2.83x |
+
+   X-ASR is the case that justifies `is_quantised` treating *any* int8 file as
+   disqualifying: its bundle is mixed precision (int8 encoder and joiner, fp32
+   decoder) and CUDA still lost by 2x.
+
+   The per-node fallback is not just an inference from that contrast: on the
+   streaming int8 model the *CUDA* path speeds up 1.7x when given more **CPU**
+   threads (17861 -> 11125 -> 10524 ms for 1/2/4). Thread count would barely
+   matter if the graph were executing on the GPU. GPU contention is not the
+   explanation either — the idle GR3D baseline was 0%, and GR3D sat at 88-92%
+   during the CUDA runs, so the work does reach the GPU, just slowly.
 
 So `hw_provider: auto` means "cuda when the wheel supports it *and* this model's
 weights are fp32". Every ASR and KWS bundle deployed today ships int8 weights, so
 auto keeps them on CPU; Matcha TTS is fp32 and gets the GPU.
 
-Caveat worth knowing: the int8 rule is what the measurements support. A
-*streaming* fp32 model is untested — the streaming penalty above (0.32x vs 0.53x
-for the same dtype) shows sherpa's per-chunk decode adds its own GPU overhead, so
-a streaming fp32 model might not reach anything like Matcha's 4.4x. Pin
-`hw_provider: cpu` explicitly if you deploy one and it disappoints.
+Caveat worth knowing: the int8 rule is what the measurements support, and only for
+these shapes. A *streaming* fp32 model is untested, and the streaming-vs-offline
+gap at the same dtype above is large (0.30x vs 0.86x) — sherpa's per-chunk decode
+carries substantial GPU overhead of its own, so a streaming fp32 model may land
+nowhere near Matcha's speed-up. Pin `hw_provider: cpu` explicitly if you deploy
+one and it disappoints. Note also that the deployed `num_threads` is 2; at 4
+threads the CPU closes much of Matcha's gap (2.83x rather than 4.28x).
 """
 
 from __future__ import annotations
@@ -64,6 +80,10 @@ def cuda_available() -> bool:
 def is_quantised(model_paths: Iterable[str]) -> bool:
     """True when any of these model files carries int8 weights.
 
+    *Any*, not all: X-ASR ships an int8 encoder and joiner beside an fp32 decoder,
+    and CUDA still lost by 2x on it, so one quantised file is enough to disqualify
+    the bundle.
+
     Filename, not graph inspection: `.int8.onnx` is the naming every sherpa-onnx
     bundle uses, and it is already what `asr.py` and `x_asr.py` match on to
     *prefer* the quantised file. Parsing the ONNX protobuf for QuantizeLinear
@@ -96,7 +116,7 @@ def resolve_provider(value: str | None, model_paths: Iterable[str] = ()) -> str:
         reason = "the installed sherpa_onnx wheel has no CUDA provider"
     elif is_quantised(paths):
         reason = ("int8 weights — ONNX Runtime's CUDA provider falls back to CPU "
-                  "per node on quantised ops, which measured 2-3x slower")
+                  "per node on quantised ops, measured up to 3x slower")
     else:
         log.info("[onnx_provider] hw_provider=auto -> cuda (fp32 weights, CUDA wheel installed)")
         return "cuda"


### PR DESCRIPTION
## What

Two things, in sequence:

1. **jp5.11 installs a CUDA-enabled sherpa-onnx wheel.** PyPI ships CPU-only, so ASR, KWS and Matcha TTS all ran on two CPU threads. The wheel is built in-house on an Orin (onnxruntime-gpu 1.16.0, CUDA 11.4, cp38) and fetched from COS; every other `JP_VERSION` keeps the PyPI CPU wheel, because that wheel links `libcudart.so.11.0` and jp6.1 is CUDA 12.6.

2. **`device: cpu | gpu` selects where sherpa-onnx runs, and the weights follow the device.** This replaces an earlier `hw_provider: auto` that inferred the provider from whichever weights were on disk — a design that hid the fast path completely, since every ASR bundle on COS is int8 and `auto` therefore always resolved to cpu.

## Why the weights have to follow the device

Quantised weights are the right choice on the CPU and the wrong one on the GPU. ONNX Runtime's CUDA provider has no kernels for int8 ops: it partitions the graph, falls back to CPU node by node, and inserts a host↔device copy at every boundary. So `device: gpu` downloads a *different bundle*, not just a different provider string.

`ASR_MODELS` in `plugins/asr.py` maps each (model, device) pair to its weights:

| `asr_model` | `device: cpu` | `device: gpu` | gpu speed-up |
|-------------|---------------|---------------|--------------|
| `sensevoice-small` (new default) | int8, 228 MB | **fp16, 448 MB** | **5.81x** |
| `paraformer-zh-en` (streaming) | int8, 226 MB | **fp32, 825 MB** | **1.77x** |
| `x-asr-zh-en` | int8 + fp32 | — not offered | 0.80x, i.e. slower |
| `paraformer-offline` | int8 | — not offered | unmeasured |
| `zipformer-en` | int8 | — not offered | unmeasured |

TTS is simpler: Matcha is fp32 only, so both devices load the same files and `device` only picks the provider (~4.3x on gpu). `vits2_trt` is unaffected — TensorRT, never touches ONNX Runtime.

## Measurements

orin5 (Orin NX, JetPack 5.11, CUDA 11.4, 6 cores), sherpa-onnx 1.13.6+cuda, steady-state median, **on an idle box** — `embodied-perception` and `agent-core` stopped, idle `GR3D_FREQ` verified 0% before each run, and a guard killing anything that appeared mid-run. Both providers swept across 1/2/4 `num_threads`, because the ratio moves a lot with thread count:

| model | dtype | CPU t=2 | CUDA t=2 | ratio |
|-------|-------|---------|----------|-------|
| streaming paraformer (30.7 s audio) | int8 | 3295 ms | 8394 ms | **0.39x** |
| streaming paraformer | fp32 | 8702 ms | **1859 ms** | **4.68x** |
| streaming paraformer | fp16 | 42890 ms | 2077 ms | 20.65x ⚠️ broken, see below |
| X-ASR, beam search (28.7 s audio) | int8 | 2645 ms | 3294 ms | **0.80x** |
| offline SenseVoice (28.7 s audio) | int8 | 1996 ms | 2753 ms | **0.73x** |
| offline SenseVoice | fp32 | 4792 ms | 416 ms | **11.52x** |
| offline SenseVoice | fp16 | 8117 ms | **344 ms** | **23.60x** |
| Matcha TTS (13.3 s audio) | fp32 | 1784 ms | 416 ms | **4.28x** |

Two independent confirmations of the per-node fallback, rather than just the int8/fp32 correlation:

- fp32 and fp16 on CUDA are **completely insensitive to CPU thread count** (417/416/415 and 343/344/346 ms at 1/2/4) with GR3D pinned at 95–97% — the graph really is on the GPU. int8 on CUDA instead **scales with CPU threads** (3793 → 2753 → 1905 for SenseVoice, 17861 → 11125 → 10524 for streaming paraformer), which only makes sense if much of it is on the CPU.
- Requantising at every partition boundary perturbs the output. Same model, same audio, `num_threads=2`, CPU vs CUDA: SenseVoice int8 differed on **3 of 4** clips, including `不然` → `主然` — a real word error, not punctuation. fp32 and fp16 differed on **0 of 4**.

## The result that set the admission bar

A gpu entry is only listed once that pair was benchmarked **and its transcripts were read**. That rule comes from streaming paraformer fp16 on CUDA, which:

- created an ONNX Runtime session without complaint,
- ran in 2077 ms, 20x faster than the same file on CPU,
- produced byte-identical output across all three thread counts,
- and emitted nothing but `</s> </s> </s> …`.

The same fp16 file on CPU transcribed correctly, so the conversion was fine and the CUDA+fp16+streaming *combination* is not. Session creation, speed and self-consistency were all green; only reading the text caught it. `paraformer-zh-en`'s gpu entry is therefore fp32 — which is also faster than fp16 there.

`tests/test_asr_device_registry.py` turns what *can* be checked mechanically into assertions: no gpu entry may be int8, no cpu entry may be fp16, download keys must resolve, model dirs must be unique, and the configSchema's device-visibility list must match the models that really have gpu weights.

## Changes

- **`perception/plugins/asr.py`** — `devices` table per model; five adapters take `device` and flip their weight-filename preference with it; downloading moves from the adapters into `_build_asr_adapter` (the registry owns the download key); the `config` action validates the (model, device) pair and returns an error for an unsupported one instead of silently degrading.
- **`perception/utils/onnx_provider.py`** — stops inferring, starts validating: `provider_for_device()`, `normalize_device()`, `is_fp16()`, `pick_weights()`. Each guard is a measured failure mode, with the numbers in the module docstring.
- **`perception/utils/model_downloader.py`** — `SHERPA_GPU_BUNDLES` + `ensure_gpu_model()`, using the existing `ensure_verified_bundle` (per-file size + SHA256). `ensure_model`'s only check is "does `check_file` exist in the archive", which is fine for a 230 MB archive and not for a 780 MB one, where a truncated transfer passes and then fails unreadably at session creation.
- **`perception/config.yaml`** — default becomes `sensevoice-small` on `cpu`. This also fixes a standing inconsistency: the configSchema already declared `sensevoice-small` as its default while `config.yaml` said `paraformer-zh-en`. It is the better default on both axes — faster on CPU (RTF 14.2x vs 9.1x) and the largest gpu upside.
- **`perception/tools/convert_onnx_fp16.py`** (new) — the fp16 recipe, in-repo rather than only in whatever produced the blob. Records the two flags that matter: `keep_io_types=True` (sherpa feeds fp32 features) and shape inference must stay **on**, or the Cast fencing around `Range` lands wrong and ORT rejects the file.
- **`agent-core/web/js/sidebar.js`** — `x-show-when` accepts an array of values, so the device selector hides itself on models without gpu weights. Backwards compatible with the existing single-value conditions.
- **KWS is now pinned to cpu** rather than following ASR: its zipformer bundle is int8 only. VAD stays cpu as before (silero infers one 512-sample window at a time; in `_vad_worker` it would also hold a second CUDA context in a child process).
- **`perception/README.md`** — § sherpa-onnx Device Selection: the tables above, the mechanism, the admission checklist, the fp16 recipe, and what does *not* follow `device`.

`hw_provider` is still read as a legacy alias, for deployments that mount their own `config.yaml`.

## Provenance of the GPU weights

The fp32 weights come from `pengzhendong`'s ModelScope mirrors of the k2-fsa zoo, accepted **only after** that mirror's int8 files were confirmed byte-identical (SHA256) to the copies we already deploy from COS — so the fp32 sitting beside them is corroborated rather than taken on faith. fp16 is converted from those with `tools/convert_onnx_fp16.py`. All five files are uploaded to `public/sherpa-onnx-gpu/` with ETag verified against the local MD5 and anonymous read confirmed.

## Verification

- `python -m pytest perception/tests -q` → **137 passed, 1 skipped**.
- Registry invariants asserted without hardware (see above).
- On orin5, against the real wheel and real model files: `provider_for_device` resolves as designed for every dtype; both `Dockerfile.jetson` branches were run verbatim in a container from the perception image (exit 0 each); the CPU-wheel path falls back to cpu.
- COS: all five GPU weight files return HTTP 200 anonymously at the pinned sizes.

**Not done:** a full `./deploy/build_perception.sh` image build for either JetPack. The one new layer was verified verbatim; the full build is left for CI or a machine with headroom.

## jp6.1 follow-up

The jp5.11 wheel links `libcudart.so.11.0` and cannot run on jp6.1 (CUDA 12.6). That target needs its own build with `SHERPA_ONNX_LINUX_ARM64_GPU_ONNXRUNTIME_VERSION=1.18.1` and `PYTHON_EXECUTABLE=python3.10` on a JetPack 6 host inside `jetson-base:jp61-torch`. Until then jp6.1 keeps the CPU wheel and `device: gpu` falls back to cpu there. Steps are in the README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
