### PR TITLE
fix(agent-core): 策略路由不再把默认路由和 DNS 一起带走

### DIFF
--- a/agent-core/src/api/network.py
+++ b/agent-core/src/api/network.py
@@ -155,13 +155,18 @@ def _get_devices_sync() -> list[dict]:
             except Exception:
                 pass
 
-        # Policy routing (ipv4.route-table) — whether replies from this device
-        # are forced back out the same device instead of the lowest-metric default route
-        route_table = 0
+        # Policy routing — whether replies from this device are forced back out the
+        # same device instead of following the lowest-metric default route. The
+        # source-based `ip rule` is what makes that happen, so that is what we key
+        # the state off. `route-table` is also accepted so profiles written by the
+        # older scheme (which relocated the routes instead of copying them, see
+        # `_set_policy_route_sync`) still read as on and can be toggled off to clean up.
+        policy_route = False
         if settings_path and settings_path != '/':
             try:
-                route_table = int(_get_connection_settings(bus, settings_path)
-                                   .get('ipv4', {}).get('route-table', 0))
+                ipv4_settings = _get_connection_settings(bus, settings_path).get('ipv4', {})
+                policy_route = (bool(ipv4_settings.get('routing-rules'))
+                                or int(ipv4_settings.get('route-table', 0)) != 0)
             except Exception:
                 pass
 
@@ -194,7 +199,7 @@ def _get_devices_sync() -> list[dict]:
             'ip': ip,
             'mask': mask,
             'gateway': gateway,
-            'policy_route': route_table != 0,
+            'policy_route': policy_route,
         })
     return results
 
@@ -366,22 +371,79 @@ def _find_device_path_sync(bus, device: str) -> str | None:
     return None
 
 
+def _policy_route_data(table: int, network: str, prefix: int, gateway: str) -> list:
+    """The routes to copy into private table `table` for a device on `network`/`prefix`.
+
+    Two entries, both pinned to the table via the per-route `table` attribute:
+
+    - the device's own subnet, kept on-link. Without it the default route below
+      would swallow same-subnet destinations too (a table with a default route
+      never falls through to main), so replies to a peer on this very subnet would
+      take a needless detour through the gateway — and break outright behind AP
+      client isolation.
+    - a default route via `gateway`, for replies to everything else.
+
+    NetworkManager adds the link route for `gateway` itself to the same table, so
+    the default route is self-sufficient; that is not our job here.
+    """
+    import dbus
+    entries = [
+        dbus.Dictionary({
+            'dest': dbus.String(network),
+            'prefix': dbus.UInt32(prefix),
+            'table': dbus.UInt32(table),
+        }, signature='sv'),
+    ]
+    if gateway:
+        entries.append(dbus.Dictionary({
+            'dest': dbus.String('0.0.0.0'),
+            'prefix': dbus.UInt32(0),
+            'next-hop': dbus.String(gateway),
+            'table': dbus.UInt32(table),
+        }, signature='sv'))
+    return entries
+
+
+def _without_policy_routes(route_data, table: int) -> list:
+    """`route_data` minus the entries we own, so a user's own static routes survive
+    both enabling and disabling."""
+    return [r for r in route_data if int(r.get('table', 0)) != table]
+
+
 def _set_policy_route_sync(device: str, enable: bool):
     """Enable/disable policy routing on a device's active connection so replies
     to addresses outside its own subnet are still sent back out through it,
     instead of following another interface's lower-metric default route
     (asymmetric routing on multi-homed hosts).
 
-    `ipv4.route-table` alone only moves the connection's routes into a private
-    table — confirmed against a live multi-homed host that it does NOT also
-    install the matching `ip rule`. The rule has to be added explicitly via
-    `ipv4.routing-rules`. It's keyed on the device's current *subnet* rather
-    than its exact address so it keeps working across a DHCP renewal that
-    hands out a different address in the same subnet (the common case); a
-    renewal into a different subnet requires re-toggling this setting.
+    Implemented by *copying* the device's routes into a private table and pointing
+    a source-based `ip rule` at it, leaving the main table alone.
 
-    Applying either property requires a full deactivate+reactivate (not
-    Device.Reapply) to take effect, which briefly drops the device's link."""
+    Do NOT reach for `ipv4.route-table` here, however natural it looks. It does not
+    copy the connection's routes into the private table, it *relocates* them — the
+    DHCP default route included. The device then stops being usable as a general
+    egress path at all, and NetworkManager additionally reports the link to
+    systemd-resolved as not-a-default-route, which silently drops its DNS servers
+    (`resolvectl status` shows `Current Scopes: none`). Bumi 2026-09-02: the toggle
+    was on for wifi, so every outbound connection fell to a dead 10.42.0.1 default
+    route on another NIC and resolution rode on that same dead link. `ip route add
+    default … dev wifi` could not even be added by hand — with the subnet route
+    relocated too, the main table had no route to the wifi gateway, so the kernel
+    rejected the nexthop as invalid.
+
+    `ipv4.routing-rules` is required and separate: setting a route table alone does
+    not install the matching `ip rule`. The rule is keyed on the device's current
+    *subnet* rather than its exact address so it survives a DHCP renewal handing out
+    a different address in the same subnet (the common case). The copied routes pin
+    the current gateway, so a renewal into a different subnet or gateway needs this
+    setting re-toggled; until then only reply symmetry is stale — the main table is
+    still whatever DHCP says, so the host keeps its connectivity.
+
+    Applied with Device.Reapply, which on NM 1.36.6 picks up routes, routing rules
+    and route-table without touching the link (verified on Bumi — an SSH session
+    over the very device being reconfigured survived). Older NM may not, so a full
+    deactivate+reactivate remains as fallback; that one does drop the link briefly.
+    """
     import dbus
     import time
     bus = _get_bus()
@@ -399,21 +461,24 @@ def _set_policy_route_sync(device: str, enable: bool):
     conn_iface = dbus.Interface(conn_obj, NM_CONN_IFACE)
     settings = conn_iface.GetSettings()
     ipv4 = settings.setdefault('ipv4', dbus.Dictionary({}, signature='sv'))
+    kept_routes = _without_policy_routes(ipv4.get('route-data', []), table)
 
     if enable:
         ip4_path = str(_get_prop(bus, dev_path, NM_DEVICE_IFACE, 'Ip4Config'))
         if not ip4_path or ip4_path == '/':
             raise RuntimeError(f'设备 "{device}" 当前没有 IP 地址')
-        addresses = _get_all_props(bus, ip4_path, NM_IP4_IFACE).get('AddressData', [])
+        ip4_props = _get_all_props(bus, ip4_path, NM_IP4_IFACE)
+        addresses = ip4_props.get('AddressData', [])
         if not addresses:
             raise RuntimeError(f'设备 "{device}" 当前没有 IP 地址')
         prefix = int(addresses[0].get('prefix', 32))
         network = _subnet_network(str(addresses[0].get('address', '')), prefix)
-        ipv4['route-table'] = dbus.UInt32(table)
+        gateway = str(ip4_props.get('Gateway', ''))
+        new_routes = kept_routes + _policy_route_data(table, network, prefix, gateway)
         # Wire format is aa{sv}, not a plain string list — confirmed by round-tripping
         # a rule set via `nmcli ... +ipv4.routing-rules "priority ... from ... table ..."`
         # through GetSettings() and inspecting the actual dbus.Dictionary it produced.
-        ipv4['routing-rules'] = dbus.Array([
+        new_rules = [
             dbus.Dictionary({
                 'family': dbus.Int32(socket.AF_INET),
                 'priority': dbus.UInt32(table),
@@ -421,12 +486,29 @@ def _set_policy_route_sync(device: str, enable: bool):
                 'from-len': dbus.Byte(prefix),
                 'table': dbus.UInt32(table),
             }, signature='sv'),
-        ], signature='a{sv}')
+        ]
     else:
-        ipv4['route-table'] = dbus.UInt32(0)
-        ipv4['routing-rules'] = dbus.Array([], signature='a{sv}')
+        new_routes = kept_routes
+        new_rules = []
+
+    # Always cleared, both to undo profiles written by the older scheme and to keep
+    # our own `table=` route attributes from being overridden by a connection-wide table.
+    ipv4['route-table'] = dbus.UInt32(0)
+    ipv4['route-data'] = dbus.Array(new_routes, signature='a{sv}')
+    ipv4['routing-rules'] = dbus.Array(new_rules, signature='a{sv}')
+    # Legacy alias for route-data; leaving a stale copy behind lets the two disagree.
+    ipv4.pop('routes', None)
 
     conn_iface.Update(settings)
+
+    try:
+        dev_iface = dbus.Interface(bus.get_object(NM_IFACE, dev_path), NM_DEVICE_IFACE)
+        # Empty connection + version_id 0 = "reapply the saved profile", which is what
+        # `nmcli device reapply` sends and what we just wrote via Update().
+        dev_iface.Reapply(dbus.Dictionary({}, signature='sa{sv}'), dbus.UInt64(0), dbus.UInt32(0))
+        return
+    except Exception:
+        pass
 
     nm_obj = bus.get_object(NM_IFACE, NM_PATH)
     nm_iface = dbus.Interface(nm_obj, NM_IFACE)
@@ -434,6 +516,7 @@ def _set_policy_route_sync(device: str, enable: bool):
     time.sleep(1)
     nm_iface.ActivateConnection(
         dbus.ObjectPath(settings_path), dbus.ObjectPath(dev_path), dbus.ObjectPath('/'))
+
 
 
 

--- a/agent-core/tests/test_policy_route_settings.py
+++ b/agent-core/tests/test_policy_route_settings.py
@@ -1,0 +1,161 @@
+"""Regression tests for the policy-route toggle in api/network.py.
+
+The trap these guard, observed on Bumi 2026-09-02: the toggle was on for wifi and
+the robot had no internet at all. The old implementation set `ipv4.route-table`,
+which does not copy a connection's routes into the private table — it *relocates*
+them, DHCP default route included. So the wifi stopped being usable as an egress
+path, every outbound connection fell to a dead `10.42.0.1` default route on another
+NIC, and NetworkManager reported the wifi link to systemd-resolved as
+not-a-default-route, which dropped its DNS servers too (`Current Scopes: none`) and
+left resolution riding the same dead link. It could not even be patched by hand:
+with the subnet route relocated as well, the main table had no route to the wifi
+gateway, so `ip route add default via 10.100.128.1 dev wlx…` was rejected with
+"Nexthop has invalid gateway".
+
+The fix copies the routes into the private table via the per-route `table`
+attribute and leaves `route-table` unset, so the main table stays whatever DHCP
+says. Verified on Bumi (NM 1.36.6): main regained the wifi default route,
+`resolvectl` went back to `+DefaultRoute` with the wifi's own DNS servers,
+`ip route get 8.8.8.8 from 10.100.129.141` still resolved via table 205, and an
+SSH session over the very device being reconfigured survived Device.Reapply.
+
+Run: cd agent-core && python3 -m pytest tests/test_policy_route_settings.py
+"""
+import os
+import pathlib
+import sys
+import tempfile
+
+import pytest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / 'src'))
+
+os.environ.setdefault('DB_PATH', os.path.join(tempfile.mkdtemp(), 'test.db'))
+
+
+# ── dbus stub ─────────────────────────────────────────────────────────────────
+# network.py imports dbus inside each function, so injecting a stub module is
+# enough — no dbus-python needed to test the settings we hand to NM.
+
+class _Dict(dict):
+    def __init__(self, value=None, signature=None):
+        super().__init__(value or {})
+        self.signature = signature
+
+
+class _Array(list):
+    def __init__(self, value=None, signature=None):
+        super().__init__(value or [])
+        self.signature = signature
+
+
+class _FakeDbus:
+    Dictionary = _Dict
+    Array = _Array
+    String = str
+    UInt32 = int
+    UInt64 = int
+    Int32 = int
+    Byte = int
+    Boolean = bool
+    ObjectPath = str
+
+    class Interface:  # pragma: no cover - unused by these tests
+        def __init__(self, obj, iface):
+            pass
+
+
+sys.modules.setdefault('dbus', _FakeDbus())
+
+from api.network import (  # noqa: E402
+    _policy_route_data,
+    _policy_route_table_for,
+    _without_policy_routes,
+)
+
+DEVICE = 'wlx001f058a5d81'
+NETWORK = '10.100.128.0'
+PREFIX = 19
+GATEWAY = '10.100.128.1'
+
+
+def _table():
+    return _policy_route_table_for(DEVICE)
+
+
+def test_table_number_is_stable_and_in_private_range():
+    """The Bumi profile in the field carries table 205; a different number here
+    would orphan every already-written rule."""
+    table = _table()
+    assert table == 205
+    assert 200 <= table <= 249
+    assert _policy_route_table_for(DEVICE) == table  # deterministic across calls
+
+
+def test_copies_are_pinned_to_the_private_table():
+    routes = _policy_route_data(_table(), NETWORK, PREFIX, GATEWAY)
+    assert [r['table'] for r in routes] == [_table(), _table()]
+
+
+def test_subnet_copy_stays_on_link():
+    """A table holding a default route never falls through to main, so without an
+    on-link subnet route replies to a same-subnet peer detour via the gateway."""
+    subnet = _policy_route_data(_table(), NETWORK, PREFIX, GATEWAY)[0]
+    assert subnet['dest'] == NETWORK
+    assert subnet['prefix'] == PREFIX
+    assert 'next-hop' not in subnet
+
+
+def test_default_copy_goes_via_the_gateway():
+    default = _policy_route_data(_table(), NETWORK, PREFIX, GATEWAY)[1]
+    assert default['dest'] == '0.0.0.0'
+    assert default['prefix'] == 0
+    assert default['next-hop'] == GATEWAY
+
+
+def test_no_gateway_yields_subnet_copy_only():
+    """A device with an address but no gateway can still answer its own subnet.
+    Emitting a default route with an empty next-hop would be rejected by NM."""
+    routes = _policy_route_data(_table(), NETWORK, PREFIX, '')
+    assert len(routes) == 1
+    assert routes[0]['dest'] == NETWORK
+
+
+def test_nothing_lands_in_the_main_table():
+    """The whole point: not one emitted route may be left for table main. An entry
+    without a `table` attribute is exactly what breaks the host's connectivity."""
+    for route in _policy_route_data(_table(), NETWORK, PREFIX, GATEWAY):
+        assert route.get('table') == _table()
+
+
+def test_user_static_routes_survive():
+    user_route = {'dest': '10.9.0.0', 'prefix': 16, 'next-hop': '10.100.128.9'}
+    other_device_route = {'dest': '10.8.0.0', 'prefix': 16, 'table': 249}
+    existing = [user_route, other_device_route,
+                *_policy_route_data(_table(), NETWORK, PREFIX, GATEWAY)]
+
+    kept = _without_policy_routes(existing, _table())
+
+    assert kept == [user_route, other_device_route]
+
+
+def test_disable_then_enable_does_not_accumulate_copies():
+    """The canvas-style repeat: toggling several times must not stack duplicates."""
+    routes = []
+    for _ in range(3):
+        routes = (_without_policy_routes(routes, _table())
+                  + _policy_route_data(_table(), NETWORK, PREFIX, GATEWAY))
+        assert len(routes) == 2
+        routes = _without_policy_routes(routes, _table())  # disable
+        assert routes == []
+
+
+def test_untabled_route_is_never_mistaken_for_ours():
+    """`int(r.get('table', 0))` must treat a missing attribute as main, or a user's
+    plain static route would be deleted on the first toggle."""
+    plain = [{'dest': '10.9.0.0', 'prefix': 16}]
+    assert _without_policy_routes(plain, _table()) == plain
+
+
+if __name__ == '__main__':
+    sys.exit(pytest.main([__file__, '-q']))

--- a/agent-core/web/js/network.js
+++ b/agent-core/web/js/network.js
@@ -51,7 +51,7 @@ async function _loadInterfaces() {
           ${i.gateway ? `<div class="network-iface-cell"><span class="network-iface-label">网关</span><span class="network-iface-value">${_esc(i.gateway)}</span></div>` : ''}
           ${i.mac ? `<div class="network-iface-cell"><span class="network-iface-label">MAC</span><span class="network-iface-value">${_esc(i.mac)}</span></div>` : ''}
         </div>` : ''}
-        ${i.state === 'connected' && i.gateway ? `<div class="network-iface-policy-route" title="开启后，来自此网卡的连接会强制从此网卡回复，用于此网卡不是主上行网络时避免外部无法访问其 IP。切换时会短暂断开重连此网卡">
+        ${i.state === 'connected' && i.gateway ? `<div class="network-iface-policy-route" title="开启后，来自此网卡的连接会强制从此网卡回复，用于此网卡不是主上行网络时避免外部无法访问其 IP。不影响此网卡作为默认出口。旧版 NetworkManager 上切换时可能会短暂断开重连此网卡">
           <span class="network-iface-label">策略路由（防止回包走错网卡）</span>
           <label class="toggle-switch">
             <input type="checkbox" class="network-policy-route-toggle" data-device="${_attr(i.device)}" ${i.policy_route ? 'checked' : ''} />
@@ -72,7 +72,7 @@ async function _loadInterfaces() {
 async function _togglePolicyRoute(el) {
   const device = el.dataset.device;
   const enable = el.checked;
-  if (!confirm(`此操作会短暂断开并重连 ${device}，确认继续？`)) {
+  if (!confirm(`此操作会重新应用 ${device} 的网络配置，旧版 NetworkManager 上可能短暂断开重连，确认继续？`)) {
     el.checked = !enable;
     return;
   }


### PR DESCRIPTION
## 问题

网络设置里的「策略路由」开关用的是 `ipv4.route-table`。这个属性不是把连接的路由**复制**进私有表，而是**搬走** —— 包括 DHCP 下发的默认路由和 on-link 的子网路由。开关一开，这块网卡就彻底不能当通用出口了。

Bumi 2026-09-02 现场：wifi 开着这个开关，机器完全上不了外网。所有主动发起的连接都掉到另一块网卡上一条走不通的 `10.42.0.1` 默认路由。NetworkManager 还会把这个 link 报给 systemd-resolved 说「不是 default-route link」，于是它的 DNS 服务器被静默弃用（`resolvectl status` 显示 `Current Scopes: none`），域名解析也吊在同一条死链路上。

连手工都补不回来 —— 子网路由也被搬走了，main 表里没有到 wifi 网关的路由，内核直接拒绝：

```
$ sudo ip route add default via 10.100.128.1 dev wlx001f058a5d81 metric 100
Error: Nexthop has invalid gateway.
```

## 改法

不设 `route-table`，让 main 表继续由 DHCP 拥有；用每条路由的 `table=` 属性往私有表里放**副本**。

子网那条副本保持 on-link（不给 next-hop）：一张含默认路由的表永远不会 fallthrough 到 main，没有这条的话，回给同网段对端的包会绕一趟网关，碰上 AP 客户端隔离直接废掉。网关自己的链路路由 NM 会自动加进同一张表，不需要我们管。

失效模式也变好了：私有表里钉住的网关在 DHCP 变更后会过期，但代价只是回包对称失效，不再连整机连通性一起带走。

其余：

- 开关状态改成读 `routing-rules` 而不是 `route-table`（后者现在恒为 0）。`route-table != 0` 仍然认，好让旧方案写出来的 profile 显示为「开」、拨一下关就能清干净。
- 应用方式改成 `Device.Reapply` 优先，失败才退回 deactivate + reactivate。原注释说 Reapply 对这几个属性不生效，**是错的**：NM 1.36.6 上它能把 routes / routing-rules / route-table 全部应用且不碰链路 —— 一条骑在被重配网卡上的 SSH 会话扛过了连续四次拨动。
- enable 和 disable 都按 `table` 属性过滤 route-data，所以用户自己的静态路由不会被吃掉，反复拨也不会堆重复条目。
- 前端 tooltip / confirm 文案跟着改：不再无条件说「会短暂断开」，并说明不影响此网卡作为默认出口。

## 验证

在 Bumi（NM 1.36.6）上走真实 D-Bus 路径验过 —— 先用 `nmcli` 在隔离的 dummy 网卡上确认了 `table=` 属性的语义，再把改好的 `network.py` 送进跑着的容器直接调 `_set_policy_route_sync`：

- `route-data` 的 `aa{sv}` 线格式 round-trip 与写入完全一致
- 两条副本正确落进 205 表，子网那条是 `scope link`；main 表保留 DHCP 的默认路由
- `resolvectl` 回到 `+DefaultRoute`，DNS 用回 wifi 自己的 `10.100.6.100 / 10.100.26.76`
- `ip route get 8.8.8.8 from 10.100.129.141` 仍然经 table 205 出去，原功能没丢
- off → on → off → on 两轮，每次 enable 恰好 2 条副本、每次 disable 归零无残留
- **开关关掉期间外网依然正常** —— 这是旧方案做不到的

全程挂了自动回滚兜底（自检失败或 180 秒内无人确认就 `nmcli` 还原），第一轮因为自检脚本 grep 的假阴性触发过一次回滚，机器功能等价、外网正常，修掉后第二轮干净通过。

新增 `agent-core/tests/test_policy_route_settings.py`，9 个用例（表号锁死 205、副本必带 `table` 属性、子网副本不能有 next-hop、无网关退化、用户静态路由不被吃、反复拨不堆积、缺 `table` 属性不被误认成我们的）。`243 passed, 1 failed`，失败的是本地缺 `lark_oapi` 的 `test_feishu_proxy.py`，与本改动无关。

## 部署注意

Bumi 上容器里的 `network.py` 目前是这份改动的手工副本，**下次镜像部署会覆盖回旧代码**。这个 PR 进镜像之前，谁在面板上拨一下那个开关都会让机器再断一次网。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
