### PR TITLE
fix(agent-core): 策略路由表号改为分配，不再按设备名哈希

### DIFF
--- a/agent-core/src/api/network.py
+++ b/agent-core/src/api/network.py
@@ -349,9 +349,79 @@ def _disconnect_wifi_sync():
     )
 
 
+_POLICY_TABLE_MIN = 200
+_POLICY_TABLE_MAX = 249
+
+
 def _policy_route_table_for(device: str) -> int:
-    """Deterministic private routing table number for a device (200-249)."""
-    return 200 + (zlib.crc32(device.encode()) % 50)
+    """Preferred private routing table number for a device (200-249).
+
+    Only a starting point — `_allocate_policy_table` may hand out a different one to
+    avoid a collision, or reuse whatever the connection already has.
+    """
+    return _POLICY_TABLE_MIN + (zlib.crc32(device.encode()) % 50)
+
+
+def _tables_of(ipv4: dict) -> set:
+    """Private-range table numbers an ipv4 setting refers to, via either its routing
+    rules or the `table` attribute of its routes."""
+    tables = set()
+    for entry in list(ipv4.get('routing-rules', [])) + list(ipv4.get('route-data', [])):
+        try:
+            table = int(entry.get('table', 0))
+        except (TypeError, ValueError):
+            continue
+        if _POLICY_TABLE_MIN <= table <= _POLICY_TABLE_MAX:
+            tables.add(table)
+    return tables
+
+
+def _allocate_policy_table(own_ipv4: dict, other_ipv4s: list, preferred: int) -> int:
+    """Pick the private table to use for one connection.
+
+    Reuse whatever this connection already refers to first. That keeps the number
+    stable across a WiFi card swap: the device name is MAC-derived, so a new card
+    renames the interface and `_policy_route_table_for` would hand out a different
+    number, stranding the routes and rule written for the old one — exactly what
+    happened on Bumi 2026-09-02 when a dead dongle was replaced (205 -> 218).
+
+    Otherwise take `preferred` if free, else the lowest free number in the range.
+    Deriving it from the device name alone collides: 50 slots and a crc32 means two
+    NICs on one host can land on the same table, and then their rules quietly share
+    one table and fight over it.
+    """
+    in_use = set()
+    for ipv4 in other_ipv4s:
+        in_use |= _tables_of(ipv4)
+
+    mine = _tables_of(own_ipv4)
+    reusable = sorted(mine - in_use)
+    if reusable:
+        return reusable[0]
+
+    if preferred not in in_use:
+        return preferred
+    for table in range(_POLICY_TABLE_MIN, _POLICY_TABLE_MAX + 1):
+        if table not in in_use:
+            return table
+    raise RuntimeError(
+        f'策略路由表号已用尽（{_POLICY_TABLE_MIN}-{_POLICY_TABLE_MAX}）')
+
+
+def _other_connection_ipv4s(bus, own_settings_path: str) -> list:
+    """ipv4 settings of every saved connection except `own_settings_path`."""
+    import dbus
+    settings_obj = bus.get_object(NM_IFACE, NM_SETTINGS_PATH)
+    settings_iface = dbus.Interface(settings_obj, NM_SETTINGS_IFACE)
+    results = []
+    for conn_path in settings_iface.ListConnections():
+        if str(conn_path) == own_settings_path:
+            continue
+        try:
+            results.append(_get_connection_settings(bus, str(conn_path)).get('ipv4', {}))
+        except Exception:
+            pass  # a connection we cannot read cannot be reasoned about; skip it
+    return results
 
 
 def _subnet_network(ip: str, prefix: int) -> str:
@@ -404,10 +474,16 @@ def _policy_route_data(table: int, network: str, prefix: int, gateway: str) -> l
     return entries
 
 
-def _without_policy_routes(route_data, table: int) -> list:
-    """`route_data` minus the entries we own, so a user's own static routes survive
-    both enabling and disabling."""
-    return [r for r in route_data if int(r.get('table', 0)) != table]
+def _without_policy_routes(route_data) -> list:
+    """`route_data` minus every entry we own, so a user's own static routes survive
+    both enabling and disabling.
+
+    Keyed on the whole private range rather than the one table currently in play:
+    a renumbering — a WiFi card swap renames the interface, so the old code derived
+    a different table — would otherwise strand the previous table's copies in the
+    profile forever, one stale pair per swap.
+    """
+    return [r for r in route_data if not _tables_of({'route-data': [r]})]
 
 
 def _set_policy_route_sync(device: str, enable: bool):
@@ -417,7 +493,10 @@ def _set_policy_route_sync(device: str, enable: bool):
     (asymmetric routing on multi-homed hosts).
 
     Implemented by *copying* the device's routes into a private table and pointing
-    a source-based `ip rule` at it, leaving the main table alone.
+    a source-based `ip rule` at it, leaving the main table alone. The table number
+    comes from `_allocate_policy_table`, which reuses whatever this connection already
+    refers to — the device name is MAC-derived, so deriving the number from it alone
+    renumbers on every card swap and strands the old copies.
 
     Do NOT reach for `ipv4.route-table` here, however natural it looks. It does not
     copy the connection's routes into the private table, it *relocates* them — the
@@ -456,12 +535,13 @@ def _set_policy_route_sync(device: str, enable: bool):
         raise RuntimeError(f'设备 "{device}" 当前未连接')
     settings_path = str(_get_prop(bus, active_conn_path, NM_ACTIVE_IFACE, 'Connection'))
 
-    table = _policy_route_table_for(device)
     conn_obj = bus.get_object(NM_IFACE, settings_path)
     conn_iface = dbus.Interface(conn_obj, NM_CONN_IFACE)
     settings = conn_iface.GetSettings()
     ipv4 = settings.setdefault('ipv4', dbus.Dictionary({}, signature='sv'))
-    kept_routes = _without_policy_routes(ipv4.get('route-data', []), table)
+    table = _allocate_policy_table(
+        ipv4, _other_connection_ipv4s(bus, settings_path), _policy_route_table_for(device))
+    kept_routes = _without_policy_routes(ipv4.get('route-data', []))
 
     if enable:
         ip4_path = str(_get_prop(bus, dev_path, NM_DEVICE_IFACE, 'Ip4Config'))

--- a/agent-core/tests/test_policy_route_settings.py
+++ b/agent-core/tests/test_policy_route_settings.py
@@ -19,6 +19,15 @@ says. Verified on Bumi (NM 1.36.6): main regained the wifi default route,
 `ip route get 8.8.8.8 from 10.100.129.141` still resolved via table 205, and an
 SSH session over the very device being reconfigured survived Device.Reapply.
 
+Second trap, same host later that day: the dead dongle was replaced. Interface names are
+MAC-derived, so `wlx001f058a5d81` became `wlx001f058a4a58` and the table number derived
+from it went 205 -> 218 — the rule and routes written for 205 were stranded in the
+profile, and cleanup keyed on "the current table" could never reap them. The number is
+now allocated (reuse what the connection already has, else the preferred number, else
+the lowest free one) and cleanup covers the whole 200-249 range. That also removes the
+collision: crc32 % 50 can put two NICs on one host in the same table, where their rules
+silently merge.
+
 Run: cd agent-core && python3 -m pytest tests/test_policy_route_settings.py
 """
 import os
@@ -68,8 +77,12 @@ class _FakeDbus:
 sys.modules.setdefault('dbus', _FakeDbus())
 
 from api.network import (  # noqa: E402
+    _POLICY_TABLE_MAX,
+    _POLICY_TABLE_MIN,
+    _allocate_policy_table,
     _policy_route_data,
     _policy_route_table_for,
+    _tables_of,
     _without_policy_routes,
 )
 
@@ -84,12 +97,95 @@ def _table():
 
 
 def test_table_number_is_stable_and_in_private_range():
-    """The Bumi profile in the field carries table 205; a different number here
-    would orphan every already-written rule."""
-    table = _table()
+    """The Bumi profile in the field carries table 205; a different preferred number
+    here would hand every existing single-NIC host a pointless renumber."""
+    table = _policy_route_table_for(DEVICE)
     assert table == 205
-    assert 200 <= table <= 249
+    assert _POLICY_TABLE_MIN <= table <= _POLICY_TABLE_MAX
     assert _policy_route_table_for(DEVICE) == table  # deterministic across calls
+
+
+def test_user_static_routes_survive():
+    user_route = {'dest': '10.9.0.0', 'prefix': 16, 'next-hop': '10.100.128.9'}
+    existing = [user_route, *_policy_route_data(_table(), NETWORK, PREFIX, GATEWAY)]
+
+    assert _without_policy_routes(existing) == [user_route]
+
+
+def test_cleanup_also_reaps_a_previous_table_number():
+    """The card-swap residue: Bumi 2026-09-02 went from table 205 to 218 because the
+    replacement dongle had a different MAC. Stripping only the current number left
+    the 205 pair in the profile forever."""
+    stale = _policy_route_data(205, NETWORK, PREFIX, GATEWAY)
+    fresh = _policy_route_data(218, NETWORK, PREFIX, GATEWAY)
+
+    assert _without_policy_routes(stale + fresh) == []
+
+
+def test_reuses_the_number_this_connection_already_has():
+    """A card swap must not renumber: the rule and routes already written for 205 keep
+    working, and nothing is stranded."""
+    own = {'routing-rules': [{'table': 205}],
+           'route-data': _policy_route_data(205, NETWORK, PREFIX, GATEWAY)}
+
+    # preferred is what the *new* device name hashes to; it must lose to the existing one
+    assert _allocate_policy_table(own, [], 218) == 205
+
+
+def test_avoids_a_number_another_connection_uses():
+    """50 slots and a crc32 collide. Two connections sharing one table would silently
+    merge their rules and fight over it."""
+    other = {'routing-rules': [{'table': 205}]}
+
+    table = _allocate_policy_table({}, [other], 205)
+
+    assert table != 205
+    assert _POLICY_TABLE_MIN <= table <= _POLICY_TABLE_MAX
+
+
+def test_gives_up_the_shared_number_rather_than_keeping_a_collision():
+    """If our own number is already claimed by someone else, reuse is not safe."""
+    own = {'routing-rules': [{'table': 205}]}
+    other = {'route-data': [{'dest': '0.0.0.0', 'prefix': 0, 'table': 205}]}
+
+    assert _allocate_policy_table(own, [other], 205) != 205
+
+
+def test_preferred_number_is_taken_when_free():
+    assert _allocate_policy_table({}, [{'routing-rules': [{'table': 207}]}], 205) == 205
+
+
+def test_exhausted_range_raises_instead_of_reusing():
+    others = [{'routing-rules': [{'table': t}]}
+              for t in range(_POLICY_TABLE_MIN, _POLICY_TABLE_MAX + 1)]
+
+    with pytest.raises(RuntimeError):
+        _allocate_policy_table({}, others, 205)
+
+
+def test_only_private_range_tables_count_as_ours():
+    """Table 254 is main and 1000 might be someone else's scheme. Claiming either would
+    make us delete routes we do not own, or hand out a number already in real use."""
+    assert _tables_of({'route-data': [{'table': 254}, {'table': 1000}, {'table': 0}]}) == set()
+    assert _tables_of({'route-data': [{'table': 205}]}) == {205}
+
+
+def test_disable_then_enable_does_not_accumulate_copies():
+    """The canvas-style repeat: toggling several times must not stack duplicates."""
+    routes = []
+    for _ in range(3):
+        routes = (_without_policy_routes(routes)
+                  + _policy_route_data(_table(), NETWORK, PREFIX, GATEWAY))
+        assert len(routes) == 2
+        routes = _without_policy_routes(routes)  # disable
+        assert routes == []
+
+
+def test_untabled_route_is_never_mistaken_for_ours():
+    """A missing attribute means main, or a user's plain static route would be deleted
+    on the first toggle."""
+    plain = [{'dest': '10.9.0.0', 'prefix': 16}]
+    assert _without_policy_routes(plain) == plain
 
 
 def test_copies_are_pinned_to_the_private_table():
@@ -126,35 +222,6 @@ def test_nothing_lands_in_the_main_table():
     without a `table` attribute is exactly what breaks the host's connectivity."""
     for route in _policy_route_data(_table(), NETWORK, PREFIX, GATEWAY):
         assert route.get('table') == _table()
-
-
-def test_user_static_routes_survive():
-    user_route = {'dest': '10.9.0.0', 'prefix': 16, 'next-hop': '10.100.128.9'}
-    other_device_route = {'dest': '10.8.0.0', 'prefix': 16, 'table': 249}
-    existing = [user_route, other_device_route,
-                *_policy_route_data(_table(), NETWORK, PREFIX, GATEWAY)]
-
-    kept = _without_policy_routes(existing, _table())
-
-    assert kept == [user_route, other_device_route]
-
-
-def test_disable_then_enable_does_not_accumulate_copies():
-    """The canvas-style repeat: toggling several times must not stack duplicates."""
-    routes = []
-    for _ in range(3):
-        routes = (_without_policy_routes(routes, _table())
-                  + _policy_route_data(_table(), NETWORK, PREFIX, GATEWAY))
-        assert len(routes) == 2
-        routes = _without_policy_routes(routes, _table())  # disable
-        assert routes == []
-
-
-def test_untabled_route_is_never_mistaken_for_ours():
-    """`int(r.get('table', 0))` must treat a missing attribute as main, or a user's
-    plain static route would be deleted on the first toggle."""
-    plain = [{'dest': '10.9.0.0', 'prefix': 16}]
-    assert _without_policy_routes(plain, _table()) == plain
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
接 #164。#164 修的是「开了策略路由就断网」，这个 PR 修的是换网卡之后暴露出来的两个表号问题。

## 现场

Bumi 2026-09-02，#164 合并后几小时，那台机器的 USB 无线网卡坏了、换了一块新的。接口名是按 MAC 生成的，于是 `wlx001f058a5d81` 变成 `wlx001f058a4a58`，`200 + crc32(device) % 50` 从 **205 变成 218**。

后果有两个：

- 已经按 205 写好的 rule 和两条路由副本成了孤儿。`_without_policy_routes` 只过滤「当前这个表号」，所以 218 上的增删永远不会碰到 205 的残留 —— 每换一块卡就积一层。
- 换卡后网络要恢复，218 的 rule 得手工补上，因为面板拨开关会重算表号、跟 profile 里已有的对不上。

## 改动

**表号改为分配，不再单纯派生：**

1. 优先复用这条连接已经引用的表号 —— 换卡后仍然是 205，不重新编号、不留残留；
2. 否则用 crc32 算出的首选号（如果没被别的连接占用）—— 存量单网卡主机的表号不变；
3. 否则取区间内最小的空闲号；
4. 区间用尽则报错，而不是和别人共用一张表。

顺带修掉一个一直存在的碰撞：50 个槽位配 crc32，同一台机器上两块网卡可能算出同一个表号，两条 rule 会静默共用一张表并互相干扰。

**清理改为按 200–249 整个私有区间过滤**，而不是单个表号，这样任何重新编号都能自愈。区间外的表号不碰 —— 254 是 main，更大的号可能是别人的方案，认领它们等于删掉不属于我们的路由。

## 验证

按那台机器上真实的 profile 形状测的：连接已经带 205 时，即使新设备名的首选号是 218，分配仍然返回 205；一份 205 残留加一份 218 新条目，两份都能被清掉。

测试从 9 个加到 16 个，新增覆盖：换卡场景的表号复用、跨连接的碰撞避让、自己的号被别人占用时放弃复用、首选号空闲时正常采用、区间用尽报错、区间外表号不被认作我们的、换卡残留能被清掉。

```
16 passed
```

全量 `251 passed, 1 failed`，失败的是本地缺 `lark_oapi` 的 `test_feishu_proxy.py`，与本改动无关。

## 部署注意

同 #164：机器上跑的镜像只要还是旧代码，在面板上拨这个开关就会把默认路由搬走一次。Bumi 现在的 profile 是手工写成正确形状的（表 218 配新卡），本 PR 进镜像后，下次拨开关会复用 218 而不是再算一遍。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
