### PR TITLE
fix(acp): report a barrier timeout as timeout, not completed

### DIFF
--- a/agent-core/src/mcp_client.py
+++ b/agent-core/src/mcp_client.py
@@ -672,6 +672,9 @@ async def await_pending(cancel_event: asyncio.Event | None = None, timeout: floa
                 # pending and reports "timeout".
                 raise asyncio.TimeoutError()
         else:
+            # Not reached from the agent loop: it creates a cancel_event for every
+            # turn (event/llm.py:887), so the branch above is the live one. Kept
+            # for direct callers.
             await asyncio.wait_for(_wait_all(), timeout=effective_timeout)
 
         # 清理已完成的

--- a/agent-core/src/mcp_client.py
+++ b/agent-core/src/mcp_client.py
@@ -639,7 +639,7 @@ async def await_pending(cancel_event: asyncio.Event | None = None, timeout: floa
             wait_task = asyncio.create_task(_wait_all())
             cancel_task = asyncio.create_task(cancel_event.wait())
             try:
-                done, pending = await asyncio.wait(
+                done, _unfinished = await asyncio.wait(
                     [wait_task, cancel_task],
                     timeout=effective_timeout,
                     return_when=asyncio.FIRST_COMPLETED,
@@ -660,6 +660,17 @@ async def await_pending(cancel_event: asyncio.Event | None = None, timeout: floa
                     _pending_timeouts.pop(aid, None)
                     _pending_tools.pop(aid, None)
                 return {"status": "cancelled"}
+            if wait_task not in done:
+                # Unlike wait_for, asyncio.wait() does not raise on timeout — it
+                # returns with an empty `done`. Falling through from here reported
+                # a silent timeout as {"status": "completed"}, so a barrier that
+                # waited out its full 120s looked identical to one that succeeded.
+                # That is precisely the case _acp_barrier_log was added to make
+                # attributable: an ACP completion callback that never arrives
+                # (self-signed cert rejected, AGENT_CORE_URL misconfigured).
+                # Converge on the TimeoutError path below, which already clears
+                # pending and reports "timeout".
+                raise asyncio.TimeoutError()
         else:
             await asyncio.wait_for(_wait_all(), timeout=effective_timeout)
 

--- a/agent-core/tests/test_acp_barrier_finish.py
+++ b/agent-core/tests/test_acp_barrier_finish.py
@@ -216,9 +216,15 @@ def test_timeout_with_a_cancel_event_is_still_reported_as_timeout():
     `asyncio.wait()` — unlike `wait_for` — does not raise on timeout; it returns
     with an empty `done`. The code fell through from there to the success path, so
     a barrier that waited out its full timeout returned {"status": "completed"}
-    and `_acp_barrier_log` stayed silent. On any robot in interrupt/followup mode
-    (collector arms cancel_event there) a completion callback that never arrived
-    was indistinguishable from clean playback.
+    and `_acp_barrier_log` stayed silent.
+
+    This is the branch production always takes, in every interrupt mode:
+    `_run`/`_one_turn` create a fresh `cancel_event` per turn unconditionally
+    (llm.py:887), and `await_pending` branches on whether that argument is None,
+    not on whether it is set. The `wait_for` branch above — the one that does
+    raise — is only reachable from a direct call, so
+    test_missing_acp_callback_times_out_and_releases was passing on a path no
+    robot runs.
     """
     async def scenario():
         _arm(timeout=0.1)

--- a/agent-core/tests/test_acp_barrier_finish.py
+++ b/agent-core/tests/test_acp_barrier_finish.py
@@ -210,6 +210,27 @@ def test_missing_acp_callback_times_out_and_releases():
     assert not mcp_client._pending_actions
 
 
+def test_timeout_with_a_cancel_event_is_still_reported_as_timeout():
+    """Same silent timeout, but on the branch that takes a cancel_event.
+
+    `asyncio.wait()` — unlike `wait_for` — does not raise on timeout; it returns
+    with an empty `done`. The code fell through from there to the success path, so
+    a barrier that waited out its full timeout returned {"status": "completed"}
+    and `_acp_barrier_log` stayed silent. On any robot in interrupt/followup mode
+    (collector arms cancel_event there) a completion callback that never arrived
+    was indistinguishable from clean playback.
+    """
+    async def scenario():
+        _arm(timeout=0.1)
+        cancel = asyncio.Event()  # armed, but nothing ever sets it
+        return await asyncio.wait_for(_finish_barrier(cancel), timeout=2)
+
+    result = asyncio.run(scenario())
+    assert result['status'] == 'timeout'
+    assert result['actions'] == [SPEAK_ID]
+    assert not mcp_client._pending_actions
+
+
 def test_barrier_uses_the_longest_pending_timeout():
     """Two utterances in flight: the barrier must outlast the slower one."""
     async def scenario():


### PR DESCRIPTION
Follow-up to #165, which turned this up while fixing the TTS idle-interrupt bug.

## The bug

`await_pending`'s `cancel_event` branch uses `asyncio.wait()`, which — unlike `wait_for` — **does not raise on timeout**. It returns with an empty `done` set. The code checked only whether `cancel_event` won the race, then fell straight through to the success path:

```python
done, _ = await asyncio.wait([wait_task, cancel_task], timeout=effective_timeout, ...)
if cancel_task in done:
    ...
    return {"status": "cancelled"}
# timeout lands here, with done == set()
...
print(f'[acp] barrier cleared: {aids}')
return {"status": "completed", "actions": aids}
```

So a barrier that waited out its full `effective_timeout` reported `{"status": "completed"}` and logged `[acp] barrier cleared` — byte-identical to a clean playback.

That defeats the one thing `_acp_barrier_log` exists for. It prints only on `timeout` / `cancelled` / `barge_in`, precisely so a silent timeout is attributable: a perception ACP completion callback that never arrived because the POST was rejected (self-signed cert) or aimed at a misconfigured `AGENT_CORE_URL`. On any robot in interrupt/followup mode — where `collector` arms `cancel_event` — that diagnosis simply wasn't available.

The non-`cancel_event` branch was never affected; it uses `wait_for`, which does raise.

## The fix

Raise `asyncio.TimeoutError()` when neither task finished, converging on the `except asyncio.TimeoutError` path that already clears pending and returns `"timeout"`.

## Why this is safe

Observability only, no behaviour change:

- Both paths clear the same four pending tables (`_pending_actions`, `_pending_results`, `_pending_timeouts`, `_pending_tools`).
- No caller branches on the status. `_acp_barrier` and both of its call sites in `event/llm.py` only hand the result to `_acp_barrier_log`.

I flagged this in #165 as "changing it changes agent behaviour, deserves its own call" — having now traced the consumers, that concern doesn't hold: nothing reads the status but the logger.

## Test

`test_timeout_with_a_cancel_event_is_still_reported_as_timeout` fails on the old code with:

```
E         - timeout
E         + completed
----------------------------- Captured stdout call -----------------------------
[acp] barrier: waiting for ['speak-deadbeef'] (timeout=0s)
[acp] barrier cleared: ['speak-deadbeef']
```

The captured stdout is the point — that's the misleading line a real diagnosis would have to work from.

`agent-core/tests` 245 passed; `perception/tests` 174 passed, 1 skipped. `test_feishu_proxy`'s `lark_oapi` import error is pre-existing and unrelated (confirmed on a clean tree).

Branch cut from `origin/main`, so the diff is these two files only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)