### PR TITLE
fix(web): 部署服务面板中当前版本号不再被目标版本挤占

### DIFF
--- a/agent-core/web/css/style.css
+++ b/agent-core/web/css/style.css
@@ -1987,7 +1987,8 @@ html, body {
 .svc-row-version-line {
   display: flex;
   align-items: center;
-  gap: 6px;
+  flex-wrap: wrap;          /* 版本太长时「→ 新版本」整块换行，而不是把当前版本挤没 */
+  gap: 2px 6px;
   min-width: 0;
 }
 .svc-row-version {
@@ -1999,6 +2000,14 @@ html, body {
   white-space: nowrap;
   min-width: 0;
 }
+/* 箭头和新版本号必须同进同退，否则换行会把「→」单独留在上一行 */
+.svc-row-update {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  max-width: 100%;
+}
 .svc-row-arrow {
   font-size: 12px;
   color: var(--text-dim);
@@ -2009,7 +2018,10 @@ html, body {
   font-family: var(--font-mono);
   color: var(--accent);
   font-weight: 600;
-  flex-shrink: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
 }
 
 .svc-row-actions {

--- a/agent-core/web/js/deploy-panel.js
+++ b/agent-core/web/js/deploy-panel.js
@@ -416,7 +416,7 @@ function _svcRowHTML({ item, id, s, latestTag, currentTag, hasUpdate }) {
         <div class="svc-row-version-line">
           <span class="svc-row-version">${versionText}</span>
           ${item._orphan ? '<span class="svc-ver-channel" title="该镜像与本机架构不匹配，或已从资源中心下架">架构不匹配</span>' : ''}
-          ${hasUpdate ? `<span class="svc-row-arrow">→</span><span class="svc-row-new-version">${latestTag}</span>` : ''}
+          ${hasUpdate ? `<span class="svc-row-update"><span class="svc-row-arrow">→</span><span class="svc-row-new-version">${latestTag}</span></span>` : ''}
         </div>
       </div>
       <div class="svc-row-actions">${actions}</div>


### PR DESCRIPTION
## 问题

「部署服务」弹窗里，可更新的服务当前版本号被目标版本挤占：Agent Core 显示成 `release.2608…`，Perception Stack 的当前版本直接被压到 0 宽、目标版本 `release.260826.d88fbbc-jetson-jp6.1` 还溢出到操作按钮下面。

## 原因

`.svc-row-version-line` 是单行 flex，`.svc-row-new-version` 带 `flex-shrink: 0`，而 `.svc-row-version` 可收缩 —— 空间不够时全部由当前版本让位。Perception 的 tag 带 `-jetson-jp6.1` 后缀更长，压到 0 宽后仍不够，于是溢出。

## 改动

- `js/deploy-panel.js`：`→` 与新版本号包进 `.svc-row-update`，换行时同进同退，避免箭头被单独留在上一行
- `css/style.css`：版本行改 `flex-wrap: wrap`（`gap: 2px 6px`），新版本号去掉 `flex-shrink: 0`、补 `min-width: 0` 与 ellipsis

## 验证

用真实 `style.css` 渲染静态页量了各宽度下的几何（测试页测完已删除）：

| 容器宽度 | 结果 |
|---|---|
| 700px | Agent Core 单行；Perception 换行，两个版本号都完整 |
| 520 / 420px | 均换行，未截断（Perception 420px 起 ellipsis） |
| 340px | 两者各自 ellipsis |

所有宽度下版本行右边界都没有越过操作按钮区左边界（即不再溢出）。

另已把两个文件热替换进 Orin 6（`10.100.121.16`）的 agent-core 容器实机确认；copy 前 diff 过容器内原文件，与本地仅差本次改动。

纯前端静态资源改动，无需改后端或重建流程。

🤖 Generated with [Claude Code](https://claude.com/claude-code)