### PR TITLE
fix(agent-core): drop empty tool_calls before they poison the history

### DIFF
--- a/agent-core/src/client/llm.py
+++ b/agent-core/src/client/llm.py
@@ -24,6 +24,14 @@ async def _log_request(request: httpx.Request):
 
 # ── 错误分类 ──────────────────────────────────────────────────────────────────
 
+def _valid_tool_call(tc) -> bool:
+    """tool_call 结构是否能被服务端接受：id 与 function.name 都必须是非空串。"""
+    if not isinstance(tc, dict) or not tc.get('id'):
+        return False
+    fn = tc.get('function')
+    return isinstance(fn, dict) and bool(fn.get('name'))
+
+
 class LLMErrorKind:
     RATE_LIMIT      = 'rate_limit'       # 429
     BILLING         = 'billing'          # 402
@@ -68,6 +76,11 @@ def _classify_error(e: Exception) -> tuple[str, float | None]:
         return LLMErrorKind.SERVER_ERROR, 3.0
 
     # 模型生成了非法 tool call（arguments 非 JSON）：可重试，下次可能正确
+    # 但如果服务端指名道姓地怪某条历史消息（messages[24].tool_calls[1]...），
+    # payload 每次都一样，重试只是把同一个 400 再撞两遍。
+    if status == 400 and 'messages[' in body_msg:
+        return LLMErrorKind.UNKNOWN, None
+
     if status == 400 and any(kw in body_msg for kw in (
         'json format', 'invalid_parameter', 'must be in json',
     )):
@@ -162,11 +175,14 @@ class Client():
                 # OpenAI SDK 可能生成 tool_calls: None，清理以避免下游迭代报错
                 if 'tool_calls' in msg and msg['tool_calls'] is None:
                     del msg['tool_calls']
-                # glm 有时返回 tool_calls 内部缺少必要字段，清理无效条目
+                # glm 有时在正常 tool_call 之后追加一条 id/name 都是空串的重复条目
+                # （{"id": "", "function": {"name": "", "arguments": "{}"}}）。字段是齐的，
+                # 所以只判断 key 存在会放过去；一旦进历史并落盘，之后每次请求都会被
+                # 服务端以 messages[N].tool_calls[M].function missing required field "name"
+                # 拒掉，重启续跑也还在。这里按「值非空」筛。
                 if 'tool_calls' in msg and isinstance(msg['tool_calls'], list):
                     msg['tool_calls'] = [
-                        tc for tc in msg['tool_calls']
-                        if isinstance(tc, dict) and 'function' in tc and 'name' in tc.get('function', {})
+                        tc for tc in msg['tool_calls'] if _valid_tool_call(tc)
                     ]
                     if not msg['tool_calls']:
                         del msg['tool_calls']

--- a/agent-core/src/event/llm.py
+++ b/agent-core/src/event/llm.py
@@ -79,6 +79,36 @@ def _build_system_tools(named_functions: list[tuple[str, callable]]) -> dict:
 
 # ── History helpers ────────────────────────────────────────────────────────────
 
+def _scrub(message_list: list[dict]) -> list[dict]:
+    """丢弃结构非法的 tool_call，以及随之失去归属的 tool 结果。
+
+    glm 偶发在正常 tool_call 后追加一条 id/name 均为空串的条目。它一旦落盘，
+    历史续跑会把它一路带回去，之后每次请求都被服务端 400
+    （messages[N].tool_calls[M].function missing required field "name"），
+    直到那一轮从 tier1/tier2 里滚出去为止——表现就是「这台机器总是报错」。
+    """
+    from client.llm import _valid_tool_call
+    orphaned: set = set()
+    out: list[dict] = []
+    for msg in message_list:
+        if msg.get('role') == 'assistant' and msg.get('tool_calls'):
+            good = [tc for tc in msg['tool_calls'] if _valid_tool_call(tc)]
+            if len(good) != len(msg['tool_calls']):
+                orphaned.update(
+                    tc.get('id') for tc in msg['tool_calls']
+                    if isinstance(tc, dict) and not _valid_tool_call(tc)
+                )
+                msg = {k: v for k, v in msg.items() if k != 'tool_calls'}
+                if good:
+                    msg['tool_calls'] = good
+                elif not msg.get('content'):
+                    continue  # 既无文本也无有效调用，整条丢掉
+        elif msg.get('role') == 'tool' and msg.get('tool_call_id') in orphaned:
+            continue
+        out.append(msg)
+    return out
+
+
 def _sanitize(message_list: list[dict]) -> list[dict]:
     """移除末尾未被 tool 结果回应的 tool_calls（避免 API 报错）。"""
     responded_ids: set[str] = set()
@@ -818,7 +848,7 @@ class Event:
             history.extend(_degrade_turn(turn))
         for turn in recent:
             history.extend(turn)
-        return _sanitize(history)
+        return _sanitize(_scrub(history))
 
     async def _maybe_compress(self):
         """检查历史是否需要压缩（基于轮数或字符数），压缩旧轮次为 rolling summary。"""
@@ -983,7 +1013,7 @@ class Event:
             # ── 构建分层 prompt ────────────────────────────────────────────
             history = [] if bot_restricted else self._build_history()
             # 本轮已产生的消息也要加入历史（多轮工具调用场景）
-            current_history = history + _sanitize(turn_messages)
+            current_history = history + _sanitize(_scrub(turn_messages))
 
             if round_idx == 0:
                 # 首轮：加入 L4 触发事件（含 L2 动态快照）
@@ -1055,7 +1085,7 @@ class Event:
                         self._turns = self._turns[-2:]
                         # 重建 history 并重试（复用冻结的 system）
                         history = self._build_history()
-                        current_history = history + _sanitize(turn_messages)
+                        current_history = history + _sanitize(_scrub(turn_messages))
                         messages = prompt_mod.build(
                             system_msg    = frozen_system,
                             message_list  = current_history,

--- a/agent-core/tests/test_malformed_tool_call.py
+++ b/agent-core/tests/test_malformed_tool_call.py
@@ -1,0 +1,121 @@
+"""glm 偶发返回的空 tool_call 不能进历史，也不能让已中毒的历史一直 400。
+
+真实样本来自 bumi（10.100.129.141）resource/log/llm.json 的 messages[24]：
+finish 之后跟了一条 {"id": "", "function": {"name": "", "arguments": "{}"}}。
+字段齐全但值是空串，所以旧的「key 在不在」检查放过去了；落盘后每次请求
+都被服务端以 messages[24].tool_calls[1].function missing required field "name" 拒掉。
+"""
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+from client.llm import LLMErrorKind, _classify_error, _valid_tool_call  # noqa: E402
+from event.llm import _sanitize, _scrub  # noqa: E402
+
+GOOD_CALL = {'id': 'call_60582d0190364c928ea901b6', 'type': 'function', 'index': 0,
+             'function': {'name': 'finish', 'arguments': '{}'}}
+EMPTY_CALL = {'id': '', 'index': 0, 'function': {'name': '', 'arguments': '{}'}}
+
+
+class _Err(Exception):
+    def __init__(self, msg, status):
+        super().__init__(msg)
+        self.status_code = status
+
+
+# ── 结构校验 ──────────────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize('tc', [
+    EMPTY_CALL,
+    {'id': 'x', 'function': {'name': '', 'arguments': '{}'}},   # name 空串
+    {'id': '', 'function': {'name': 'finish'}},                 # id 空串
+    {'id': 'x', 'function': {'arguments': '{}'}},               # 缺 name
+    {'id': 'x'},                                                # 缺 function
+    {'id': 'x', 'function': None},
+    'not-a-dict',
+])
+def test_invalid_tool_calls_rejected(tc):
+    assert not _valid_tool_call(tc)
+
+
+def test_valid_tool_call_accepted():
+    assert _valid_tool_call(GOOD_CALL)
+
+
+# ── 历史清洗 ──────────────────────────────────────────────────────────────────
+
+def test_scrub_drops_empty_call_keeps_good_one():
+    history = [
+        {'role': 'user', 'content': '站起来'},
+        {'role': 'assistant', 'content': '', 'tool_calls': [GOOD_CALL, EMPTY_CALL]},
+        {'role': 'tool', 'tool_call_id': GOOD_CALL['id'], 'content': 'ok'},
+    ]
+    out = _scrub(history)
+    assert [m['role'] for m in out] == ['user', 'assistant', 'tool']
+    assert out[1]['tool_calls'] == [GOOD_CALL]
+
+
+def test_scrub_drops_orphaned_tool_result():
+    """空 id 的调用被 dispatch 过，于是历史里还有一条 tool_call_id="" 的结果。
+    调用没了，结果也必须走，否则换成 orphan tool message 继续 400。"""
+    history = [
+        {'role': 'assistant', 'content': '', 'tool_calls': [GOOD_CALL, EMPTY_CALL]},
+        {'role': 'tool', 'tool_call_id': GOOD_CALL['id'], 'content': 'ok'},
+        {'role': 'tool', 'tool_call_id': '', 'content': 'Unknown tool: '},
+    ]
+    out = _scrub(history)
+    assert [m.get('tool_call_id') for m in out if m['role'] == 'tool'] == [GOOD_CALL['id']]
+
+
+def test_scrub_drops_message_with_no_content_and_no_valid_call():
+    history = [
+        {'role': 'user', 'content': 'hi'},
+        {'role': 'assistant', 'content': '', 'tool_calls': [EMPTY_CALL]},
+    ]
+    assert _scrub(history) == [{'role': 'user', 'content': 'hi'}]
+
+
+def test_scrub_keeps_text_when_only_call_was_invalid():
+    history = [{'role': 'assistant', 'content': '我想想', 'tool_calls': [EMPTY_CALL]}]
+    out = _scrub(history)
+    assert out == [{'role': 'assistant', 'content': '我想想'}]
+
+
+def test_scrub_leaves_clean_history_untouched():
+    history = [
+        {'role': 'user', 'content': 'hi'},
+        {'role': 'assistant', 'content': '', 'tool_calls': [GOOD_CALL]},
+        {'role': 'tool', 'tool_call_id': GOOD_CALL['id'], 'content': 'ok'},
+    ]
+    assert _scrub(history) == history
+
+
+def test_scrub_then_sanitize_composes():
+    """_scrub 之后 _sanitize 仍应砍掉末尾没有结果回应的调用。"""
+    history = [
+        {'role': 'user', 'content': 'hi'},
+        {'role': 'assistant', 'content': '', 'tool_calls': [GOOD_CALL, EMPTY_CALL]},
+    ]
+    assert _sanitize(_scrub(history)) == [{'role': 'user', 'content': 'hi'}]
+
+
+# ── 错误分类 ──────────────────────────────────────────────────────────────────
+
+def test_payload_400_is_not_retried():
+    """指名某条历史消息的 400 每次都一样，重试只是多撞两次。"""
+    err = _Err('Error code: 400 - InvalidParameter: messages[24].tool_calls[1].'
+               'function missing required field "name"', 400)
+    kind, delay = _classify_error(err)
+    assert kind == LLMErrorKind.UNKNOWN
+    assert delay is None
+
+
+def test_bad_arguments_400_still_retried():
+    """模型把 arguments 写成非 JSON 是随机的，这种仍然值得重试。"""
+    err = _Err('Error code: 400 - arguments must be in json format', 400)
+    kind, delay = _classify_error(err)
+    assert kind == LLMErrorKind.SERVER_ERROR
+    assert delay == 1.0


### PR DESCRIPTION
## 问题

bumi（10.100.129.141）反复报错，每次都是同一个 400：

```
400 InvalidParameter: messages[24].tool_calls[1].function missing required field "name"
```

不是驱动或硬件问题。glm 偶发在一个正常 tool_call 之后追加一条重复条目，`id` 和 `function.name` 都是空串（取自机器上 `resource/log/llm.json` 的 messages[24]）：

```json
{"id": "call_60582d01...", "function": {"name": "finish", "arguments": "{}"}, "type": "function"},
{"id": "",                "function": {"name": "",       "arguments": "{}"}}
```

`client/llm.py` 原有的清理只判断 **key 在不在**：

```python
if isinstance(tc, dict) and 'function' in tc and 'name' in tc.get('function', {})
```

字段是齐的，所以放行 → 进 `_current_turn` → 进 `_turns`。之后这一轮还在 tier1+tier2 窗口里的**每一次**请求都被路由端拒掉。

两小时命中 4 次，索引随历史增长从 `messages[24]` 漂到 `messages[27]`，但永远是 `tool_calls[1]` —— 同一条尾部空调用。要等那一轮滚出 14 轮窗口才自愈，而 `src/event/llm.py` 启动时会 `resumed session ... (10 turns)` 从 SQLite 续跑，所以脏轮次能跨重启活下来。表现就是「这台机器总是报错」。

**放大器**：`_classify_error` 把含 `invalid_parameter` 的 400 归成 `server_error` 去重试。但这个 400 是我们自己 payload 的问题，payload 每次一样，三次必然全挂 —— 白烧 25+18+13s。第三次还撞上另一个 400（`Expecting value: line 1 column 1`）直接把整个 turn 打死，用户那句「站起来」就没了。

## 改动

- **`src/client/llm.py`** — 抽出 `_valid_tool_call()`，要求 `id` 和 `function.name` 的**值**非空；响应清理改用它。堵住入口。
- **`src/event/llm.py`** — 新增 `_scrub()`，建历史时丢掉畸形 `tool_call` 以及随之失去归属的 `tool` 结果。三个 `_sanitize()` 调用点都套上。这条是为了让**已经中毒**的历史自愈，而不是只防新的。
  - 为什么要连 tool 结果一起删：空 id 的调用是被 dispatch 过的，历史里还留着一条 `tool_call_id: ""` 的结果。只删调用会把它变成 orphan tool message，继续 400。
- **`src/client/llm.py`** — 报错里点名 `messages[...]` 的 400 归为不可重试。`arguments` 非 JSON 那类随机错误仍然重试，行为不变。

## 测试

新增 `agent-core/tests/test_malformed_tool_call.py`，16 个用例，用的就是 bumi 上那条真实脏消息：结构校验、`_scrub` 保留好的丢坏的、orphan tool 结果、只剩空调用时整条丢掉 / 有文本时保留文本、干净历史不动、`_scrub` + `_sanitize` 组合、两类 400 的分类。

```
109 passed, 1 failed
```

唯一失败是 `test_feishu_proxy.py::test_websocket_sdk_proxy_patch_is_idempotent`（本地缺 `lark_oapi`），改动前就在，与本 PR 无关。

## 部署说明

`agent-core` 不带 `deploy/service.yml`，所以 `run-pr-image.sh` 用不上，得走控制台或手动换 host compose 里的 image tag。

bumi 当前的污染只在内存里（DB 里查不到脏数据），重启 agent-core 容器就能立刻恢复 —— 但那只是止血，glm 下次再吐空调用还会复现。

🤖 Generated with [Claude Code](https://claude.com/claude-code)