### PR TITLE
fix(core): start a card after the cards that feed it, not before

### DIFF
--- a/agent-core/src/api/config.py
+++ b/agent-core/src/api/config.py
@@ -119,14 +119,67 @@ async def get_project_running():
 
 # ── Start / Stop Project (统一入口) ─────────────────────────────────────────────
 
+def order_cards_by_dependency(cards, connections):
+    """Start order: no card before the cards that feed it.
+
+    A card's input topic is only knowable once its source is running and has
+    answered `info` — a derived topic (ASR publishes `{input_topic}/asr`) exists
+    nowhere until then. So the order the cards are started in decides whether
+    the graph can be resolved at all.
+
+    The previous split — sources (no inbound connection) then processors (some
+    inbound connection) — is only a topological order for a graph two levels
+    deep. `mic → asr → decision_core` is three, and asr and decision_core both
+    landed in the second group, ordered by their position in the layout: the
+    card built first started first. On R1 decision_core had been on the canvas
+    for four days and asr was added that morning, so decision_core started
+    ahead of its own source, found no topic for it, and subscribed to nothing.
+    ASR heard the wake word and published; the agent loop was not listening.
+    Nothing failed and nothing was logged — the only visible symptom was that
+    speaking to the robot did nothing while typing to it worked.
+
+    Kahn's algorithm, levelled, so cards that do not depend on each other keep
+    their layout order and the two-level case still starts exactly as before.
+    Returns `(ordered, leftover)`; `leftover` is non-empty only for a cycle,
+    which has no valid order — the caller starts those last and says so.
+    """
+    ids = {c.get('id') for c in cards if c.get('id')}
+    # Self-loops and connections naming a card that is no longer on the canvas
+    # are ignored rather than treated as unsatisfiable: they would strand every
+    # card behind them, turning stale layout data into a total failure to start.
+    deps = {}
+    for conn in connections or []:
+        src, dst = conn.get('fromCardId'), conn.get('toCardId')
+        if src in ids and dst in ids and src != dst:
+            deps.setdefault(dst, set()).add(src)
+
+    ordered, started = [], set()
+    remaining = list(cards)
+    while remaining:
+        ready = [c for c in remaining
+                 if deps.get(c.get('id'), set()) <= started]
+        if not ready:
+            break
+        ordered.extend(ready)
+        started.update(c.get('id') for c in ready)
+        remaining = [c for c in remaining if c.get('id') not in started]
+    return ordered, remaining
+
+
 async def _do_start_project():
     """启动所有 canvas cards — 前端按钮和 auto-start 共用此函数。
 
     Topic resolution strategy:
-      1. Start source cards first, then call info() to get their actual topic_out
-      2. Build a resolved_topics map: card_id → [topic_out entries]
-      3. When starting processor cards, look up source card's topic_out via connections
-      4. Fallback: use connection's persisted fromTopic if info() didn't return topic_out
+      1. Order the cards so every card starts after the cards feeding it
+         (order_cards_by_dependency)
+      2. Start each card, then call info() to get its actual topic_out, and
+         record it in resolved_topics: card_id → [topic_out entries]
+      3. A card's input_topic is read from its sources' resolved_topics, which
+         step 1 guarantees are already populated
+      4. Fallbacks, for a source that could not answer info(): the connection's
+         persisted fromTopic, then the source card's persisted topicOut
+      5. An inbound connection that resolves to no topic at all fails its card
+         rather than starting it deaf — see _resolve_input_topics
     """
     from api.mcp_manage import mcp_call_tool, MCPCallRequest
     from api.motus_stream import push_event
@@ -246,14 +299,16 @@ async def _do_start_project():
     if not cards:
         return
 
-    # 分类：sources (无入连接) 和 processors (有入连接)
-    cards_with_inbound = set()
-    for conn in connections:
-        cards_with_inbound.add(conn.get('toCardId'))
-
-    sources = [c for c in cards if c['id'] not in cards_with_inbound]
-    processors = [c for c in cards if c['id'] in cards_with_inbound]
-    all_ordered = sources + processors
+    ordered, cyclic = order_cards_by_dependency(cards, connections)
+    if cyclic:
+        # No order satisfies a cycle. Starting them last at least gives every
+        # acyclic card a resolved input; say which ones so a graph that quietly
+        # cannot resolve is not mistaken for the bug this ordering fixed.
+        print('[start-project] connection cycle involving '
+              f'{", ".join(c.get("toolName", "?") for c in cyclic)}'
+              ' — starting those last, input topics may not resolve')
+        ordered = ordered + cyclic
+    all_ordered = ordered
 
     # 广播启动开始
     await push_event({'type': 'project_start_begin', 'payload': {
@@ -358,38 +413,74 @@ async def _do_start_project():
             }})
             errors.append(tool_name)
 
-    def _resolve_input_topic(card_id: str) -> tuple[str, list]:
-        """Resolve input_topic(s) for a processor card from its inbound connections."""
-        in_conns = [c for c in connections if c.get('toCardId') == card_id]
-        topics = []
-        for conn in in_conns:
-            from_card_id = conn.get('fromCardId', '')
-            port_idx = int(conn.get('fromPortIdx', 0))
-            # Primary: use resolved topic_out from source card's info() response
-            if from_card_id in resolved_topics:
-                out_list = resolved_topics[from_card_id]
-                if port_idx < len(out_list) and out_list[port_idx].get('topic'):
-                    topics.append(out_list[port_idx]['topic'])
-                elif out_list and out_list[0].get('topic'):
-                    topics.append(out_list[0]['topic'])
-            # Fallback: use persisted fromTopic in connection data
-            elif conn.get('fromTopic'):
-                topics.append(conn['fromTopic'])
-            # Fallback 2: use source card's persisted topicOut
-            else:
-                from_card = next((c for c in cards if c.get('id') == from_card_id), None)
-                if from_card:
-                    card_topic_out = from_card.get('topicOut') or []
-                    if port_idx < len(card_topic_out) and card_topic_out[port_idx].get('topic'):
-                        topics.append(card_topic_out[port_idx]['topic'])
-                    elif card_topic_out and card_topic_out[0].get('topic'):
-                        topics.append(card_topic_out[0]['topic'])
-        topics = list(set(t for t in topics if t))
+    def _port_topic(out_list: list, port_idx: int) -> str:
+        """The topic a source publishes on `port_idx`, or its first one."""
+        if 0 <= port_idx < len(out_list) and out_list[port_idx].get('topic'):
+            return out_list[port_idx]['topic']
+        return (out_list[0].get('topic') or '') if out_list else ''
+
+    def _topic_of_connection(conn: dict) -> str:
+        """The topic carried by one connection, best answer first.
+
+        The three sources are tried in turn rather than chosen by which one
+        *exists*: the old code took the source card's presence in
+        resolved_topics as proof it had an answer, so a card that started and
+        reported topic_out without a topic on the wanted port consumed its turn
+        and blocked both fallbacks.
+        """
+        from_card_id = conn.get('fromCardId', '')
+        try:
+            port_idx = int(conn.get('fromPortIdx', 0) or 0)
+        except (TypeError, ValueError):
+            port_idx = 0
+        # Live info() answer from the source, which the start order guarantees
+        # has already run.
+        topic = _port_topic(resolved_topics.get(from_card_id) or [], port_idx)
+        # Persisted fallbacks, for a source that could not answer info(). Both
+        # are snapshots taken by the canvas page and can be stale or, for a
+        # derived topic never resolved in a browser, empty.
+        if not topic:
+            topic = conn.get('fromTopic') or ''
+        if not topic:
+            from_card = next((c for c in cards if c.get('id') == from_card_id), None)
+            topic = _port_topic((from_card or {}).get('topicOut') or [], port_idx)
+        return topic
+
+    def _resolve_input_topics(card_id: str) -> tuple[str, list, list]:
+        """Resolve input_topic(s) for a card from its inbound connections.
+
+        Returns `(input_topic, input_topics, unresolved)`. `unresolved` holds
+        the inbound connections that carry no topic — checked per connection,
+        not per card, because a card fed by several sources of which only some
+        resolve used to start with the rest silently missing. That is how
+        decision_core came up subscribed to `/remote_control/message` alone
+        while its ASR input was dropped, which looks from the outside like
+        multi-input never having worked.
+
+        Insertion order is kept: `list(set(...))` made the argument sent to the
+        driver differ between runs of an unchanged canvas.
+        """
+        topics, unresolved = [], []
+        for conn in [c for c in connections if c.get('toCardId') == card_id]:
+            topic = _topic_of_connection(conn)
+            if not topic:
+                unresolved.append(conn)
+            elif topic not in topics:
+                topics.append(topic)
         if len(topics) > 1:
-            return '', topics
+            return '', topics, unresolved
         elif len(topics) == 1:
-            return topics[0], []
-        return '', []
+            return topics[0], [], unresolved
+        return '', [], unresolved
+
+    def _unresolved_message(card: dict, unresolved: list) -> str:
+        """Name the upstream cards whose topic could not be found."""
+        names = []
+        for conn in unresolved:
+            src = next((c for c in cards if c.get('id') == conn.get('fromCardId')), None)
+            names.append((src or {}).get('toolName') or '?')
+        return (f'连线缺少 topic: {", ".join(names)} → '
+                f'{card.get("toolName", "?")}，请检查上游卡片是否能报出输出话题')
 
     # 先确保 channel adapters 已连接（被 Stop 过 / 上次启动失败的在此拉起）。
     # 必须在卡片启动之前：channel 卡片的自检要求 adapter 真的连通，
@@ -404,13 +495,25 @@ async def _do_start_project():
             except Exception as e:
                 print(f'[start-project] channel {ch_id} restart failed: {e}')
 
-    # Phase 1: start sources (no input_topic needed) and collect their topic_out
-    for card in sources:
-        await _start_and_resolve(card)
-
-    # Phase 2: start processors with resolved input_topic from sources
-    for card in processors:
-        input_topic, input_topics = _resolve_input_topic(card['id'])
+    # One pass in dependency order: a card's sources have already started and
+    # answered info(), so a card with no inbound connection resolves to no
+    # input_topic exactly as the old "sources first" phase gave it.
+    for card in all_ordered:
+        input_topic, input_topics, unresolved = _resolve_input_topics(card.get('id', ''))
+        if unresolved:
+            # Starting it anyway is what made this class of bug invisible: the
+            # card comes up subscribed to nothing and reports 已就绪. Fail it
+            # instead and let strict mode roll the project back, which is what
+            # the frontend did before this function took over the start.
+            message = _unresolved_message(card, unresolved)
+            tool_name = card.get('toolName', '')
+            print(f'[start-project] {tool_name}: {message}')
+            await push_event({'type': 'project_start_item', 'payload': {
+                'tool': tool_name, 'mcp_id': card.get('mcpId', ''),
+                'status': 'error', 'message': message,
+            }})
+            errors.append(tool_name)
+            continue
         await _start_and_resolve(card, input_topic=input_topic, input_topics=input_topics)
 
     # 有 card 失败 → 全部回滚，不标记 running

--- a/agent-core/tests/test_start_project_order.py
+++ b/agent-core/tests/test_start_project_order.py
@@ -1,0 +1,152 @@
+"""Regression: a card must not start before the cards that feed it.
+
+Observed on R1 2026-09-06. Speaking to the robot did nothing; typing the same
+instruction through remote_control worked. Perception was fine — the ASR log
+shows the wake word matched and `'小范小范，现在几点了？' → '现在几点了？'`
+published on `/ubuntu/mic/audio/asr`, and asking the driver `action: info`
+returns that exact topic. But the agent loop's own prompt listed one input:
+
+    <subscribed_sensors><source name="dds:/remote_control/message" /></subscribed_sensors>
+
+`_do_start_project` split the cards into sources (no inbound connection) and
+processors (some inbound connection) and started the two groups in turn. That is
+a topological order only for a graph two levels deep. The R1 canvas is three:
+`mic → asr → decision_core`. asr and decision_core both fell in the processor
+group, which was ordered by position in the layout — decision_core had been on
+the canvas since 09-02, asr was added at 01:27 that morning — so decision_core
+started first, found no topic for its ASR input, and subscribed to nothing.
+
+ASR's output topic is derived (`{input_topic}/asr`), so it exists nowhere until
+the plugin is running: no fallback could have covered for the order. The
+persisted `fromTopic` on the connection was `''` and the card's persisted
+`topicOut` was format-only, which is what a multiInstance tool's schema
+declares by design.
+
+Nothing failed and nothing was logged. Both halves are fixed here: the order,
+and the silence — an inbound connection carrying no topic now fails its card
+instead of starting it deaf.
+
+Run: cd agent-core && python3 -m pytest tests/test_start_project_order.py
+"""
+import os
+import pathlib
+import sys
+import tempfile
+
+import pytest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / 'src'))
+
+os.environ.setdefault('DB_PATH', os.path.join(tempfile.mkdtemp(), 'test.db'))
+
+from api.config import order_cards_by_dependency  # noqa: E402
+
+
+def card(cid, tool):
+    return {'id': cid, 'toolName': tool, 'mcpId': 'mcp-1'}
+
+
+def conn(src, dst, topic='', port='0'):
+    return {'fromCardId': src, 'toCardId': dst, 'fromPortIdx': port,
+            'toPortIdx': '0', 'fromTopic': topic}
+
+
+def order(cards, connections):
+    ordered, cyclic = order_cards_by_dependency(cards, connections)
+    assert cyclic == []
+    return [c['toolName'] for c in ordered]
+
+
+# ── the reported layout ──────────────────────────────────────────────────────
+
+# Card order as saved on R1: decision_core was built four days before asr, and
+# the layout lists cards in creation order.
+R1_CARDS = [
+    card('card-mtjr82bgdxo9', 'tts'),
+    card('card-mtjr86idgact', 'speaker'),
+    card('card-mtju428pljp9', 'decision_core'),
+    card('card-mtju5os2wysg', 'switch_mode'),
+    card('card-mtju62eb0v8z', 'remote_message'),
+    card('card-mtju68d9au22', 'loco'),
+    card('card-mtlb92gin0yq', 'joints'),
+    card('card-mtlbv2htotvc', 'mic'),
+    card('card-mtonohvr64vl', 'asr'),
+]
+R1_CONNS = [
+    conn('card-mtjr82bgdxo9', 'card-mtjr86idgact', '/perception/tts'),
+    conn('card-mtlbv2htotvc', 'card-mtonohvr64vl', '/ubuntu/mic/audio'),
+    conn('card-mtonohvr64vl', 'card-mtju428pljp9', ''),   # the empty one
+    conn('card-mtju62eb0v8z', 'card-mtju428pljp9', '/remote_control/message'),
+]
+
+
+def test_asr_starts_before_the_agent_loop_that_reads_it():
+    got = order(R1_CARDS, R1_CONNS)
+    assert got.index('mic') < got.index('asr') < got.index('decision_core')
+
+
+def test_the_old_split_is_what_this_replaces():
+    """Guard the premise: the previous grouping really did invert the pair."""
+    with_inbound = {c['toCardId'] for c in R1_CONNS}
+    old = ([c['toolName'] for c in R1_CARDS if c['id'] not in with_inbound]
+           + [c['toolName'] for c in R1_CARDS if c['id'] in with_inbound])
+    assert old.index('decision_core') < old.index('asr')
+
+
+def test_every_card_still_starts_exactly_once():
+    got = order(R1_CARDS, R1_CONNS)
+    assert sorted(got) == sorted(c['toolName'] for c in R1_CARDS)
+
+
+# ── order properties ────────────────────────────────────────────────────────
+
+def test_a_two_level_graph_keeps_the_order_it_had():
+    """The common case must not change: sources in layout order, then the rest."""
+    cards = [card('a', 'mic'), card('b', 'speaker'), card('c', 'tts')]
+    conns = [conn('a', 'b', '/mic'), conn('c', 'b', '/tts')]
+    assert order(cards, conns) == ['mic', 'tts', 'speaker']
+
+
+def test_cards_that_do_not_depend_on_each_other_keep_layout_order():
+    cards = [card('a', 'loco'), card('b', 'joints'), card('c', 'switch_mode')]
+    assert order(cards, []) == ['loco', 'joints', 'switch_mode']
+
+
+def test_a_four_level_chain_resolves():
+    cards = [card('d', 'speaker'), card('c', 'tts'), card('b', 'asr'), card('a', 'mic')]
+    conns = [conn('a', 'b'), conn('b', 'c'), conn('c', 'd')]
+    assert order(cards, conns) == ['mic', 'asr', 'tts', 'speaker']
+
+
+def test_a_card_fed_by_two_levels_waits_for_the_deeper_one():
+    """decision_core's shape: one source is a source, the other is derived."""
+    cards = [card('core', 'decision_core'), card('rm', 'remote_message'),
+             card('mic', 'mic'), card('asr', 'asr')]
+    conns = [conn('mic', 'asr'), conn('asr', 'core'), conn('rm', 'core')]
+    got = order(cards, conns)
+    assert got.index('asr') < got.index('decision_core')
+    assert got.index('remote_message') < got.index('decision_core')
+
+
+# ── degenerate graphs must still start something ─────────────────────────────
+
+def test_a_cycle_is_reported_rather_than_dropped_or_hung():
+    cards = [card('a', 'tts'), card('b', 'asr'), card('c', 'mic')]
+    ordered, cyclic = order_cards_by_dependency(cards, [conn('a', 'b'), conn('b', 'a')])
+    assert [c['toolName'] for c in ordered] == ['mic']
+    assert sorted(c['toolName'] for c in cyclic) == ['asr', 'tts']
+
+
+def test_a_self_loop_does_not_strand_its_own_card():
+    cards = [card('a', 'vop')]
+    assert order(cards, [conn('a', 'a')]) == ['vop']
+
+
+def test_a_connection_from_a_deleted_card_does_not_strand_the_survivor():
+    """Layout writes and connection deletes are separate saves; either can lag."""
+    cards = [card('b', 'asr')]
+    assert order(cards, [conn('card-gone', 'b')]) == ['asr']
+
+
+def test_no_cards_and_no_connections():
+    assert order_cards_by_dependency([], []) == ([], [])

--- a/agent-core/tests/test_start_project_resolution.py
+++ b/agent-core/tests/test_start_project_resolution.py
@@ -1,0 +1,241 @@
+"""What _do_start_project actually passes each card, on the R1 layout.
+
+Companion to test_start_project_order.py, which tests the order alone. This
+drives the real function against a fake driver that behaves like perception's
+ASR plugin — its `topic_out` is `{input_topic}/asr`, known only once it has been
+started with an input — so the order is not merely asserted, it is load-bearing:
+get it wrong and the fake cannot answer, exactly as on the robot.
+
+Run: cd agent-core && python3 -m pytest tests/test_start_project_resolution.py
+"""
+import asyncio
+import os
+import pathlib
+import sys
+import tempfile
+import types
+
+import pytest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / 'src'))
+
+os.environ.setdefault('DB_PATH', os.path.join(tempfile.mkdtemp(), 'test.db'))
+
+from api import config as config_api  # noqa: E402
+import config  # noqa: E402
+
+
+# ── the R1 layout, as saved ──────────────────────────────────────────────────
+
+def _card(cid, tool, topic_out=None):
+    c = {'id': cid, 'toolName': tool, 'mcpId': 'mcp-perception'}
+    if topic_out is not None:
+        c['topicOut'] = topic_out
+    return c
+
+
+def _conn(src, dst, topic=''):
+    return {'fromCardId': src, 'toCardId': dst, 'fromPortIdx': '0',
+            'toPortIdx': '0', 'fromTopic': topic}
+
+
+MIC, ASR, CORE, RM = 'card-mic', 'card-asr', 'card-core', 'card-rm'
+# A card whose driver answers `info` with no topic at all — an offline plugin,
+# or one whose output genuinely cannot be inferred. The fallback chain and the
+# unresolved-input check are the only things that can speak for it.
+SILENT = 'card-silent'
+
+# decision_core precedes asr, as it does on R1: cards are listed in the order
+# they were created and asr was added four days later.
+R1_LAYOUT = {
+    'cards': [
+        _card(CORE, 'decision_core', [{'topic': '/decision_core', 'format': 'data/json'}]),
+        _card(RM, 'remote_message', [{'topic': '/remote_control/message', 'format': 'data/json'}]),
+        _card(MIC, 'mic', [{'topic': '/ubuntu/mic/audio', 'format': 'audio/pcm-16k'}]),
+        # What a multiInstance tool's schema declares: a format, no topic.
+        _card(ASR, 'asr', [{'format': 'data/json', 'desc': 'ASR result event'}]),
+    ],
+    'connections': [
+        _conn(MIC, ASR, '/ubuntu/mic/audio'),
+        _conn(ASR, CORE, ''),                        # never resolved in a browser
+        _conn(RM, CORE, '/remote_control/message'),
+    ],
+}
+
+
+@pytest.fixture
+def driver(monkeypatch):
+    """A fake perception whose ASR output is derived from its input.
+
+    Returns the recorded `start` arguments per card id. `info` answers from the
+    input the card was started with, which is the whole point: an ASR that was
+    never started, or started without an input, has no output topic to report.
+    """
+    starts, started_input = {}, {}
+
+    async def _call(mcp_id, req):
+        args = dict(req.arguments)
+        action, card_id = args.get('action'), args.get('instance_id')
+        if action == 'start':
+            starts[card_id] = args
+            started_input[card_id] = args.get('input_topic') or ''
+            return {'code': 200, 'data': {'state': 'running'}}
+        if action == 'info':
+            return {'code': 200, 'data': {'state': 'running',
+                                          'topic_out': _topic_out(card_id, args)}}
+        return {'code': 200, 'data': {'state': 'idle'}}
+
+    def _topic_out(card_id, args):
+        if card_id == ASR:
+            # Derived. `info` is asked with the input the card was started with;
+            # without one there is nothing to derive from and perception would
+            # answer its fallback, which for ASR is no topic at all.
+            src = args.get('input_topic') or started_input.get(card_id) or ''
+            return [{'topic': f'{src}/asr', 'format': 'data/json'}] if src else []
+        static = {
+            MIC: [{'topic': '/ubuntu/mic/audio', 'format': 'audio/pcm-16k'}],
+            RM: [{'topic': '/remote_control/message', 'format': 'data/json'}],
+            CORE: [{'topic': '/decision_core', 'format': 'data/json'}],
+        }
+        # Anything else — SILENT included — answers with nothing, which is what
+        # an offline driver or an uninferable output looks like.
+        return static.get(card_id, [])
+
+    class _Req:
+        def __init__(self, tool, arguments):
+            self.tool = tool
+            self.arguments = arguments
+
+    mcp = types.ModuleType('api.mcp_manage')
+    mcp.mcp_call_tool = _call
+    mcp.MCPCallRequest = _Req
+
+    events = []
+
+    async def _push(event):
+        events.append(event)
+
+    stream = types.ModuleType('api.motus_stream')
+    stream.push_event = _push
+
+    registered = []
+
+    async def _register(topic, fmt, mcp_id):
+        registered.append(topic)
+
+    inspection = types.ModuleType('api.inspection')
+    inspection.register_topic_internal = _register
+
+    chan = types.ModuleType('channel.manager')
+    chan.manager = types.SimpleNamespace(sync_from_canvas=lambda: None, _adapters={})
+    chan._get_channel_configs = lambda: []
+
+    for name, mod in (('api.mcp_manage', mcp), ('api.motus_stream', stream),
+                      ('api.inspection', inspection), ('channel.manager', chan)):
+        monkeypatch.setitem(sys.modules, name, mod)
+
+    return types.SimpleNamespace(starts=starts, events=events, registered=registered)
+
+
+def _start(layout):
+    config.main['canvas_layout'] = layout
+    return asyncio.get_event_loop_policy().new_event_loop().run_until_complete(
+        config_api._do_start_project())
+
+
+def _errors(events):
+    return [e['payload'] for e in events
+            if e.get('type') == 'project_start_item'
+            and e['payload'].get('status') == 'error']
+
+
+# ── the reported failure ─────────────────────────────────────────────────────
+
+def test_the_agent_loop_is_given_the_asr_topic(driver):
+    assert _start(R1_LAYOUT) is True
+    # Two inputs, so they arrive as input_topics rather than input_topic.
+    assert sorted(driver.starts[CORE]['input_topics']) == [
+        '/remote_control/message', '/ubuntu/mic/audio/asr']
+
+
+def test_asr_is_started_with_the_mic_topic(driver):
+    _start(R1_LAYOUT)
+    assert driver.starts[ASR]['input_topic'] == '/ubuntu/mic/audio'
+
+
+def test_a_derived_topic_reaches_the_bus(driver):
+    """The dashboard subscribes to what start-project registers."""
+    _start(R1_LAYOUT)
+    assert '/ubuntu/mic/audio/asr' in driver.registered
+
+
+def test_a_source_card_is_started_with_no_input_topic(driver):
+    _start(R1_LAYOUT)
+    assert 'input_topic' not in driver.starts[MIC]
+    assert 'input_topics' not in driver.starts[MIC]
+
+
+# ── the silence half of the bug ──────────────────────────────────────────────
+
+def test_an_input_that_cannot_be_resolved_fails_its_card(driver):
+    """A card fed by a source that reports no topic must not come up deaf.
+
+    The source here is on the canvas but publishes nothing under any name, so
+    no ordering and no fallback can supply the topic. Before this, decision_core
+    started with its ASR input silently absent and reported 已就绪.
+    """
+    layout = {
+        'cards': [_card(SILENT, 'mic', []), _card(CORE, 'decision_core')],
+        'connections': [_conn(SILENT, CORE, '')],
+    }
+    assert _start(layout) is False
+    errors = _errors(driver.events)
+    assert len(errors) == 1
+    assert errors[0]['tool'] == 'decision_core'
+    assert 'mic' in errors[0]['message']
+    assert CORE not in driver.starts
+
+
+def test_one_unresolved_input_out_of_two_is_not_silently_dropped(driver):
+    """The multi-input case: a partial answer used to look like a whole one."""
+    layout = {
+        'cards': [_card(SILENT, 'mic', []),
+                  _card(RM, 'remote_message', [{'topic': '/remote_control/message',
+                                                'format': 'data/json'}]),
+                  _card(CORE, 'decision_core')],
+        'connections': [_conn(SILENT, CORE, ''), _conn(RM, CORE, '/remote_control/message')],
+    }
+    assert _start(layout) is False
+    assert CORE not in driver.starts
+
+
+# ── fallbacks, for a source that cannot answer ───────────────────────────────
+
+def test_a_persisted_fromTopic_still_covers_a_silent_source(driver):
+    """The old fallback chain has to keep working for offline drivers."""
+    layout = {
+        'cards': [_card(SILENT, 'mic', []), _card(CORE, 'decision_core')],
+        'connections': [_conn(SILENT, CORE, '/ubuntu/mic/audio')],
+    }
+    assert _start(layout) is True
+    assert driver.starts[CORE]['input_topic'] == '/ubuntu/mic/audio'
+
+
+def test_a_persisted_topicOut_covers_a_connection_with_no_fromTopic(driver):
+    layout = {
+        'cards': [_card(SILENT, 'mic', [{'topic': '/saved/mic', 'format': 'audio/pcm-16k'}]),
+                  _card(CORE, 'decision_core')],
+        'connections': [_conn(SILENT, CORE, '')],
+    }
+    assert _start(layout) is True
+    assert driver.starts[CORE]['input_topic'] == '/saved/mic'
+
+
+def test_a_live_answer_beats_a_stale_persisted_one(driver):
+    """A running instance's topic wins over the canvas page's old snapshot."""
+    layout = {
+        'cards': [_card(MIC, 'mic'), _card(CORE, 'decision_core')],
+        'connections': [_conn(MIC, CORE, '/remote_control/message/stale')],
+    }
+    assert _start(layout) is True
+    assert driver.starts[CORE]['input_topic'] == '/ubuntu/mic/audio'


### PR DESCRIPTION
## 症状

对着 R1 说话没反应；同样一句话从遥控器打字过去正常。

感知侧是好的 —— ASR 日志里唤醒词命中，`'小范小范，现在几点了？' → '现在几点了？'`，发在 `/ubuntu/mic/audio/asr`；直接问驱动 `action: info` 也确实回这个话题。但 agent-core 的 `event.subscribe_topics` 只有 `["/remote_control/message"]`。ASR 结果发出去了，没人听。整条链路上没有任何一处报错或打日志，agent-core 全部 `[decision] received` 事件里没有一条来自 ASR topic。

## 原因

`_do_start_project` 把卡片分成 sources（无入连线）和 processors（有入连线）两批依次启动。这只在图深**两层**时才是拓扑序。R1 的画布是三层：

```
mic → asr → decision_core
```

`asr` 和 `decision_core` 都落在 processors 里，组内按卡片在 layout 里的位置排 —— `decision_core` 建于 09-02，`asr` 是当天早上 01:27 才加的，于是 `decision_core` 排在自己的数据源前面启动，问不到 asr 的话题，订了个空。

ASR 的输出话题是**推导**出来的（`{input_topic}/asr`），插件跑起来之前它在任何地方都不存在，所以没有任何 fallback 能替启动顺序兜底：连线上持久化的 `fromTopic` 是 `''`，卡片上持久化的 `topicOut` 只有 format 没有 topic —— 后者是 multiInstance 工具 schema 的设计如此。

回归点是 `1c3a7e3`（07-28，启动逻辑从前端搬到后端）：搬过来时只搬了 sources/processors 这个两层切分，前端原来"启动前主动问驱动补话题"和"缺 topic 就拒绝启动"两步都没搬。三天后的 `8401f8e` 补了"start 完调 info() 拿真实话题"，但那是启动之后才问，对三层链无效。

## 改动

1. **`order_cards_by_dependency`** —— 真正的拓扑序（分层 Kahn，同层保持 layout 顺序，所以两层图的启动顺序和以前逐个一致）。提到模块级好单测。环没有合法顺序，单独返回并打日志后放到最后启动，而不是静默丢掉或者死循环。

2. **入连线解析不出话题的卡片判失败**，走既有的严格模式回滚，不再启动一个聋的卡片。检查粒度是**逐条连线**而不是逐张卡片 —— `decision_core` 两条入线只解析出一条时，旧代码拿着这一条就启动了，另一条无声消失，从外面看就像 multi input 从来没 work 过。这条校验是搬到后端之前前端 `_startProject` 做过的（`连线缺少 topic: X → Y`）。

顺带：三级 fallback 改成依次尝试而不是按"哪个来源存在"二选一 —— 旧代码把源卡片出现在 `resolved_topics` 里当成它有答案，于是一张启动了、但在目标端口上没报出话题的卡片会占掉机会并挡住后面两级。`input_topics` 也不再过 `list(set())`，同一张画布两次启动传给驱动的参数顺序不该不一样。

## R1 实测

同一份 layout，只换 `config.py` 这一个文件：

| | 启动顺序 | `event.subscribe_topics` |
|---|---|---|
| 改前 | … mic, speaker, **decision_core, asr** | `["/remote_control/message"]` |
| 改后 | … mic, speaker, **asr, decision_core** | `["/ubuntu/mic/audio/asr", "/remote_control/message"]` |

`ros2 topic info -v /ubuntu/mic/audio/asr` 的订阅端从 2 个变 3 个，多出来的是 `motus_core_subscriber` —— 即 `topic_subscriber.py:61` 那个节点，decision_core 启动时 `subscribe()` 挂在它上面。

## 测试

- `agent-core/tests/test_start_project_order.py` —— 顺序本身，11 个，含 R1 那份真实卡片顺序，以及环/自环/连线指向已删卡片这些退化图
- `agent-core/tests/test_start_project_resolution.py` —— 拿假驱动驱动**真的** `_do_start_project`，9 个。假驱动的 ASR 输出话题同样由输入推导，所以顺序不对它就答不上来，顺序是 load-bearing 而不只是被断言

回退 `src` 改动后其中 3 个失败（含 decision_core 拿不到 ASR 话题这条）。全量 `506 passed, 1 skipped`。

## 部署注意

R1 上目前是 `docker cp` 热补的这个文件（验证用），镜像还没重建 —— 合并后需要重新出镜像走 console 部署，否则下次 recreate 容器就回退了。

🤖 Generated with [Claude Code](https://claude.com/claude-code)