### PR TITLE
fix(channel): let viewer-role turns use read-only system tools

### DIFF
--- a/agent-core/src/event/llm.py
+++ b/agent-core/src/event/llm.py
@@ -167,13 +167,23 @@ def _missed_channel_reply_warning(trigger_event: dict, replied_message_ids: set[
 
 _BOT_READ_ONLY_SYSTEM_TOOLS = frozenset({'finish'})
 
+# viewer 是已注册的合法 ACL 用户（不是可以随便伪造身份的群里 Bot），"只读" 的定义
+# 可以松一档：纯信息检索、没有副作用的系统工具（联网搜索、历史/记忆检索、原始输入
+# 查询）都算读，不算 mutate。Bot 门禁维持只给 finish，因为群里任何人都能顶一个
+# Bot 身份，是更弱的信任边界。
+_VIEWER_READ_ONLY_SYSTEM_TOOLS = _BOT_READ_ONLY_SYSTEM_TOOLS | frozenset({
+    'WebSearch', 'search_history', 'memory_recall', 'raw_input_info',
+})
 
-def _restricted_channel_tool_allowed(name: str) -> bool:
+
+def _restricted_channel_tool_allowed(name: str, *, bot_restricted: bool = True) -> bool:
     """Shared allow-list for turns that must not mutate or actuate: untrusted-bot
     Channel turns, and (see _viewer_channel_restricted) viewer-role human Channel
-    turns. May read state and reply, nothing else."""
+    turns. May read state and reply, nothing else — viewer additionally gets the
+    read-only system tools (search, history/memory recall)."""
     if not name.startswith('mcp__'):
-        return name in _BOT_READ_ONLY_SYSTEM_TOOLS
+        allowed = _BOT_READ_ONLY_SYSTEM_TOOLS if bot_restricted else _VIEWER_READ_ONLY_SYSTEM_TOOLS
+        return name in allowed
     if name == 'mcp__channel__channel_reply':
         return True
     parts = name.split('__')
@@ -929,11 +939,11 @@ class Event:
         if tool_restricted:
             system_tools = [
                 tool for tool in system_tools
-                if _restricted_channel_tool_allowed(tool['schema']['name'])
+                if _restricted_channel_tool_allowed(tool['schema']['name'], bot_restricted=bot_restricted)
             ]
             bound_schemas = [
                 schema for schema in bound_schemas
-                if _restricted_channel_tool_allowed(schema['name'])
+                if _restricted_channel_tool_allowed(schema['name'], bot_restricted=bot_restricted)
             ]
         all_tool_list = (
             [{'type': 'function', 'function': t['schema']} for t in system_tools]
@@ -1152,7 +1162,7 @@ class Event:
                     'payload': {'tool': name, 'args': args},
                 })
 
-                if tool_restricted and not _restricted_channel_tool_allowed(name):
+                if tool_restricted and not _restricted_channel_tool_allowed(name, bot_restricted=bot_restricted):
                     reason = 'an untrusted bot source' if bot_restricted else 'a viewer-role source'
                     result = (
                         f'Error: this turn is tool-restricted ({reason}) and cannot call '

--- a/agent-core/src/start.py
+++ b/agent-core/src/start.py
@@ -256,8 +256,10 @@ def _register_core_mcp(silent=False):
                     'what this particular person/chat actually said; other people\'s chats may appear '
                     'elsewhere in your shared history and must not be attributed to this one. '
                     'If the triggering user_role is "viewer" (read-only), you will only be offered '
-                    'sensor/resource tools plus this one — actuator/processor/delegated tools are rejected; '
-                    'reply with what you can read, and say so if the request needs an action you cannot take.'
+                    'sensor/resource tools, read-only tools (WebSearch, search_history, memory_recall, '
+                    'raw_input_info) plus this one — actuator/processor/delegated tools are rejected; '
+                    'reply with what you can read or look up, and say so if the request needs an action '
+                    'you cannot take.'
                 ),
                 'inputSchema': {
                     'type': 'object',

--- a/agent-core/tests/test_channel_role_authorization.py
+++ b/agent-core/tests/test_channel_role_authorization.py
@@ -76,11 +76,19 @@ class ViewerRoleAuthorizationTest(unittest.TestCase):
             },
         }
         with mock.patch.dict(mcp_client.registry, registry, clear=True):
-            self.assertTrue(_restricted_channel_tool_allowed('finish'))
-            self.assertTrue(_restricted_channel_tool_allowed('mcp__channel__channel_reply'))
-            self.assertTrue(_restricted_channel_tool_allowed('mcp__device__camera'))
-            self.assertFalse(_restricted_channel_tool_allowed('mcp__device__navigate'))
-            self.assertFalse(_restricted_channel_tool_allowed('mcp__device__load_map'))
+            self.assertTrue(_restricted_channel_tool_allowed('finish', bot_restricted=False))
+            self.assertTrue(_restricted_channel_tool_allowed('mcp__channel__channel_reply', bot_restricted=False))
+            self.assertTrue(_restricted_channel_tool_allowed('mcp__device__camera', bot_restricted=False))
+            self.assertFalse(_restricted_channel_tool_allowed('mcp__device__navigate', bot_restricted=False))
+            self.assertFalse(_restricted_channel_tool_allowed('mcp__device__load_map', bot_restricted=False))
+
+    def test_viewer_can_use_read_only_system_tools_but_bot_cannot(self):
+        for name in ('WebSearch', 'search_history', 'memory_recall', 'raw_input_info'):
+            self.assertTrue(_restricted_channel_tool_allowed(name, bot_restricted=False), name)
+            self.assertFalse(_restricted_channel_tool_allowed(name, bot_restricted=True), name)
+        # Still no mutating desktop tools for either — read-only means read-only.
+        for name in ('Bash', 'Write', 'Edit', 'WebFetch', 'subagent_spawn'):
+            self.assertFalse(_restricted_channel_tool_allowed(name, bot_restricted=False), name)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Background

Follow-up to #134, which merged while this fix was still in review — this couldn't be pushed onto that branch anymore, so it's a fresh PR against `main`.

`_restricted_channel_tool_allowed()` (added in #134's viewer-role enforcement work) only allowed `finish` among non-`mcp__` system tools. That meant viewer-role Channel turns were blocked not just from actuator/processor tools, but also from `WebSearch`, `search_history`, `memory_recall`, and `raw_input_info` — none of which mutate anything or have side effects, so they fit "viewer: read-only" fine. This surfaced concretely: a Feishu user asking the bot to look up the weather got told "I'm in read-only mode" because `WebSearch` wasn't in the turn's tool list at all.

## Change

Split the allow-list by restriction kind instead of sharing one list:
- Untrusted-bot Channel turns keep the strict `finish`-only list — anyone in a shared group chat can spoof a bot identity, so this stays maximally conservative.
- Viewer-role human turns (registered ACL users, not spoofable the same way) additionally get the read-only system tools: `WebSearch`, `search_history`, `memory_recall`, `raw_input_info`.

Updated the `channel_reply` tool description so the model knows viewer turns can search/look up, not just read sensors and reply.

## Verification

- [x] `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest tests -q` — 83 passed, 1 pre-existing unrelated failure (missing `lark_oapi` dependency in this environment).
- [x] `python -m compileall -q agent-core/src agent-core/tests`