### PR TITLE
docs(pr_review): 修正厂商名拼写 PNPbotics → PNDbotics

### DIFF
--- a/PR_REVIEW_AGENT.md
+++ b/PR_REVIEW_AGENT.md
@@ -476,7 +476,7 @@ which diverges more than once:
 
 For a new driver the reference is chosen by shape — `unitree/go1` for structure,
 `robotera/q5_bundle` for decomposition, `dji/mavic3e` for a native-SDK bridge,
-`pnpbotics/adam` for gRPC, `unitree/go2` for SLAM. `deep_robotics/lynx_m20` and
+`pndbotics/adam` for gRPC, `unitree/go2` for SLAM. `deep_robotics/lynx_m20` and
 `unitree/g1/device.py` are deliberately excluded as models.
 
 ### Sandbox

--- a/agents/pr_review/components.py
+++ b/agents/pr_review/components.py
@@ -37,7 +37,7 @@ DRIVER_REFERENCES = [
 # Extra references picked when the PR's shape suggests them.
 DRIVER_REFERENCE_HINTS = [
     (("dji/",), "dji/mavic3e", "native-SDK C bridge (psdk_bridge) pattern"),
-    (("grpc", "proto"), "pnpbotics/adam", "gRPC vendor-SDK pattern"),
+    (("grpc", "proto"), "pndbotics/adam", "gRPC vendor-SDK pattern"),
     (("lidar", "slam", "pointcloud", "icp", "mapping"),
      "unitree/go2", "SLAM / spatial reference"),
 ]

--- a/agents/pr_review/rules/common.md
+++ b/agents/pr_review/rules/common.md
@@ -50,7 +50,7 @@ https://agi-phanthy-dev-1252788780.cos.ap-beijing.myqcloud.com/public/
 The established patterns, in rough order of preference:
 
 1. **Dockerfile `ARG` pointing at COS** — how `unitree/g1`, `unitree/go2`,
-   `unitree/r1` and `pnpbotics/adam` all obtain `cyclonedds-0.10.5.tar.gz`.
+   `unitree/r1` and `pndbotics/adam` all obtain `cyclonedds-0.10.5.tar.gz`.
    This is the right answer for a driver needing an SDK tarball.
 2. **A manifest entry downloaded at runtime** — `perception/utils/model_downloader.py`
    does this for every ASR/TTS/KWS/VAD model.

--- a/agents/pr_review/rules/driver.md
+++ b/agents/pr_review/rules/driver.md
@@ -112,7 +112,7 @@ Pick the closest existing driver and check the new one against it. Good models:
 - `robotera/q5_bundle/` — best decomposition, one module per capability
 - `x-humanoid/tianyi2.0/` — largest complete bundle (30 plugins), has tests
 - `unitree/r1/`, `noetix/bumi/` — compact, conventional; good for a small driver
-- `dji/mavic3e/` — native-SDK C bridge; `pnpbotics/adam/` — gRPC vendor SDK;
+- `dji/mavic3e/` — native-SDK C bridge; `pndbotics/adam/` — gRPC vendor SDK;
   `unitree/go2/` — SLAM and spatial work
 
 Not models to copy: `deep_robotics/lynx_m20/` (empty `plugins:`, no


### PR DESCRIPTION
跟随 phanthymotus-driver#216 的目录重命名 `pnpbotics/adam` → `pndbotics/adam`。

厂商正式名称是 **PNDbotics**（派得机器人）。本仓库只有 PR review agent 的参考路径与规则文档引用了旧拼写：

- `PR_REVIEW_AGENT.md`
- `agents/pr_review/components.py`
- `agents/pr_review/rules/common.md`
- `agents/pr_review/rules/driver.md`

`docs/architecture.svg` 里的 `pnp-robotics.svg` 是**另一家**公司 PNP ROBOTICS，未改动。

关联：phanthymotus-driver#216

🤖 Generated with [Claude Code](https://claude.com/claude-code)