### PR TITLE
fix(interrupt): 打断兜底路径从未真正下发到设备

### DIFF
--- a/agent-core/src/event/llm.py
+++ b/agent-core/src/event/llm.py
@@ -831,25 +831,49 @@ class Event:
             return
 
         # Fallback: hardcoded lookup (no hook registered)
+        #
+        # registry[mcp_id]['tools'] holds *bare* plugin names ('tts', 'loco') --
+        # mcp_client._connect_one does `tools.append(tool['name'])`. This used to
+        # hand those straight to call_tool(), which parses its argument as a full
+        # `mcp__<id>__<tool>` name: it split 'loco' into one segment, failed the
+        # `len(parts) != 3` check and returned the *string* '工具名格式错误: loco'.
+        # A returned string is not an exception, so the error check below never
+        # fired and the log still announced "interrupted N active output(s)" --
+        # while nothing had been interrupted, on any robot.
+        #
+        # call_tool_direct takes (mcp_id, bare_tool_name) and is the intended entry
+        # point for hooks: it also skips the ACP barrier, which an interrupt must.
+        #
+        # Deliberately not interrupting switch_mode: aborting a posture change
+        # partway is how a controlled descent becomes a fall, so a running
+        # stand-up/lie-down is left to finish.
         tasks = []
         for mcp_id, info in mcp_client.registry.items():
+            if not info.get('online'):
+                continue
             tools = info.get('tools', [])
-            for t in tools:
-                short_name = t.split('__')[-1] if '__' in t else t
-                if short_name == 'tts':
-                    tasks.append(mcp_client.call_tool(t, {'action': 'interrupt'}))
-                    break
-            for t in tools:
-                short_name = t.split('__')[-1] if '__' in t else t
-                if short_name == 'loco':
-                    tasks.append(mcp_client.call_tool(t, {'action': 'stop_move'}))
-                    break
-        if tasks:
-            results = await asyncio.gather(*tasks, return_exceptions=True)
-            for i, r in enumerate(results):
-                if isinstance(r, Exception):
-                    print(f'[decision] interrupt_active_outputs: task {i} failed: {r}')
-            print(f'[decision] interrupted {len(tasks)} active output(s) (fallback)')
+            for short_name, action in (('tts', 'interrupt'), ('loco', 'stop_move')):
+                if short_name in tools:
+                    tasks.append((f'{mcp_id}:{short_name}',
+                                  mcp_client.call_tool_direct(mcp_id, short_name,
+                                                              {'action': action})))
+        if not tasks:
+            print('[decision] interrupt_active_outputs: no tts/loco tool registered')
+            return
+
+        labels = [label for label, _ in tasks]
+        results = await asyncio.gather(*[coro for _, coro in tasks],
+                                       return_exceptions=True)
+        ok = 0
+        for label, r in zip(labels, results):
+            if isinstance(r, Exception):
+                print(f'[decision] interrupt_active_outputs: {label} raised: {r}')
+            elif isinstance(r, dict) and r.get('error'):
+                print(f'[decision] interrupt_active_outputs: {label} failed: {r["error"]}')
+            else:
+                ok += 1
+        print(f'[decision] interrupted {ok}/{len(tasks)} active output(s) (fallback)')
+
 
     # ── 主循环 ───────────────────────────────────────────────────────────────
 

--- a/agent-core/tests/test_interrupt_fallback.py
+++ b/agent-core/tests/test_interrupt_fallback.py
@@ -1,0 +1,220 @@
+"""The barge-in fallback must actually reach the device.
+
+`_interrupt_active_outputs` runs when no `on_interrupt_all` hook binding exists --
+the path taken on R1. It looked up tools from `registry[mcp_id]['tools']`, which
+holds *bare* plugin names ('tts', 'loco'), and passed them to `call_tool()`.
+
+`call_tool` parses its argument as a full `mcp__<id>__<tool>` name. Given 'loco' it
+split into one segment, failed `len(parts) != 3`, and returned the *string*
+'工具名格式错误: loco'. A string is not an exception, so the error check never
+fired and the log still said "interrupted 2 active output(s)". Nothing had been
+interrupted -- on any robot, for both TTS and locomotion.
+
+Observed on R1 2026-09-02: `[decision] interrupted 3 active output(s) (fallback)`
+during a barge-in, with no corresponding call reaching the driver.
+
+Run: cd agent-core && PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest \
+     tests/test_interrupt_fallback.py -q
+"""
+import asyncio
+import os
+import pathlib
+import sys
+import tempfile
+
+import pytest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / 'src'))
+
+os.environ.setdefault('DB_PATH', os.path.join(tempfile.mkdtemp(), 'test.db'))
+
+import mcp_client  # noqa: E402
+import hooks  # noqa: E402
+from event.llm import Event as DecisionLoop  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def clean_registry():
+    saved = dict(mcp_client.registry)
+    mcp_client.registry.clear()
+    yield
+    mcp_client.registry.clear()
+    mcp_client.registry.update(saved)
+
+
+@pytest.fixture(autouse=True)
+def no_hooks(monkeypatch):
+    """Force the fallback path -- with a binding registered it is never reached."""
+    async def _fire(hook_id, *a, **kw):
+        return []
+    monkeypatch.setattr(hooks, 'fire', _fire)
+
+
+@pytest.fixture
+def direct_calls(monkeypatch):
+    """Record call_tool_direct instead of hitting a device."""
+    seen = []
+
+    async def _direct(mcp_id, tool_name, args):
+        seen.append((mcp_id, tool_name, args))
+        return {'ok': True}
+
+    monkeypatch.setattr(mcp_client, 'call_tool_direct', _direct)
+    return seen
+
+
+@pytest.fixture
+def forbid_call_tool(monkeypatch):
+    """call_tool cannot be used here: it needs a full mcp__id__tool name, and the
+    registry only has bare ones. Fail loudly if the old path comes back."""
+    async def _call_tool(full_name, args):
+        raise AssertionError(f'call_tool must not be used for interrupts: {full_name!r}')
+
+    monkeypatch.setattr(mcp_client, 'call_tool', _call_tool)
+
+
+def _register(mcp_id='mcp-1', tools=('tts', 'loco'), online=True):
+    # Exactly the shape mcp_client._connect_one builds: bare plugin names.
+    mcp_client.registry[mcp_id] = {
+        'name': mcp_id, 'url': f'http://localhost/{mcp_id}', 'online': online,
+        'tools': list(tools), 'schemas': {}, 'input_schemas': {}, 'tool_meta': {},
+    }
+
+
+def _run(loop=None):
+    loop = loop or DecisionLoop.__new__(DecisionLoop)
+    asyncio.run(loop._interrupt_active_outputs())
+
+
+# ── the regression ───────────────────────────────────────────────────────────
+
+def test_interrupt_reaches_tts_and_loco(direct_calls, forbid_call_tool):
+    _register(tools=['mic', 'tts', 'speaker', 'loco', 'switch_mode', 'arm'])
+    _run()
+    assert sorted(direct_calls) == [
+        ('mcp-1', 'loco', {'action': 'stop_move'}),
+        ('mcp-1', 'tts', {'action': 'interrupt'}),
+    ]
+
+
+def test_bare_tool_names_are_not_mangled(direct_calls, forbid_call_tool):
+    """'loco' must be passed as-is with its mcp_id, not parsed as a full name."""
+    _register(tools=['loco'])
+    _run()
+    assert direct_calls == [('mcp-1', 'loco', {'action': 'stop_move'})]
+
+
+def test_split_tools_do_not_hide_the_plugin(direct_calls, forbid_call_tool):
+    """R1's loco is split by x-action-params into loco__move / loco__stop_move, but
+    registry['tools'] still lists the bare 'loco' -- the split names live in
+    'schemas'/'tool_groups'. The old `t.split('__')[-1]` reasoning was aimed at
+    those; this asserts we key off the bare list."""
+    mcp_client.registry['mcp-1'] = {
+        'name': 'mcp-1', 'url': 'http://x', 'online': True,
+        'tools': ['loco', 'tts'],
+        'tool_groups': {'loco': ['mcp__mcp-1__loco__move',
+                                 'mcp__mcp-1__loco__stop_move']},
+        'schemas': {}, 'input_schemas': {}, 'tool_meta': {},
+    }
+    _run()
+    assert ('mcp-1', 'loco', {'action': 'stop_move'}) in direct_calls
+
+
+def test_every_online_device_is_interrupted(direct_calls, forbid_call_tool):
+    _register('mcp-1', tools=['tts'])
+    _register('mcp-2', tools=['loco'])
+    _run()
+    assert sorted(direct_calls) == [
+        ('mcp-1', 'tts', {'action': 'interrupt'}),
+        ('mcp-2', 'loco', {'action': 'stop_move'}),
+    ]
+
+
+def test_offline_devices_are_skipped(direct_calls, forbid_call_tool):
+    _register('mcp-1', tools=['tts', 'loco'], online=False)
+    _run()
+    assert direct_calls == []
+
+
+def test_switch_mode_is_not_interrupted(direct_calls, forbid_call_tool):
+    """Aborting a posture change partway is how a controlled descent becomes a
+    fall, so a running stand-up/lie-down is left to finish."""
+    _register(tools=['switch_mode'])
+    _run()
+    assert direct_calls == []
+
+
+# ── honest reporting ─────────────────────────────────────────────────────────
+
+def test_a_failed_call_is_not_counted_as_interrupted(monkeypatch, capsys,
+                                                     forbid_call_tool):
+    """The whole point: an error must not be reported as a successful interrupt."""
+    async def _direct(mcp_id, tool_name, args):
+        return {'error': 'device offline'}
+
+    monkeypatch.setattr(mcp_client, 'call_tool_direct', _direct)
+    _register(tools=['tts', 'loco'])
+    _run()
+    out = capsys.readouterr().out
+    assert 'interrupted 0/2 active output(s)' in out
+    assert 'device offline' in out
+
+
+def test_an_exception_is_reported_and_not_counted(monkeypatch, capsys,
+                                                  forbid_call_tool):
+    async def _direct(mcp_id, tool_name, args):
+        if tool_name == 'loco':
+            raise RuntimeError('boom')
+        return {'ok': True}
+
+    monkeypatch.setattr(mcp_client, 'call_tool_direct', _direct)
+    _register(tools=['tts', 'loco'])
+    _run()
+    out = capsys.readouterr().out
+    assert 'interrupted 1/2 active output(s)' in out
+    assert 'boom' in out
+
+
+def test_success_is_counted(direct_calls, capsys, forbid_call_tool):
+    _register(tools=['tts', 'loco'])
+    _run()
+    assert 'interrupted 2/2 active output(s)' in capsys.readouterr().out
+
+
+def test_no_interruptible_tool_says_so(direct_calls, capsys, forbid_call_tool):
+    """Silence here used to look identical to a successful interrupt."""
+    _register(tools=['mic', 'camera'])
+    _run()
+    out = capsys.readouterr().out
+    assert 'no tts/loco tool registered' in out
+    assert direct_calls == []
+
+
+# ── the hook path still wins ─────────────────────────────────────────────────
+
+def test_a_registered_hook_short_circuits_the_fallback(monkeypatch, direct_calls):
+    async def _fire(hook_id, *a, **kw):
+        return ['binding-1']
+
+    monkeypatch.setattr(hooks, 'fire', _fire)
+    _register(tools=['tts', 'loco'])
+    _run()
+    assert direct_calls == [], 'the hook handled it; the fallback must not also fire'
+
+
+def test_the_hook_path_clears_pending_acp(monkeypatch):
+    async def _fire(hook_id, *a, **kw):
+        return ['binding-1']
+
+    monkeypatch.setattr(hooks, 'fire', _fire)
+
+    async def scenario():
+        ev = asyncio.Event()
+        mcp_client._pending_actions['speak-1'] = ev
+        await DecisionLoop.__new__(DecisionLoop)._interrupt_active_outputs()
+        return ev.is_set()
+
+    try:
+        assert asyncio.run(scenario()) is True
+    finally:
+        mcp_client._pending_actions.clear()


### PR DESCRIPTION
## 问题

`_interrupt_active_outputs` 是**没有 `on_interrupt_all` hook 绑定时**走的兜底路径 —— R1 上就是这条。它从
`registry[mcp_id]['tools']` 取工具名，然后交给 `call_tool()`。

但那个列表里是**裸插件名**。`mcp_client._connect_one` 是 `tools.append(tool['name'])`，所以内容是
`'tts'` / `'loco'` / `'switch_mode'`。

而 `call_tool` 把参数当完整的 `mcp__<id>__<tool>` 名字解析：

```python
parts = full_name.split('__', 2)      # 'loco' → ['loco']
if len(parts) != 3:
    return f'工具名格式错误: {full_name}'   # ← 返回字符串，不是抛异常
```

**返回的是字符串，不是异常**，所以下面这个检查永远不会命中：

```python
for i, r in enumerate(results):
    if isinstance(r, Exception):      # 字符串不是 Exception
        print(...)
print(f'[decision] interrupted {len(tasks)} active output(s) (fallback)')   # ← 照样宣布成功
```

R1 上 2026-09-02 的真实日志里就有这一行：

```
[decision] interrupted 3 active output(s) (fallback)
```

而驱动侧**没有收到任何对应的调用**。

**影响范围：所有没有 hook 绑定的机器人，TTS 和运动都停不了。** 不是 R1 专属，也不只是腿。

（我最初的判断是 `t.split('__')[-1]` 把 `loco__move` 取成了 `move` —— 那是错的。`registry['tools']`
里根本没有拆分后的名字，拆分名在 `schemas` / `tool_groups` 里。真正的原因是把裸名喂给了需要完整名的
`call_tool`，而且失败被静默吞掉。）

## 改动

改用 `call_tool_direct(mcp_id, bare_name, args)`。它本来就是为 hook 设计的入口（docstring 原文：
"Used by system hooks for immediate execution (e.g. interrupt, LED effects)"）：接收裸工具名 + mcp_id，
并且**跳过 ACP barrier** —— 打断本来就不该排在 barrier 后面。

同时把上报改诚实：

- 成功、`{'error': ...}`、抛异常三种结果分开统计；
- 日志变成 `interrupted 1/2 active output(s)`，失败原因单独打印；
- registry 里没有 tts/loco 时明确说 `no tts/loco tool registered` —— 之前这种情况什么都不打，
  和"成功打断"在日志上完全一样。

**仍然不打断 `switch_mode`**（有测试固定这一点）：姿态切换中途中止正是"受控下放退化成摔倒"的成因，
起立/躺下一旦开始就让它跑完。

## 测试

新增 `agent-core/tests/test_interrupt_fallback.py`，12 个：

- 打断真的到达 tts 和 loco，参数正确
- 裸名不被当完整名解析
- 拆分工具（R1 的 `loco__move` / `loco__stop_move`）不影响按裸名查找
- 多设备各自打断、离线设备跳过
- `switch_mode` 不被打断
- 失败/异常**不计入**成功数，且原因打印出来
- 无可打断工具时明确说明
- 有 hook 绑定时兜底不重复触发，且 hook 路径仍清 pending ACP

其中 `forbid_call_tool` fixture 把 `call_tool` 换成抛断言的实现 —— **旧路径回来会立刻测试失败**，
不会再静默退化。

```
PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest agent-core/tests -q
234 passed, 1 failed
```

失败的是 `test_feishu_proxy.py`（`ModuleNotFoundError: lark_oapi`），先前就存在，与本 PR 无关。

## 关联

与 phanthymotus#161（`finish` barrier + barge-in 唤醒）和 phanthymotus-driver#227（R1 `switch_mode`
异步 + ACP）同一条线：#161 让 barrier 能被新用户消息唤醒并调用打断，本 PR 让那个打断真的下发出去。

🤖 Generated with [Claude Code](https://claude.com/claude-code)