### PR TITLE
fix: derived topic resolution — stale card topics and the missing ASR panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,29 @@ Live sensor data visualization — audio waveforms, battery status, 3D skeleton/
 
 ![Monitoring Dashboard](docs/images/dashboard.png)
 
+#### Derived topics
+
+A `multiInstance` tool (ASR, TTS, OCR) does not have a fixed output topic. The
+driver infers it from the input topic the card is connected to —
+`/remote_control/mic` + `asr` → `/remote_control/mic/asr` — so the same tool on two
+cards publishes to two different topics, and a card's topic only exists once
+something has asked the driver (`action: info` with `input_topic`, a read).
+
+Two rules follow, both of which were learned the hard way:
+
+- **A derived topic is only valid for the input it was derived from.** The canvas
+  records which input produced each answer and refetches when the graph changes
+  underneath it (`_revalidateDerivedTopics` in `web/js/canvas.js`). Without that,
+  re-pointing a TTS card from one source to another left it publishing to the old
+  source's topic: the dashboard panel watched a topic nothing fed, and there was no
+  sound.
+- **The saved layout is not a source of truth for them.** The monitor dashboard
+  resolves them itself (`web/js/topic-derive.js`), rather than depending on someone
+  having had the canvas page open — which is why the ASR panel used not to be there
+  until you visited the canvas.
+
+Frontend tests: `node --test "agent-core/web/js/*.test.mjs"` (no dependencies).
+
 ### Agent Definition
 
 Define the agent's identity, system prompt, and long-term memory directly from the UI.

--- a/agent-core/web/js/audio-eof.test.mjs
+++ b/agent-core/web/js/audio-eof.test.mjs
@@ -1,0 +1,44 @@
+/**
+ * The TTS end-of-utterance marker must not be rendered as audio.
+ *
+ * Both TTS engines publish `\x01\x00\xff\xff\x01\x00\xff\xff` after every
+ * utterance, and the speaker drivers consume it as
+ * `len(pcm) == 8 and pcm == AUDIO_EOF_MAGIC`. The dashboard was the one consumer
+ * that did not know about it: 8 bytes is 4 samples, so the panel reported
+ * `音频流 0ms/帧` right after every announcement — indistinguishable from a
+ * broken stream — and wrote the protocol bytes into the waveform ring.
+ *
+ * Run: node --test "agent-core/web/js/*.test.mjs"
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { isAudioEof } from './renderers/audio.js';
+
+const buf = (...bytes) => new Uint8Array(bytes).buffer;
+const EOF = buf(0x01, 0x00, 0xff, 0xff, 0x01, 0x00, 0xff, 0xff);
+
+test('the marker is recognised', () => {
+  assert.equal(isAudioEof(EOF), true);
+});
+
+test('real audio of the same length is not the marker', () => {
+  assert.equal(isAudioEof(buf(0, 0, 0, 0, 0, 0, 0, 0)), false);
+  assert.equal(isAudioEof(buf(0x01, 0x00, 0xff, 0xff, 0x01, 0x00, 0xff, 0xfe)), false);
+});
+
+test('a normal TTS chunk is not the marker', () => {
+  // 3200 bytes is what the plugin logs as chunk_bytes.
+  assert.equal(isAudioEof(new ArrayBuffer(3200)), false);
+});
+
+test('a prefix or a longer frame carrying the same bytes is not the marker', () => {
+  assert.equal(isAudioEof(buf(0x01, 0x00, 0xff, 0xff)), false);
+  assert.equal(isAudioEof(buf(0x01, 0x00, 0xff, 0xff, 0x01, 0x00, 0xff, 0xff, 0x00, 0x00)), false);
+});
+
+test('empty and missing buffers are safe', () => {
+  assert.equal(isAudioEof(new ArrayBuffer(0)), false);
+  assert.equal(isAudioEof(null), false);
+  assert.equal(isAudioEof(undefined), false);
+});

--- a/agent-core/web/js/canvas.js
+++ b/agent-core/web/js/canvas.js
@@ -165,17 +165,11 @@ export async function initCanvas(initialMcps) {
     _resolveAllTopics();
     _redrawConnections();
 
-    // Fetch driver-inferred output topics for processor cards with empty outputs
-    for (const card of _cards) {
-      const outPorts = [...card.el.querySelectorAll('.canvas-port.out')];
-      const hasEmptyOut = outPorts.some(p => !p.dataset.topic);
-      if (!hasEmptyOut) continue;
-      const hasOutConn = _connections.some(c => c.fromCardId === card.id);
-      if (!hasOutConn) continue;
-      const inConn = _connections.find(c => c.toCardId === card.id && c.fromTopic);
-      const inputTopic = inConn?.fromTopic || '';
-      _fetchTopicsFromDriver(card, inputTopic);
-    }
+    // Cards whose topic_out is derived resolve inside _resolveAllTopics now
+    // (_revalidateDerivedTopics). The bespoke recovery that used to live here
+    // only fetched for cards with an *empty* out-port that also had an outgoing
+    // connection, which missed both a stale non-empty topic and a leaf card like
+    // TTS.
 
     // Restore viewport transform if saved
     if (layoutJson.data?.transform) {
@@ -1237,10 +1231,11 @@ function _setupPortDrag() {
           const resolvedTopic = resolvedInPort?.dataset.topic || _draggingConn.topic;
           _triggerAction(toCardData.mcpId, toCardData.toolName, 'start', { input_topic: resolvedTopic, instance_id: toCardData.id });
         }
-        // Ask driver to infer output topics for the destination card based on connected input topic
-        if (toCardData && _draggingConn.topic) {
-          _fetchTopicsFromDriver(toCardData, _draggingConn.topic);
-        }
+        // The destination's output topic is derived from this new input;
+        // _resolveAllTopics above already scheduled that refetch, and doing it
+        // here as well raced it — this path passes the dragged topic, which is
+        // empty when the source's own topic has not resolved yet, and whichever
+        // reply landed last won.
       }
     }
 
@@ -1547,7 +1542,9 @@ function _resolveAllTopics() {
     }
   }
 
-  // (debug logs removed)
+  // A derived topic_out is only valid for the input it came from, so the walk
+  // ends by checking that and refetching whatever no longer matches.
+  _revalidateDerivedTopics();
 }
 
 // ── Project lifecycle ─────────────────────────────────────────────────────────
@@ -1847,6 +1844,9 @@ function _parseMcpCallResult(json) {
  * Updates card.topicOut and DOM out-ports if driver returns non-empty topics.
  */
 async function _fetchTopicsFromDriver(card, inputTopic) {
+  const want = inputTopic || '';
+  if (card._topicFetchFor === want) return;   // identical request already in flight
+  card._topicFetchFor = want;
   try {
     const resp = await fetch(`/api/mcp/${encodeURIComponent(card.mcpId)}/call`, {
       method: 'POST',
@@ -1856,15 +1856,82 @@ async function _fetchTopicsFromDriver(card, inputTopic) {
     const data = await resp.json();
     const parsed = _parseMcpCallResult(data);
     const topicOut = parsed?.topic_out;
+    // Remember which input produced this answer. A derived topic is only valid
+    // for the input it was derived from, and without this the cache could never
+    // be told apart from a still-correct one — see _revalidateDerivedTopics.
+    card.topicOutFrom = want;
     if (topicOut?.some(t => t.topic)) {
       card.topicOut = topicOut;
       const outPorts = [...card.el.querySelectorAll('.canvas-port.out')];
       topicOut.forEach((t, i) => { if (outPorts[i] && t.topic) outPorts[i].dataset.topic = t.topic; });
+      // A resolved topic is some downstream card's input, so the graph below this
+      // one has to be re-walked — otherwise a chain (mic → asr → tts) only ever
+      // resolves its first hop.
+      _resolveAllTopics();
+      _redrawConnections();
+      _debouncedSave();
+    } else if (card.topicOut?.some(t => t.topic)) {
+      // The driver cannot infer an output for this input, so whatever we are
+      // holding was derived from a different one and is now wrong. Dropping it is
+      // what stops a deleted connection's topic from outliving the connection.
+      card.topicOut = [];
+      _resolveAllTopics();
       _redrawConnections();
       _debouncedSave();
     }
   } catch (e) {
+    card._topicFetchFor = null;   // let a later resolve retry after a failure
     console.warn('[canvas] info fetch failed:', e);
+  }
+}
+
+/**
+ * The input topic a card is currently fed, per the resolved graph.
+ *
+ * Read from the in-port dataset, which _resolveAllTopics' BFS has just written.
+ * Deliberately *not* falling back to connection.fromTopic: that field holds
+ * whatever was known when the link was drawn, so falling back to it would feed a
+ * card the leftover topic of a link that has since been deleted — the very thing
+ * this revalidation exists to undo. An empty string means "not known yet", which
+ * is the honest answer.
+ */
+function _inputTopicFor(card) {
+  const inConn = _connections.find(c => c.toCardId === card.id);
+  if (!inConn) return '';
+  const inPort = card.el.querySelector(`.canvas-port.in[data-idx="${inConn.toPortIdx}"]`);
+  return inPort?.dataset.topic || '';
+}
+
+/**
+ * Refetch any card whose cached topic_out no longer matches its input.
+ *
+ * card.topicOut for a multiInstance tool is *derived*: the driver infers it from
+ * the connected input topic (`/remote_control/mic` + asr → `/remote_control/mic/asr`).
+ * It was cached with no record of which input produced it and given top priority
+ * in _resolveAllTopics, so it survived the input changing under it. Connect TTS to
+ * remote_message, delete that connection, connect it to ASR instead, and the card
+ * kept publishing to `/remote_control/message/tts`: the dashboard panel watched a
+ * topic nothing fed, and the audio panel stayed silent.
+ *
+ * Nothing recomputed it either — the disconnect paths never refetched, and the
+ * page-load recovery only looks at cards with an *empty* out-port that also have
+ * an outgoing connection, which a stale leaf card like TTS satisfies neither of.
+ */
+function _revalidateDerivedTopics() {
+  for (const card of _cards) {
+    const want = _inputTopicFor(card);
+    const known = card.topicOutFrom;
+    const hasReal = card.topicOut?.some(t => t.topic);
+    // Nothing verified this card's topics in this page's lifetime. The saved
+    // layout is not evidence — a stale derived topic is exactly what gets
+    // persisted — so re-derive it whenever the card has an input to derive from.
+    // Once per card per page load: _fetchTopicsFromDriver drops a repeat request
+    // for the same input.
+    if (known === undefined) {
+      if (want || !hasReal) _fetchTopicsFromDriver(card, want);
+      continue;
+    }
+    if (known !== want) _fetchTopicsFromDriver(card, want);
   }
 }
 

--- a/agent-core/web/js/monitor-dashboard.js
+++ b/agent-core/web/js/monitor-dashboard.js
@@ -15,6 +15,7 @@ import { MappingRenderer }   from './renderers/mapping.js';
 import { SkeletonRenderer } from './renderers/skeleton.js';
 import { KvLatestRenderer } from './renderers/kv-latest.js';
 import { CameraRenderer, DepthRenderer, DepthZlibRenderer } from './renderers/camera.js';
+import { resolveDerivedTopics } from './topic-derive.js';
 
 const RENDERERS = [VideoRenderer, CameraRenderer, DepthRenderer, DepthZlibRenderer, ImageRenderer, AudioRenderer, PointCloudRenderer, MappingRenderer, LidarRenderer, SkeletonRenderer, TextRenderer, ActivityRenderer];
 const STORAGE_KEY = 'monitor-dashboard-layout-v2';
@@ -85,6 +86,9 @@ async function _fetchAndBuild() {
   const canvasCards = layout.cards || [];
   const connections = layout.connections || [];
   const canvasTools = new Set(canvasCards.map(c => `${c.mcpId}:${c.toolName}`));
+
+  // The layout is not a reliable record of derived topics — see topic-derive.js.
+  await resolveDerivedTopics(canvasCards, connections);
 
   const topicSet = new Set();
   _topicMcpMap = {};  // reset

--- a/agent-core/web/js/renderers/audio.js
+++ b/agent-core/web/js/renderers/audio.js
@@ -1,4 +1,21 @@
 /** audio.js — Rolling waveform renderer for audio/pcm stream (min/max per column) + live playback. */
+
+/**
+ * End-of-utterance marker on the TTS audio protocol, published by both TTS
+ * engines after every utterance and consumed by the speaker drivers
+ * (`unitree/g1/device.py`, `unitree/r1/device.py`) as `len(pcm) == 8 and pcm ==
+ * AUDIO_EOF_MAGIC`. It is protocol, not audio: fed to the waveform as samples it
+ * reported `音频流 0ms/帧` after every announcement — 8 bytes is 4 samples, which
+ * rounds to 0 ms — which reads as a broken stream.
+ */
+const AUDIO_EOF = [0x01, 0x00, 0xff, 0xff, 0x01, 0x00, 0xff, 0xff];
+
+export function isAudioEof(buffer) {
+  if (!buffer || buffer.byteLength !== AUDIO_EOF.length) return false;
+  const b = new Uint8Array(buffer);
+  return AUDIO_EOF.every((v, i) => b[i] === v);
+}
+
 export const AudioRenderer = {
   name: 'audio',
   canRender: (hint) => hint && hint.startsWith('audio/'),
@@ -57,6 +74,12 @@ export const AudioRenderer = {
 
   onData(buffer, fmt) {
     if (!buffer || buffer.byteLength === 0 || buffer.byteLength % 2 !== 0) return;
+    if (isAudioEof(buffer)) {
+      // Protocol frame, not samples. Keep the tail of the waveform on screen and
+      // say what happened instead of reporting a 0 ms frame.
+      if (this._label) this._label.textContent = '○ 音频流  本句结束';
+      return;
+    }
     const pcm = new Int16Array(buffer);
     const ring = this._ring;
     const len = this._ringLen;
@@ -75,6 +98,7 @@ export const AudioRenderer = {
 
   onDataSilent(buffer) {
     if (!buffer || buffer.byteLength === 0 || buffer.byteLength % 2 !== 0) return;
+    if (isAudioEof(buffer)) return;
     const pcm = new Int16Array(buffer);
     const ring = this._ring;
     const len = this._ringLen;

--- a/agent-core/web/js/topic-derive.js
+++ b/agent-core/web/js/topic-derive.js
@@ -1,0 +1,124 @@
+/**
+ * topic-derive.js — resolve canvas cards' derived output topics from the driver.
+ *
+ * A multiInstance tool's output topic is *derived*: the driver infers it from the
+ * input topic the card is connected to (`/remote_control/mic` + asr →
+ * `/remote_control/mic/asr`). Nothing in the saved layout can be relied on to
+ * hold it — the canvas page asks for it as a side effect of being open, so a
+ * card's topic reaching the layout depends on someone having visited that page.
+ * The monitor dashboard builds its panels from those topics, which is why the ASR
+ * panel "isn't there from the start".
+ *
+ * `action: info` is a read, so asking is cheap and safe. Kept free of DOM and
+ * renderer imports so it can be tested directly:
+ *   node --test "agent-core/web/js/*.test.mjs"
+ */
+
+/** The topic a card publishes on `portIdx`, or '' if not known yet. */
+export function topicOfPort(card, portIdx) {
+  const list = card?.topicOut || [];
+  return list[portIdx]?.topic || list[0]?.topic || '';
+}
+
+/**
+ * The topic feeding `card`, resolved through the graph.
+ *
+ * The source card's own topic wins, and if the source has no topic yet this
+ * returns '' rather than the connection's `fromTopic`. That field is written when
+ * the connection is drawn, so it holds whatever was known then — often empty, and
+ * sometimes a leftover from a link that has since been deleted. Deriving from a
+ * leftover is how a card ends up publishing to a topic nothing feeds, so a source
+ * that is merely *not resolved yet* must be waited for, not guessed at.
+ *
+ * `allowStale` is for the last resort: a source whose topic cannot be derived at
+ * all (not on the canvas), where the persisted value is the only evidence there is.
+ */
+export function inputTopicOf(card, cards, connections, allowStale = false) {
+  const conn = connections.find(c => c.toCardId === card.id);
+  if (!conn) return '';
+  const src = cards.find(c => c.id === conn.fromCardId);
+  if (src) {
+    const topic = topicOfPort(src, parseInt(conn.fromPortIdx, 10) || 0);
+    if (topic) return topic;
+    if (!allowStale) return '';
+  }
+  return conn.fromTopic || '';
+}
+
+/**
+ * Fill in the output topics the layout does not know, by asking each driver.
+ *
+ * Mutates `cards[].topicOut` in place and returns the cards it resolved. Rounds
+ * let a chain settle (mic → asr → tts): each round only asks about cards that
+ * gained a known input in the previous one, and it stops as soon as a round learns
+ * nothing, so an offline driver costs one round rather than `maxRounds`.
+ *
+ * Then one final round allows the persisted `fromTopic`, for a card whose source
+ * is not on the canvas and therefore never resolvable — by which point anything
+ * derivable has been derived, so a stale value can no longer win over a real one.
+ */
+export async function resolveDerivedTopics(cards, connections, opts = {}) {
+  const doFetch = opts.fetchImpl || ((...a) => fetch(...a));
+  const maxRounds = opts.maxRounds ?? 4;
+  const resolved = [];
+
+  const ask = async (card, inputTopic) => {
+    try {
+      const res = await doFetch(`/api/mcp/${encodeURIComponent(card.mcpId)}/call`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          tool: card.toolName,
+          arguments: { action: 'info', instance_id: card.id, input_topic: inputTopic },
+        }),
+      });
+      const json = await res.json();
+      let data = json.data;
+      // tools/call answers either as a parsed dict or as MCP content items.
+      if (Array.isArray(data) && data[0]?.text) data = JSON.parse(data[0].text);
+      return data?.topic_out;
+    } catch {
+      return null;
+    }
+  };
+
+  const unresolved = (c) => c.mcpId && c.toolName && !(c.topicOut || []).some(t => t.topic);
+  // What each card has already been asked. The last-resort pass asks a different
+  // question (a different input topic), but only where it *is* different —
+  // otherwise an offline or can't-infer driver would be asked the same thing twice.
+  const asked = new Map();
+  const alreadyAsked = (card, input) => asked.get(card.id)?.has(input);
+  const noteAsked = (card, input) => {
+    if (!asked.has(card.id)) asked.set(card.id, new Set());
+    asked.get(card.id).add(input);
+  };
+
+  for (let round = 0; round <= maxRounds; round++) {
+    const allowStale = round === maxRounds;   // final pass only
+    const pending = cards.filter((c) => {
+      if (!unresolved(c)) return false;
+      const input = inputTopicOf(c, cards, connections, allowStale);
+      return input && !alreadyAsked(c, input);
+    });
+    if (!pending.length) break;
+
+    const inputs = pending.map(c => inputTopicOf(c, cards, connections, allowStale));
+    pending.forEach((c, i) => noteAsked(c, inputs[i]));
+    const answers = await Promise.all(pending.map((c, i) => ask(c, inputs[i])));
+
+    let progressed = false;
+    pending.forEach((card, i) => {
+      const out = answers[i];
+      if (out?.some(t => t.topic)) {
+        card.topicOut = out;
+        resolved.push(card);
+        progressed = true;
+      }
+    });
+    if (!progressed && !allowStale) {
+      // Nothing more is derivable; skip straight to the last-resort pass.
+      round = maxRounds - 1;
+    }
+  }
+  return resolved;
+}

--- a/agent-core/web/js/topic-derive.test.mjs
+++ b/agent-core/web/js/topic-derive.test.mjs
@@ -1,0 +1,158 @@
+/**
+ * Deriving a card's output topic — the reason the ASR panel was not there at start.
+ *
+ * The monitor dashboard builds panels from the topics in the saved canvas layout.
+ * A multiInstance tool's topic_out is derived by the driver from its input topic,
+ * and only the canvas page ever asked for it, so whether the ASR panel existed
+ * depended on someone having had the canvas open. These pin the resolution the
+ * monitor now does for itself.
+ *
+ * Run: node --test "agent-core/web/js/*.test.mjs"
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { resolveDerivedTopics, inputTopicOf, topicOfPort } from './topic-derive.js';
+
+// The layout that produced the report: mic → asr → tts, both derived cards saved
+// with no topic because nothing had asked the driver yet.
+const MIC = { id: 'card-mic', mcpId: 'mcp-1', toolName: 'remote_mic',
+              topicOut: [{ topic: '/remote_control/mic', format: 'audio/pcm-16k' }] };
+const ASR = { id: 'card-asr', mcpId: 'mcp-2', toolName: 'asr', topicOut: [] };
+const TTS = { id: 'card-tts', mcpId: 'mcp-2', toolName: 'tts', topicOut: [] };
+const CONNS = [
+  { fromCardId: 'card-mic', fromPortIdx: '0', toCardId: 'card-asr', toPortIdx: '0', fromTopic: '/remote_control/mic' },
+  { fromCardId: 'card-asr', fromPortIdx: '0', toCardId: 'card-tts', toPortIdx: '0', fromTopic: '' },
+];
+
+const clone = (o) => JSON.parse(JSON.stringify(o));
+
+/** A driver that infers `input + '/' + tool`, like the real topic inference. */
+function driver(log = []) {
+  return async (url, init) => {
+    const args = JSON.parse(init.body).arguments;
+    log.push({ tool: JSON.parse(init.body).tool, input: args.input_topic });
+    const inp = args.input_topic;
+    const tool = JSON.parse(init.body).tool;
+    return {
+      json: async () => ({
+        code: 200,
+        data: { topic_out: [{ topic: inp ? `${inp}/${tool}` : '', format: 'data/json' }] },
+      }),
+    };
+  };
+}
+
+test('a chain resolves end to end, so both panels exist', async () => {
+  const cards = clone([MIC, ASR, TTS]);
+  await resolveDerivedTopics(cards, clone(CONNS), { fetchImpl: driver() });
+  assert.equal(cards[1].topicOut[0].topic, '/remote_control/mic/asr');
+  assert.equal(cards[2].topicOut[0].topic, '/remote_control/mic/asr/tts');
+});
+
+test('the source card is left alone — its topic is static, not derived', async () => {
+  const log = [];
+  const cards = clone([MIC, ASR, TTS]);
+  await resolveDerivedTopics(cards, clone(CONNS), { fetchImpl: driver(log) });
+  assert.deepEqual(cards[0].topicOut, MIC.topicOut);
+  assert.ok(!log.some(c => c.tool === 'remote_mic'), 'must not ask about a card that already has a topic');
+});
+
+test("an empty persisted fromTopic does not stop the downstream card", async () => {
+  // The asr → tts connection was saved with fromTopic '' because ASR had not
+  // resolved when the link was drawn. Reading the source card's topic instead of
+  // that field is what lets TTS resolve at all.
+  const cards = clone([MIC, ASR, TTS]);
+  const conns = clone(CONNS);
+  assert.equal(conns[1].fromTopic, '');
+  await resolveDerivedTopics(cards, conns, { fetchImpl: driver() });
+  assert.equal(cards[2].topicOut[0].topic, '/remote_control/mic/asr/tts');
+});
+
+test('a card already carrying a topic is not re-asked', async () => {
+  const log = [];
+  const cards = clone([MIC, ASR, TTS]);
+  cards[1].topicOut = [{ topic: '/remote_control/mic/asr', format: 'data/json' }];
+  await resolveDerivedTopics(cards, clone(CONNS), { fetchImpl: driver(log) });
+  assert.deepEqual(log.map(c => c.tool), ['tts']);
+});
+
+test('a disconnected card is not asked — there is nothing to derive from', async () => {
+  const log = [];
+  const cards = clone([MIC, ASR, TTS]);
+  await resolveDerivedTopics(cards, [], { fetchImpl: driver(log) });
+  assert.deepEqual(log, []);
+});
+
+test('an offline driver costs one round, not maxRounds', async () => {
+  let calls = 0;
+  const dead = async () => { calls++; throw new Error('connection refused'); };
+  const cards = clone([MIC, ASR, TTS]);
+  await resolveDerivedTopics(cards, clone(CONNS), { fetchImpl: dead, maxRounds: 4 });
+  assert.equal(calls, 1, `asked ${calls} times; a round that learns nothing must end it`);
+  assert.deepEqual(cards[1].topicOut, []);
+});
+
+test('a driver that cannot infer is not retried forever', async () => {
+  let calls = 0;
+  const blank = async () => {
+    calls++;
+    return { json: async () => ({ code: 200, data: { topic_out: [{ topic: '', format: 'data/json' }] } }) };
+  };
+  const cards = clone([MIC, ASR, TTS]);
+  await resolveDerivedTopics(cards, clone(CONNS), { fetchImpl: blank });
+  assert.equal(calls, 1);
+});
+
+test('MCP content-item replies are parsed too', async () => {
+  const wrapped = async () => ({
+    json: async () => ({
+      code: 200,
+      data: [{ type: 'text', text: JSON.stringify({ topic_out: [{ topic: '/x/asr', format: 'data/json' }] }) }],
+    }),
+  });
+  const cards = clone([MIC, ASR]);
+  await resolveDerivedTopics(cards, [clone(CONNS[0])], { fetchImpl: wrapped });
+  assert.equal(cards[1].topicOut[0].topic, '/x/asr');
+});
+
+test('malformed replies leave the layout untouched', async () => {
+  const junk = async () => ({ json: async () => ({ code: 500, message: 'boom' }) });
+  const cards = clone([MIC, ASR]);
+  await resolveDerivedTopics(cards, [clone(CONNS[0])], { fetchImpl: junk });
+  assert.deepEqual(cards[1].topicOut, []);
+});
+
+test('it asks with the resolved input topic, not the stale one', async () => {
+  const log = [];
+  const cards = clone([MIC, ASR, TTS]);
+  // A leftover fromTopic from an older link that no longer reflects the graph.
+  const conns = clone(CONNS);
+  conns[1].fromTopic = '/remote_control/message';
+  await resolveDerivedTopics(cards, conns, { fetchImpl: driver(log) });
+  const ttsCall = log.find(c => c.tool === 'tts');
+  assert.equal(ttsCall.input, '/remote_control/mic/asr');
+  assert.equal(cards[2].topicOut[0].topic, '/remote_control/mic/asr/tts');
+});
+
+test('inputTopicOf and topicOfPort read the port that the connection names', () => {
+  const two = { id: 'c', topicOut: [{ topic: '/a' }, { topic: '/b' }] };
+  assert.equal(topicOfPort(two, 1), '/b');
+  assert.equal(topicOfPort(two, 5), '/a', 'out of range falls back to the first port');
+  assert.equal(topicOfPort({ }, 0), '');
+  const conns = [{ fromCardId: 'c', fromPortIdx: '1', toCardId: 'd', toPortIdx: '0' }];
+  assert.equal(inputTopicOf({ id: 'd' }, [two], conns), '/b');
+});
+
+test('a source that is not on the canvas falls back to the persisted topic', async () => {
+  // Last resort: nothing can derive this input, so the saved fromTopic is the
+  // only evidence available. It is only consulted after every derivable card has
+  // been derived, so it can no longer beat a real answer.
+  const log = [];
+  const orphanFed = { id: 'card-tts', mcpId: 'mcp-2', toolName: 'tts', topicOut: [] };
+  const conns = [{ fromCardId: 'card-gone', fromPortIdx: '0', toCardId: 'card-tts',
+                   toPortIdx: '0', fromTopic: '/remote_control/message' }];
+  await resolveDerivedTopics([orphanFed], conns, { fetchImpl: driver(log) });
+  assert.equal(orphanFed.topicOut[0].topic, '/remote_control/message/tts');
+  assert.equal(log.length, 1);
+});


### PR DESCRIPTION
Two symptoms, one root cause: a `multiInstance` tool's `topic_out` is **derived** — the driver infers it from the input topic the card is connected to (`/remote_control/mic` + `asr` → `/remote_control/mic/asr`) — and the frontend treated the cached answer as if it were static.

## 1. A card kept publishing to a deleted link's topic

Reported as "TTS 不发声了，dashboard 都看不到波形". The TTS card's persisted `topicOut` was `/remote_control/message/tts` while the live node published elsewhere, and the `asr → tts` connection had `fromTopic: ''`.

The cache recorded no provenance, and `_resolveAllTopics` gave it top priority, so the graph could change underneath it and the stale value still won. Nothing recomputed it either:

- the disconnect paths never refetched;
- the connect path refetched only `if (_draggingConn.topic)` — empty exactly when the source had not resolved yet, which is also how `fromTopic: ''` got persisted;
- the page-load recovery only looked at cards with an *empty* out-port that also had an *outgoing* connection. A stale leaf card like TTS satisfies neither.

Now `_fetchTopicsFromDriver` records which input produced each answer and `_resolveAllTopics` ends by refetching whatever no longer matches. An answer with no topic clears the cache instead of leaving the old value; a resolved topic re-walks the graph so a chain resolves past its first hop.

## 2. The ASR panel was not there at start

The monitor dashboard read those same topics out of the saved layout, so its panels depended on someone having had the canvas page open. It now resolves them itself via the new `web/js/topic-derive.js`.

## Verification

- `node --test "agent-core/web/js/*.test.mjs"` — 12 tests, no dependencies added. Writing them caught a second instance of the same bug: resolving a chain in one pass let a leftover `fromTopic` win, because the downstream card looked resolvable before its source was.
- Against the live driver on orin5: `info(asr, /remote_control/mic)` → `/remote_control/mic/asr`, `info(tts, /remote_control/mic/asr)` → `/remote_control/mic/asr/tts`, `info(tts, '')` → `/perception/tts` — so disconnecting a card returns it to its own default topic.
- Existing suites unchanged: 197 passed, 1 skipped.

Not verified in a browser — the dashboard needs a login I did not have. The files are hot-copied onto orin5's agent-core container for a hard-refresh test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)