### PR TITLE
fix(perception): bundle libnvdla_compiler.so so jp6.1 TensorRT survives a thin host BSP

### DIFF
--- a/perception/Dockerfile.jetson
+++ b/perception/Dockerfile.jetson
@@ -40,19 +40,23 @@ ARG PYPI_MIRROR APT_MIRROR JP_VERSION ENABLE_VITS2_TRT
 #                  at all (it happened to work only because the shell default
 #                  was hardcoded to 3.8) while jp6.1's sets 3.10. Asking python
 #                  is correct on any base, present or future.
+#   DLA_COMPILER_SO  COS key of the bundled libnvdla_compiler.so, or empty for a
+#                  line that does not need one (see the dla-fallback step).
 #
 # It is also a record: `docker exec <c> cat /etc/jetpack.env` says what line an
 # image was built for, which is otherwise guesswork from the tag alone.
 ARG SHERPA_GPU_WHEEL_511=jp511/sherpa_onnx-1.13.6+cuda-cp38-cp38-linux_aarch64.whl
 ARG SHERPA_GPU_WHEEL_61=jp61/sherpa_onnx-1.13.6+cuda-cp310-cp310-linux_aarch64.whl
+ARG DLA_COMPILER_SO_61=jp61/libnvdla_compiler.so
 RUN case "${JP_VERSION}" in \
-        511) NUMPY=1.24.4; WHEEL="${SHERPA_GPU_WHEEL_511}" ;; \
-        61)  NUMPY=1.26.4; WHEEL="${SHERPA_GPU_WHEEL_61}"  ;; \
-        *)   NUMPY=1.24.4; WHEEL= ;; \
+        511) NUMPY=1.24.4; WHEEL="${SHERPA_GPU_WHEEL_511}"; DLA= ;; \
+        61)  NUMPY=1.26.4; WHEEL="${SHERPA_GPU_WHEEL_61}"; DLA="${DLA_COMPILER_SO_61}" ;; \
+        *)   NUMPY=1.24.4; WHEEL=; DLA= ;; \
     esac; \
-    printf 'NUMPY_VERSION=%s\nSHERPA_GPU_WHEEL=%s\nPY_ABI=%s\n' \
+    printf 'NUMPY_VERSION=%s\nSHERPA_GPU_WHEEL=%s\nPY_ABI=%s\nDLA_COMPILER_SO=%s\n' \
         "${NUMPY}" "${WHEEL}" \
         "$(python3 -c 'import sys; print("%d.%d" % sys.version_info[:2])')" \
+        "${DLA}" \
         > /etc/jetpack.env && \
     echo "[build] jp${JP_VERSION}:" && cat /etc/jetpack.env
 
@@ -234,6 +238,79 @@ print('sherpa-onnx', sherpa_onnx.__version__, 'with CUDA provider')"; \
         pip3 install --no-cache-dir -i ${PYPI_MIRROR} sherpa-onnx; \
     fi
 
+# ── libnvdla_compiler.so fallback (jp6.1) ────────────────────────────────────
+# `import tensorrt` on JetPack 6 has libnvdla_compiler.so as a hard DT_NEEDED,
+# and no image can ship it: /usr/lib/aarch64-linux-gnu/nvidia/ is owned by
+# nvidia-container-runtime, which bind-mounts the host's copies over the
+# zero-length placeholders the L4T base ships. A host that does not have the
+# library has nothing to mount, the placeholder stays 0 bytes, and TensorRT dies
+# with "libnvdla_compiler.so: cannot open shared object file" — taking down every
+# TensorRT plugin at once (VITS2 TTS, OCR, obstacle).
+#
+# That is not hypothetical: Bumi's Orin NX ships an L4T R36.5.0 vendor BSP with
+# no nvidia-l4t-dla-compiler, so drivers.csv line 85 names a file the host does
+# not have. Fixing the host would mean pushing an NVIDIA package into a vendor
+# BSP on every robot we ever ship to, and having it reverted by the next flash.
+#
+# So carry our own copy, at a path the CSV does not name — a second copy inside
+# /usr/lib/aarch64-linux-gnu/nvidia/ would just be another placeholder for the
+# runtime to overwrite or leave empty. It is reached only through the guard in
+# /etc/dla-fallback.env below, which leaves the host's copy in charge whenever
+# there is one. DLA itself is unused (our engines run on the GPU) — this
+# satisfies the dynamic linker, nothing more, which is also why a copy taken from
+# L4T R36.4.3 is fine on an R36.5.0 host (verified on Bumi: builder +
+# deserialize_cuda_engine both work).
+#
+# jp5.11 needs none of this: L4T R35 resolves both nvdla libraries out of
+# /usr/lib/aarch64-linux-gnu/tegra/, which its own base image populates, so
+# DLA_COMPILER_SO is empty for that line and this step is a no-op.
+RUN . /etc/jetpack.env; \
+    if [ -n "${DLA_COMPILER_SO}" ]; then \
+        mkdir -p /opt/nvidia/dla-fallback && \
+        echo "[build] dla-fallback: ${DLA_COMPILER_SO}" && \
+        python3 -c "import urllib.request, urllib.parse, sys; \
+key, dest = sys.argv[1], sys.argv[2]; \
+urllib.request.urlretrieve('https://agi-phanthy-dev-1252788780.cos.ap-beijing.myqcloud.com/public/nvidia/' + urllib.parse.quote(key), dest)" \
+            "${DLA_COMPILER_SO}" /opt/nvidia/dla-fallback/libnvdla_compiler.so && \
+        python3 -c "import pathlib; \
+p = pathlib.Path('/opt/nvidia/dla-fallback/libnvdla_compiler.so'); \
+assert p.read_bytes()[:4] == b'\177ELF', 'not an ELF object — COS served an error page?'; \
+print('[build] dla-fallback:', p.stat().st_size, 'bytes')"; \
+    else \
+        echo "[build] dla-fallback: not needed for jp${JP_VERSION}"; \
+    fi
+
+# The guard, sourced by CMD. Both conditions matter, and they test *size*, not
+# existence: the placeholder always exists, so `-e` is true even when there is no
+# usable library behind it.
+#
+#   libcuda.so.1 non-empty    → the nvidia runtime really did take over. Under
+#                               plain runc every file in that directory stays a
+#                               0-byte placeholder and the container has no GPU
+#                               at all (see `runtime: nvidia` in deploy/
+#                               service.yml). Papering the linker error over in
+#                               that case would trade one clear failure at import
+#                               for a confusing one much later, at engine build.
+#   libnvdla_compiler.so empty → the host BSP has no copy to mount. This is the
+#                               one case the fallback is for. When the host does
+#                               have one it is non-empty, this test is false, and
+#                               we leave TensorRT to use it: it matches the host
+#                               kernel and DLA hardware and ours does not.
+#
+# Appended, never prepended: LD_LIBRARY_PATH is searched before ld.so.cache, so
+# putting this directory first would let our copy shadow a correctly mounted host
+# library on every other robot.
+RUN printf '%s\n' \
+    '# Sourced by CMD. See the dla-fallback step in Dockerfile.jetson.' \
+    'DLA_FALLBACK_SO=/opt/nvidia/dla-fallback/libnvdla_compiler.so' \
+    'DLA_NV_LIB_DIR=/usr/lib/aarch64-linux-gnu/nvidia' \
+    'if [ -f "$DLA_FALLBACK_SO" ] && [ -s "$DLA_NV_LIB_DIR/libcuda.so.1" ] && [ ! -s "$DLA_NV_LIB_DIR/libnvdla_compiler.so" ]; then' \
+    '    export LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:/opt/nvidia/dla-fallback"' \
+    '    echo "[dla-fallback] host BSP has no libnvdla_compiler.so (missing nvidia-l4t-dla-compiler); using the copy bundled in this image" >&2' \
+    'fi' \
+    > /etc/dla-fallback.env && \
+    sh -n /etc/dla-fallback.env && echo "[build] /etc/dla-fallback.env ok"
+
 # ── OCR runtime deps (PP-OCRv6 TensorRT engines; TensorRT/CUDA come from base) ──
 # libvips42 (apt, above) is the runtime library pyvips dlopens for JPEG decode
 # + downscale; rapidocr is used --no-deps for its pure-Python DB/CTC post-
@@ -359,4 +436,5 @@ CMD ["/bin/bash", "-c", \
     "export LD_PRELOAD=/usr/lib/aarch64-linux-gnu/libgomp.so.1 && \
      source /opt/ros/humble/install/setup.bash && \
      source /ros_ws/install/setup.bash && \
+     source /etc/dla-fallback.env && \
      python3 /work/main.py"]

--- a/perception/README.md
+++ b/perception/README.md
@@ -438,6 +438,59 @@ Notes:
 
 ---
 
+### `libnvdla_compiler.so` — the jp6.1 image carries its own
+
+On JetPack 6, `import tensorrt` has `libnvdla_compiler.so` as a hard `DT_NEEDED`,
+and no image can ship it at its real path: `/usr/lib/aarch64-linux-gnu/nvidia/` is
+owned by nvidia-container-runtime, which bind-mounts the host's copies over the
+zero-length placeholders the L4T base ships. A host BSP without
+`nvidia-l4t-dla-compiler` has nothing to mount, the placeholder stays 0 bytes, and
+every TensorRT plugin is down at once — VITS2 TTS, OCR, obstacle:
+
+```
+ImportError: libnvdla_compiler.so: cannot open shared object file
+  → utils.tensorrt_runtime.TensorRTError: TensorRT is not available in this runtime
+```
+
+Bumi's Orin NX ships exactly that BSP (L4T R36.5.0, vendor-flashed): `drivers.csv`
+line 85 names the library, `dpkg -l | grep dla` finds nothing, and
+`find / -name 'libnvdla_compiler*'` on the host comes back empty. `torch.cuda` is
+fine on that host, so the symptom is TTS-only and reads like a TTS regression.
+
+So `Dockerfile.jetson` downloads a copy from COS
+(`public/nvidia/jp61/libnvdla_compiler.so`, taken from `nvidia-l4t-dla-compiler
+36.4.3`) into `/opt/nvidia/dla-fallback/` — **a path the CSV does not name**, or it
+would be just another placeholder for the runtime to leave empty. `/etc/dla-fallback.env`,
+sourced by `CMD`, appends that directory to `LD_LIBRARY_PATH` only when both hold:
+
+| test | why |
+|---|---|
+| `-s .../nvidia/libcuda.so.1` | the nvidia runtime really took over. Under plain runc every file there is a 0-byte placeholder and the container has no GPU at all — masking the linker error would trade one clear failure at import for a baffling one later at engine build. |
+| `! -s .../nvidia/libnvdla_compiler.so` | the host has no copy to mount. When it does have one, this is false and TensorRT uses it: the host's matches its kernel and DLA hardware, ours does not. |
+
+Both test **size**, not existence — the placeholder always exists, so `-e` is true
+even when nothing usable is behind it. And the directory is *appended*, never
+prepended: `LD_LIBRARY_PATH` is searched before `ld.so.cache`, so going first would
+shadow a correctly mounted host library on every other robot.
+
+DLA is never used — our engines run on the GPU and this only satisfies the linker,
+which is why an R36.4.3 copy works on an R36.5.0 host. Verified on Bumi (fallback
+fires, `build_serialized_network` + `deserialize_cuda_engine` both succeed), on Bumi
+under `--runtime=runc` (guard stays silent, import still fails loudly), and on orin6
+where the host has the library (guard silent, `/proc/self/maps` shows the host copy
+loaded, `LD_LIBRARY_PATH` untouched).
+
+jp5.11 needs none of this: L4T R35 resolves both nvdla libraries out of
+`/usr/lib/aarch64-linux-gnu/tegra/`, which its own base image populates, so
+`DLA_COMPILER_SO` is empty for that line and the build step is a no-op.
+
+**Corollary for debugging:** a `libnvdla_compiler.so` error is no longer proof that
+`runtime: nvidia` is missing from the compose fragment — but with the fallback in
+place it is again the *only* remaining cause, and the log line
+`[dla-fallback] host BSP has no libnvdla_compiler.so` tells you which case you are in.
+
+---
+
 ## asr_kws and espeak
 
 `trigger_mode: asr_kws` transcribes every utterance and gates on a phoneme-level

--- a/perception/deploy/service.yml
+++ b/perception/deploy/service.yml
@@ -2,12 +2,18 @@ perception:
   image: __IMAGE__
   container_name: embodied-perception
   # The L4T base image ships zero-length placeholders for the driver libraries
-  # (/usr/lib/aarch64-linux-gnu/nvidia/libnvdla_compiler.so and friends); only
-  # the nvidia runtime bind-mounts the host's real ones over them. Under the
-  # default runc runtime the placeholders stay, so `import tensorrt` dies with
-  # "libnvdla_compiler.so: file too short" and torch.cuda.is_available() is
-  # False — i.e. no GPU at all for OCR, VOP or VITS2 TTS, whatever privileged
-  # and /dev:/dev suggest. Same flag the adam driver uses.
+  # (/usr/lib/aarch64-linux-gnu/nvidia/libcuda.so.1 and friends); only the nvidia
+  # runtime bind-mounts the host's real ones over them. Under the default runc
+  # runtime the placeholders stay, so `import tensorrt` dies on
+  # libnvdla_compiler.so and torch.cuda.is_available() is False — i.e. no GPU at
+  # all for OCR, VOP or VITS2 TTS, whatever privileged and /dev:/dev suggest.
+  # Same flag the adam driver uses.
+  #
+  # Do not read a libnvdla_compiler.so error as proof that this flag is missing:
+  # a host BSP without nvidia-l4t-dla-compiler produces the identical message
+  # with the runtime working correctly. The image carries a fallback for exactly
+  # that case and logs "[dla-fallback] host BSP has no libnvdla_compiler.so" when
+  # it uses it — see the dla-fallback step in Dockerfile.jetson.
   runtime: nvidia
   network_mode: host
   ipc: host

--- a/perception/plugins/vits2_tts_trt/plugin.py
+++ b/perception/plugins/vits2_tts_trt/plugin.py
@@ -121,8 +121,10 @@ def _error_chain(error: BaseException) -> str:
 
     The interesting part is usually the cause, not the wrapper: "TensorRT is not
     available in this runtime" says nothing, while
-    "... : libnvdla_compiler.so: file too short" points straight at a container
-    started without the nvidia runtime.
+    "... : libnvdla_compiler.so: cannot open shared object file" narrows it to two
+    container-level causes — no `runtime: nvidia` (see deploy/service.yml), or a
+    host BSP missing nvidia-l4t-dla-compiler. The image's dla-fallback covers the
+    second, so in practice this error now means the first.
     """
     parts = []
     seen = set()

--- a/perception/tests/test_vits2_tts_plugin.py
+++ b/perception/tests/test_vits2_tts_plugin.py
@@ -407,7 +407,10 @@ def test_load_error_keeps_the_underlying_cause(monkeypatch):
 
     def explode(model_dir, family=None):
         try:
-            raise ImportError("libnvdla_compiler.so: file too short")
+            raise ImportError(
+                "libnvdla_compiler.so: cannot open shared object file: "
+                "No such file or directory"
+            )
         except ImportError as cause:
             raise RuntimeError("TensorRT is not available in this runtime") from cause
 


### PR DESCRIPTION
## Why

VITS2 TTS was down on Bumi:

```
ImportError: libnvdla_compiler.so: cannot open shared object file
  → TensorRTError: TensorRT is not available in this runtime
```

Not a TTS bug. `import tensorrt` on JetPack 6 has that library as a hard `DT_NEEDED`, and **no image can ship it at its real path**: `/usr/lib/aarch64-linux-gnu/nvidia/` belongs to nvidia-container-runtime, which bind-mounts the host's copies over the zero-length placeholders the L4T base ships.

Bumi's Orin NX runs a vendor-flashed **L4T R36.5.0** BSP with no `nvidia-l4t-dla-compiler`:

```
drivers.csv:85  lib, /usr/lib/aarch64-linux-gnu/nvidia/libnvdla_compiler.so
dpkg -l | grep dla                     → nothing
find / -name 'libnvdla_compiler*'      → empty
docker inspect …Runtime                → nvidia          (runtime is fine)
torch.cuda.is_available()              → True            (GPU is fine)
```

Nothing to mount → the placeholder stays 0 bytes → every TensorRT plugin is down at once (VITS2 TTS, OCR, obstacle). `torch.cuda` being unaffected is what makes it read like a TTS regression.

## Why not fix the host

Installing `nvidia-l4t-dla-compiler` works, but it means pushing an NVIDIA package into a vendor BSP on **every robot we ship to**, and having it reverted by the next flash.

## What this does

Carry our own copy at `/opt/nvidia/dla-fallback/` — a path the CSV does not name, or it would just be another placeholder for the runtime to leave empty — reached only through `/etc/dla-fallback.env`, sourced by `CMD`, which appends that directory to `LD_LIBRARY_PATH` when both hold:

| test | why |
|---|---|
| `-s .../nvidia/libcuda.so.1` | the nvidia runtime really took over. Under `runc` there is no GPU at all; masking the linker error there would trade one clear failure at import for a baffling one later at engine build. |
| `! -s .../nvidia/libnvdla_compiler.so` | the host has no copy to mount. When it does, this is false and TensorRT uses the host's — it matches its kernel and DLA hardware. |

Both test **size**, not existence: the placeholder always exists, so `-e` is true even with nothing usable behind it. And the directory is **appended, never prepended** — `LD_LIBRARY_PATH` beats `ld.so.cache`, so going first would shadow a correctly mounted host library on every other robot.

DLA is never used (our engines run on the GPU), so this only satisfies the linker — which is why an R36.4.3 copy works on an R36.5.0 host.

**jp5.11 needs none of it**: L4T R35 resolves both nvdla libraries out of `tegra/`, populated by its own base image, so `DLA_COMPILER_SO` is empty there and the build step is a no-op.

## Verification

New Dockerfile steps built on both Orin 6 and Bumi, then run through the real `CMD` chain:

| host | runtime | guard | result |
|---|---|---|---|
| Bumi (host lib missing) | nvidia | fires | `build_serialized_network` + `deserialize_cuda_engine` both succeed |
| Bumi | runc | silent | import still fails loudly — missing `runtime: nvidia` stays diagnosable |
| Orin 6 (host has it) | nvidia | silent, `LD_LIBRARY_PATH` untouched | `/proc/self/maps` shows the **host** copy loaded, TRT works |

`perception/tests`: **172 passed, 1 skipped**.

## Also corrected

`service.yml`'s comment and `_error_chain`'s docstring both claimed this error means a missing `runtime: nvidia`, and quoted `"file too short"`. Neither is what the runtime actually produces — a thin host BSP yields the identical message with the runtime working correctly. Corrected, and the one test that hardcoded the old string now uses the real message.

## Note

The bundled `.so` is NVIDIA's, published to the existing anonymous-read COS `public/` prefix as `public/nvidia/jp61/libnvdla_compiler.so` (sha256 `c21986be…c778bec`, from `nvidia-l4t-dla-compiler 36.4.3`). Flagging in case that prefix should not carry NVIDIA redistributables — moving it behind a signed URL is a one-line change to the download step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)