### PR TITLE
refactor(perception): state each JetPack fact once

### DIFF
--- a/deploy/build_actucore.sh
+++ b/deploy/build_actucore.sh
@@ -52,22 +52,9 @@ TAG="release.${DATE}.${COMMIT}-jetson-jp${JP_VERSION}"
 
 BUILD_ARGS=""
 # ── 根据 jp_version 选择 base image  ────────────────────────
-# ACC_ARCH 是 resource-center 的过滤依据（大版本粒度，见 resource-center/lib/arch.ts）：
-# 机器上报自己的 JetPack 线，跑不了的镜像就不会出现在驱动市场里。
-case "${JP_VERSION}" in
-    5.11)
-        BUILD_ARGS="${BUILD_ARGS} JP_VERSION=511"
-        ACC_ARCH="jetson-jp5"
-        ;;
-    6.1)
-        BUILD_ARGS="${BUILD_ARGS} JP_VERSION=61"
-        ACC_ARCH="jetson-jp6"
-        ;;
-    *)
-        echo "Unknown JetPack version: ${JP_VERSION} (support: 5.11, 6.1)"
-        exit 1
-        ;;
-esac
+# 表在 build_common.sh 的 jetpack_vars 里，build_perception.sh 共用同一份。
+jetpack_vars "${JP_VERSION}" || exit 1
+BUILD_ARGS="${BUILD_ARGS} JP_VERSION=${JP_ARG}"
 
 # Dockerfile.jetson 基于 L4T base image —— 只有 arm64
 CPU_ARCH="arm64"

--- a/deploy/build_common.sh
+++ b/deploy/build_common.sh
@@ -133,3 +133,25 @@ parse_mirror_arg() {
     fi
     echo ""
 }
+
+# ── JetPack 线 ────────────────────────────────────────────────────────
+# jetpack_vars <5.11|6.1> —— 把一条 JetPack 线的构建期事实解析出来，设置：
+#   JP_ARG    传给 Dockerfile 的 JP_VERSION build arg（511 / 61），它同时选定
+#             base 镜像，并在镜像内解析出 numpy pin 与 sherpa wheel
+#             （见 perception/Dockerfile.jetson 的 /etc/jetpack.env）
+#   ACC_ARCH  resource-center 的过滤依据（大版本粒度，见 resource-center/lib/arch.ts）：
+#             机器上报自己的 JetPack 线，跑不了的镜像就不会出现在驱动市场里
+#
+# build_perception.sh 与 build_actucore.sh 此前各带一份逐字节相同的 case 块。
+# 新增一条 JetPack 线时改这里一处即可，不必记得还有另一个脚本。
+jetpack_vars() {
+    case "$1" in
+        5.11) JP_ARG=511; ACC_ARCH="jetson-jp5" ;;
+        6.1)  JP_ARG=61;  ACC_ARCH="jetson-jp6" ;;
+        *)
+            echo "Unknown JetPack version: $1 (support: 5.11, 6.1)" >&2
+            return 1
+            ;;
+    esac
+    export JP_ARG ACC_ARCH
+}

--- a/deploy/build_perception.sh
+++ b/deploy/build_perception.sh
@@ -52,22 +52,9 @@ TAG="release.${DATE}.${COMMIT}-jetson-jp${JP_VERSION}"
 
 BUILD_ARGS=""
 # ── 根据 jp_version 选择 base image  ────────────────────────
-# ACC_ARCH 是 resource-center 的过滤依据（大版本粒度，见 resource-center/lib/arch.ts）：
-# 机器上报自己的 JetPack 线，跑不了的镜像就不会出现在驱动市场里。
-case "${JP_VERSION}" in
-    5.11)
-        BUILD_ARGS="${BUILD_ARGS} JP_VERSION=511"
-        ACC_ARCH="jetson-jp5"
-        ;;
-    6.1)
-        BUILD_ARGS="${BUILD_ARGS} JP_VERSION=61"
-        ACC_ARCH="jetson-jp6"
-        ;;
-    *)
-        echo "Unknown JetPack version: ${JP_VERSION} (support: 5.11, 6.1)"
-        exit 1
-        ;;
-esac
+# 表在 build_common.sh 的 jetpack_vars 里，build_actucore.sh 共用同一份。
+jetpack_vars "${JP_VERSION}" || exit 1
+BUILD_ARGS="${BUILD_ARGS} JP_VERSION=${JP_ARG}"
 
 # Dockerfile.jetson 基于 L4T base image —— 只有 arm64
 CPU_ARCH="arm64"

--- a/perception/Dockerfile.jetson
+++ b/perception/Dockerfile.jetson
@@ -151,23 +151,34 @@ ENV YOLO_CONFIG_DIR=/work
 # Cost: 74 MB compressed / ~250 MB unpacked, nearly all of it
 # libonnxruntime_providers_cuda.so, versus ~30 MB for the CPU wheel.
 #
-# The URL needs %2B for the '+cuda' local version, but the file on disk must
-# keep the literal '+' or pip refuses to parse the version out of the filename.
-ARG SHERPA_GPU_WHEEL_511=sherpa_onnx-1.13.6+cuda-cp38-cp38-linux_aarch64.whl
-ARG SHERPA_GPU_WHEEL_61=sherpa_onnx-1.13.6+cuda-cp310-cp310-linux_aarch64.whl
+# The COS key carries the JetPack, the filename does not. Upstream's setup.py
+# tags the wheel `1.13.6+cuda-cp<abi>`, so the only thing separating the two
+# builds in a flat directory would be `cp38` vs `cp310` — which is a *Python*
+# discriminator, not a CUDA one. It happens to select correctly today, since each
+# image ships exactly one Python, but a second cp310 build for another JetPack 6.x
+# on a different CUDA would collide. Renaming the file is not an option (pip parses
+# the version out of it and it must match the wheel metadata), so the directory
+# records what the name cannot.
+#
+# The URL needs %2B for the '+cuda' local version — `quote` leaves the '/' of the
+# key alone — while the file on disk must keep the literal '+' or pip refuses to
+# parse the version out of the filename.
+ARG SHERPA_GPU_WHEEL_511=jp511/sherpa_onnx-1.13.6+cuda-cp38-cp38-linux_aarch64.whl
+ARG SHERPA_GPU_WHEEL_61=jp61/sherpa_onnx-1.13.6+cuda-cp310-cp310-linux_aarch64.whl
 RUN case "${JP_VERSION}" in \
         511) WHEEL="${SHERPA_GPU_WHEEL_511}" ;; \
         61)  WHEEL="${SHERPA_GPU_WHEEL_61}"  ;; \
         *)   WHEEL="" ;; \
     esac; \
     if [ -n "${WHEEL}" ]; then \
+        FILE="$(basename "${WHEEL}")" && \
         echo "[build] sherpa-onnx: GPU wheel for jp${JP_VERSION} — ${WHEEL}" && \
         python3 -c "import urllib.request, urllib.parse, sys; \
-name = sys.argv[1]; \
-urllib.request.urlretrieve('https://agi-phanthy-dev-1252788780.cos.ap-beijing.myqcloud.com/public/sherpa-onnx/' + urllib.parse.quote(name), '/tmp/' + name)" \
-            "${WHEEL}" && \
-        pip3 install --no-cache-dir "/tmp/${WHEEL}" && \
-        rm -f "/tmp/${WHEEL}" && \
+key, dest = sys.argv[1], sys.argv[2]; \
+urllib.request.urlretrieve('https://agi-phanthy-dev-1252788780.cos.ap-beijing.myqcloud.com/public/sherpa-onnx/' + urllib.parse.quote(key), dest)" \
+            "${WHEEL}" "/tmp/${FILE}" && \
+        pip3 install --no-cache-dir "/tmp/${FILE}" && \
+        rm -f "/tmp/${FILE}" && \
         python3 -c "import sherpa_onnx, pathlib; \
 lib = pathlib.Path(sherpa_onnx.__file__).parent / 'lib' / 'libonnxruntime_providers_cuda.so'; \
 assert lib.is_file(), 'CUDA provider missing from the installed wheel'; \

--- a/perception/Dockerfile.jetson
+++ b/perception/Dockerfile.jetson
@@ -18,6 +18,44 @@ ARG ENABLE_VITS2_TRT=1
 FROM bj-warehouse.tencentcloudcr.com/phanthy-motus/jetson-base:jp${JP_VERSION}-torch
 ARG PYPI_MIRROR APT_MIRROR JP_VERSION ENABLE_VITS2_TRT
 
+# ── Everything that differs per JetPack line, resolved once ──────────────────
+# These facts used to be restated at each point of use — the numpy pin appeared
+# twice in this file alone, and the two copies had to agree or the C-ABI those
+# wheels were built against breaks. Resolve them here and have each consumer
+# `. /etc/jetpack.env` instead.
+#
+# Deliberately kept in the Dockerfile rather than passed in as build args from
+# deploy/build_perception.sh: JP_VERSION already selects the base image on the
+# FROM line above, so a build that passed JP_VERSION but forgot NUMPY_VERSION
+# would produce a jp6.1 base pinned to jp5.11's numpy — silently, and only
+# failing later at import. One argument in, everything else derived.
+#
+#   NUMPY_VERSION  matches the torch/cv2 stack each base ships, so nothing in
+#                  the base image is upgraded or downgraded under it.
+#   SHERPA_GPU_WHEEL  COS key *with* its directory (see the sherpa-onnx step).
+#                  Empty for a line we have not built a wheel for, which selects
+#                  the PyPI CPU wheel.
+#   PY_ABI         read from the interpreter, not from the base image's
+#                  PYTHON_VERSION env: jp5.11's base does not set that variable
+#                  at all (it happened to work only because the shell default
+#                  was hardcoded to 3.8) while jp6.1's sets 3.10. Asking python
+#                  is correct on any base, present or future.
+#
+# It is also a record: `docker exec <c> cat /etc/jetpack.env` says what line an
+# image was built for, which is otherwise guesswork from the tag alone.
+ARG SHERPA_GPU_WHEEL_511=jp511/sherpa_onnx-1.13.6+cuda-cp38-cp38-linux_aarch64.whl
+ARG SHERPA_GPU_WHEEL_61=jp61/sherpa_onnx-1.13.6+cuda-cp310-cp310-linux_aarch64.whl
+RUN case "${JP_VERSION}" in \
+        511) NUMPY=1.24.4; WHEEL="${SHERPA_GPU_WHEEL_511}" ;; \
+        61)  NUMPY=1.26.4; WHEEL="${SHERPA_GPU_WHEEL_61}"  ;; \
+        *)   NUMPY=1.24.4; WHEEL= ;; \
+    esac; \
+    printf 'NUMPY_VERSION=%s\nSHERPA_GPU_WHEEL=%s\nPY_ABI=%s\n' \
+        "${NUMPY}" "${WHEEL}" \
+        "$(python3 -c 'import sys; print("%d.%d" % sys.version_info[:2])')" \
+        > /etc/jetpack.env && \
+    echo "[build] jp${JP_VERSION}:" && cat /etc/jetpack.env
+
 # ── APT mirror (conditional) ─────────────────────────────────────
 RUN if [ -n "${APT_MIRROR}" ]; then \
         sed -i "s/archive.ubuntu.com/${APT_MIRROR}/g; s/ports.ubuntu.com/${APT_MIRROR}/g" /etc/apt/sources.list; \
@@ -90,14 +128,28 @@ RUN pip3 install --no-cache-dir -i ${PYPI_MIRROR} --ignore-installed PyYAML && \
     websockets webrtcvad
 
 # ── VOP deps (YOLOv8-World object detection) ─────────────────────
-# Fix broken system cv2 __init__.py (mat_wrapper circular import on Jetson)
-RUN python3 -c "import cv2" 2>/dev/null || { \
-    echo 'import importlib.util, sys, os' > /usr/lib/python3.8/dist-packages/cv2/__init__.py && \
-    echo '_so = os.path.join(os.path.dirname(__file__), "python-3.8", "cv2.cpython-38-aarch64-linux-gnu.so")' >> /usr/lib/python3.8/dist-packages/cv2/__init__.py && \
-    echo '_spec = importlib.util.spec_from_file_location("cv2", _so)' >> /usr/lib/python3.8/dist-packages/cv2/__init__.py && \
-    echo '_mod = importlib.util.module_from_spec(_spec)' >> /usr/lib/python3.8/dist-packages/cv2/__init__.py && \
-    echo '_spec.loader.exec_module(_mod)' >> /usr/lib/python3.8/dist-packages/cv2/__init__.py && \
-    echo 'sys.modules["cv2"] = _mod' >> /usr/lib/python3.8/dist-packages/cv2/__init__.py; \
+# Fix broken system cv2 __init__.py (mat_wrapper circular import on Jetson).
+# Only jp5.11's base is broken; on jp6.1 the import succeeds and this is a no-op.
+#
+# The shim locates the extension by glob rather than naming it. The previous
+# version hardcoded `/usr/lib/python3.8/...`, `python-3.8/` and
+# `cv2.cpython-38-aarch64-linux-gnu.so` — three restatements of the same ABI that
+# only jp5.11 satisfies, in a step that runs on both lines. Globbing has no
+# version in it at all, and still fails loudly (IndexError at import) if the
+# extension is somewhere else entirely.
+RUN . /etc/jetpack.env; \
+    CV2_DIR="/usr/lib/python${PY_ABI}/dist-packages/cv2"; \
+    python3 -c "import cv2" 2>/dev/null || { \
+      echo "[build] repairing ${CV2_DIR}/__init__.py" && \
+      printf '%s\n' \
+        'import importlib.util, sys, os, glob' \
+        '_here = os.path.dirname(__file__)' \
+        '_hits = glob.glob(os.path.join(_here, "python-*", "cv2*.so")) or glob.glob(os.path.join(_here, "cv2*.so"))' \
+        '_spec = importlib.util.spec_from_file_location("cv2", _hits[0])' \
+        '_mod = importlib.util.module_from_spec(_spec)' \
+        '_spec.loader.exec_module(_mod)' \
+        'sys.modules["cv2"] = _mod' \
+        > "${CV2_DIR}/__init__.py"; \
     }
 # Install ultralytics WITHOUT replacing Jetson's CUDA torch + torchvision
 RUN pip3 install --no-cache-dir --no-deps -i ${PYPI_MIRROR} ultralytics && \
@@ -163,20 +215,14 @@ ENV YOLO_CONFIG_DIR=/work
 # The URL needs %2B for the '+cuda' local version — `quote` leaves the '/' of the
 # key alone — while the file on disk must keep the literal '+' or pip refuses to
 # parse the version out of the filename.
-ARG SHERPA_GPU_WHEEL_511=jp511/sherpa_onnx-1.13.6+cuda-cp38-cp38-linux_aarch64.whl
-ARG SHERPA_GPU_WHEEL_61=jp61/sherpa_onnx-1.13.6+cuda-cp310-cp310-linux_aarch64.whl
-RUN case "${JP_VERSION}" in \
-        511) WHEEL="${SHERPA_GPU_WHEEL_511}" ;; \
-        61)  WHEEL="${SHERPA_GPU_WHEEL_61}"  ;; \
-        *)   WHEEL="" ;; \
-    esac; \
-    if [ -n "${WHEEL}" ]; then \
-        FILE="$(basename "${WHEEL}")" && \
-        echo "[build] sherpa-onnx: GPU wheel for jp${JP_VERSION} — ${WHEEL}" && \
+RUN . /etc/jetpack.env; \
+    if [ -n "${SHERPA_GPU_WHEEL}" ]; then \
+        FILE="$(basename "${SHERPA_GPU_WHEEL}")" && \
+        echo "[build] sherpa-onnx: GPU wheel for jp${JP_VERSION} — ${SHERPA_GPU_WHEEL}" && \
         python3 -c "import urllib.request, urllib.parse, sys; \
 key, dest = sys.argv[1], sys.argv[2]; \
 urllib.request.urlretrieve('https://agi-phanthy-dev-1252788780.cos.ap-beijing.myqcloud.com/public/sherpa-onnx/' + urllib.parse.quote(key), dest)" \
-            "${WHEEL}" "/tmp/${FILE}" && \
+            "${SHERPA_GPU_WHEEL}" "/tmp/${FILE}" && \
         pip3 install --no-cache-dir "/tmp/${FILE}" && \
         rm -f "/tmp/${FILE}" && \
         python3 -c "import sherpa_onnx, pathlib; \
@@ -199,7 +245,7 @@ print('sherpa-onnx', sherpa_onnx.__version__, 'with CUDA provider')"; \
 # torch/cv2 stack already ships so nothing in the base image is upgraded.
 # Measured layer growth: apt (ffmpeg+libvips42) 17.2 MB + this step 24.5 MB
 # ≈ 42 MB on a ~14.6 GB image (<0.3%).
-RUN if [ "${JP_VERSION}" = "61" ]; then NUMPY_VERSION=1.26.4; else NUMPY_VERSION=1.24.4; fi; \
+RUN . /etc/jetpack.env; \
     pip3 install --no-cache-dir -i ${PYPI_MIRROR} \
       "numpy==${NUMPY_VERSION}" pyclipper==1.3.0.post3 Shapely==2.0.5 \
       omegaconf==2.3.0 colorlog==6.12.0 && \
@@ -262,7 +308,7 @@ RUN if [ "${ENABLE_VITS2_TRT}" = "1" ] && \
       rm -rf /var/lib/apt/lists/*; \
     fi
 RUN if [ "${ENABLE_VITS2_TRT}" = "1" ]; then \
-      if [ "${JP_VERSION}" = "61" ]; then NUMPY_VERSION=1.26.4; else NUMPY_VERSION=1.24.4; fi; \
+      . /etc/jetpack.env; \
       pip3 install --no-cache-dir -i "${PYPI_MIRROR}" \
         "numpy==${NUMPY_VERSION}" -r /tmp/vits2-requirements.txt && \
       python3 -c "import importlib.util as u, sys, numpy, kaldifst, pypinyin, jieba, inflect, nltk; \
@@ -285,8 +331,18 @@ EXPOSE 15720
 EXPOSE 15721
 
 # 确保 ROS2 Python 包始终在 PYTHONPATH 中（不依赖 source setup.bash）
-RUN find /ros_ws/install -name "site-packages" -type d > /usr/local/lib/python${PYTHON_VERSION-3.8}/dist-packages/ros_ws.pth && \
-    find /opt/ros/humble/install -name "site-packages" -type d >> /usr/local/lib/python${PYTHON_VERSION-3.8}/dist-packages/ros_ws.pth
+#
+# PY_ABI comes from the interpreter (see /etc/jetpack.env near the top). This used
+# to read `python${PYTHON_VERSION-3.8}`, which was correct only by coincidence:
+# jp5.11's base never sets PYTHON_VERSION so it fell back to the hardcoded 3.8,
+# while jp6.1's base sets 3.10. A base that started setting it, or set it
+# differently, would drop this .pth into a directory nothing imports from — and
+# the failure would surface at runtime as a missing rclpy, not at build time.
+RUN . /etc/jetpack.env; \
+    PTH="/usr/local/lib/python${PY_ABI}/dist-packages/ros_ws.pth"; \
+    find /ros_ws/install -name "site-packages" -type d > "${PTH}" && \
+    find /opt/ros/humble/install -name "site-packages" -type d >> "${PTH}" && \
+    echo "[build] ${PTH}:" && cat "${PTH}"
 
 # ROS2 shared libraries（audio_msgs .so 等）
 ENV LD_LIBRARY_PATH="/ros_ws/install/audio_msgs/lib:/opt/ros/humble/install/lib:${LD_LIBRARY_PATH}"

--- a/perception/Dockerfile.jetson
+++ b/perception/Dockerfile.jetson
@@ -117,8 +117,8 @@ RUN mkdir -p /work/weights/clip && \
 ENV YOLO_CONFIG_DIR=/work
 
 # ── sherpa-onnx (on-device ASR/TTS/KWS) ──────────────────────────
-# jp5.11 installs a CUDA-enabled wheel built on an Orin against onnxruntime-gpu
-# 1.16.0 (CUDA 11.4, cuDNN 8) with -DSHERPA_ONNX_ENABLE_GPU=ON.
+# PyPI ships CPU-only sherpa-onnx, so each JetPack line installs a CUDA-enabled
+# wheel built in-house on an Orin with -DSHERPA_ONNX_ENABLE_GPU=ON.
 #
 # Installing it does NOT move anything to the GPU on its own: that is opt-in via
 # `device: gpu` in the ASR/TTS config, and only for the (model, device) pairs
@@ -128,31 +128,52 @@ ENV YOLO_CONFIG_DIR=/work
 # SenseVoice fp16 5.8x faster, streaming paraformer fp32 1.8x faster, while the
 # same models' int8 weights were 0.4-0.7x, i.e. worse. The numbers, the thread
 # sweep and the reasoning are in perception/README.md § sherpa-onnx Device
-# Selection, along with how to rebuild this wheel.
+# Selection, along with how to rebuild these wheels.
 #
-# The gate is on JP_VERSION, not on "is this a Jetson": the wheel links
-# libcudart.so.11.0, which jp6.1 (CUDA 12.6) does not provide. jp6.1 would need
-# its own build against onnxruntime-gpu 1.18.1 on a JetPack 6 host, so until then
-# it keeps the CPU wheel from PyPI and `device: gpu` falls back to cpu there.
+# One wheel per JetPack line, not one wheel: the ONNX Runtime a wheel links is
+# what ties it to a CUDA/cuDNN pair, and the pybind extension is tagged with the
+# CPython ABI it was compiled against. Neither is portable.
+#
+#   jp5.11  onnxruntime-gpu 1.16.0  CUDA 11.4 / cuDNN 8  cp38   (focal)
+#   jp6.1   onnxruntime-gpu 1.18.1  CUDA 12.6 / cuDNN 9  cp310  (jammy)
+#
+# Verified rather than assumed for jp6.1: 1.18.1's aarch64 GPU package needs
+# libcudnn.so.9 / libcudart.so.12 / libcublas.so.12, and all of them resolve
+# inside this image (cuDNN 9.4.0, CUDA 12.6). 1.18.0 would not — it is built
+# against cuDNN 8.9.4. sherpa-onnx's own cmake pins 1.18.1 for L4T R36 + CUDA
+# 12.6, which is what this line targets.
+#
+# An unlisted JP_VERSION (and any non-Jetson build) falls back to the PyPI CPU
+# wheel, where `device: gpu` degrades to cpu with a warning rather than failing
+# to start. The gate is therefore on JP_VERSION, not on "is this a Jetson":
+# there is nothing sensible to guess for a line we have not built a wheel for.
 #
 # Cost: 74 MB compressed / ~250 MB unpacked, nearly all of it
 # libonnxruntime_providers_cuda.so, versus ~30 MB for the CPU wheel.
 #
 # The URL needs %2B for the '+cuda' local version, but the file on disk must
 # keep the literal '+' or pip refuses to parse the version out of the filename.
-ARG SHERPA_GPU_WHEEL=sherpa_onnx-1.13.6+cuda-cp38-cp38-linux_aarch64.whl
-RUN if [ "${JP_VERSION}" = "511" ]; then \
+ARG SHERPA_GPU_WHEEL_511=sherpa_onnx-1.13.6+cuda-cp38-cp38-linux_aarch64.whl
+ARG SHERPA_GPU_WHEEL_61=sherpa_onnx-1.13.6+cuda-cp310-cp310-linux_aarch64.whl
+RUN case "${JP_VERSION}" in \
+        511) WHEEL="${SHERPA_GPU_WHEEL_511}" ;; \
+        61)  WHEEL="${SHERPA_GPU_WHEEL_61}"  ;; \
+        *)   WHEEL="" ;; \
+    esac; \
+    if [ -n "${WHEEL}" ]; then \
+        echo "[build] sherpa-onnx: GPU wheel for jp${JP_VERSION} — ${WHEEL}" && \
         python3 -c "import urllib.request, urllib.parse, sys; \
 name = sys.argv[1]; \
 urllib.request.urlretrieve('https://agi-phanthy-dev-1252788780.cos.ap-beijing.myqcloud.com/public/sherpa-onnx/' + urllib.parse.quote(name), '/tmp/' + name)" \
-            "${SHERPA_GPU_WHEEL}" && \
-        pip3 install --no-cache-dir "/tmp/${SHERPA_GPU_WHEEL}" && \
-        rm -f "/tmp/${SHERPA_GPU_WHEEL}" && \
+            "${WHEEL}" && \
+        pip3 install --no-cache-dir "/tmp/${WHEEL}" && \
+        rm -f "/tmp/${WHEEL}" && \
         python3 -c "import sherpa_onnx, pathlib; \
 lib = pathlib.Path(sherpa_onnx.__file__).parent / 'lib' / 'libonnxruntime_providers_cuda.so'; \
 assert lib.is_file(), 'CUDA provider missing from the installed wheel'; \
 print('sherpa-onnx', sherpa_onnx.__version__, 'with CUDA provider')"; \
     else \
+        echo "[build] sherpa-onnx: no GPU wheel for jp${JP_VERSION} — CPU wheel from PyPI" && \
         pip3 install --no-cache-dir -i ${PYPI_MIRROR} sherpa-onnx; \
     fi
 

--- a/perception/README.md
+++ b/perception/README.md
@@ -308,19 +308,26 @@ are converted from those with `tools/convert_onnx_fp16.py`.
 ### The CUDA wheels
 
 PyPI ships CPU-only `sherpa-onnx`, so `Dockerfile.jetson` downloads a wheel built
-in-house from COS (`public/sherpa-onnx/sherpa_onnx-<ver>+cuda-<abi>-linux_aarch64.whl`),
-one per JetPack line, and falls back to the PyPI CPU wheel for any `JP_VERSION`
-without one:
+in-house from COS under `public/sherpa-onnx/<jp>/`, one per JetPack line, and falls
+back to the PyPI CPU wheel for any `JP_VERSION` without one:
 
-| | onnxruntime-gpu | CUDA / cuDNN | wheel |
+| | onnxruntime-gpu | CUDA / cuDNN | COS key |
 |---|---|---|---|
-| jp5.11 (focal, L4T R35) | 1.16.0 | 11.4 / 8 | `…+cuda-cp38-cp38-linux_aarch64.whl` |
-| jp6.1 (jammy, L4T R36) | 1.18.1 | 12.6 / 9 | `…+cuda-cp310-cp310-linux_aarch64.whl` |
+| jp5.11 (focal, L4T R35) | 1.16.0 | 11.4 / 8 | `jp511/sherpa_onnx-<ver>+cuda-cp38-cp38-linux_aarch64.whl` |
+| jp6.1 (jammy, L4T R36) | 1.18.1 | 12.6 / 9 | `jp61/sherpa_onnx-<ver>+cuda-cp310-cp310-linux_aarch64.whl` |
 
 Neither the ONNX Runtime pairing nor the CPython ABI is portable, which is why
 there are two wheels rather than one. `cmake/onnxruntime-linux-aarch64-gpu.cmake`
 in sherpa-onnx pins the URL and SHA256 per version and names the target board for
 each; 1.18.1 is the one it lists for L4T R36 + CUDA 12.6.
+
+**The directory carries the JetPack, because the filename cannot.** Upstream's
+`setup.py` tags the wheel `<ver>+cuda-cp<abi>`, so in a flat directory the only
+thing separating the two builds is `cp38` vs `cp310` — a *Python* discriminator,
+not a CUDA one. It selects correctly today, since each image ships exactly one
+Python and pip refuses a wheel built for another, but a second cp310 build for
+another JetPack 6.x on a different CUDA would collide. Renaming the file is not an
+option: pip parses the version out of it and it has to match the wheel metadata.
 
 **Check the cuDNN soname before committing to a build.** ONNX Runtime's aarch64 GPU
 packages do not encode it in the filename past 1.18.0, and it is what decides
@@ -372,9 +379,12 @@ Notes:
   `cmake/onnxruntime-linux-aarch64-gpu.cmake` checks there before GitHub. Use that
   exact generic name even when the release asset is called something else — the
   hash it checks is the one for the asset it would have downloaded.
-- Upload the result under the `public/` COS prefix (anonymous read, same prefix
-  `utils/model_downloader.py` uses) and bump the matching `SHERPA_GPU_WHEEL_<jp>`
-  in `Dockerfile.jetson`.
+- Upload the result to `public/sherpa-onnx/<jp>/` (anonymous read, same `public/`
+  prefix `utils/model_downloader.py` uses) and bump the matching
+  `SHERPA_GPU_WHEEL_<jp>` in `Dockerfile.jetson` — the ARG holds the key *with* its
+  directory, and the build downloads it to `/tmp/$(basename …)`. COS credentials
+  live in `resource-center/deploy/values.env` (`COS_SECRET_ID` / `COS_SECRET_KEY`);
+  the bucket is `agi-phanthy-dev-1252788780` in `ap-beijing`.
 
 ---
 

--- a/perception/README.md
+++ b/perception/README.md
@@ -88,11 +88,16 @@ just a different provider string.
 
 | `asr_model` | `device: cpu` | `device: gpu` | gpu speed-up |
 |-------------|---------------|---------------|--------------|
-| `sensevoice-small` (default) | int8, 228 MB | **fp16, 448 MB** | **3.4x** per utterance |
+| `sensevoice-small` (default) | int8, 228 MB | **fp16, 448 MB** | **3.4x** per utterance ⚠️ |
 | `paraformer-zh-en` (streaming) | int8, 226 MB | **fp32, 825 MB** | **1.77x** |
 | `x-asr-zh-en` | int8 + fp32 | — not offered | 0.80x, i.e. slower |
 | `paraformer-offline` | int8 | — not offered | unmeasured |
 | `zipformer-en` | int8 | — not offered | unmeasured |
+
+⚠️ **`sensevoice-small` on gpu drops some utterances entirely** — fp16 under the
+CUDA provider returns an empty transcript for certain inputs, silently and
+reproducibly, on both JetPack lines. Read § jp6.1, and a silent failure the gpu
+path has always had before enabling it; the speed-up is real but so is the loss.
 
 **gpu costs about 2 GB of RAM, and ~1.4 GB of that is unreturnable.** Measured with
 only ASR resident: the cpu adapter adds 542 MB and drops back to 129 MB when
@@ -162,6 +167,51 @@ unwarmed adapter earlier in the same process had already paid the CUDA init.)
 The batch figures in § Measurements are larger (up to 23x) because they decode the
 model's own `test_wavs`, which are 7 s each. Those compare dtypes with each other;
 this table is what a user experiences.
+
+### jp6.1, and a silent failure the gpu path has always had
+
+Same measurement on orin6 (Orin NX, JetPack 6.1, CUDA 12.6, onnxruntime-gpu
+1.18.1, 6 cores), SenseVoice, `num_threads=2`, through `_build_asr_adapter` so the
+registry and provider selection are the production ones. `provider_for_device('gpu',
+fp16)` returns `'cuda'`, and 120 calls per device:
+
+| audio | cpu (int8) p50 / p99 | gpu (fp16) p50 / p99 | speed-up |
+|---|---|---|---|
+| rig's own VAD captures, 0.8–2.1 s | 119 / 194 ms | **49 / 58 ms** | 2.4x / 3.3x |
+| KWS bundle test_wavs, 4.5–16.7 s | 462 / 1305 ms | **67 / 169 ms** | 6.9x / 7.7x |
+
+The gpu p99 is below the cpu *minimum* in both rows, which is the useful sanity
+check that CUDA is actually doing the work. Longer audio wins more, consistent with
+the jp5.11 numbers. Building the gpu adapter took 3.7 s with weights already
+local, 86.3 s including the 449 MB fp16 download. Whole-box `MemAvailable` fell
+~605 MB while gpu was resident — well short of the ~2 GB the jp5.11 table reports,
+so budget from a measurement on the box you are deploying to rather than from
+either figure.
+
+**But `device: gpu` can lose an utterance outright.** SenseVoice fp16 under the
+CUDA provider returns an **empty** transcript for some inputs — deterministically,
+5/5 attempts, on the KWS bundle's own `en_0.wav`: 6.6 s of clear English peaking at
+0.535 FS, louder than the `en_1.wav` that decodes fine. Eight of the nine files in
+that bundle match cpu exactly.
+
+Isolated by varying one thing at a time, since dtype and provider normally change
+together:
+
+| | en_0.wav |
+|---|---|
+| `model.int8.onnx` + cpu | correct |
+| `model.fp16.onnx` + cpu | correct |
+| `model.fp16.onnx` + cuda | **empty** |
+
+So the fp16 export is fine and the CUDA provider is at fault. Reproduced on **both**
+lines — onnxruntime-gpu 1.16.0 on orin5 and 1.18.1 on orin6, byte-identical
+`model.fp16.onnx` — so it is not a property of either wheel and not new. An earlier
+note in `ASR_MODELS` claimed fp16 was "transcript-identical to fp32 on both
+providers"; that was wrong, and the failure is silent. An empty transcript is
+indistinguishable from silence, so the utterance is dropped with nothing in the
+log to say so. Untested alternative: SenseVoice fp32 on CUDA, which measured
+11.52x on jp5.11 and would still beat cpu — no fp32 bundle is published, so
+switching the registry to it means building one first.
 
 ### Switching engine or device blocks for the bounded part
 

--- a/perception/README.md
+++ b/perception/README.md
@@ -611,3 +611,31 @@ packaging blanks declared fields only, there is no field-name blocklist:
 An unmarked credential is uploaded in clear text and readable by anyone who
 downloads the solution. Full spec: `phanthymotus-driver/README_dev.md`
 § "Marking sensitive fields".
+
+---
+
+## Running the tests inside a perception image
+
+`python3 -m pytest tests -q` from a checkout works anywhere. Running the same
+suite **inside a perception container** — which is how you confirm a fix behaves on
+the Python the device actually ships — needs one flag:
+
+```bash
+docker cp tests <container>:/work/
+docker exec <container> bash -c 'source /opt/ros/humble/install/setup.bash && \
+  source /ros_ws/install/setup.bash && cd /work && \
+  PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest tests -q -p pytest_mock'
+```
+
+Without `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1`, **`caplog` captures nothing** and every
+test that asserts on a log record fails while the log line is plainly there in the
+captured stderr. The image inherits ROS 2's own pytest plugins from the base
+(`launch_testing`, `launch_testing_ros`, six `ament_*`, `colcon-core`) alongside
+`pytest-cov 3.0.0` / `pytest-timeout 2.1.0`, and something in that set breaks
+`_pytest.logging`'s capture handler under pytest 8. Verified by reduction: a
+two-line test logging to a plain `logging.getLogger("probe")` fails the same way,
+and passes the moment autoload is off. It is not the tests, and not a Python 3.10
+difference.
+
+Measured on jp6.1 (Python 3.10.12, pytest 8.3.3): 175 passed / 1 failed with
+autoload on, **176 passed** with it off.

--- a/perception/README.md
+++ b/perception/README.md
@@ -107,9 +107,11 @@ TTS is simpler: Matcha is fp32 only, so both devices load the same files and
 `device` only picks the provider (gpu measured ~4.3x). The `vits2_trt` engine
 ignores `device` entirely — it is a TensorRT engine and never touches ONNX Runtime.
 
-`device: gpu` also needs the CUDA sherpa-onnx wheel, which only the jp5.11 image
-installs (see § The jp5.11 CUDA wheel). On jp6.1 and x86 dev hosts it falls back to
-`cpu` with a warning rather than failing to start.
+`device: gpu` also needs a CUDA sherpa-onnx wheel. Both Jetson images install one —
+jp5.11 and jp6.1 each have their own build, because the wheel is tied to a
+CUDA/cuDNN pair and a CPython ABI (see § The CUDA wheels). On x86 dev hosts, and on
+any JetPack line we have not built a wheel for, it falls back to `cpu` with a
+warning rather than failing to start.
 
 ### Latency per utterance, which is what an operator feels
 
@@ -303,14 +305,37 @@ are converted from those with `tools/convert_onnx_fp16.py`.
 
 ---
 
-### The jp5.11 CUDA wheel
+### The CUDA wheels
 
 PyPI ships CPU-only `sherpa-onnx`, so `Dockerfile.jetson` downloads a wheel built
-in-house for JetPack 5.11 from COS
-(`public/sherpa-onnx/sherpa_onnx-<ver>+cuda-cp38-cp38-linux_aarch64.whl`) and
-falls back to the PyPI CPU wheel for every other `JP_VERSION`.
+in-house from COS (`public/sherpa-onnx/sherpa_onnx-<ver>+cuda-<abi>-linux_aarch64.whl`),
+one per JetPack line, and falls back to the PyPI CPU wheel for any `JP_VERSION`
+without one:
 
-To rebuild it, build **inside a container started from the perception image** for
+| | onnxruntime-gpu | CUDA / cuDNN | wheel |
+|---|---|---|---|
+| jp5.11 (focal, L4T R35) | 1.16.0 | 11.4 / 8 | `…+cuda-cp38-cp38-linux_aarch64.whl` |
+| jp6.1 (jammy, L4T R36) | 1.18.1 | 12.6 / 9 | `…+cuda-cp310-cp310-linux_aarch64.whl` |
+
+Neither the ONNX Runtime pairing nor the CPython ABI is portable, which is why
+there are two wheels rather than one. `cmake/onnxruntime-linux-aarch64-gpu.cmake`
+in sherpa-onnx pins the URL and SHA256 per version and names the target board for
+each; 1.18.1 is the one it lists for L4T R36 + CUDA 12.6.
+
+**Check the cuDNN soname before committing to a build.** ONNX Runtime's aarch64 GPU
+packages do not encode it in the filename past 1.18.0, and it is what decides
+whether the provider loads at all. Two minutes with `readelf` beats an hour of
+compiling:
+
+```bash
+readelf -d libonnxruntime_providers_cuda.so | grep NEEDED
+```
+
+1.18.1 needs `libcudnn.so.9` / `libcudart.so.12` / `libcublas.so.12`, all of which
+the jp6.1 image resolves (cuDNN 9.4.0, CUDA 12.6). 1.18.0 would not — it is built
+against cuDNN 8.9.4, which that image does not carry.
+
+To build one, build **inside a container started from the perception image** for
 the target JetPack — that image already carries cmake, g++, the matching CPython
 headers and CUDA, so the pybind extension lands on the right CPython ABI and
 glibc. Building on the host instead is what produces an unusable wheel: the
@@ -319,20 +344,21 @@ Python.
 
 ```bash
 # on the build host (must match the target JetPack: jp5.11 → L4T R35, jp6.1 → R36)
-docker run -d --name sherpa-build \
+docker run -d --name sherpa-build --runtime nvidia \
   -v /path/to/k2-fsa/sherpa-onnx:/src:ro -v /path/to/outdir:/out \
   --entrypoint bash <perception-image-for-that-jp> /out/build.sh
 
-# inside, against a *writable* copy of the tree (setup.py appends __version__ to it):
+# inside, against a *writable* copy of the tree (setup.py appends __version__ to it).
+# jp6.1 shown; for jp5.11 use 1.16.0 and python3.8.
 export SHERPA_ONNX_ENABLE_GPU=ON
-export SHERPA_ONNX_LINUX_ARM64_GPU_ONNXRUNTIME_VERSION=1.16.0   # jp5.11 / CUDA 11.4
-export SHERPA_ONNX_MAKE_ARGS="-j2"                              # Orin has 6 cores but ~4 GB free
+export SHERPA_ONNX_LINUX_ARM64_GPU_ONNXRUNTIME_VERSION=1.18.1   # jp6.1 / CUDA 12.6
+export SHERPA_ONNX_MAKE_ARGS="-j2"                              # Orin has 6 cores but ~3 GB free
 SHERPA_ONNX_CMAKE_ARGS="-DCMAKE_BUILD_TYPE=Release \
   -DSHERPA_ONNX_ENABLE_GPU=ON \
-  -DSHERPA_ONNX_LINUX_ARM64_GPU_ONNXRUNTIME_VERSION=1.16.0 \
-  -DPYTHON_EXECUTABLE=/usr/bin/python3.8 \
-  -DPython_EXECUTABLE=/usr/bin/python3.8" \
-  python3.8 setup.py bdist_wheel
+  -DSHERPA_ONNX_LINUX_ARM64_GPU_ONNXRUNTIME_VERSION=1.18.1 \
+  -DPYTHON_EXECUTABLE=/usr/bin/python3.10 \
+  -DPython_EXECUTABLE=/usr/bin/python3.10" \
+  python3.10 setup.py bdist_wheel
 ```
 
 Notes:
@@ -343,17 +369,12 @@ Notes:
   not reusable — expect a full compile.
 - To avoid re-downloading onnxruntime, drop
   `onnxruntime-linux-aarch64-gpu-<ver>.tar.bz2` in `/tmp/`;
-  `cmake/onnxruntime-linux-aarch64-gpu.cmake` checks there before GitHub.
+  `cmake/onnxruntime-linux-aarch64-gpu.cmake` checks there before GitHub. Use that
+  exact generic name even when the release asset is called something else — the
+  hash it checks is the one for the asset it would have downloaded.
 - Upload the result under the `public/` COS prefix (anonymous read, same prefix
-  `utils/model_downloader.py` uses) and bump `SHERPA_GPU_WHEEL` in
-  `Dockerfile.jetson`.
-
-**TODO — jp6.1.** The jp5.11 wheel links `libcudart.so.11.0` and cannot run on
-jp6.1 (CUDA 12.6). That target needs its own build with
-`SHERPA_ONNX_LINUX_ARM64_GPU_ONNXRUNTIME_VERSION=1.18.1` and
-`PYTHON_EXECUTABLE=python3.10`, run on a JetPack 6 host inside
-`jetson-base:jp61-torch`. Until then jp6.1 stays on the CPU wheel and
-`device: gpu` falls back to `cpu` there.
+  `utils/model_downloader.py` uses) and bump the matching `SHERPA_GPU_WHEEL_<jp>`
+  in `Dockerfile.jetson`.
 
 ---
 

--- a/perception/plugins/asr.py
+++ b/perception/plugins/asr.py
@@ -545,9 +545,10 @@ class SherpaOnnxSenseVoiceAdapter(ASRAdapter):
         from utils.onnx_provider import pick_weights, provider_for_device
 
         import sherpa_onnx
-        # The gpu bundle ships fp16 (fastest here and transcript-identical to
-        # fp32); the cpu bundle ships int8. fp32 is listed as a middle fallback
-        # for a hand-assembled directory.
+        # The gpu bundle ships fp16 (fastest here); the cpu bundle ships int8.
+        # fp32 is listed as a middle fallback for a hand-assembled directory.
+        # fp16 on CUDA is NOT transcript-identical — see the note on the
+        # sensevoice gpu entry in ASR_MODELS.
         names = ("model.fp16.onnx", "model.onnx", "model.int8.onnx") \
             if device == "gpu" else \
             ("model.int8.onnx", "model.onnx")
@@ -702,8 +703,22 @@ ASR_MODELS = {
         "devices": {
             "cpu": {"download": "asr_sensevoice", "dtype": "int8",
                     "dir": "/models/sherpa-onnx/sensevoice"},
-            # fp16: 344 ms vs 416 ms for fp32 on CUDA, half the size, and
-            # transcript-identical to fp32 on both providers.
+            # fp16: 344 ms vs 416 ms for fp32 on CUDA, and half the size.
+            #
+            # KNOWN DEFECT, not fixed here: fp16 under the CUDA provider returns an
+            # **empty** transcript for some inputs. Reproduced deterministically
+            # (5/5) on the KWS bundle's own en_0.wav, 6.6 s of clear English at
+            # 0.535 FS, while en_1.wav and all seven Chinese files decode
+            # identically to cpu. Isolated to the provider, not the weights: the
+            # same model.fp16.onnx on the *cpu* provider transcribes en_0
+            # correctly. Present on both lines — onnxruntime-gpu 1.16.0 (jp5.11)
+            # and 1.18.1 (jp6.1) — so it is not a property of either wheel.
+            #
+            # An earlier comment here claimed fp16 was "transcript-identical to
+            # fp32 on both providers". It is not, and the failure mode is silent:
+            # an empty transcript is indistinguishable from silence, so the
+            # utterance is simply lost. Weigh that against the ~7x latency win
+            # before turning `device: gpu` on for this model.
             "gpu": {"download": "asr_sensevoice_gpu", "dtype": "fp16",
                     "dir": "/models/sherpa-onnx/sensevoice-gpu"},
         },

--- a/perception/tests/test_shared_utils.py
+++ b/perception/tests/test_shared_utils.py
@@ -48,6 +48,29 @@ def test_tensorrt_family_rejects_unknown(version):
         trt_rt.tensorrt_family(version)
 
 
+@pytest.mark.parametrize("version", ["11.0.0", "12.2.1"])
+def test_tensorrt_family_warns_for_a_major_newer_than_any_bundle(version, caplog):
+    """A newer major still resolves, but must not do so silently.
+
+    Refusing would take a device down on a JetPack upgrade, and the engines may
+    well still load. But plans are not guaranteed portable across TensorRT
+    majors, so without the warning a mismatch surfaces later as an unexplained
+    deserialization failure. Needs PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 — caplog
+    captures nothing inside a perception image otherwise (see perception/README).
+    """
+    with caplog.at_level("WARNING"):
+        assert trt_rt.tensorrt_family(version) == "jp61"
+    assert any("not portable across majors" in r.getMessage()
+               for r in caplog.records), caplog.records
+
+
+@pytest.mark.parametrize("version", ["8.5.2.2", "10.3.0"])
+def test_tensorrt_family_is_quiet_for_a_known_major(version, caplog):
+    with caplog.at_level("WARNING"):
+        trt_rt.tensorrt_family(version)
+    assert not [r for r in caplog.records if "tensorrt" in r.getMessage().lower()]
+
+
 def test_normalize_family_aliases():
     assert trt_rt.normalize_family("61") == "jp61"
     assert trt_rt.normalize_family("JP511") == "jp511"

--- a/perception/utils/onnx_provider.py
+++ b/perception/utils/onnx_provider.py
@@ -85,11 +85,14 @@ def cuda_available() -> bool:
     """True when the installed sherpa_onnx wheel bundles the CUDA provider.
 
     The marker is `sherpa_onnx/lib/libonnxruntime_providers_cuda.so`, which only a
-    `-DSHERPA_ONNX_ENABLE_GPU=ON` build ships. jetson jp5.11 installs such a wheel
-    from COS; jp6.1 is CUDA 12.6 and cannot use it, and x86 dev hosts get the PyPI
-    CPU wheel — see Dockerfile.jetson. This deliberately does not probe the driver
-    or create a session: on Jetson the wheel is built for the same L4T release it
-    is deployed on, and a probe would cost a full ONNX Runtime session at import.
+    `-DSHERPA_ONNX_ENABLE_GPU=ON` build ships. Both Jetson lines install such a
+    wheel from COS — jp5.11 and jp6.1 have separate builds, because the wheel is
+    tied to an ONNX Runtime version (and through it a CUDA/cuDNN pair) and to a
+    CPython ABI. A JetPack line we have not built a wheel for, and x86 dev hosts,
+    get the PyPI CPU wheel — see Dockerfile.jetson. This deliberately does not
+    probe the driver or create a session: on Jetson the wheel is built for the same
+    L4T release it is deployed on, and a probe would cost a full ONNX Runtime
+    session at import.
     """
     try:
         import sherpa_onnx

--- a/perception/utils/tensorrt_runtime.py
+++ b/perception/utils/tensorrt_runtime.py
@@ -78,14 +78,29 @@ def tensorrt_family(version: str | None = None) -> str:
 
     Passing an explicit `version` skips importing tensorrt (used by tests and
     by manifests that want to describe both families).
+
+    A major newer than any family we ship engines for is treated as the newest
+    family and warned about, rather than refused: refusing would take a device
+    down on a JetPack upgrade, and the engines may well still load. But plans are
+    not guaranteed portable across TensorRT majors, so the warning is the only
+    thing standing between a silent mismatch and a confusing runtime failure —
+    when it appears, build engines for that major.
     """
     text = tensorrt_version() if version is None else str(version)
     try:
         major = int(text.split(".", 1)[0])
     except ValueError as error:
         raise TensorRTError(f"Unsupported TensorRT version: {text or 'unknown'}") from error
-    if major >= 10:
-        return "jp61"
+    newest_major = max(_TRT_FAMILIES)
+    if major > newest_major:
+        newest = _TRT_FAMILIES[newest_major]
+        log.warning(
+            "[tensorrt] TensorRT %s is newer than any engine family we ship; "
+            "using '%s' engines, which were built for TensorRT %d. Plans are not "
+            "portable across majors — build a '%s' bundle for TensorRT %d.",
+            text, newest, newest_major, newest, major,
+        )
+        return newest
     family = _TRT_FAMILIES.get(major)
     if family is None:
         raise TensorRTError(f"Unsupported TensorRT version: {text}")


### PR DESCRIPTION
Review of the jp5.11 / jp6.1 split after #137. **The architecture holds up** — what needed cleaning is how many places restate the same fact.

Targets `feat/sherpa-onnx-gpu-jp61` rather than `main` so the diff shows only this change; retarget to `main` once #137 merges.

## The split itself is sound, and worth keeping

It draws the line in the right place, and actually follows it:

| forks | why it must |
|---|---|
| base image, sherpa wheel, TensorRT engines, numpy pin | ABI- or major-bound; none of them portable |

| shared | why it can be |
|---|---|
| sherpa GPU **weights** (one base URL, no jp key) | ONNX weights are portable |
| every plugin and runtime module | `grep -rn 'jp511\|jp61\|JP_VERSION' plugins/` matches **comments only — zero code branches** |

The strongest part is that the selection mechanism differs by *when* the decision happens: things installed into the image use the `JP_VERSION` build arg, while things loaded from `/models` use the TensorRT that is actually importable and explicitly refuse to trust the build arg (`tensorrt_runtime.py`). That paid off — VITS2 and OCR needed **zero changes** to pick the right bundle on jp6.1.

## What was wrong: six places that must agree, and no list of them

- **numpy pinned twice in one file.** The copies had to match or the C-ABI the base's torch/cv2 were built against breaks — and the second copy exists *precisely* to stop the VITS2 layer downgrading numpy, so a disagreement silently disabled the guard it was there to be.
- **Two build scripts carried a byte-identical 14-line `case` block** (`diff` produced no output).
- **`python${PYTHON_VERSION-3.8}`** was correct only by coincidence. Verified on both rigs: jp5.11's base **never sets** `PYTHON_VERSION`, so it fell through to the hardcoded 3.8; jp6.1's sets 3.10. A base that started setting it would drop the ROS `.pth` where nothing imports from — surfacing at *runtime* as a missing rclpy.
- **The cv2 shim hardcoded `python3.8`, `python-3.8/` and `cpython-38`** — three restatements of an ABI only jp5.11 has, in a step that runs on both lines.
- **`tensorrt_family()` mapped `major >= 10` to jp61 silently**, in a module whose own header says plans are not portable across majors. Asymmetric too: major 9 raised, 11 passed quietly.
- **`cuda_available()`'s docstring still said jp6.1 "cannot use" the CUDA wheel** — in the function that decides whether gpu is offered at all.

## The change

- **`/etc/jetpack.env`** resolved once after `FROM`, carrying `NUMPY_VERSION`, `SHERPA_GPU_WHEEL`, `PY_ABI`; five later steps source it. Kept in the Dockerfile, not passed in from `build_perception.sh` — `JP_VERSION` already selects the base image on the `FROM` line, so a build that passed it and forgot `NUMPY_VERSION` would produce a jp6.1 base pinned to jp5.11's numpy, silently. It doubles as a record: `docker exec <c> cat /etc/jetpack.env` says what line an image was built for, which the tag alone does not.
- **`PY_ABI` read from the interpreter**, used for the ROS `.pth` and the cv2 directory.
- **The cv2 shim globs for its extension** — no version constants left, still fails loudly if it moves.
- **`jetpack_vars` in `build_common.sh`**, which both scripts already source.
- **`tensorrt_family()` warns** for a major newer than any bundle. Still resolves to the newest — refusing would take a device down on a JetPack upgrade and the engines may well load — but no longer silently.

Left alone: `SUPPORTED_JP_VERSIONS` in `agents/pr_review/models.py` is a third list, but unifying across the Python/shell boundary buys little.

## Verified on both rigs, by rebuilding both lines

`/etc/jetpack.env` resolves as intended, and `.pth` lands where it did before:

| | jp5.11 (orin5) | jp6.1 (orin6) |
|---|---|---|
| `PY_ABI` | **3.8** | **3.10** |
| `NUMPY_VERSION` | 1.24.4 | 1.26.4 |
| wheel | `jp511/…cp38…` | `jp61/…cp310…` |
| `.pth` written to | `/usr/local/lib/python3.8/…` | `/usr/local/lib/python3.10/…` |
| build assertions | VITS2 ok on numpy 1.24.4; sherpa with CUDA provider | VITS2 ok on numpy 1.26.4; sherpa with CUDA provider |

**A/B against the pre-change image on each line** — full `pip freeze`, `.pth` path and contents, and imports of `rclpy` / `audio_msgs.msg` / `cv2` / `numpy` / `sherpa_onnx` / `tensorrt`. The only difference on either line is `ultralytics 8.4.126→8.4.129` (jp5.11) and `8.4.128→8.4.129` (jp6.1) — that package is installed unpinned, so PyPI moved between builds. Everything else byte-identical, all six imports ok on all four images.

Tests: **180 passed** on jp6.1 (176 + 4 covering the new warning). Note `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1` is required for the two `caplog` tests inside a perception image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)