### PR TITLE
fix(tts): remove the synthesis stalls and jitter-buffer gaps behind TTS stutter

### DIFF
--- a/agent-core/src/api/inspection.py
+++ b/agent-core/src/api/inspection.py
@@ -73,30 +73,42 @@ def _push_factory(topic: str):
         # 处理 perf_span 类型消息（来自 perception TTS 等组件）
         if topic == '/perception/perf_spans':
             try:
-                import json, perf_log, config
+                import json
                 text = data.decode('utf-8') if isinstance(data, bytes) else data
                 span_data = json.loads(text)
                 if span_data.get('type') == 'perf_span':
-                    trace_id = span_data.pop('trace_id', None)
-                    if trace_id:
-                        # 直接归属（trace_id 由 agent-core 透传）
-                        perf_log.commit_spans(trace_id, [span_data], source='perception')
-                    else:
-                        # 兼容旧版本 perception: fallback 到时间窗口匹配
-                        span_start = span_data.get('start_ts', 0)
-                        conn = config._get_conn()
-                        row = conn.execute(
-                            '''SELECT trace_id FROM perf_spans
-                               WHERE span LIKE 'tool:tts%' AND start_ts <= ? AND start_ts >= ? - 30
-                               ORDER BY start_ts DESC LIMIT 1''',
-                            (span_start, span_start)
-                        ).fetchone()
-                        conn.close()
-                        if row:
-                            perf_log.commit_spans(row[0], [span_data], source='perception')
+                    # commit_spans and the fallback lookup are both synchronous
+                    # SQLite. Running them here blocked the event loop — and so
+                    # every audio WS send on it — once per utterance, exactly at
+                    # the utterance boundary where playback is most sensitive.
+                    await asyncio.to_thread(_commit_perf_span, span_data)
             except Exception:
                 pass
     return _push
+
+
+def _commit_perf_span(span_data: dict) -> None:
+    """Attribute one perception perf span to a trace. Blocking; off-loop only."""
+    import perf_log, config
+    trace_id = span_data.pop('trace_id', None)
+    if trace_id:
+        # 直接归属（trace_id 由 agent-core 透传）
+        perf_log.commit_spans(trace_id, [span_data], source='perception')
+        return
+    # 兼容旧版本 perception: fallback 到时间窗口匹配
+    span_start = span_data.get('start_ts', 0)
+    conn = config._get_conn()
+    try:
+        row = conn.execute(
+            '''SELECT trace_id FROM perf_spans
+               WHERE span LIKE 'tool:tts%' AND start_ts <= ? AND start_ts >= ? - 30
+               ORDER BY start_ts DESC LIMIT 1''',
+            (span_start, span_start)
+        ).fetchone()
+    finally:
+        conn.close()
+    if row:
+        perf_log.commit_spans(row[0], [span_data], source='perception')
 
 
 def _ensure_primary_sub(topic: str, fmt: str, loop: asyncio.AbstractEventLoop):

--- a/agent-core/web/js/canvas.js
+++ b/agent-core/web/js/canvas.js
@@ -848,9 +848,7 @@ function _buildCardEl({ id, mcpId, toolName, driverName, x, y, topicIn: savedTop
 
     el.querySelector('.canvas-view-btn').addEventListener('click', (e) => {
       e.stopPropagation();
-      const liveMcp = _allMcps.find(m => m.id === mcpId);
-      const topics = topicOut.length ? topicOut : (liveMcp?.topic_out || []);
-      if (topics.length) showTopicDetail(topics[0].topic, topics[0].format || '');
+      _openTopicDetailFor(el, mcpId, topicOut);
     });
 
     const sensorExecBtn = el.querySelector('.canvas-exec-btn');
@@ -1041,9 +1039,7 @@ function _buildCardEl({ id, mcpId, toolName, driverName, x, y, topicIn: savedTop
     if (viewBtn) {
       viewBtn.addEventListener('click', (e) => {
         e.stopPropagation();
-        const liveMcp = _allMcps.find(m => m.id === mcpId);
-        const topics = topicOut.length ? topicOut : (liveMcp?.topic_out || []);
-        if (topics.length) showTopicDetail(topics[0].topic, topics[0].format || '');
+        _openTopicDetailFor(el, mcpId, topicOut);
       });
     }
 
@@ -1895,11 +1891,43 @@ async function _fetchTopicsFromDriver(card, inputTopic) {
  * this revalidation exists to undo. An empty string means "not known yet", which
  * is the honest answer.
  */
+/**
+ * Open the data-stream detail panel for a card's output topic.
+ *
+ * Two things this must not do, both of which it used to:
+ *
+ * 1. Trust the `topicOut` captured when the card was rendered. That closure
+ *    goes stale as soon as a connection changes; the out-port dataset is the
+ *    live value, kept current by _resolveAllTopics. Same idiom as the topic
+ *    reads elsewhere in this file.
+ *
+ * 2. Accept an entry just because the array is non-empty. The old test was
+ *    `topics.length`, and for a multiInstance tool the MCP-level `topic_out` is
+ *    format-only by design — mcp_manage deliberately does not back-fill
+ *    per-instance topics, since those live on the cards. So `tts` reported
+ *    `[{format: 'audio/pcm-16k'}]`, which passed a length check with
+ *    `topic === undefined`; showTopicDetail then built `/ws/bus` + undefined,
+ *    matching no route (`/ws/bus/{topic:path}`). That is why "查看数据流" on a
+ *    TTS card opened a panel that never showed a waveform, and why the server
+ *    log filled with `ASGI callable returned without completing handshake`.
+ */
+function _openTopicDetailFor(el, mcpId, cachedTopicOut) {
+  const livePorts = [...el.querySelectorAll('.canvas-port.out')]
+    .map(p => ({ topic: p.dataset.topic, format: p.dataset.format }));
+  const liveMcp = _allMcps.find(m => m.id === mcpId);
+  const candidate = [...livePorts, ...(cachedTopicOut || []), ...(liveMcp?.topic_out || [])]
+    .find(t => t && t.topic);
+  if (!candidate) {
+    _showToast('该卡片还没有解析出输出 topic —— 先点「开始控制」把它启动起来');
+    return;
+  }
+  showTopicDetail(candidate.topic, candidate.format || '');
+}
+
 function _inputTopicFor(card) {
   const inConn = _connections.find(c => c.toCardId === card.id);
   if (!inConn) return '';
-  const inPort = card.el.querySelector(`.canvas-port.in[data-idx="${inConn.toPortIdx}"]`);
-  return inPort?.dataset.topic || '';
+  const inPort = card.el.querySelector(`.canvas-port.in[data-idx="${inConn.toPortIdx}"]`);  return inPort?.dataset.topic || '';
 }
 
 /**

--- a/agent-core/web/js/dashboard.js
+++ b/agent-core/web/js/dashboard.js
@@ -266,6 +266,11 @@ function setupGlobalCtrl() {
 
 function _wsUrlFor(path) {
   if (!path) return null;
+  // A bus path with no topic after it (an unresolved card) matches no route —
+  // the endpoint is `/ws/bus/{topic:path}` — so the handshake fails and uvicorn
+  // logs `ASGI callable returned without completing handshake` + a 500. Treat
+  // it as "no stream yet" rather than opening a doomed connection.
+  if (path === '/ws/bus' || path === '/ws/bus/') return null;
   const proto = location.protocol === 'https:' ? 'wss' : 'ws';
   return `${proto}://${location.host}${path}`;
 }

--- a/agent-core/web/js/detail-panel.js
+++ b/agent-core/web/js/detail-panel.js
@@ -44,7 +44,14 @@ export function showTopicDetail(topicPath, format) {
   _renderer = Object.assign(Object.create(Object.getPrototypeOf(Renderer)), Renderer);
   _renderer.mount(body, 'detail');
 
-  // Connect WebSocket — /ws/bus/* is proxied through agent-core
+  // Connect WebSocket — /ws/bus/* is proxied through agent-core.
+  // Skip it when the topic is unresolved: `/ws/bus` with nothing after it
+  // matches no route (`/ws/bus/{topic:path}`), so the handshake fails and
+  // uvicorn logs a 500 that looks like a server fault rather than "no topic".
+  if (!topicPath || topicPath === '/') {
+    console.debug('[detail-panel] no topic yet, not opening a bus WS');
+    return;
+  }
   const proto = location.protocol === 'https:' ? 'wss' : 'ws';
   const wsHost = location.host;
   const wsUrl = `${proto}://${wsHost}/ws/bus${topicPath}`;

--- a/agent-core/web/js/monitor-dashboard.js
+++ b/agent-core/web/js/monitor-dashboard.js
@@ -299,8 +299,11 @@ function _refreshRenderer(topicPath) {
   const renderer = _createRenderer(card.format, card.mode);
   renderer.mount(body, _topicMcpMap[topicPath] || 'dashboard');
   card.renderer = renderer;
-  // Re-wire WS
-  card.ws.onmessage = (ev) => _handleWsMessage(ev, card.renderer, card.format);
+  // Re-wire WS. Optional: _connectWs returns null for a card whose topic is
+  // not resolved yet, and a mode switch on such a card must not throw.
+  if (card.ws) {
+    card.ws.onmessage = (ev) => _handleWsMessage(ev, card.renderer, card.format);
+  }
 }
 
 function _switchMode(topicPath, newMode, modeBtns) {

--- a/agent-core/web/js/monitor-dashboard.js
+++ b/agent-core/web/js/monitor-dashboard.js
@@ -241,6 +241,15 @@ function _applyPlacement(el, col, row, colSpan, rowSpan) {
 }
 
 function _connectWs(topicPath, format, renderer) {
+  // An unresolved topic used to build `/ws/bus` with nothing after it. That
+  // matches no route (the endpoint is `/ws/bus/{topic:path}`), so Starlette
+  // failed the handshake and uvicorn logged `ASGI callable returned without
+  // completing handshake` + a 500 — noise that reads like a server fault when
+  // the real state is simply "this card has no topic yet".
+  if (!topicPath || topicPath === '/') {
+    console.debug('[monitor] no topic yet, not opening a bus WS');
+    return null;
+  }
   const proto = location.protocol === 'https:' ? 'wss' : 'ws';
   const wsUrl = `${proto}://${location.host}/ws/bus${topicPath}`;
 

--- a/agent-core/web/js/renderers/audio.js
+++ b/agent-core/web/js/renderers/audio.js
@@ -36,6 +36,10 @@ export const AudioRenderer = {
   _nextStartTime: 0,
   _prebufCount:   0,
   _prebufQueue:   null,
+  // Scheduled buffers, so ⏸ can actually stop them. Created per instance in
+  // mount(): renderers are cloned with Object.assign, so a Set built here on
+  // the prototype would be shared and pausing one card would cut another's audio.
+  _sources:       null,
   _PREBUF_CHUNKS: 5,     // 首包预载：攒够 5 个 chunk (~500ms) 再开始播放
   _UNDERRUN_LEAD: 0.20,  // 欠载重启时给出的余量，秒
   _MAX_LEAD:      1.5,   // 允许领先播放头的上限，秒
@@ -72,6 +76,7 @@ export const AudioRenderer = {
     this._ring = new Float32Array(this._ringLen);
     this._writePos = 0;
     this._drawnPos = -1;
+    this._sources = new Set();
 
     this._raf = requestAnimationFrame(() => this._draw());
   },
@@ -172,6 +177,17 @@ export const AudioRenderer = {
     this._playing = false;
     this._prebufQueue = null;
     this._prebufCount = 0;
+    // Stop the buffers already handed to the audio thread. Setting _playing
+    // false only stops *scheduling* new ones; everything queued ahead of the
+    // playhead kept sounding, so ⏸ appeared to do nothing and only closing the
+    // panel (which calls unmount → audioCtx.close) actually silenced it.
+    // Raising _MAX_LEAD to 1.5s made a long-standing bug obvious: with the old
+    // ~50ms of lead there was barely anything queued to keep playing.
+    for (const source of this._sources || []) {
+      try { source.onended = null; source.stop(); } catch { /* already ended */ }
+    }
+    this._sources?.clear();
+    this._nextStartTime = 0;
     if (this._playBtn) {
       this._playBtn.textContent = '▶';
       this._playBtn.title = '播放实时音频';
@@ -246,6 +262,10 @@ export const AudioRenderer = {
 
     source.start(this._nextStartTime);
     this._nextStartTime += audioBuffer.duration;
+    // Track it so _stopPlay can actually silence what is already queued.
+    // Self-removing on end, so the set only ever holds pending buffers.
+    this._sources?.add(source);
+    source.onended = () => this._sources?.delete(source);
   },
 
   // ── Waveform drawing ──────────────────────────────────────────────────────

--- a/agent-core/web/js/renderers/audio.js
+++ b/agent-core/web/js/renderers/audio.js
@@ -36,7 +36,10 @@ export const AudioRenderer = {
   _nextStartTime: 0,
   _prebufCount:   0,
   _prebufQueue:   null,
-  _PREBUF_CHUNKS: 3,    // 首包预载：攒够 3 个 chunk 再开始播放
+  _PREBUF_CHUNKS: 5,     // 首包预载：攒够 5 个 chunk (~500ms) 再开始播放
+  _UNDERRUN_LEAD: 0.20,  // 欠载重启时给出的余量，秒
+  _MAX_LEAD:      1.5,   // 允许领先播放头的上限，秒
+  _drawnPos:      -1,
 
   mount(container) {
     this._el = document.createElement('div');
@@ -68,6 +71,7 @@ export const AudioRenderer = {
     this._ctx2d = this._canvas.getContext('2d');
     this._ring = new Float32Array(this._ringLen);
     this._writePos = 0;
+    this._drawnPos = -1;
 
     this._raf = requestAnimationFrame(() => this._draw());
   },
@@ -78,6 +82,20 @@ export const AudioRenderer = {
       // Protocol frame, not samples. Keep the tail of the waveform on screen and
       // say what happened instead of reporting a 0 ms frame.
       if (this._label) this._label.textContent = '○ 音频流  本句结束';
+      // An utterance boundary is exactly when the jitter buffer has to be
+      // re-armed. The prebuffer used to be spent on the first utterance and
+      // never rebuilt, so every later one started from _scheduleChunk's
+      // underrun branch — a fixed, tiny lead — and gapped on the first hiccup.
+      // Flush first: an utterance shorter than _PREBUF_CHUNKS never fills the
+      // prebuffer, and re-arming without flushing would discard it unplayed.
+      // _nextStartTime is deliberately left alone: it is the end of the audio
+      // already handed to the audio thread, and resetting it would schedule the
+      // next utterance on top of this one's still-playing tail.
+      if (this._playing) {
+        this._flushPrebuf();
+        this._prebufQueue = [];
+        this._prebufCount = 0;
+      }
       return;
     }
     const pcm = new Int16Array(buffer);
@@ -111,6 +129,7 @@ export const AudioRenderer = {
   clear() {
     if (this._ring) this._ring.fill(0);
     this._writePos = 0;
+    this._drawnPos = -1;
     if (this._label) this._label.textContent = '等待音频流…';
   },
 
@@ -160,6 +179,16 @@ export const AudioRenderer = {
     }
   },
 
+  _flushPrebuf() {
+    if (!this._prebufQueue || this._prebufQueue.length === 0) return;
+    const queue = this._prebufQueue;
+    this._prebufQueue = null;
+    this._prebufCount = 0;
+    for (const buf of queue) {
+      this._scheduleChunk(buf);
+    }
+  },
+
   _feedPlayback(buffer) {
     if (!this._audioCtx || !this._playing) return;
 
@@ -168,12 +197,7 @@ export const AudioRenderer = {
       this._prebufQueue.push(buffer);
       this._prebufCount++;
       if (this._prebufCount >= this._PREBUF_CHUNKS) {
-        // Flush all prebuffered chunks
-        const queue = this._prebufQueue;
-        this._prebufQueue = null;
-        for (const buf of queue) {
-          this._scheduleChunk(buf);
-        }
+        this._flushPrebuf();
       }
       return;
     }
@@ -206,8 +230,18 @@ export const AudioRenderer = {
     // Schedule playback time
     const currentTime = ctx.currentTime;
     if (this._nextStartTime < currentTime) {
-      // Buffer underrun — restart from current time + small delay
-      this._nextStartTime = currentTime + 0.05;
+      // Underrun. The old +0.05 here left a 50ms lead as the *permanent*
+      // steady-state margin against a producer that sends 100ms of audio per
+      // 100ms of wall clock, so the next delay over 50ms gapped again — and
+      // again. _UNDERRUN_LEAD gives the recovery something to work with.
+      this._nextStartTime = currentTime + this._UNDERRUN_LEAD;
+    } else if (this._nextStartTime - currentTime > this._MAX_LEAD) {
+      // Too far ahead. The relay queues frames (agent-core keeps a very deep
+      // per-consumer queue), so a stall followed by a flush arrives as a burst
+      // and every chunk gets appended contiguously into the future — latency
+      // that grows monotonically and is never recovered. Drop back rather than
+      // drift; one seam here beats playing minutes behind live.
+      this._nextStartTime = currentTime + this._MAX_LEAD;
     }
 
     source.start(this._nextStartTime);
@@ -221,13 +255,26 @@ export const AudioRenderer = {
 
     const cw = this._canvas.offsetWidth;
     const ch = this._canvas.offsetHeight;
-    // Compare against the backing-store size, not the CSS size: after a resize
+
+    // The waveform shares the main thread with _scheduleChunk, which has only a
+    // few hundred ms of scheduling lead to work with. A full redraw is a
+    // per-column fillRect plus a scan of the whole ring, so skip the ones that
+    // cannot change anything the user sees: a hidden tab, and frames where
+    // neither new samples nor a resize arrived (audio is 10 fps, this is 60).
+    const wantW = Math.round(cw * devicePixelRatio);
+    const wantH = Math.round(ch * devicePixelRatio);
+    const resized = this._canvas.width !== wantW || this._canvas.height !== wantH;
+    if (document.hidden || (!resized && this._writePos === this._drawnPos)) {
+      this._raf = requestAnimationFrame(() => this._draw());
+      return;
+    }
+    this._drawnPos = this._writePos;
+
+    // Assign the backing-store size, not the CSS size: after a resize
     // canvas.width is cw * devicePixelRatio, so `canvas.width !== cw` is always
     // true on a HiDPI display and this reallocated the canvas and reset the
     // transform on every animation frame.
-    const wantW = Math.round(cw * devicePixelRatio);
-    const wantH = Math.round(ch * devicePixelRatio);
-    if (cw > 0 && (this._canvas.width !== wantW || this._canvas.height !== wantH)) {
+    if (cw > 0 && resized) {
       this._canvas.width  = wantW;
       this._canvas.height = wantH;
       this._canvas.style.width  = cw + 'px';

--- a/perception/main.py
+++ b/perception/main.py
@@ -132,6 +132,16 @@ class PerceptionBundle:
                 return p.dispatch(name, args)
         return None
 
+    def owns(self, full_name: str) -> bool:
+        """True when some loaded plugin claims this tool name.
+
+        Lets the caller tell a genuinely unknown tool apart from a loaded
+        plugin returning None for an action it does not handle. Mirrors
+        `dispatch`'s prefix split so the two can never disagree.
+        """
+        prefix, _, _ = full_name.partition("_")
+        return any(p.PREFIX == prefix for p in self._plugins)
+
     def tts_synthesize_raw(self, text: str) -> bytes:
         for p in self._plugins:
             if getattr(p, 'PREFIX', None) == 'tts':
@@ -299,7 +309,20 @@ def make_handler():
                         log.info(f"[mcp] tools/call: {name}({args})")
                     result = _bundle.dispatch(name, args)
                     if result is None:
-                        err(-32601, f"Unknown tool: {name}")
+                        # `dispatch` returns None for two very different things:
+                        # no plugin owns the name, or a plugin owns it and
+                        # declined the action. Reporting both as "Unknown tool"
+                        # is actively misleading — it sent a debugging session
+                        # hunting a tool-registration race that did not exist,
+                        # when the tool was registered the whole time.
+                        if _bundle.owns(name):
+                            log.warning(
+                                "[mcp] %s declined action %r", name, args.get("action")
+                            )
+                            err(-32603, f"Tool {name} does not handle action "
+                                        f"{args.get('action')!r}")
+                        else:
+                            err(-32601, f"Unknown tool: {name}")
                     else:
                         if not is_info:
                             log.info(f"[mcp] tools/call result: {json.dumps(result)[:200]}")

--- a/perception/plugins/tts.py
+++ b/perception/plugins/tts.py
@@ -24,6 +24,31 @@ log = logging.getLogger(__name__)
 
 SAMPLE_RATE = 16000
 CHUNK_BYTES = 3200  # 100ms @ 16kHz 16-bit mono
+PCM_FRAME_S = CHUNK_BYTES / (SAMPLE_RATE * 2)  # 0.1s of audio per frame
+
+# Frames held back before pacing starts, then published in one burst, so the
+# consumer begins with a real cushion. 5 frames = 500ms, matching the
+# vits2_tts_trt engine's MIX_VITS_PREBUFFER_FRAMES default.
+PREBUF_FRAMES = 5
+# Deliberately shorter than PCM_FRAME_S: sending 100ms frames every 70ms accrues
+# 30ms of cushion per frame, so downstream keeps building margin instead of
+# living on whatever it started with. Pacing at exactly PCM_FRAME_S — what this
+# engine used to do — means the cushion never grows and every jitter spike above
+# it is an audible gap. Safe here because this adapter synthesizes the whole
+# utterance before publishing anything, so there is no risk of outrunning it.
+FRAME_INTERVAL_S = 0.07
+if FRAME_INTERVAL_S > PCM_FRAME_S:
+    log.warning(
+        "[tts] FRAME_INTERVAL_S=%.3fs is slower than the %.3fs of audio each "
+        "frame carries; downstream will underrun on every utterance",
+        FRAME_INTERVAL_S, PCM_FRAME_S,
+    )
+# Depth of the synthesis→publish handoff queue, in frames (20s of audio).
+SYNTH_QUEUE_FRAMES = 200
+
+# Sentinel closing the synthesis→publish queue. A dedicated object rather than
+# None so a genuinely empty frame could never be mistaken for end-of-stream.
+_SYNTH_DONE = object()
 
 # EOF magic: 8 bytes (4 samples [1, -1, 1, -1])，标记 utterance 结束
 # 正常 chunk 始终 3200 bytes，8 bytes 短 chunk 不会被误判
@@ -36,6 +61,73 @@ _LOW_LAT_QOS = QoSProfile(
     depth=200,
     durability=DurabilityPolicy.VOLATILE,
 )
+
+
+def _agent_core_url() -> str:
+    import os
+    return os.environ.get("AGENT_CORE_URL", "https://localhost:15678")
+
+
+def _unverified_ssl_context():
+    """Agent Core serves HTTPS with a self-signed certificate."""
+    import ssl
+    ctx = ssl.create_default_context()
+    ctx.check_hostname = False
+    ctx.verify_mode = ssl.CERT_NONE
+    return ctx
+
+
+def _post_json(path: str, payload: dict, timeout: float) -> None:
+    import urllib.request
+    request = urllib.request.Request(
+        f"{_agent_core_url()}{path}",
+        data=json.dumps(payload).encode(),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    urllib.request.urlopen(request, timeout=timeout, context=_unverified_ssl_context())
+
+
+def fire_hook(name: str) -> None:
+    """Fire an agent-core hook without blocking the caller.
+
+    on_speaking used to be a synchronous urlopen(timeout=2) inside the publish
+    loop, fired after the pacing clock had already been latched — so the request
+    latency was charged to the utterance's pacing budget and every frame after
+    the prebuffer went out late. Hooks are advisory (LED state); they must never
+    sit between two audio frames.
+    """
+    def _send():
+        try:
+            _post_json("/api/hooks/fire", {"hook": name}, timeout=2)
+        except Exception as exc:
+            log.debug("[tts] hook %s failed: %s", name, exc)
+
+    threading.Thread(target=_send, name=f"tts-hook-{name}", daemon=True).start()
+
+
+def _complete_action(action_id: str, text: str, frames_sent: int,
+                     interrupted: bool) -> None:
+    """Notify Agent Core that a speak action has terminated.
+
+    Module level, not a node method: an utterance can also die before the worker
+    ever sees it (interrupt/stop drains the queue), and the ACP barrier in
+    agent-core waits out its full timeout for every action it registered but
+    never heard back about.
+    """
+    if not action_id:
+        return
+    try:
+        _post_json("/api/acp/complete", {
+            "action_id": action_id,
+            "status": "cancelled" if interrupted else "completed",
+            "result": {"text": text[:100], "frames": frames_sent},
+        }, timeout=3)
+        log.info("[tts] ACP complete: %s (%s)", action_id,
+                 "cancelled" if interrupted else "completed")
+    except Exception as exc:
+        log.warning("[tts] ACP callback failed: %s", exc)
+
 
 TOOLS = [
     {
@@ -236,21 +328,35 @@ class _TTSNode(Node):
 
     def stop(self) -> dict:
         self._stop_event.set()
+        self._complete_discarded_actions()
         if self._worker_thread and self._worker_thread.is_alive():
             self._worker_thread.join(timeout=3)
         self.state = "idle"
         return {"state": "idle"}
 
-    def interrupt(self) -> dict:
-        """立即中止当前播放：清空队列 + 设置 interrupt flag 让 worker 停止当前 utterance。"""
-        # 清空待播放队列
-        cleared = 0
-        while not self._text_queue.empty():
+    def _complete_discarded_actions(self) -> int:
+        """Cancel queued ACP actions that will never reach the worker."""
+        discarded = []
+        while True:
             try:
-                self._text_queue.get_nowait()
-                cleared += 1
+                item = self._text_queue.get_nowait()
             except queue.Empty:
                 break
+            if isinstance(item, tuple):
+                text = str(item[0])
+                action_id = item[2] if len(item) >= 3 else ''
+            else:
+                text, action_id = str(item), ''
+            discarded.append((text, action_id))
+        for text, action_id in discarded:
+            _complete_action(action_id, text, 0, interrupted=True)
+        return len(discarded)
+
+    def interrupt(self) -> dict:
+        """立即中止当前播放：清空队列 + 设置 interrupt flag 让 worker 停止当前 utterance。"""
+        # 清空待播放队列。丢掉的 item 必须逐个回 ACP cancelled，否则 agent-core
+        # 的 barrier 会为每个注册过的 action 干等到超时。
+        cleared = self._complete_discarded_actions()
         # 设置 interrupt flag（worker 在每个 frame 前检查）
         self._interrupt_flag.set()
         log.info(f"[tts] interrupted: cleared {cleared} queued item(s)")
@@ -259,16 +365,12 @@ class _TTSNode(Node):
     def enqueue(self, text: str, trace_id: str = '', action_id: str = ''):
         if self.state != "running":
             raise RuntimeError("TTS not running; call start first")
-        # 分段：超过 280 字按标点切分，避免超长合成导致延迟或失败
-        segments = self._split_text(text, max_chars=280)
-        if len(segments) <= 1:
-            self._text_queue.put((text, trace_id, action_id))
-        else:
-            # 只有最后一段带 action_id（触发 ACP callback）
-            for i, seg in enumerate(segments):
-                is_last = (i == len(segments) - 1)
-                self._text_queue.put((seg, trace_id, action_id if is_last else ''))
-            log.info(f"[tts] split {len(text)} chars into {len(segments)} segments")
+        # One queue item = one utterance = one EOF = one ACP action. The 280-char
+        # split happens inside the worker instead: splitting here put each
+        # segment on the queue as its own utterance, so a long text emitted an
+        # EOF and reset the pacing clock every 280 characters, and the gap
+        # between segments was a full synthesis with no audio flowing at all.
+        self._text_queue.put((text, trace_id, action_id))
 
     @staticmethod
     def _split_text(text: str, max_chars: int = 280) -> list:
@@ -303,10 +405,6 @@ class _TTSNode(Node):
         from audio_msgs.msg import AudioChunk
         import time as _time
 
-        # Real-time pacing: publish frames at playback rate to avoid bursts/gaps
-        FRAME_DURATION = CHUNK_BYTES / (SAMPLE_RATE * 2)  # 0.1s per 3200-byte frame
-        PREBUF_FRAMES  = 3  # buffer 3 frames (~300ms) before starting real-time pacing
-
         while not self._stop_event.is_set():
             try:
                 item = self._text_queue.get(timeout=1)
@@ -323,103 +421,154 @@ class _TTSNode(Node):
                     text, _trace_id, _action_id = str(item[0]), '', ''
             else:
                 text, _trace_id, _action_id = item, '', ''
+            synth_thread = None
+            # Set on every exit path. The stop/interrupt flags are not enough to
+            # release the synth thread: if the consumer dies on an exception,
+            # nothing is cancelled and nothing is draining, so a blocking put
+            # would wedge that thread forever. Bound before the try so the
+            # finally can always reach it.
+            utterance_abort = threading.Event()
             try:
-                import time as _time
                 t_start = _time.monotonic()
                 t_start_wall = _time.time()  # wall-clock for perf span
                 t0_wall = None  # wall-clock when playback starts (prebuf complete)
                 total = 0
-                buf   = b''
-                t0    = None  # wall-clock start of playback
+                buf = b''
+                t0 = None  # monotonic start of the pacing schedule
                 frames_sent = 0
                 prebuf = []   # pre-buffer queue
 
-                for raw_chunk in self._adapter.synthesize_stream(text):
-                    if self._stop_event.is_set() or self._interrupt_flag.is_set():
-                        break
-                    buf  += raw_chunk
-                    total += len(raw_chunk)
-                    # split into CHUNK_BYTES frames
-                    while len(buf) >= CHUNK_BYTES:
-                        frame = buf[:CHUNK_BYTES]
-                        buf   = buf[CHUNK_BYTES:]
-
-                        # Check interrupt before publishing each frame
-                        if self._interrupt_flag.is_set():
-                            break
-
-                        # Pre-buffer phase: accumulate a few frames before pacing
-                        if t0 is None:
-                            prebuf.append(frame)
-                            if len(prebuf) >= PREBUF_FRAMES:
-                                # Flush pre-buffer and start real-time clock
-                                t0 = _time.monotonic()
-                                t0_wall = _time.time()
-                                # Fire on_speaking hook (playback starting)
-                                try:
-                                    import urllib.request as _ureq
-                                    import json as _jhook
-                                    _hreq = _ureq.Request(
-                                        "https://localhost:15678/api/hooks/fire",
-                                        data=_jhook.dumps({"hook": "on_speaking"}).encode(),
-                                        headers={"Content-Type": "application/json"},
-                                        method="POST"
-                                    )
-                                    import ssl as _ssl
-                                    _sctx = _ssl.create_default_context()
-                                    _sctx.check_hostname = False
-                                    _sctx.verify_mode = _ssl.CERT_NONE
-                                    _ureq.urlopen(_hreq, timeout=2, context=_sctx)
-                                except Exception:
-                                    pass
-                                for pf in prebuf:
-                                    msg = AudioChunk()
-                                    msg.header.stamp = self.get_clock().now().to_msg()
-                                    msg.format = "audio/pcm-16k"
-                                    msg.data   = list(pf)
-                                    self._pub.publish(msg)
-                                    frames_sent += 1
-                                prebuf = []
-                            continue
-
-                        # Real-time pacing
-                        target = t0 + frames_sent * FRAME_DURATION
-                        now = _time.monotonic()
-                        if now < target:
-                            _time.sleep(target - now)
-                        msg = AudioChunk()
-                        msg.header.stamp = self.get_clock().now().to_msg()
-                        msg.format = "audio/pcm-16k"
-                        msg.data   = list(frame)
-                        self._pub.publish(msg)
-                        frames_sent += 1
-
-                # Flush any remaining pre-buffer (short utterances < PREBUF_FRAMES)
-                if prebuf and not self._stop_event.is_set() and not self._interrupt_flag.is_set():
-                    t0 = _time.monotonic()
-                    for pf in prebuf:
-                        msg = AudioChunk()
-                        msg.header.stamp = self.get_clock().now().to_msg()
-                        msg.format = "audio/pcm-16k"
-                        msg.data   = list(pf)
-                        self._pub.publish(msg)
-                        frames_sent += 1
-
-                # flush remainder
-                if buf and not self._stop_event.is_set() and not self._interrupt_flag.is_set():
-                    if t0 is not None:
-                        target = t0 + frames_sent * FRAME_DURATION
-                        now = _time.monotonic()
-                        if now < target:
-                            _time.sleep(target - now)
+                def publish(frame: bytes) -> None:
+                    nonlocal frames_sent
                     msg = AudioChunk()
                     msg.header.stamp = self.get_clock().now().to_msg()
                     msg.format = "audio/pcm-16k"
-                    msg.data   = list(buf)
+                    msg.data = list(frame)
                     self._pub.publish(msg)
+                    frames_sent += 1
 
+                def emit(frame: bytes) -> None:
+                    """Pace and publish one frame; latches the clock on the first."""
+                    nonlocal t0, t0_wall
+                    if t0 is None:
+                        # Backdate by the frames already in the prebuffer so all
+                        # of them are due in the past and go out in one burst —
+                        # the consumer then starts holding PREBUF_FRAMES of audio.
+                        now = _time.monotonic()
+                        t0 = now - max(0, len(prebuf) - 1) * FRAME_INTERVAL_S
+                        t0_wall = _time.time()
+                        fire_hook("on_speaking")
+                    target = t0 + frames_sent * FRAME_INTERVAL_S
+                    now = _time.monotonic()
+                    if now < target:
+                        _time.sleep(target - now)
+                    # No rebase when behind: publishing immediately is the
+                    # catch-up, since the schedule is already ahead of realtime.
+                    publish(frame)
+
+                def flush_prebuf() -> None:
+                    while prebuf:
+                        emit(prebuf[0])
+                        prebuf.pop(0)
+
+                # 分段：超过 280 字按标点切分，避免超长合成导致延迟或失败。分段是
+                # 合成的实现细节 —— pacing/prebuffer/EOF 都跨段延续，下游看到的
+                # 仍然是一句完整的话。
+                segments = self._split_text(text, max_chars=280)
+                if len(segments) > 1:
+                    log.info(f"[tts] split {len(text)} chars into {len(segments)} segments")
+
+                # Synthesis runs on its own thread. This adapter's
+                # synthesize_stream calls generate() once per segment and blocks
+                # until the whole segment's audio exists, so doing it on the
+                # publishing thread meant no frame at all went out for the
+                # duration of every segment after the first — a guaranteed gap
+                # every 280 characters, as long as the synthesis took. Here
+                # segment N+1 is synthesized while segment N is still playing.
+                frame_queue: queue.Queue = queue.Queue(maxsize=SYNTH_QUEUE_FRAMES)
+                synth_state: dict = {"total": 0}
+
+                def enqueue_frame(frame) -> bool:
+                    """Blocking put that still honours interrupt/stop/abort."""
+                    while True:
+                        if (self._stop_event.is_set() or self._interrupt_flag.is_set()
+                                or utterance_abort.is_set()):
+                            return False
+                        try:
+                            frame_queue.put(frame, timeout=0.1)
+                            return True
+                        except queue.Full:
+                            continue
+
+                def synthesize_into_queue() -> None:
+                    pending = b''
+                    try:
+                        for seg in segments:
+                            for raw_chunk in self._adapter.synthesize_stream(seg):
+                                pending += raw_chunk
+                                synth_state["total"] += len(raw_chunk)
+                                while len(pending) >= CHUNK_BYTES:
+                                    frame, pending = pending[:CHUNK_BYTES], pending[CHUNK_BYTES:]
+                                    if not enqueue_frame(frame):
+                                        return
+                        if pending:
+                            enqueue_frame(pending)
+                    except BaseException as exc:  # surfaced on the worker thread
+                        synth_state["error"] = exc
+                    finally:
+                        # Unblock the consumer on every exit path.
+                        enqueue_frame(_SYNTH_DONE)
+
+                synth_thread = threading.Thread(
+                    target=synthesize_into_queue, name="tts-synth", daemon=True)
+                synth_thread.start()
+
+                interrupted = False
+                while True:
+                    if self._stop_event.is_set() or self._interrupt_flag.is_set():
+                        interrupted = True
+                        break
+                    try:
+                        frame = frame_queue.get(timeout=0.1)
+                    except queue.Empty:
+                        continue
+                    if frame is _SYNTH_DONE:
+                        break
+                    if len(frame) < CHUNK_BYTES:
+                        # Trailing partial frame — paced, then done.
+                        buf = frame
+                        break
+                    if t0 is None:
+                        prebuf.append(frame)
+                        if len(prebuf) >= PREBUF_FRAMES:
+                            flush_prebuf()
+                        continue
+                    emit(frame)
+
+                cancelled = self._stop_event.is_set() or self._interrupt_flag.is_set()
+                synth_thread.join(timeout=5)
+                if "error" in synth_state and not cancelled:
+                    raise synth_state["error"]
+                total = synth_state["total"]  # read after join, not concurrently
+                # Flush any remaining pre-buffer (utterances < PREBUF_FRAMES)
+                if prebuf and not cancelled:
+                    flush_prebuf()
+
+                # flush remainder
+                if buf and not cancelled:
+                    if t0 is not None:
+                        target = t0 + frames_sent * FRAME_INTERVAL_S
+                        now = _time.monotonic()
+                        if now < target:
+                            _time.sleep(target - now)
+                    publish(buf)
+
+                # Capture before clearing: reading the flag after the clear below
+                # made this always False, so an interrupted utterance reported ACP
+                # "completed" instead of "cancelled".
+                was_interrupted = self._interrupt_flag.is_set()
                 # Clear interrupt flag after utterance is done (interrupted or complete)
-                if self._interrupt_flag.is_set():
+                if was_interrupted:
                     self._interrupt_flag.clear()
                     log.info(f"[tts] utterance interrupted after {frames_sent} frames")
                 else:
@@ -457,40 +606,21 @@ class _TTSNode(Node):
                 # ACP: 推送动作完成回调到 Agent Core
                 # Also fire on_idle hook (LED off immediately after playback)
                 if _action_id:
-                    try:
-                        import urllib.request as _urllib
-                        import ssl as _ssl
-                        import os as _os
-                        _agent_core_url = _os.environ.get("AGENT_CORE_URL", "https://localhost:15678")
-                        _ctx = _ssl.create_default_context()
-                        _ctx.check_hostname = False
-                        _ctx.verify_mode = _ssl.CERT_NONE
-                        # Fire on_idle to turn off LED
-                        _idle_req = _urllib.Request(
-                            f"{_agent_core_url}/api/hooks/fire",
-                            data=json.dumps({"hook": "on_idle"}).encode(),
-                            headers={"Content-Type": "application/json"},
-                            method="POST"
-                        )
-                        _urllib.urlopen(_idle_req, timeout=2, context=_ctx)
-                        was_interrupted = self._interrupt_flag.is_set()
-                        _payload = json.dumps({
-                            "action_id": _action_id,
-                            "status": "cancelled" if was_interrupted else "completed",
-                            "result": {"text": text[:100], "frames": frames_sent},
-                        }).encode()
-                        _req = _urllib.Request(
-                            f"{_agent_core_url}/api/acp/complete",
-                            data=_payload,
-                            headers={"Content-Type": "application/json"},
-                            method="POST",
-                        )
-                        _urllib.urlopen(_req, timeout=3, context=_ctx)
-                        log.info(f"[tts] ACP complete: {_action_id} ({'cancelled' if was_interrupted else 'completed'})")
-                    except Exception as e:
-                        log.warning(f"[tts] ACP callback failed: {e}")
+                    fire_hook("on_idle")
+                    _complete_action(_action_id, text, frames_sent, was_interrupted)
             except Exception as e:
                 log.error(f"[tts] synthesis error: {e}", exc_info=True)
+                _complete_action(_action_id, text, 0, interrupted=True)
+                self._publish_eof()
+            finally:
+                # Release the synth thread on every path, including the one where
+                # the consumer above died: it can otherwise sit on a blocking put
+                # forever, holding a reference to the adapter.
+                utterance_abort.set()
+                if synth_thread is not None and synth_thread.is_alive():
+                    synth_thread.join(timeout=5)
+                    if synth_thread.is_alive():
+                        log.error("[tts] synth thread did not exit")
 
     def _status_dict(self) -> dict:
         return {
@@ -686,12 +816,14 @@ class SherpaOnnxTTSPlugin:
                     node = self._nodes.get(node_key)
                     if node is None:
                         input_topic = args.get("input_topic") or None
-                        adapter = self._adapter
-                        if instance_id and instance_id in self._instance_configs:
-                            inst_adapter = _build_tts_adapter(self._instance_configs[instance_id])
-                            if inst_adapter:
-                                adapter = inst_adapter
-                        node = _TTSNode(input_topic, adapter,
+                        # No per-instance adapter: `config` writes into self._cfg
+                        # globally (it strips instance_id), so there has never
+                        # been anywhere to read a per-instance config from. This
+                        # used to consult a self._instance_configs that is never
+                        # assigned anywhere, i.e. `speak` with an instance_id and
+                        # no running node raised AttributeError instead of
+                        # synthesizing.
+                        node = _TTSNode(input_topic, self._adapter,
                                         node_suffix=node_key.replace('/', '_').replace('-', '_'))
                         self._executor.add_node(node)
                         self._nodes[node_key] = node

--- a/perception/plugins/vits2_tts_trt/plugin.py
+++ b/perception/plugins/vits2_tts_trt/plugin.py
@@ -59,6 +59,21 @@ def _env_int(name: str, default: int, low: int, high: int) -> int:
 
 FRAME_INTERVAL_MS = _env_int("MIX_VITS_FRAME_INTERVAL_MS", 70, 0, 1000)
 FIRST_FRAME_DELAY_MS = _env_int("MIX_VITS_FIRST_FRAME_DELAY_MS", 0, 0, 1000)
+# Frames held back before pacing starts, then published in one burst so every
+# consumer begins with a real cushion instead of zero. Without it the only
+# margin downstream ever has is the (PCM_FRAME_MS - FRAME_INTERVAL_MS) = 30ms
+# per frame that the schedule accrues, so the opening of every utterance is
+# one jitter spike away from an audible gap. The sherpa engine has always done
+# this (plugins/tts.py PREBUF_FRAMES); this is the same idea on this engine.
+PREBUFFER_FRAMES = _env_int("MIX_VITS_PREBUFFER_FRAMES", 5, 0, 100)
+# Depth of the synthesis→publish handoff queue, in frames. Bounds memory while
+# still letting TensorRT run a whole text chunk ahead of the paced publisher.
+SYNTH_QUEUE_FRAMES = _env_int("MIX_VITS_SYNTH_QUEUE_FRAMES", 200, 1, 4000)
+# How many frames may be published back-to-back while catching up after a
+# stall. agent-core subscribes BEST_EFFORT with depth=20 (agent-core/src/
+# ros2_bridge.py), so an unbounded catch-up burst is dropped frames, not
+# recovered audio.
+MAX_BURST_FRAMES = _env_int("MIX_VITS_MAX_BURST_FRAMES", 20, 1, 200)
 SUBSCRIBER_WAIT_MS = _env_int("MIX_VITS_SUBSCRIBER_WAIT_MS", 5000, 0, 60000)
 SUBSCRIBER_POLL_MS = _env_int("MIX_VITS_SUBSCRIBER_POLL_MS", 10, 1, 1000)
 SUBSCRIBER_SETTLE_MS = _env_int("MIX_VITS_SUBSCRIBER_SETTLE_MS", 500, 0, 5000)
@@ -78,6 +93,10 @@ _LOW_LAT_QOS = QoSProfile(
     depth=200,
     durability=DurabilityPolicy.VOLATILE,
 )
+
+# Sentinel closing the synthesis→publish queue. A dedicated object rather than
+# None so a genuinely empty frame could never be mistaken for end-of-stream.
+_SYNTH_DONE = object()
 
 # The tool contract (actions, x-completion, x-hooks, configSchema) is owned by
 # plugins/tts.py — this package is one implementation behind it. Importing it
@@ -336,19 +355,36 @@ class _Vits2TTSNode(Node):
             # become pure TTFT overhead.
             subscriber_gate_thread.start()
             eof_published = False
+            synth_thread = None
+            # Set on every exit path. `_utterance_cancelled()` alone is not
+            # enough to release the synth thread: if the consumer dies on an
+            # exception (a subscriber-gate failure, say) nothing is cancelled
+            # and nothing is draining, so a blocking put would wedge that
+            # thread forever — holding the adapter lock, which would then
+            # deadlock every later utterance. Bound before the try so the
+            # finally can always reach it.
+            utterance_abort = threading.Event()
             try:
                 task_started = time.monotonic()
                 first_published_at = None
+                last_published_at = None
+                max_frame_gap = 0.0
                 total_bytes = 0
                 started = None
                 frames_sent = 0
-                buffer = bytearray()
+                burst_frames = 0
+                burst_limit = max(MAX_BURST_FRAMES, PREBUFFER_FRAMES)
+                prebuffer: list[bytes] = []
+                prebuffering = PREBUFFER_FRAMES > 0
                 subscriber_wait_seconds = None
                 subscriber_settle_seconds = None
                 subscriber_count = 0
+                frame_queue: queue.Queue = queue.Queue(maxsize=SYNTH_QUEUE_FRAMES)
+                synth_result: dict = {}
 
-                def publish_frame(frame: bytes) -> bool:
+                def emit(frame: bytes) -> bool:
                     nonlocal started, frames_sent, first_published_at, total_bytes
+                    nonlocal last_published_at, max_frame_gap, burst_frames
                     nonlocal subscriber_wait_seconds, subscriber_settle_seconds
                     nonlocal subscriber_count
                     if self._utterance_cancelled():
@@ -369,43 +405,141 @@ class _Vits2TTSNode(Node):
                         ) = subscriber_gate_result["value"]
                         if FIRST_FRAME_DELAY_MS:
                             time.sleep(FIRST_FRAME_DELAY_MS / 1000.0)
-                        started = time.monotonic()
-                        now = started
+                        now = time.monotonic()
+                        # Backdate the schedule origin by the frames already
+                        # waiting in the prebuffer so every one of them is due
+                        # in the past and they go out in a single burst. The
+                        # consumer therefore starts holding PREBUFFER_FRAMES
+                        # worth of audio, and the frame after them is due one
+                        # interval from now — pacing continues untouched.
+                        started = now - max(0, len(prebuffer) - 1) * frame_interval
                     if frame_interval:
                         target = started + frames_sent * frame_interval
-                        if target < now - frame_interval:
-                            started = now - frames_sent * frame_interval
-                            target = now
                         delay = target - now
                         if delay > 0:
                             time.sleep(delay)
+                            burst_frames = 0
+                        else:
+                            # Behind schedule (a synthesis stall, a slow
+                            # publish). Publishing immediately *is* the
+                            # catch-up: the schedule emits 100ms frames every
+                            # 70ms, so racing back onto it is what refills the
+                            # consumer's buffer. Rebasing `started` to `now`
+                            # here — what this used to do unconditionally —
+                            # threw the whole accumulated cushion away instead,
+                            # so the next hiccup had nothing to absorb it and
+                            # one stall reliably became a run of them.
+                            burst_frames += 1
+                            if burst_frames > burst_limit:
+                                # Too far behind to recover on this schedule.
+                                # Give up the cushion rather than dump an
+                                # unbounded burst into a BEST_EFFORT reader.
+                                started = now - frames_sent * frame_interval
+                                burst_frames = 0
                     if self._utterance_cancelled():
                         return False
                     self._publish(frame)
+                    published_at = time.monotonic()
                     if first_published_at is None:
-                        first_published_at = time.monotonic()
+                        first_published_at = published_at
+                    else:
+                        max_frame_gap = max(
+                            max_frame_gap, published_at - last_published_at
+                        )
+                    last_published_at = published_at
                     total_bytes += len(frame)
                     frames_sent += 1
                     return True
 
+                def flush_prebuffer() -> bool:
+                    nonlocal prebuffering
+                    prebuffering = False
+                    while prebuffer:
+                        if not emit(prebuffer[0]):
+                            return False
+                        prebuffer.pop(0)
+                    return True
+
+                def publish_frame(frame: bytes) -> bool:
+                    if prebuffering:
+                        prebuffer.append(frame)
+                        if len(prebuffer) < PREBUFFER_FRAMES:
+                            return True
+                        return flush_prebuffer()
+                    return emit(frame)
+
+                def enqueue_frame(item) -> bool:
+                    """Blocking put that still honours interrupt/stop/abort."""
+                    while True:
+                        if self._utterance_cancelled() or utterance_abort.is_set():
+                            return False
+                        try:
+                            frame_queue.put(item, timeout=0.1)
+                            return True
+                        except queue.Full:
+                            continue
+
+                def synthesize_into_queue() -> None:
+                    """Run TensorRT ahead of the paced publisher.
+
+                    `synthesize_stream` blocks for a whole text chunk at a time
+                    (the adapter calls the engine once per chunk and only then
+                    slices the result into frames), so running it on the
+                    publishing thread meant not one frame went out for the
+                    duration of every chunk after the first. That stall was the
+                    root cause of the audible gaps in both the browser player
+                    and the robot speakers: the only margin the consumer had
+                    was the 30ms/frame the 70ms-for-100ms schedule accrues, and
+                    a 256-token chunk takes far longer than that to synthesize.
+                    """
+                    buffer = bytearray()
+                    try:
+                        for pcm in self._adapter.synthesize_stream(text):
+                            buffer.extend(pcm)
+                            while len(buffer) >= CHUNK_BYTES:
+                                frame = bytes(buffer[:CHUNK_BYTES])
+                                del buffer[:CHUNK_BYTES]
+                                if not enqueue_frame(frame):
+                                    return
+                        if buffer:
+                            enqueue_frame(bytes(buffer))
+                    except BaseException as exc:  # surfaced on the worker thread
+                        synth_result["error"] = exc
+                    finally:
+                        # Unblock the consumer on every exit path. If it has
+                        # already given up, enqueue_frame sees the cancellation
+                        # and returns rather than blocking on a full queue.
+                        enqueue_frame(_SYNTH_DONE)
+
+                synth_thread = threading.Thread(
+                    target=synthesize_into_queue,
+                    name="vits2-trt-synth",
+                    daemon=True,
+                )
+                synth_thread.start()
+
                 interrupted = False
-                for pcm in self._adapter.synthesize_stream(text):
+                while True:
                     if self._utterance_cancelled():
                         interrupted = True
                         break
-                    buffer.extend(pcm)
-                    while len(buffer) >= CHUNK_BYTES:
-                        frame = bytes(buffer[:CHUNK_BYTES])
-                        del buffer[:CHUNK_BYTES]
-                        if not publish_frame(frame):
-                            interrupted = True
-                            break
-                    if interrupted:
+                    try:
+                        item = frame_queue.get(timeout=0.1)
+                    except queue.Empty:
+                        continue
+                    if item is _SYNTH_DONE:
+                        break
+                    if not publish_frame(item):
+                        interrupted = True
                         break
 
-                if buffer and not self._utterance_cancelled():
-                    if not publish_frame(bytes(buffer)):
+                if not interrupted and prebuffer:
+                    # Utterance shorter than the prebuffer — nothing emitted yet.
+                    if not flush_prebuffer():
                         interrupted = True
+                synth_thread.join(timeout=5)
+                if "error" in synth_result and not interrupted:
+                    raise synth_result["error"]
                 interrupted = interrupted or self._interrupt_event.is_set()
                 if total_bytes:
                     finished_at = time.monotonic()
@@ -415,6 +549,7 @@ class _Vits2TTSNode(Node):
                         "[vits2_tts_trt] server delivery: bytes=%d frames=%d "
                         "ttft=%.3fs elapsed=%.3fs audio=%.3fs rtf=%.4f "
                         "chunk_bytes=%d frame_interval_ms=%d "
+                        "max_frame_gap_ms=%.1f prebuffer_frames=%d "
                         "first_frame_delay_ms=%d subscriber_wait_ms=%.1f "
                         "subscriber_settle_ms=%.1f subscriber_count=%d",
                         total_bytes,
@@ -425,6 +560,8 @@ class _Vits2TTSNode(Node):
                         elapsed / audio_seconds,
                         CHUNK_BYTES,
                         FRAME_INTERVAL_MS,
+                        max_frame_gap * 1000.0,
+                        PREBUFFER_FRAMES,
                         FIRST_FRAME_DELAY_MS,
                         (subscriber_wait_seconds or 0.0) * 1000.0,
                         (subscriber_settle_seconds or 0.0) * 1000.0,
@@ -447,6 +584,17 @@ class _Vits2TTSNode(Node):
                     self._publish_eof()
                 subscriber_gate_cancel.set()
                 subscriber_gate_thread.join(timeout=0.1)
+                # The synth thread holds the adapter lock for the whole
+                # generator; leaving it running would make the next utterance
+                # block on it inside synthesize_stream.
+                utterance_abort.set()
+                if synth_thread is not None and synth_thread.is_alive():
+                    synth_thread.join(timeout=5)
+                    if synth_thread.is_alive():
+                        log.error(
+                            "[vits2_tts_trt] synth thread did not exit; the "
+                            "adapter lock may still be held"
+                        )
 
     def status(self):
         return {


### PR DESCRIPTION
## 问题

TTS 推理速度已经很快（RTF 良好），但播放仍**偶发卡顿**：web 监控试听能听到断续，机器人 `speak` 上间断更明显。

定位后是**三层各自独立的缓冲缺陷**。本 PR 修 perception 与 agent-core 两层（两个 TTS 引擎都覆盖）；driver 层的放大效应在 phanthymotus-driver#207（另一个 repo，必须独立）。

---

# 第一层 · perception

## `vits2_trt`（当前 `config.yaml` 部署的引擎）：合成与发帧串行

`adapter.py` 的 `synthesize_stream` 每个文本 chunk 调一次 `self._engine.synthesize()`，**阻塞返回整段 PCM** 后才切帧 yield。而 `plugin.py` 的 worker 在**同一个线程**里边消费这个 generator 边按 `FRAME_INTERVAL_MS=70` 节流发布。

⇒ 合成 chunk N+1 期间**一帧都不发**。下游唯一余量是「100ms 帧每 70ms 发一个」攒出的 **30ms/帧**，而 `chunking.py` 贪心把文本填满 `max_chunk_tokens=256`，单 chunk 合成耗时远超这点余量。

雪上加霜的 rebase：

```python
if target < now - frame_interval:
    started = now - frames_sent * frame_interval   # 落后就重定基准
```

落后时把已积累的 lead **一次抹平**，所以卡过一次后下一次抖动必定再卡。此外该引擎完全没有 prebuffer（sherpa 分支有），起播余量为 0。

**改动**

- **合成前瞻**：新增 `vits2-trt-synth` 生产者线程，切帧后写入 bounded queue（`MIX_VITS_SYNTH_QUEUE_FRAMES=200`）；worker 只做 get + 节流发布。chunk N+1 的 TRT 推理与 chunk N 的发布重叠。
- **起播 cushion**：`MIX_VITS_PREBUFFER_FRAMES=5`（500ms）攒够后一次性 burst。
- **rebase 不再抹平 lead**：落后时立即发布来追赶（70ms 的 schedule 本身快于 100ms 的音频），仅在连续 burst 超过 `MIX_VITS_MAX_BURST_FRAMES=20` 时才放弃 cushion —— 上限是为了不冲垮 agent-core 的 depth-20 BEST_EFFORT reader。
- **埋点**：日志新增 `max_frame_gap_ms`，直接量化上述断流。
- **线程安全**：synth 线程持 adapter 锁覆盖整个 generator，新增 `utterance_abort` 保证任何退出路径（含 consumer 异常）都能释放它，否则会死锁后续所有 utterance。

## `sherpa_onnx`：段间断流 + cushion 永不增长

**它没有上面那个句内断流** —— adapter 的 `generate()` 一次算完整段返回，段内没有东西可以重叠。问题在上一层：

**1. 280 字切分切出了独立的 utterance。** `enqueue()` 把每段单独入队 → 各自跑一次 `generate()`、各自 prebuffer、**各自发一个 EOF**。长文本每 280 字就给下游一个「本句结束」并重置节流时钟，段间是一次完整合成、期间一帧不发。切分移进 worker：一个 queue item = 一个 utterance = 一个 EOF = 一个 ACP action，pacing 和 prebuffer 跨段延续。

**2. 合成移到独立线程**，段 N+1 与段 N 的播放重叠。

**3. 节流 100ms → 70ms。** 原来 `FRAME_DURATION = 0.1`，100ms 音频每 100ms 发一个 —— cushion 永远不超过起播那点 prebuffer，任何超过它的抖动都是**永不愈合**的空洞。这里改快是安全的，恰恰因为 adapter 非流式：整段音频在发帧前已存在，不存在追过合成的风险。`PREBUF_FRAMES` 3 → 5 对齐。

**4. `on_speaking` hook 移出发帧循环。** 原来是循环里的同步 `urlopen(timeout=2)`，且在 `t0` latch **之后**才发 —— 请求耗时被算进节流预算，卡一下则 prebuffer 之后每帧都已迟了。改走 `fire_hook()`（daemon 线程）。顺带：原来硬编码 `https://localhost:15678`，忽略 `AGENT_CORE_URL`。

**5. 三个 bug**

| 位置 | 问题 |
|---|---|
| `was_interrupted` | 在 flag 被 `clear()` **之后**才读，恒为 `False` → 被打断的 utterance 上报 ACP `completed` 而非 `cancelled` |
| `_instance_configs` | 全文件只有一处读、**无任何赋值** → 带 `instance_id` 的 `speak` 在没有运行节点时抛 `AttributeError`。且本就无 per-instance 配置可读（`config` 会剥掉 `instance_id`、全局写 `self._cfg`），删掉死分支 |
| `interrupt()` / `stop()` | 清队列时不回 ACP，agent-core 的 barrier 为每个丢掉的 action 干等到超时。补 `_complete_discarded_actions()`，与 vits2 分支一致 |

---

# 第二层 · agent-core

## 浏览器：预缓冲只生效一次

`audio.js` 的 `_prebufQueue` 只在 `_startPlay()` 设置，首次 flush 后永久置 `null`；欠载处理只给 `currentTime + 0.05`。

⇒ 第一句正常（有预缓冲），**第 2..N 句起播余量只有 50ms**，而生产端每 100ms 只送 100ms 音频。任何 >50ms 抖动就是一个可听空洞，且恢复后仍是零余量。而 `AUDIO_EOF_MAGIC`（明确的句边界信号）被解析出来只用于改 label 就丢掉了。

- **EOF 重装预缓冲**：先 flush（短于 `_PREBUF_CHUNKS` 的句子否则会被丢掉不播），再重新装填。`_nextStartTime` 特意不重置 —— 它是已交给音频线程的音频末端，重置会让下一句盖在上一句还在播的尾巴上。
- `_PREBUF_CHUNKS` 3 → 5，欠载余量 0.05 → 0.20。
- **封顶前向漂移** 1.5s：relay 的 per-consumer 队列很深，突发 flush 会把每个 chunk 连续排到未来，延迟单调累积且永不回收。
- **波形重绘降载**：`document.hidden` 或 ring 未变化时跳过。该 rAF 循环原本无条件 60fps 跑满，与 `_scheduleChunk` 抢同一个主线程。

## `inspection.py`：事件循环上的同步 SQLite

`_push` 在事件循环上同步跑 `commit_spans` 和一个 `LIKE 'tool:tts%'` 扫描。`sherpa` **每句结束都发** perf span，于是每句尾都阻塞所有 WebSocket 发送（含音频），正好在播放余量最小的时刻。移到 `asyncio.to_thread`。

（`vits2` 不发 perf span，所以这一项在当前部署下不触发；但它对所有引擎、所有 topic 都有好处。）

---

## 验证

`perception/tests`：**172 passed, 1 skipped**。

> 注：`CLAUDE.md` 写「No dedicated test suite exists」是错的，`perception/tests/` 有 10 个测试文件。本地跑需要 `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1`，否则全局装的 `fugue_test` 插件会让 collection 失败。

三处 fake-clock 仿真（都是用 AST 抽出**真实**函数来跑，不是复制逻辑）：

**vits2 节奏** —— 起播 500ms cushion（原 0）、稳态 70ms 恒定、1s 停顿后追赶恢复到 1.28s cushion、5s 停顿时 burst 精确截断在 20 帧。

**浏览器**（fake AudioContext 驱动真实 `audio.js`）

| | 修复前 | 修复后 |
|---|---|---|
| 第 2 句起播余量 | 50ms | **700ms** |
| 300ms 抖动下的空洞 | 有 | **无** |
| 短句（2 帧 < PREBUF 5） | 被丢弃 | **EOF 时播出** |

**sherpa**（3 段 × 4s 音频，每段 1.2s 合成）

| | 修复前 | 只改节流 | 本 PR |
|---|---|---|---|
| EOF 标记数 | 3 | 1 | **1** |
| 段边界空洞 | 1.2s × 2 | 1.2s × 2 | **无** |
| cushion 走向 | 恒定 | 增长 | 0.1s → 3.95s |

真机试听待验证：build `perception` + `core` 两个镜像，`docker logs | grep "server delivery"` 看 `max_frame_gap_ms` 应稳定在 70±10，然后在 dashboard 上连续触发多句、重点听第 2、3 句开头。

🤖 Generated with [Claude Code](https://claude.com/claude-code)