### PR TITLE
feat(account): require nickname on register, show local RC token in 我的 modal

### DIFF
--- a/agent-core/src/api/account.py
+++ b/agent-core/src/api/account.py
@@ -90,14 +90,13 @@ async def register(req: RegisterRequest):
     而仪表盘是跨域调用、拿不到那个 cookie，所以注册成功后必须再走一次登录。
     """
     identifier = req.identifier.strip()
-    if not identifier or not req.password:
-        return {'code': 422, 'error': '请输入账号和密码'}
+    name = req.name.strip()
+    if not identifier or not req.password or not name:
+        return {'code': 422, 'error': '请输入账号、密码和昵称'}
     if len(req.password) < 8:
         return {'code': 422, 'error': '密码至少 8 位'}
 
-    body = {'identifier': identifier, 'password': req.password}
-    if req.name.strip():
-        body['name'] = req.name.strip()
+    body = {'identifier': identifier, 'password': req.password, 'name': name}
 
     result = await _rc('POST', '/api/auth/register', None, body)
     if not result['ok']:

--- a/agent-core/web/css/style.css
+++ b/agent-core/web/css/style.css
@@ -7503,6 +7503,29 @@ html, body {
   font-size: 11px;
   cursor: pointer;
 }
+.account-token-card {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+.account-token-value {
+  flex: 1;
+  min-width: 0;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.account-token-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-shrink: 0;
+}
+.account-token-reset { color: var(--red); }
 
 .account-form {
   display: flex;

--- a/agent-core/web/js/account.js
+++ b/agent-core/web/js/account.js
@@ -159,6 +159,7 @@ function _render() {
   const html = `
     ${_notice ? `<div class="account-notice">${_esc(_notice)}</div>` : ''}
     ${_user ? _renderIdentity() : _renderAuthForm()}
+    ${_renderTokenSection()}
     <div class="account-section-label">内容</div>
     <div class="settings-list account-entry-list">
       <button class="settings-item" data-entry="skills">
@@ -205,6 +206,24 @@ function _renderIdentity() {
     </div>`;
 }
 
+/** 登录后才有 token；单独一个 section，别再挤进 identity 卡片的元信息行里。 */
+function _renderTokenSection() {
+  const token = getRcToken();
+  if (!_user || !token) return '';
+  const shortToken = token.length > 20
+    ? `${token.slice(0, 10)}…${token.slice(-6)}`
+    : token;
+  return `
+    <div class="account-section-label">本机 Token</div>
+    <div class="account-card account-token-card">
+      <code class="account-token-value" title="${_esc(token)}">${_esc(shortToken)}</code>
+      <div class="account-token-actions">
+        <button class="account-copy-btn" data-copy="${_esc(token)}" title="复制完整 Token">复制</button>
+        <button class="account-link account-token-reset" data-action="reset-token" title="清除本机 Token 并重新登录">重置</button>
+      </div>
+    </div>`;
+}
+
 function _renderAuthForm() {
   const isRegister = _mode === 'register';
   return `
@@ -221,7 +240,7 @@ function _renderAuthForm() {
         <input type="password" name="password" placeholder="${isRegister ? '密码（至少 8 位）' : '密码'}"
                autocomplete="${isRegister ? 'new-password' : 'current-password'}" required
                ${isRegister ? 'minlength="8"' : ''}>
-        ${isRegister ? `<input type="text" name="name" placeholder="昵称（可选）" autocomplete="nickname">` : ''}
+        ${isRegister ? `<input type="text" name="name" placeholder="昵称" autocomplete="nickname" required>` : ''}
         ${_formError ? `<p class="account-form-error">${_esc(_formError)}</p>` : ''}
         <button type="submit" class="account-submit-btn" ${_busy ? 'disabled' : ''}>
           ${_busy ? '处理中…' : (isRegister ? '注册并登录' : '登录')}
@@ -297,6 +316,14 @@ function _onClick(e) {
     _notice = '';
     _mode = 'login';
     refreshAccount();
+  } else if (action === 'reset-token') {
+    // Token 是 Resource Center 签发的无状态 JWT，服务端不持有可撤销的会话记录，
+    // 所以"重置"只能清掉本机存的这一份——下次操作会引导重新登录换取新 token。
+    if (!confirm('重置后需要重新登录才能获得新的 Token，确定继续？')) return;
+    clearRcToken();
+    _notice = '';
+    _mode = 'login';
+    refreshAccount();
   } else if (action === 'to-register') {
     _mode = 'register'; _formError = ''; _render();
   } else if (action === 'to-login') {
@@ -315,7 +342,14 @@ async function _onSubmit(e) {
     identifier: form.identifier.value.trim(),
     password:   form.password.value,
   };
-  if (kind === 'register' && form.name) body.name = form.name.value.trim();
+  if (kind === 'register') {
+    body.name = form.name.value.trim();
+    if (!body.name) {
+      _formError = '请输入昵称';
+      _render();
+      return;
+    }
+  }
 
   _busy = true; _formError = ''; _render();
   try {


### PR DESCRIPTION
## Summary
- Registration now rejects a missing/blank nickname client- and server-side, matching the same fix already shipped on the Resource Center backend it proxies to.
- The 「我的」account modal gets a dedicated "本机 Token" section showing the device's Resource Center bearer token (`rc_token`), with copy and reset actions.
- 重置 clears the local token so the next action forces a fresh login — the token is a stateless JWT with no server-side revoke, so that's the only real "reset" available.

## Test plan
- [x] Verified via a static preview of `web/` with mocked `/api/auth/verify` and `/api/account/session` responses: register form now requires nickname, identity card + new token section render correctly, copy/reset buttons work.
- [ ] Smoke-test on a real device with ROS2 + Resource Center reachable (not possible from this dev machine).