### PR TITLE
fix(tts): stop over-delivering frames; never rewind the playback schedule

### DIFF
--- a/agent-core/web/js/renderers/audio.js
+++ b/agent-core/web/js/renderers/audio.js
@@ -42,7 +42,8 @@ export const AudioRenderer = {
   _sources:       null,
   _PREBUF_CHUNKS: 5,     // 首包预载：攒够 5 个 chunk (~500ms) 再开始播放
   _UNDERRUN_LEAD: 0.20,  // 欠载重启时给出的余量，秒
-  _MAX_LEAD:      1.5,   // 允许领先播放头的上限，秒
+  _MAX_LEAD:      1.5,   // 允许领先播放头的上限，超过则丢帧（绝不回拨时间轴）
+  _dropped:       0,     // 因超前而丢弃的帧数
   _drawnPos:      -1,
 
   mount(container) {
@@ -77,6 +78,7 @@ export const AudioRenderer = {
     this._writePos = 0;
     this._drawnPos = -1;
     this._sources = new Set();
+    this._dropped = 0;
 
     this._raf = requestAnimationFrame(() => this._draw());
   },
@@ -246,18 +248,25 @@ export const AudioRenderer = {
     // Schedule playback time
     const currentTime = ctx.currentTime;
     if (this._nextStartTime < currentTime) {
-      // Underrun. The old +0.05 here left a 50ms lead as the *permanent*
-      // steady-state margin against a producer that sends 100ms of audio per
-      // 100ms of wall clock, so the next delay over 50ms gapped again — and
-      // again. _UNDERRUN_LEAD gives the recovery something to work with.
+      // Underrun — every scheduled buffer has already finished, so this only
+      // ever moves the schedule *forward*. The old +0.05 here left a 50ms lead
+      // as the permanent steady-state margin, so the next delay over 50ms
+      // gapped again, and again. _UNDERRUN_LEAD gives the recovery something to
+      // work with.
       this._nextStartTime = currentTime + this._UNDERRUN_LEAD;
     } else if (this._nextStartTime - currentTime > this._MAX_LEAD) {
-      // Too far ahead. The relay queues frames (agent-core keeps a very deep
-      // per-consumer queue), so a stall followed by a flush arrives as a burst
-      // and every chunk gets appended contiguously into the future — latency
-      // that grows monotonically and is never recovered. Drop back rather than
-      // drift; one seam here beats playing minutes behind live.
-      this._nextStartTime = currentTime + this._MAX_LEAD;
+      // Too far ahead. Drop this chunk rather than reschedule: _nextStartTime is
+      // the end of audio already handed to the audio thread, so assigning
+      // `currentTime + _MAX_LEAD` here — which is what this used to do — placed
+      // the next buffer *inside* the previous one. That is what made playback
+      // overlap and run fast: once the lead was pinned at the cap, every frame
+      // was rewound onto the one before it, so 100ms of audio played every 70ms.
+      // Advancing only by `+= duration` makes contiguity structural.
+      this._dropped = (this._dropped || 0) + 1;
+      if (this._label) {
+        this._label.textContent = `● 音频流  丢帧 ${this._dropped}（缓冲超前）`;
+      }
+      return;
     }
 
     source.start(this._nextStartTime);

--- a/perception/plugins/tts.py
+++ b/perception/plugins/tts.py
@@ -28,15 +28,16 @@ PCM_FRAME_S = CHUNK_BYTES / (SAMPLE_RATE * 2)  # 0.1s of audio per frame
 
 # Frames held back before pacing starts, then published in one burst, so the
 # consumer begins with a real cushion. 5 frames = 500ms, matching the
-# vits2_tts_trt engine's MIX_VITS_PREBUFFER_FRAMES default.
+# vits2_tts_trt engine's MIX_VITS_PREBUFFER_FRAMES default. This — not the pacing
+# interval — is where the downstream margin comes from.
 PREBUF_FRAMES = 5
-# Deliberately shorter than PCM_FRAME_S: sending 100ms frames every 70ms accrues
-# 30ms of cushion per frame, so downstream keeps building margin instead of
-# living on whatever it started with. Pacing at exactly PCM_FRAME_S — what this
-# engine used to do — means the cushion never grows and every jitter spike above
-# it is an audible gap. Safe here because this adapter synthesizes the whole
-# utterance before publishing anything, so there is no risk of outrunning it.
-FRAME_INTERVAL_S = 0.07
+# Pace at exactly the audio each frame carries. Anything shorter over-delivers
+# forever, and over-delivery has no safe landing on a live consumer: it either
+# buffers without bound or has to discard audio. Briefly setting this to 0.07s
+# (matching what the vits2 engine then did) accrued 30ms of surplus per frame
+# until the browser player hit its lead cap, rewound its own schedule into audio
+# it had already queued, and played back overlapped and 1.43x too fast.
+FRAME_INTERVAL_S = PCM_FRAME_S
 if FRAME_INTERVAL_S > PCM_FRAME_S:
     log.warning(
         "[tts] FRAME_INTERVAL_S=%.3fs is slower than the %.3fs of audio each "

--- a/perception/plugins/vits2_tts_trt/plugin.py
+++ b/perception/plugins/vits2_tts_trt/plugin.py
@@ -57,14 +57,21 @@ def _env_int(name: str, default: int, low: int, high: int) -> int:
     return value
 
 
-FRAME_INTERVAL_MS = _env_int("MIX_VITS_FRAME_INTERVAL_MS", 70, 0, 1000)
+# Pace at exactly the audio duration each frame carries. It used to be 70ms for
+# a 100ms frame, which over-delivers by 1.43x *forever*: that was this engine's
+# way of slowly accruing a downstream cushion at 30ms/frame back when it had no
+# prebuffer, and it cost an unbounded lead. PREBUFFER_FRAMES now hands the
+# consumer its whole cushion up front, so the accrual is pure surplus — and
+# surplus with no end has no safe landing. A consumer can only absorb it by
+# buffering without bound or by discarding audio; the browser player tried to
+# cap its lead instead and rewound its own schedule into audio it had already
+# queued, which played back overlapped and 1.43x too fast.
+FRAME_INTERVAL_MS = _env_int("MIX_VITS_FRAME_INTERVAL_MS", int(PCM_FRAME_MS), 0, 1000)
 FIRST_FRAME_DELAY_MS = _env_int("MIX_VITS_FIRST_FRAME_DELAY_MS", 0, 0, 1000)
 # Frames held back before pacing starts, then published in one burst so every
-# consumer begins with a real cushion instead of zero. Without it the only
-# margin downstream ever has is the (PCM_FRAME_MS - FRAME_INTERVAL_MS) = 30ms
-# per frame that the schedule accrues, so the opening of every utterance is
-# one jitter spike away from an audible gap. The sherpa engine has always done
-# this (plugins/tts.py PREBUF_FRAMES); this is the same idea on this engine.
+# consumer begins with a real cushion instead of zero. This — not the pacing
+# interval — is where the downstream margin comes from. The sherpa engine has
+# always done this (plugins/tts.py PREBUF_FRAMES); same idea on this engine.
 PREBUFFER_FRAMES = _env_int("MIX_VITS_PREBUFFER_FRAMES", 5, 0, 100)
 # Depth of the synthesis→publish handoff queue, in frames. Bounds memory while
 # still letting TensorRT run a whole text chunk ahead of the paced publisher.
@@ -77,12 +84,18 @@ MAX_BURST_FRAMES = _env_int("MIX_VITS_MAX_BURST_FRAMES", 20, 1, 200)
 SUBSCRIBER_WAIT_MS = _env_int("MIX_VITS_SUBSCRIBER_WAIT_MS", 5000, 0, 60000)
 SUBSCRIBER_POLL_MS = _env_int("MIX_VITS_SUBSCRIBER_POLL_MS", 10, 1, 1000)
 SUBSCRIBER_SETTLE_MS = _env_int("MIX_VITS_SUBSCRIBER_SETTLE_MS", 500, 0, 5000)
-ALLOW_FAST_DELIVERY = os.getenv("MIX_VITS_ALLOW_FAST_DELIVERY", "1") == "1"
+# Off by default: sending faster than realtime has no safe landing on a live
+# consumer. It either buffers without bound or has to discard audio, and the
+# browser player's attempt to bound its lead instead produced overlapped,
+# 1.43x-fast playback. Only useful for an offline benchmark that drains as fast
+# as it can, so it must be asked for explicitly.
+ALLOW_FAST_DELIVERY = os.getenv("MIX_VITS_ALLOW_FAST_DELIVERY", "0") == "1"
 if FRAME_INTERVAL_MS < PCM_FRAME_MS and not ALLOW_FAST_DELIVERY:
     log.warning(
         "[vits2_tts_trt] MIX_VITS_FRAME_INTERVAL_MS=%d sends %.0fms PCM frames "
-        "faster than realtime; pacing at %.0fms instead (set "
-        "MIX_VITS_ALLOW_FAST_DELIVERY=1 for an offline benchmark)",
+        "faster than realtime, which a live consumer cannot absorb; pacing at "
+        "%.0fms instead (set MIX_VITS_ALLOW_FAST_DELIVERY=1 for an offline "
+        "benchmark)",
         FRAME_INTERVAL_MS, PCM_FRAME_MS, PCM_FRAME_MS,
     )
     FRAME_INTERVAL_MS = int(PCM_FRAME_MS)


### PR DESCRIPTION
## 症状

#140 合并后：**播放越来越快、语音重叠，且与引擎无关**。

用复现 harness（fake AudioContext 驱动真实 `audio.js`，按服务端真实节奏喂 85 帧）：

```
overlapping boundaries: 44   first at frame 41   worst -30.0ms
audio delivered: 8.50s   occupies timeline: 7.20s   → effective rate 1.181x
lead at end: 1600ms (cap 1500ms)
```

这是我在 #140 里引入的回归。

## 成因

**1. 服务端永久超速发送 1.43×**

两个引擎都是「100ms 的帧每 70ms 发一个」。这原本是 vits2 在**没有 prebuffer** 时用每帧 30ms 富余慢慢给下游攒 cushion 的手段，代价是 lead 无上限增长。

#140 加了 5 帧 prebuffer burst —— cushion 起播就给足了，那个累积变成**纯冗余**；#140 同时把 sherpa 从 100ms 改成 70ms 去"对齐"，于是冗余变成了**两个引擎共有**，这就是"与模型无关"的原因。

**2. 致命的一半：上限是用「往回拨」实现的**

```js
} else if (this._nextStartTime - currentTime > this._MAX_LEAD) {
  this._nextStartTime = currentTime + this._MAX_LEAD;   // ← 往回拨
}
```

但 `_nextStartTime` 是**已经交给音频线程的音频末端**。往回拨等于把下一个 buffer 排进上一个还在排队播放的区间里。

lead 从 500ms 起每帧 +30ms，约第 40 帧撞上限，此后**每一帧都被拨回到上一帧身上**：相邻 buffer 重叠 30ms，100ms 音频按 70ms 播出 —— 加速和重叠同时出现。

**一般性结论**：超速发送对一个实时消费者**没有安全落点** —— 只能无界缓冲，或者丢音频，没有第三条路。用「把时间轴往回移」来限制 lead 两者都不做，所以只能重叠。这是我设计上的错误。

## 修复

**perception 两个引擎：按帧时长精确节流**（`PCM_FRAME_MS` / `PCM_FRAME_S`）。

cushion 继续由 prebuffer 提供；追赶 burst 保留 —— 它**只在落后时触发**，且只追到 schedule 为止，不会超发。`MIX_VITS_ALLOW_FAST_DELIVERY` 默认改为 **off**，想为 benchmark 重新开启超速发送必须显式声明。

**agent-core web：超过上限时丢掉这一帧，而不是重排。**

`_nextStartTime` 现在只能通过 `+= duration` 前进 —— 连续性成为**结构性保证**，而不是依赖算术去维持。丢帧数计入卡片 label，不让它变成又一个静默行为。

欠载分支保留不动：它只在**已排期音频全部播完**时触发（`_nextStartTime < currentTime`），是向前移动，安全。

## 验证

| 场景 | overlaps | 速率 | lead |
|---|---|---|---|
| **正常路径**（服务端 100ms） | **0** | **1.000×** | 恒定 500ms，不增长 → 上限永不触发 |
| 有人强行设回 70ms | **0** | **1.000×** | 顶在 1500ms，85 帧丢 13 帧（诚实代价） |

回归全部重跑通过：多句 cushion（第 2 句 700ms）、短句 EOF flush、⏸ 停止已排期音频（20 个全部 `stop()`）、波形绘制。`perception/tests` **172 passed, 1 skipped**。

## 读日志的人注意

`max_frame_gap_ms` 现在会显示 **≈100** 而不是 ≈70。**那是修复本身，不是回归** —— 该指标衡量的是相邻发帧间隔，而正确的间隔就是一帧音频的时长。

真机试听待验证（重点听 4 秒之后，那是原 bug 的触发点）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)