### PR TITLE
feat(deploy): register per-image MCP card manifests with resource-center

### DIFF
--- a/deploy/build_actucore.sh
+++ b/deploy/build_actucore.sh
@@ -105,6 +105,9 @@ if ${PUSH_ENABLED} && [ -n "${RESOURCE_CENTER_API_KEY:-}" ]; then
     fi
     if [[ ! "${SYNC_CONFIRM}" =~ ^[Nn] ]]; then
         echo "Registering image to resource-center (${RESOURCE_CENTER_URL})..."
+        # cards 目前为空：actucore/plugins/ 还没有任何已注册的卡片（见
+        # actucore/main.py 的卡片注册区注释和 actucore/README.md）。第一个卡片落地时
+        # 把它加进这个数组，不要漏掉。
         HTTP_STATUS=$(curl -s -o /tmp/rc_register_resp.json -w "%{http_code}" \
             -X POST "${RESOURCE_CENTER_URL}/api/admin/register" \
             -H "Content-Type: application/json" \
@@ -118,7 +121,8 @@ if ${PUSH_ENABLED} && [ -n "${RESOURCE_CENTER_API_KEY:-}" ]; then
                 \"cpu_arch\": \"${CPU_ARCH}\",
                 \"name\": \"ActuCore\",
                 \"port\": 15730,
-                \"description\": \"执行模型层 — VLA 策略 / 导航 / 抓取 / locomotion / 全身控制，以 processor 卡片接入\"
+                \"description\": \"执行模型层 — VLA 策略 / 导航 / 抓取 / locomotion / 全身控制，以 processor 卡片接入\",
+                \"cards\": []
             }")
 
         if [ "${HTTP_STATUS}" = "200" ] || [ "${HTTP_STATUS}" = "201" ]; then

--- a/deploy/build_core.sh
+++ b/deploy/build_core.sh
@@ -74,6 +74,13 @@ if ${PUSH_ENABLED} && [ -n "${RESOURCE_CENTER_API_KEY:-}" ]; then
         echo "Registering image to resource-center (${RESOURCE_CENTER_URL})..."
         # acc_arch=agnostic 是硬要求：core 不依赖 CUDA，且必须在所有主机可见 —— 一旦被架构
         # 过滤掉，agent-core 的 api/system.py:_check_update_sync 会默默报「已是最新」。
+        #
+        # cards 与 src/start.py:_register_core_mcp() 里注册的两个内建 internal MCP 设备
+        # （AgentCore 的 decision_core，Channel 的 channel_request/channel_reply）手动保持
+        # 一致 —— 这些卡片不是走真实 MCP HTTP 进程暴露的，是 agent-core 启动时自己注册的，
+        # 新增/改名时记得同步这里。decision_core 的 type 是 controller（既不是可以绕过
+        # barrier 的 sensor/resource，也不是普通 actuator/processor，见
+        # src/event/llm.py 的 _needs_barrier）。
         HTTP_STATUS=$(curl -s -o /tmp/rc_register_resp.json -w "%{http_code}" \
             -X POST "${RESOURCE_CENTER_URL}/api/admin/register" \
             -H "Content-Type: application/json" \
@@ -85,7 +92,16 @@ if ${PUSH_ENABLED} && [ -n "${RESOURCE_CENTER_API_KEY:-}" ]; then
                 \"category\": \"core\",
                 \"acc_arch\": \"agnostic\",
                 \"cpu_arch\": \"arm64\",
-                \"name\": \"Agent Core\"
+                \"name\": \"Agent Core\",
+                \"cards\": [
+                    {\"name\": \"decision_core\", \"type\": \"controller\"},
+                    {\"name\": \"remote_mic\", \"type\": \"sensor\"},
+                    {\"name\": \"remote_message\", \"type\": \"sensor\"},
+                    {\"name\": \"remote_audio\", \"type\": \"sensor\"},
+                    {\"name\": \"remote_image\", \"type\": \"sensor\"},
+                    {\"name\": \"channel_request\", \"type\": \"sensor\"},
+                    {\"name\": \"channel_reply\", \"type\": \"actuator\"}
+                ]
             }")
 
         if [ "${HTTP_STATUS}" = "200" ] || [ "${HTTP_STATUS}" = "201" ]; then

--- a/deploy/build_perception.sh
+++ b/deploy/build_perception.sh
@@ -106,6 +106,9 @@ if ${PUSH_ENABLED} && [ -n "${RESOURCE_CENTER_API_KEY:-}" ]; then
     fi
     if [[ ! "${SYNC_CONFIRM}" =~ ^[Nn] ]]; then
         echo "Registering image to resource-center (${RESOURCE_CENTER_URL})..."
+        # cards 与 plugins/{asr,tts,vop,ocr}.py 里各自的 TOOLS 声明手动保持一致（全部
+        # type: processor，且都常开，见 config.yaml 的 enabled 默认值）。新增插件时
+        # 别忘了在这里补一行。
         HTTP_STATUS=$(curl -s -o /tmp/rc_register_resp.json -w "%{http_code}" \
             -X POST "${RESOURCE_CENTER_URL}/api/admin/register" \
             -H "Content-Type: application/json" \
@@ -118,7 +121,13 @@ if ${PUSH_ENABLED} && [ -n "${RESOURCE_CENTER_API_KEY:-}" ]; then
                 \"acc_arch\": \"${ACC_ARCH}\",
                 \"cpu_arch\": \"${CPU_ARCH}\",
                 \"name\": \"Perception Stack\",
-                \"description\": \"语音感知套件 — ASR 语音识别 + TTS 语音合成 + VAD 静音检测 + 唤醒词检测\"
+                \"description\": \"语音感知套件 — ASR 语音识别 + TTS 语音合成 + VAD 静音检测 + 唤醒词检测\",
+                \"cards\": [
+                    {\"name\": \"asr\", \"type\": \"processor\"},
+                    {\"name\": \"tts\", \"type\": \"processor\"},
+                    {\"name\": \"vop\", \"type\": \"processor\"},
+                    {\"name\": \"ocr\", \"type\": \"processor\"}
+                ]
             }")
 
         if [ "${HTTP_STATUS}" = "200" ] || [ "${HTTP_STATUS}" = "201" ]; then


### PR DESCRIPTION
## Summary
- Adds `cards: [{name, type}]` to the resource-center registration payload for `core`, `perception`, and `actucore` builds.
- `core`'s cards are its two internal MCP devices registered at startup in `src/start.py` (`decision_core` = new `controller` type, `remote_mic`/`remote_message`/`remote_audio`/`remote_image`, `channel_request`/`channel_reply`).
- `perception`'s cards are its 4 enabled processor plugins (asr/tts/vop/ocr).
- `actucore` sends `cards: []` — it has no plugins registered yet (empty `plugins/__init__.py`).

Companion changes: `phanthymotus-driver` (per-bundle `driver.yaml` cards + build.sh parser) and `resource-center` (schema/API/UI to store and render them).

## Test plan
- [x] Verified `build_core.sh`/`build_perception.sh`/`build_actucore.sh` payloads are valid JSON with the new field spliced in.
- [x] Verified resource-center renders Agent Core's 7 cards (5 sensor / 1 actuator / 1 controller) and Perception's 4 processor cards correctly after backfilling the DB with the same data these scripts will now send on next build.