### PR TITLE
fix(deploy): lock and atomically write the host compose file

### DIFF
--- a/agent-core/src/api/drivers.py
+++ b/agent-core/src/api/drivers.py
@@ -4,7 +4,11 @@ Manifest stored in SQLite config DB (key: 'drivers'). Populated via registry syn
 """
 
 import asyncio
+import contextlib
+import fcntl
 import os
+import threading
+import time
 from typing import Optional
 
 import fastapi
@@ -79,6 +83,157 @@ def _clear_deploy_log(driver_id: str):
     _deploy_logs.pop(driver_id, None)
 
 
+# ── Host compose file mutation ─────────────────────────────────────────────
+#
+# The host compose file has two independent writers: this module (merging each
+# image's deploy/service.yml fragment) and deploy/restart/entrypoint.sh (swapping
+# agent-core's image tag during a self-update). Neither used to lock, and both
+# wrote with a plain open(...,'w') — which truncates at open and flushes at
+# close, with no truncate in between. Two overlapping writers therefore left the
+# shorter document at offset 0 followed by the tail of the longer one, i.e. a
+# file that no YAML parser accepts and that nothing could repair afterwards
+# (every retry died in safe_load before it could write).
+#
+# Two deploys landing in the same second is not hypothetical: it is what a
+# double-clicked or retried deploy in the console does, since the
+# already-running-same-image guard only short-circuits a container that is
+# already up.
+
+_COMPOSE_LOCK_NAME = '.compose.lock'
+
+
+@contextlib.contextmanager
+def _compose_lock(compose_dir: str, timeout: float = 120.0):
+    """Hold an exclusive lock over the host compose file for the whole RMW cycle.
+
+    The lock file lives in COMPOSE_DIR, which is bind-mounted into both this
+    container and the restart helper, so both contend on one host inode.
+    deploy/restart/entrypoint.sh takes the same lock by name — keep them in sync.
+    """
+    lock_path = os.path.join(compose_dir, _COMPOSE_LOCK_NAME)
+    fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o644)
+    try:
+        deadline = time.monotonic() + timeout
+        while True:
+            try:
+                fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                break
+            except BlockingIOError:
+                if time.monotonic() >= deadline:
+                    raise TimeoutError(
+                        f'timed out after {timeout:.0f}s waiting for {lock_path}; '
+                        'another deploy or an agent-core self-update is in progress'
+                    )
+                time.sleep(0.2)
+        yield
+    finally:
+        try:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+        except OSError:
+            pass
+        os.close(fd)
+
+
+def _merge_service_into_compose(compose_file: str, service_def: dict) -> tuple[bool, str]:
+    """Merge a service fragment into the host compose file under lock.
+
+    Returns (ok, error). On any doubt about the existing file this refuses to
+    write rather than guessing: a compose we cannot read is a compose whose other
+    services we cannot preserve, and silently dropping them is how agent-core
+    disappeared from the file on orin6.
+    """
+    import yaml
+
+    compose_dir = os.path.dirname(compose_file) or '.'
+    with _compose_lock(compose_dir):
+        try:
+            with open(compose_file) as f:
+                raw = f.read()
+        except FileNotFoundError:
+            # Genuine fresh install — install.sh has not run yet.
+            raw = ''
+            existing: dict = {}
+        else:
+            # An existing-but-empty file is NOT a fresh install; it is a
+            # truncated read or a damaged file. `safe_load(...) or {}` used to
+            # turn this into "no other services exist" and write a compose
+            # containing only the service being deployed.
+            if not raw.strip():
+                return False, f'{compose_file} exists but is empty — refusing to overwrite'
+            try:
+                loaded = yaml.safe_load(raw)
+            except yaml.YAMLError as e:
+                return False, f'{compose_file} is not valid YAML, refusing to overwrite: {e}'
+            if not isinstance(loaded, dict):
+                return False, f'{compose_file} is not a mapping, refusing to overwrite'
+            existing = loaded
+
+        services = existing.setdefault('services', {})
+        if not isinstance(services, dict):
+            return False, f'{compose_file}: services is not a mapping, refusing to overwrite'
+
+        preserved = set(services)
+        services.update(service_def)
+
+        text = yaml.dump(existing, default_flow_style=False, allow_unicode=True, sort_keys=False)
+
+        # Re-parse what we are about to write and confirm every service we
+        # started with survived. Cheap insurance: corruption here is otherwise
+        # invisible until the next `docker compose` call, by which point the
+        # last good copy is gone.
+        try:
+            check = yaml.safe_load(text) or {}
+        except yaml.YAMLError as e:
+            return False, f'refusing to write unparseable compose: {e}'
+        written = set((check.get('services') or {}))
+        missing = preserved - written
+        if missing:
+            return False, f'refusing to write: would drop service(s) {sorted(missing)}'
+
+        # Keep the last good copy before replacing.
+        if raw:
+            try:
+                with open(compose_file + '.bak', 'w') as f:
+                    f.write(raw)
+            except OSError as e:
+                return False, f'could not write backup {compose_file}.bak: {e}'
+
+        # Atomic replace: a concurrent reader sees either the old or the new
+        # file, never a half-written one.
+        tmp = compose_file + '.tmp'
+        with open(tmp, 'w') as f:
+            f.write(text)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp, compose_file)
+
+    return True, ''
+
+
+# ── Per-driver in-flight guard ─────────────────────────────────────────────
+
+_deploy_inflight: set[str] = set()
+_deploy_inflight_lock = threading.Lock()
+
+
+@contextlib.contextmanager
+def _deploy_slot(driver_id: str):
+    """Reject a second concurrent deploy of the same driver.
+
+    Yields True if this call owns the slot, False if a deploy is already running.
+    """
+    with _deploy_inflight_lock:
+        owned = driver_id not in _deploy_inflight
+        if owned:
+            _deploy_inflight.add(driver_id)
+    try:
+        yield owned
+    finally:
+        if owned:
+            with _deploy_inflight_lock:
+                _deploy_inflight.discard(driver_id)
+
+
 def _get_status_sync(driver_id: str, container_name_override: str = '') -> dict:
     try:
         client = _docker()
@@ -103,6 +258,22 @@ def _get_status_sync(driver_id: str, container_name_override: str = '') -> dict:
 
 
 def _deploy_sync(driver: dict) -> dict:
+    """Deploy a driver, rejecting a second concurrent deploy of the same driver.
+
+    The console retries and double-clicks; two deploys of one driver racing each
+    other is what corrupted the host compose file on orin6.
+    """
+    with _deploy_slot(driver['id']) as owned:
+        if not owned:
+            return {
+                'status':  'deploying',
+                'message': 'a deploy for this driver is already in progress',
+                'skipped': True,
+            }
+        return _deploy_sync_inner(driver)
+
+
+def _deploy_sync_inner(driver: dict) -> dict:
     """Deploy a driver/perception container via docker compose.
 
     Extracts service.yml from the target image and merges it into the host
@@ -184,17 +355,18 @@ def _deploy_sync(driver: dict) -> dict:
         'options': {'max-size': LOG_MAX_SIZE, 'max-file': LOG_MAX_FILE},
     })
 
-    # Read existing compose (or create minimal)
+    # Merge into the host compose under lock, atomically. Bail out before
+    # touching any container if the existing file cannot be read safely — a
+    # failed merge that still removed the old container would leave the driver
+    # both stopped and undeployable.
+    ok, err = False, ''
     try:
-        with open(compose_file) as f:
-            compose = yaml.safe_load(f) or {}
-    except FileNotFoundError:
-        compose = {'services': {}}
-
-    compose.setdefault('services', {}).update(service_def)
-
-    with open(compose_file, 'w') as f:
-        yaml.dump(compose, f, default_flow_style=False, allow_unicode=True, sort_keys=False)
+        ok, err = _merge_service_into_compose(compose_file, service_def)
+    except TimeoutError as e:
+        err = str(e)
+    if not ok:
+        _log_deploy(driver['id'], f'[compose] {err}')
+        return {'status': 'error', 'error': err}
 
     # Remove old container if it exists (may be from legacy docker run)
     try:

--- a/agent-core/tests/test_compose_merge_race.py
+++ b/agent-core/tests/test_compose_merge_race.py
@@ -1,0 +1,259 @@
+"""Regression tests for the host compose file merge in api/drivers.py.
+
+The trap these guard, observed on orin6 2026-09-01: two deploys of one driver
+landed in the same second (a retried console click). Both did
+
+    compose = yaml.safe_load(open(f)) or {}      # read
+    ...
+    with open(f, 'w') as fh: yaml.dump(...)      # truncate at open, flush at close
+
+open(...,'w') truncates when it opens and Python flushes when it closes, with no
+truncate in between — so the writer that closed second laid a shorter document
+over offset 0 of a longer one and left the longer one's tail behind. The result
+parsed nowhere, and `or {}` had already let the loser read the truncated file as
+"no other services exist" and drop agent-core from the compose entirely. Every
+later retry then died in safe_load before it could write, so the host could not
+self-heal.
+
+Run: python3 -m pytest agent-core/tests/test_compose_merge_race.py -q
+  or: python3 agent-core/tests/test_compose_merge_race.py
+"""
+import os
+import sys
+import tempfile
+import threading
+
+import pytest
+import yaml
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+from api.drivers import (  # noqa: E402
+    _deploy_slot,
+    _merge_service_into_compose,
+)
+
+# The exact shape found on orin6: a complete perception service, then the tail of
+# another document starting mid-`environment`, then a duplicate service.
+CORRUPT_COMPOSE = """\
+services:
+  perception:
+    image: registry/perception:a
+    container_name: embodied-perception
+    environment:
+    - ROS_DOMAIN_ID=42
+    restart: unless-stopped
+   - ROS_DOMAIN_ID=42
+    - RMW_IMPLEMENTATION=rmw_fastrtps_cpp
+    restart: unless-stopped
+  perception:
+    image: registry/perception:a
+    restart: unless-stopped
+"""
+
+GOOD_COMPOSE = {
+    'services': {
+        'agent-core': {
+            'image': 'registry/core:v1',
+            'container_name': 'phanthy-motus-agent-core-1',
+            'restart': 'unless-stopped',
+        },
+        'perception': {
+            'image': 'registry/perception:v1',
+            'container_name': 'embodied-perception',
+            'restart': 'unless-stopped',
+        },
+    }
+}
+
+
+def _fragment(name, image='registry/x:new'):
+    return {name: {'image': image, 'container_name': f'embodied-{name}',
+                   'restart': 'unless-stopped'}}
+
+
+@pytest.fixture
+def compose_file():
+    with tempfile.TemporaryDirectory() as d:
+        yield os.path.join(d, 'docker-compose.yml')
+
+
+def _write(path, obj):
+    with open(path, 'w') as f:
+        if isinstance(obj, str):
+            f.write(obj)
+        else:
+            yaml.safe_dump(obj, f, sort_keys=False)
+
+
+# ── The race itself ────────────────────────────────────────────────────────
+
+def test_concurrent_merges_preserve_every_service(compose_file):
+    """N threads merging distinct services at once: all of them survive.
+
+    This is the orin6 scenario with the timing widened. Pre-lock, this left a
+    file that yaml.safe_load rejects.
+    """
+    _write(compose_file, GOOD_COMPOSE)
+    names = [f'driver-{i}' for i in range(12)]
+
+    start = threading.Barrier(len(names))
+    errors = []
+
+    def worker(name):
+        start.wait()
+        ok, err = _merge_service_into_compose(compose_file, _fragment(name))
+        if not ok:
+            errors.append((name, err))
+
+    threads = [threading.Thread(target=worker, args=(n,)) for n in names]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=60)
+    assert not any(t.is_alive() for t in threads), 'merge deadlocked'
+    assert errors == [], f'merges failed: {errors}'
+
+    with open(compose_file) as f:
+        result = yaml.safe_load(f)          # would raise pre-fix
+    assert set(result['services']) == {'agent-core', 'perception', *names}
+    # The pre-existing services kept their definitions, not just their keys.
+    assert result['services']['agent-core']['image'] == 'registry/core:v1'
+
+
+def test_concurrent_reader_never_sees_a_partial_document(compose_file):
+    """A reader polling during a write storm only ever observes valid YAML.
+
+    os.replace() is what buys this: readers see the old inode or the new one.
+    """
+    _write(compose_file, GOOD_COMPOSE)
+    stop = threading.Event()
+    bad = []
+
+    def reader():
+        while not stop.is_set():
+            try:
+                with open(compose_file) as f:
+                    doc = yaml.safe_load(f)
+            except FileNotFoundError:
+                bad.append('file vanished')
+                continue
+            except yaml.YAMLError as e:
+                bad.append(f'unparseable: {e}')
+                continue
+            if not doc or 'agent-core' not in (doc.get('services') or {}):
+                bad.append(f'agent-core missing from {sorted((doc or {}).get("services") or {})}')
+
+    r = threading.Thread(target=reader, daemon=True)
+    r.start()
+    try:
+        for i in range(40):
+            ok, err = _merge_service_into_compose(compose_file, _fragment(f'd{i}'))
+            assert ok, err
+    finally:
+        stop.set()
+        r.join(timeout=10)
+    assert bad == [], f'reader saw {len(bad)} bad state(s); first: {bad[0]}'
+
+
+# ── Refusing to guess ──────────────────────────────────────────────────────
+
+def test_refuses_empty_existing_file(compose_file):
+    """An existing-but-empty compose is a damaged read, not a fresh install.
+
+    `safe_load(...) or {}` used to turn this into an empty service map, so the
+    merge wrote a compose holding only the driver being deployed.
+    """
+    _write(compose_file, '')
+    ok, err = _merge_service_into_compose(compose_file, _fragment('perception'))
+    assert not ok
+    assert 'empty' in err
+    with open(compose_file) as f:
+        assert f.read() == '', 'refused merge must not touch the file'
+
+
+def test_refuses_corrupt_existing_file(compose_file):
+    """The orin6 file itself: abort, and leave it for a human to inspect."""
+    _write(compose_file, CORRUPT_COMPOSE)
+    ok, err = _merge_service_into_compose(compose_file, _fragment('perception'))
+    assert not ok
+    assert 'not valid YAML' in err
+    with open(compose_file) as f:
+        assert f.read() == CORRUPT_COMPOSE
+
+
+def test_refuses_when_services_is_not_a_mapping(compose_file):
+    _write(compose_file, {'services': ['perception']})
+    ok, err = _merge_service_into_compose(compose_file, _fragment('perception'))
+    assert not ok
+    assert 'not a mapping' in err
+
+
+# ── Ordinary behaviour still works ─────────────────────────────────────────
+
+def test_missing_file_is_a_fresh_install(compose_file):
+    assert not os.path.exists(compose_file)
+    ok, err = _merge_service_into_compose(compose_file, _fragment('perception'))
+    assert ok, err
+    with open(compose_file) as f:
+        assert set(yaml.safe_load(f)['services']) == {'perception'}
+
+
+def test_merge_replaces_target_and_keeps_the_rest(compose_file):
+    _write(compose_file, GOOD_COMPOSE)
+    ok, err = _merge_service_into_compose(
+        compose_file, _fragment('perception', image='registry/perception:v2'))
+    assert ok, err
+    with open(compose_file) as f:
+        result = yaml.safe_load(f)
+    assert result['services']['perception']['image'] == 'registry/perception:v2'
+    assert result['services']['agent-core'] == GOOD_COMPOSE['services']['agent-core']
+
+
+def test_merge_leaves_a_backup(compose_file):
+    _write(compose_file, GOOD_COMPOSE)
+    ok, err = _merge_service_into_compose(compose_file, _fragment('perception'))
+    assert ok, err
+    with open(compose_file + '.bak') as f:
+        assert yaml.safe_load(f) == GOOD_COMPOSE
+
+
+def test_no_tmp_file_left_behind(compose_file):
+    _write(compose_file, GOOD_COMPOSE)
+    ok, err = _merge_service_into_compose(compose_file, _fragment('perception'))
+    assert ok, err
+    assert not os.path.exists(compose_file + '.tmp')
+
+
+# ── Per-driver in-flight guard ─────────────────────────────────────────────
+
+def test_deploy_slot_rejects_a_second_concurrent_deploy():
+    """Two console clicks on one driver: the second is told to wait.
+
+    The already-running-same-image short circuit does not cover this — a driver
+    that is not up yet lets both callers straight through.
+    """
+    with _deploy_slot('perception') as first:
+        assert first is True
+        with _deploy_slot('perception') as second:
+            assert second is False, 'second concurrent deploy was allowed in'
+        # A different driver is unaffected.
+        with _deploy_slot('unitree-g1') as other:
+            assert other is True
+
+
+def test_deploy_slot_is_released_after_an_exception():
+    class Boom(Exception):
+        pass
+
+    try:
+        with _deploy_slot('perception'):
+            raise Boom
+    except Boom:
+        pass
+    with _deploy_slot('perception') as owned:
+        assert owned is True, 'slot leaked after an exception'
+
+
+if __name__ == '__main__':
+    sys.exit(pytest.main([__file__, '-q']))

--- a/deploy/restart/Dockerfile
+++ b/deploy/restart/Dockerfile
@@ -1,5 +1,5 @@
 FROM mirror.ccs.tencentyun.com/library/alpine:3.19
 RUN sed -i 's|https://dl-cdn.alpinelinux.org|https://mirrors.cloud.tencent.com|g' /etc/apk/repositories \
-    && apk add --no-cache docker-cli docker-cli-compose python3 py3-yaml
+    && apk add --no-cache docker-cli docker-cli-compose python3 py3-yaml util-linux-misc
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/deploy/restart/entrypoint.sh
+++ b/deploy/restart/entrypoint.sh
@@ -28,52 +28,91 @@ if [ ! -f /tmp/new-compose.yml ]; then
 fi
 
 # ── Step 2: Update compose file ──────────────────────────────────────────────
-# Strategy: if other services exist in current compose, preserve them and only
-# replace the target service definition. Otherwise use extracted file directly.
+# Merge the target service's new definition into the existing compose, preserving
+# every other service. Held under the same lock agent-core's driver deploy takes
+# (agent-core/src/api/drivers.py :: _compose_lock) — both write this one
+# host-mounted file, and without the lock two overlapping open(...,'w') writers
+# leave a truncated document that no parser accepts.
+#
+# The old code had an `else` branch that shutil.copy2'd the image's template over
+# the host compose whenever it saw no other services — including when it read a
+# momentarily-truncated file. That silently deleted every other service. There is
+# no wholesale-overwrite path any more: a compose we cannot parse aborts the
+# upgrade instead of being replaced.
 
-if [ -f "${COMPOSE_FILE}" ] && command -v python3 >/dev/null 2>&1; then
-    python3 - "${COMPOSE_FILE}" /tmp/new-compose.yml "${NEW_IMAGE}" "${SERVICE}" <<'PY'
-import sys, yaml
+LOCK_FILE="${COMPOSE_DIR}/.compose.lock"
+exec 9>"${LOCK_FILE}"
+if ! flock -w 120 9; then
+    echo "[restart] ERROR: timed out waiting for ${LOCK_FILE}; a driver deploy is in progress"
+    exit 1
+fi
+
+python3 - "${COMPOSE_FILE}" /tmp/new-compose.yml "${NEW_IMAGE}" "${SERVICE}" <<'PY'
+import os, sys, yaml
 
 compose_path, new_path, new_image, service = sys.argv[1:5]
 
-with open(compose_path) as f:
-    existing = yaml.safe_load(f) or {}
+
+def die(msg):
+    sys.stderr.write(f'[restart] ERROR: {msg}\n')
+    sys.exit(1)
+
 
 with open(new_path) as f:
     new = yaml.safe_load(f) or {}
+new_services = new.get('services') or {}
+if service not in new_services:
+    die(f'{new_path} has no service {service!r}')
 
-existing_services = existing.get('services', {})
-new_services = new.get('services', {})
-
-# Check if there are other services beyond the target one
-other_services = {k: v for k, v in existing_services.items() if k != service}
-
-if other_services and service in new_services:
-    # Preserve other services, replace target service with new definition
-    new_services[service]['image'] = new_image
-    existing_services[service] = new_services[service]
-    existing['services'] = existing_services
-    with open(compose_path, 'w') as f:
-        yaml.dump(existing, f, default_flow_style=False, allow_unicode=True, sort_keys=False)
-else:
-    # No other services — use extracted compose directly (same as install.sh)
-    import shutil
-    shutil.copy2(new_path, compose_path)
-    # Replace __IMAGE__ placeholder and any existing image line for the service
+try:
     with open(compose_path) as f:
-        content = f.read()
-    content = content.replace('__IMAGE__', new_image)
-    with open(compose_path, 'w') as f:
-        f.write(content)
+        raw = f.read()
+except FileNotFoundError:
+    # Genuine fresh install — nothing to preserve.
+    raw, existing = '', {}
+else:
+    # Existing-but-empty means truncated or damaged, not fresh.
+    if not raw.strip():
+        die(f'{compose_path} exists but is empty — refusing to overwrite')
+    try:
+        existing = yaml.safe_load(raw)
+    except yaml.YAMLError as e:
+        die(f'{compose_path} is not valid YAML, refusing to overwrite: {e}')
+    if not isinstance(existing, dict):
+        die(f'{compose_path} is not a mapping, refusing to overwrite')
+
+existing_services = existing.setdefault('services', {})
+if not isinstance(existing_services, dict):
+    die(f'{compose_path}: services is not a mapping, refusing to overwrite')
+
+preserved = set(existing_services)
+new_services[service]['image'] = new_image
+existing_services[service] = new_services[service]
+
+text = yaml.dump(existing, default_flow_style=False, allow_unicode=True, sort_keys=False)
+
+# Confirm the result parses and kept every service we started with.
+try:
+    check = yaml.safe_load(text) or {}
+except yaml.YAMLError as e:
+    die(f'refusing to write unparseable compose: {e}')
+missing = preserved - set(check.get('services') or {})
+if missing:
+    die(f'refusing to write: would drop service(s) {sorted(missing)}')
+
+if raw:
+    with open(compose_path + '.bak', 'w') as f:
+        f.write(raw)
+
+tmp = compose_path + '.tmp'
+with open(tmp, 'w') as f:
+    f.write(text)
+    f.flush()
+    os.fsync(f.fileno())
+os.replace(tmp, compose_path)
 PY
-else
-    # No existing compose or no python3 — use extracted file with sed (same as install.sh)
-    cp /tmp/new-compose.yml "${COMPOSE_FILE}"
-    sed -i "s|image:.*__IMAGE__.*|image: ${NEW_IMAGE}|" "${COMPOSE_FILE}"
-    # Also replace any existing image line under the service block
-    sed -i "/^  ${SERVICE}:/,/^  [^ ]/{s|image:.*|image: ${NEW_IMAGE}|}" "${COMPOSE_FILE}"
-fi
+
+flock -u 9
 
 echo "[restart] compose file updated"
 


### PR DESCRIPTION
## 问题

orin6 上 perception 启不来，报：

```
while parsing a block mapping in "/opt/phanthy-motus/docker-compose.yml", line 2, column 3
expected <block end>, but found '<block sequence start>' in ... line 23, column 4
```

不是 perception 的问题 —— `/opt/phanthy-motus/docker-compose.yml` 被写坏了：

| 行 | 内容 |
|---|---|
| 1–22 | 完整的 `perception` service |
| 23–31 | 另一份文档的尾巴，从 `environment` 中间开始，缩进错位 |
| 32–52 | 重复的 `perception` service |
| — | `agent-core` 整段消失 |

`docker events` 显示 **21:56:17 同一秒有两个 perception deploy**（`drivers.py` 抽取 `service.yml` 用的一次性容器各建了一个），坏文件 mtime 正是 `21:56:17.33`。之后 21:57–21:58 的 4 次重试全部在 `yaml.safe_load` 抛异常、写都没写进去，所以 mtime 没再变过 —— 宿主机自己修不回来。

## 三个缺陷

**1. 无锁 + 非原子写**

这个文件有两个独立 writer：本模块（合并镜像里的 `deploy/service.yml`）和 `deploy/restart/entrypoint.sh`（自升级时换 agent-core 的 tag）。两边都用裸 `open(...,'w')` —— **打开时截断，关闭时才 flush，中间没有第二次截断**。后关闭的那个把较短的文档写到 offset 0，较长那份的尾部就原地留了下来。

**2. `yaml.safe_load(f) or {}` 把截断的读当成全新安装**

谁在对方截断之后读，就拿到 `{}`，`update(service_def)` 只塞进自己一个 service，写出一份**只有 perception 的 compose**。这就是 agent-core 消失的原因 —— 不是被覆盖，是被"当作本来不存在"。

restart helper 里同一个隐患更凶：`else` 分支在看不到其它 service 时 `shutil.copy2` **用镜像模板整体覆盖宿主 compose**。

**3. 写完不校验、不备份**

坏了要等下一次 `docker compose` 调用才暴露，那时已经没有可回滚的副本。

## 改动

- **一把 flock**，放在 `COMPOSE_DIR`（该目录同时 bind-mount 进 agent-core 和 restart helper，两边争的是同一个宿主 inode），两个 writer 共用
- **`os.replace()` 原子替换** —— reader 只会看到旧 inode 或新 inode
- 写前留 `.bak`，写后**回读校验**：确认合并前存在的每个 service 合并后都还在
- **区分"文件不存在"和"读到空/坏内容"**：只有 `FileNotFoundError` 才当新装；空文件或 parse 失败一律**中止 deploy，不写**
- 中止发生在**动任何容器之前**，所以被拒绝的 merge 不会留下一个既停了又部署不了的 driver
- **删掉 restart helper 的整体覆盖分支**（连同它后面那段永远走不到的 sed fallback）
- **per-driver in-flight 去重锁**：原有的短路只覆盖"已在跑且同镜像"，driver 没起来时并发点两次会双双放行

`deploy/restart/Dockerfile` 加了 `util-linux-misc`（提供 `flock`）。

## 验证

新增 `agent-core/tests/test_compose_merge_race.py`（11 个用例）：12 路并发 merge、写风暴中持续轮询的 reader、以及每条 refuse-to-guess 路径。

```
$ PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest agent-core/tests/test_compose_merge_race.py -q
11 passed in 4.75s
```

**这些用例确实抓得住旧 bug** —— 拿修复前的逻辑复刻跑同样场景：

```
S1 empty-file    -> services now ['perception']   BUG: agent-core dropped
S2 12 concurrent -> parsed, 3/14 services; missing 11   BUG: lost services
S3 reader        -> 40 bad observations   BUG: partial/invalid reads
S4 corrupt-file  -> raised YAMLError out of _deploy_sync (no repair path)   BUG
```

（S2 这一轮表现为丢 service；"文件完全无法解析"那种形态依赖更特定的交错时序，但两者同源。）

restart helper 的 merge 单独跑了 5 个场景：保留其它 service、只有 agent-core（旧代码在这里整体覆盖）、空文件拒绝、**orin6 那个坏文件本身**拒绝且原文件未被改动、无文件时全新安装。

全量 `agent-core/tests`：93 passed, 1 failed —— 唯一失败是 `test_feishu_proxy.py` 缺本地 `lark_oapi` 依赖，已在干净树上确认为既有问题、与本改动无关。

## 备注

- orin6 上的坏文件我已手工修好并启动了 perception（ASR/TTS/OCR/VOP 全部加载正常）。备份留在 `/opt/phanthy-motus/docker-compose.yml.bak-corrupt-260901`。
- 顺带一提：根目录 `CLAUDE.md` 写着 "agent-core/ 无测试套件"，实际 `agent-core/tests/` 已有 12 个文件 / 94 个用例。那个文件不在本仓库里，所以没在这个 PR 改。

🤖 Generated with [Claude Code](https://claude.com/claude-code)