### PR TITLE
fix(llm): 请求日志钩子不再把带斜杠的模型名打成「网络不通」

### DIFF
--- a/agent-core/src/client/llm.py
+++ b/agent-core/src/client/llm.py
@@ -14,12 +14,22 @@ LOG_PATH = pathlib.Path('./resource/log')
 
 
 async def _log_request(request: httpx.Request):
-    """httpx event hook: dump the real HTTP request body to disk for debugging."""
-    if request.content:
+    """httpx event hook: dump the real HTTP request body to disk for debugging.
+
+    这个钩子在请求发出前执行，任何异常都会中断发送；而 openai SDK 把非超时异常
+    一律包成 APIConnectionError('Connection error.')，于是一个写文件失败会伪装成
+    「网络不通」并触发三次重试。所以这里既要保证文件名合法（模型名可能带厂商前缀
+    的斜杠，如 zai-org/glm-5.2），也要整体吞掉异常——调试日志不该拖垮真实请求。
+    """
+    try:
+        if not request.content:
+            return
         body = json.loads(request.content)
-        model = body.get('model', 'unknown')
+        model = str(body.get('model', 'unknown')).replace('/', '_')
         path = LOG_PATH / f'llm_request_{model}.json'
         path.write_text(json.dumps(body, ensure_ascii=False, indent=2))
+    except Exception as e:
+        print(f'[llm] request log failed (ignored): {type(e).__name__}: {e}')
 
 
 # ── 错误分类 ──────────────────────────────────────────────────────────────────

--- a/agent-core/tests/test_llm_request_log_hook.py
+++ b/agent-core/tests/test_llm_request_log_hook.py
@@ -1,0 +1,97 @@
+"""调试用的请求日志钩子，绝不能把真实 LLM 请求打挂。
+
+真实故障来自 orin6（10.100.121.16）：模型配成 PPIO 的 `zai-org/glm-5.2`，
+_log_request 拼出 `resource/log/llm_request_zai-org/glm-5.2.json`，而 `zai-org/`
+目录不存在 → FileNotFoundError。钩子跑在请求发出之前，openai SDK 又把所有非超时
+异常包成 APIConnectionError('Connection error.')，于是一次写文件失败伪装成了
+「网络不通」，还白白重试三次：
+
+    [llm] zai-org/glm-5.2 @ https://api.ppio.com/openai/ failed after 0.03s:
+          APIConnectionError: Connection error.
+    [llm] connection failed after 3 attempts — LLM unreachable, check network
+
+同样的 curl 请求是 200。凡是带厂商前缀（斜杠）的模型 id 都会踩到。
+"""
+import asyncio
+import importlib
+import json
+import os
+import sys
+
+import httpx
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+# `client/__init__.py` 里的 `llm = client.llm.Client()` 把同名子模块属性盖掉了，
+# 所以 `import client.llm as llm_mod` 拿到的是 Client 实例，只能走 sys.modules。
+llm_mod = importlib.import_module('client.llm')  # noqa: E402
+
+
+def _request(model: str) -> httpx.Request:
+    return httpx.Request(
+        'POST', 'https://api.ppio.com/openai/chat/completions',
+        json={'model': model, 'messages': [{'role': 'user', 'content': 'hi'}]},
+    )
+
+
+def _run_hook(tmp_path, model: str):
+    original = llm_mod.LOG_PATH
+    llm_mod.LOG_PATH = tmp_path
+    try:
+        asyncio.run(llm_mod._log_request(_request(model)))
+    finally:
+        llm_mod.LOG_PATH = original
+
+
+# ── 带斜杠的模型名 ────────────────────────────────────────────────────────────
+
+def test_vendor_prefixed_model_does_not_raise(tmp_path):
+    """`zai-org/glm-5.2` 不能因为缺目录而抛异常。"""
+    _run_hook(tmp_path, 'zai-org/glm-5.2')
+
+
+def test_vendor_prefixed_model_writes_flat_file(tmp_path):
+    """斜杠被压平成下划线，落在 LOG_PATH 下而不是子目录里。"""
+    _run_hook(tmp_path, 'zai-org/glm-5.2')
+
+    path = tmp_path / 'llm_request_zai-org_glm-5.2.json'
+    assert path.exists()
+    assert not (tmp_path / 'zai-org').exists()
+    assert json.loads(path.read_text())['model'] == 'zai-org/glm-5.2'
+
+
+def test_plain_model_name_still_works(tmp_path):
+    """不带斜杠的老模型名行为不变。"""
+    _run_hook(tmp_path, 'glm-5.2')
+    assert (tmp_path / 'llm_request_glm-5.2.json').exists()
+
+
+# ── 钩子整体不可抛 ────────────────────────────────────────────────────────────
+
+def test_unwritable_log_dir_is_swallowed(tmp_path, capsys):
+    """LOG_PATH 根本不存在时也只记一行日志，不能中断请求。"""
+    _run_hook(tmp_path / 'does' / 'not' / 'exist', 'glm-5.2')
+    assert 'request log failed' in capsys.readouterr().out
+
+
+def test_empty_body_is_ignored(tmp_path):
+    """GET 之类没有 body 的请求直接跳过。"""
+    original = llm_mod.LOG_PATH
+    llm_mod.LOG_PATH = tmp_path
+    try:
+        asyncio.run(llm_mod._log_request(httpx.Request('GET', 'https://api.ppio.com/openai')))
+    finally:
+        llm_mod.LOG_PATH = original
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_non_json_body_is_swallowed(tmp_path, capsys):
+    """body 不是 JSON 也不能抛。"""
+    original = llm_mod.LOG_PATH
+    llm_mod.LOG_PATH = tmp_path
+    try:
+        asyncio.run(llm_mod._log_request(
+            httpx.Request('POST', 'https://api.ppio.com/openai', content=b'not json')))
+    finally:
+        llm_mod.LOG_PATH = original
+    assert 'request log failed' in capsys.readouterr().out


### PR DESCRIPTION
## 问题

Orin6（10.100.121.16）上 agent core 请求 LLM 一直失败，但同样的 entrypoint + key 直接 curl 是通的。

日志里表现成网络问题：

```
[llm] zai-org/glm-5.2 @ https://api.ppio.com/openai/ failed after 0.03s: APIConnectionError: Connection error.
[llm] connection failed after 3 attempts — LLM unreachable, check network connectivity
```

0.03s 就失败，其实根本没发包。

## 根因

模型配的是 PPIO 的 `zai-org/glm-5.2`，带厂商前缀。`_log_request` 这个 httpx 事件钩子拿模型名直接拼文件名：

```python
path = LOG_PATH / f'llm_request_{model}.json'
# → resource/log/llm_request_zai-org/glm-5.2.json
```

`resource/log/zai-org/` 目录不存在 → `FileNotFoundError`。

钩子跑在请求发出**之前**，异常直接打断发送；而 openai SDK 的 `_base_client` 对所有非超时异常一律 `except Exception → raise APIConnectionError`，于是一个写文件失败被伪装成了「网络不通」，还触发三次重试。

curl 通是因为不走这个钩子。

## 验证

容器内 A/B，同 URL 同 key 同模型，唯一变量是钩子：

```
hook= True  -> FAIL APIConnectionError | cause: FileNotFoundError(2, 'No such file or directory')
hook= False -> OK
```

旁证：`/work/resource/log/` 里躺着 `llm_request_glm-5.1.json`、`llm_request_glm-5.2.json`——都是模型名还不带斜杠时写成功的，换成 `厂商/模型` 命名后就再没写进去过。

这个 bug 对所有带斜杠的模型 id 都会触发（PPIO / OpenRouter / SiliconFlow 那一类），不是 orin6 独有。

## 改动

- 模型名里的 `/` 压平成 `_`
- 整个钩子包 try/except，失败只打印一行不抛

第二点和 `client/__init__.py:69-71` 对 `llm_logger` 的处理是同一个原则——诊断用的旁路日志不该有能力打断真实请求。那次是损坏的 `llm_request_*.jsonl` 把整个 agent loop 拖死，这次是缺个目录。

## 测试

新增 `agent-core/tests/test_llm_request_log_hook.py`，6 个用例覆盖带斜杠模型名、不带斜杠的回归、目录不可写、空 body、非 JSON body。

- 去掉修复后跑：`4 failed, 2 passed` —— 确认能抓住这个 bug
- 加上修复后跑：`6 passed`
- 全量 `agent-core/tests`：`116 passed, 1 failed`，唯一失败是 `test_feishu_proxy.py` 本地缺 `lark_oapi` 模块，与本次改动无关

🤖 Generated with [Claude Code](https://claude.com/claude-code)