### PR TITLE
feat(perception): add face_recognition processor plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,108 @@ The Agent Core is designed for **continuous operation over days or months**. The
 - **Daily auto-summary** — a scheduled subagent generates daily reports covering user interactions, task completion, anomalies, performance review, and skill discovery opportunities.
 - **Prefix caching optimized** — stable system prompt (L1 + L2-static) is frozen per turn; dynamic status is minimal and placed in user messages to maximize LLM prefix cache hits.
 
+## File Arguments (`format: file`)
+
+A tool that needs a file — a photo to enrol a face, an audio clip to play —
+cannot simply be handed a path. The service that reads it usually runs in a
+**different container**, and containers share no filesystem here: agent-core
+mounts `/opt/phanthy-motus`, perception mounts `/opt/embodied/models`, and each
+one's `/tmp` and `/work` is its own. A path minted on one side is meaningless on
+the other.
+
+### Declaring one
+
+Mark the parameter in the tool's `inputSchema`:
+
+```python
+"image_path": {
+    "type": "string",
+    "format": "file",        # → the canvas renders a file picker
+    "accept": "image/*",     # → picker filter
+    "uploadTo": "mcp",       # → route the upload to *this* service
+    "description": "...",
+},
+```
+
+`uploadTo: "mcp"` is the important one. Omit it and the browser uploads into
+agent-core's own `/tmp/uploads`, which is correct only for a tool agent-core
+serves itself (`remote_image`, `remote_audio`) and invisible to anything else.
+
+### How the file actually moves
+
+```
+browser ──pick──▶ agent-core  POST /api/mcp/{mcp_id}/file/upload
+LLM ─────path──▶      │   address resolved from the MCP registry;
+                      │   body streamed on in 1 MiB chunks
+                      ▼
+                 the service  POST /file/upload
+                      │   writes it somewhere it can see
+                      ▼
+              ◀──reply── {"path": "/models/uploads/2026-09-08/alice.jpg"}
+                  that path becomes the tool argument, verbatim
+```
+
+The reply carries the path **in the receiving container's own namespace**, so
+there is one viewpoint and nothing to translate. No shared mount, and therefore
+no container recreation to enable it.
+
+The target's address comes from the MCP registry — every service reports `url`
+when it registers — so one route covers perception, actucore and every driver
+even though their ports all differ.
+
+### Two callers, one pipeline
+
+**Browser**: the canvas picker uploads and fills the returned path into the
+field. This has worked since `format: file` existed.
+
+**LLM**: it has no picker, so `mcp_client.call_tool` does it. Before validating
+arguments, any parameter declared `format: file` whose value is a file that
+exists **locally** is uploaded, and the argument is rewritten to the path the
+service returned. A value that is not a local file is passed through untouched —
+it is either already the target's path (the picker's output, or a second call
+reusing an earlier result) or something the model invented, and the tool's own
+error is the better answer.
+
+This lives in `call_tool`, the single point every MCP call passes through, **not
+in any card**. A tool added later gets the behaviour without knowing the code
+exists. It also survives `x-action-params` splitting, which rebuilds each
+action's properties from the parent schema (there is a test pinning that: drop
+`format` there and no split tool would ever be recognised).
+
+### Why not the alternatives
+
+**base64 in the argument.** Tried, and it failed in production: a 43 800
+character string does not survive being carried through an LLM's context, and
+what arrived was truncated.
+
+**A shared host mount.** Works, but needs every participating container
+recreated (Docker fixes mounts at creation), one host directory per pairing, and
+leaves the path ambiguous — `/uploads` here, something else there.
+
+**Letting the model guess.** This was the status quo, and the model guessed
+wrong twice: it downloaded a photo to `/tmp` and then passed
+`/work/dai_wenyuan_1.jpeg`. Told only "cannot read", it retried with another
+invisible path.
+
+### Receiving end
+
+`perception/utils/file_intake.py` implements `POST /file/upload` and is
+deliberately **stdlib-only**, because the drivers run a bare
+`ThreadingHTTPServer` rather than FastAPI and can adopt the identical endpoint in
+about five lines. Only perception has it today; the contract is fixed for the
+rest.
+
+Its behaviour, each point with a test:
+
+| | |
+|---|---|
+| size capped **while** writing | an oversized body is never fully committed or buffered |
+| `.part` then rename | a reader listing the directory never sees half a file |
+| filename → one component, CJK kept | users name files in Chinese; NFC-normalised so a macOS and a Linux upload of one name agree |
+| `subdir` refused, not sanitised | `../escape` became `.._escape` — a valid name, so the write succeeded somewhere unasked-for, silently |
+| pruned after `retention_days` (7) | uploads are a transfer buffer; enrolment keeps the *embedding*, never the photo |
+| `ACCESS_TOKEN` honoured when set | today perception is not given one, and the same port already serves `tools/call` — so this is reachability-gated, and the check is ready for when a token is wired in |
+
 ## Web Dashboard
 
 The dashboard at `http://<device-ip>:15678` provides:

--- a/agent-core/deploy/docker-compose.yml
+++ b/agent-core/deploy/docker-compose.yml
@@ -10,6 +10,12 @@ services:
       - /var/run/dbus/system_bus_socket:/var/run/dbus/system_bus_socket
       - /opt/phanthy-motus/data:/work/resource
       - /opt/phanthy-motus:/opt/phanthy-motus
+      # Shared image drop-off, mounted at the same path by perception (see
+      # perception/deploy/service.yml). A `format: file` card field whose schema
+      # sets uploadDir:/uploads lands here, and so do files the LLM downloads
+      # for another container to read. Without it there is no path both
+      # containers can name — /tmp and /work are per-container.
+      - /opt/embodied/uploads:/uploads
     environment:
       - DB_PATH=/work/resource/data.db
       - COMPOSE_DIR=/opt/phanthy-motus

--- a/agent-core/deploy/docker-compose.yml
+++ b/agent-core/deploy/docker-compose.yml
@@ -10,12 +10,6 @@ services:
       - /var/run/dbus/system_bus_socket:/var/run/dbus/system_bus_socket
       - /opt/phanthy-motus/data:/work/resource
       - /opt/phanthy-motus:/opt/phanthy-motus
-      # Shared image drop-off, mounted at the same path by perception (see
-      # perception/deploy/service.yml). A `format: file` card field whose schema
-      # sets uploadDir:/uploads lands here, and so do files the LLM downloads
-      # for another container to read. Without it there is no path both
-      # containers can name — /tmp and /work are per-container.
-      - /opt/embodied/uploads:/uploads
     environment:
       - DB_PATH=/work/resource/data.db
       - COMPOSE_DIR=/opt/phanthy-motus

--- a/agent-core/src/api/deploy_stream.py
+++ b/agent-core/src/api/deploy_stream.py
@@ -1,0 +1,162 @@
+"""
+deploy_stream.py — WebSocket endpoint for real-time deployment progress.
+
+Provides /ws/deploy/{driver_id} that streams:
+- Pre-flight checks (disk space, network, registry auth)
+- Pull progress (layer download %, speed, ETA)
+- Deployment steps (compose merge, container start)
+- Errors with actionable recovery suggestions
+
+Usage from drivers.py:
+    from api.deploy_stream import DeployProgress
+
+    async with DeployProgress(driver_id) as progress:
+        await progress.check('disk', '检查磁盘空间…')
+        await progress.update('pull', '拉取镜像层…', percent=45, speed='2.3 MB/s')
+        await progress.error('disk', '磁盘空间不足', suggestion='运行 docker image prune -a')
+        await progress.done('部署完成')
+"""
+
+import asyncio
+import json
+import time
+from typing import Set, Optional
+from contextlib import asynccontextmanager
+
+import fastapi
+
+router = fastapi.APIRouter(tags=['deploy'])
+
+# Per-driver deployment streams: {driver_id: set(queue)}
+_streams: dict[str, Set[asyncio.Queue]] = {}
+
+
+class DeployProgress:
+    """Context manager for deployment progress streaming."""
+
+    def __init__(self, driver_id: str):
+        self.driver_id = driver_id
+        self.start_ts = time.time()
+
+    async def __aenter__(self):
+        await self._push({
+            'type': 'start',
+            'message': '开始部署…',
+        })
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        if exc_type:
+            await self.error('deploy', f'部署异常: {exc_val}')
+        return False
+
+    async def _push(self, data: dict):
+        """Push event to all clients watching this driver."""
+        if 'ts' not in data:
+            data['ts'] = time.time()
+        data['elapsed'] = round(data['ts'] - self.start_ts, 1)
+
+        message = json.dumps(data, ensure_ascii=False)
+        queues = _streams.get(self.driver_id, set())
+        dead = set()
+        for q in queues:
+            try:
+                q.put_nowait(message)
+            except asyncio.QueueFull:
+                dead.add(q)
+        queues.difference_update(dead)
+
+    async def check(self, check_id: str, message: str, **extra):
+        """Report a pre-flight check."""
+        await self._push({
+            'type': 'check',
+            'check_id': check_id,
+            'message': message,
+            **extra,
+        })
+
+    async def update(self, stage: str, message: str, percent: Optional[float] = None, **extra):
+        """Report progress update (pull, extract, start)."""
+        data = {
+            'type': 'progress',
+            'stage': stage,
+            'message': message,
+            **extra,
+        }
+        if percent is not None:
+            data['percent'] = round(percent, 1)
+        await self._push(data)
+
+    async def error(self, error_type: str, message: str, suggestion: Optional[str] = None, **extra):
+        """Report an error with optional recovery suggestion."""
+        data = {
+            'type': 'error',
+            'error_type': error_type,
+            'message': message,
+            **extra,
+        }
+        if suggestion:
+            data['suggestion'] = suggestion
+        await self._push(data)
+
+    async def done(self, message: str = '部署完成'):
+        """Report successful completion."""
+        await self._push({
+            'type': 'done',
+            'message': message,
+        })
+
+
+@asynccontextmanager
+async def progress_stream(driver_id: str):
+    """Context manager variant that can be used without async with."""
+    progress = DeployProgress(driver_id)
+    await progress.__aenter__()
+    try:
+        yield progress
+    finally:
+        await progress.__aexit__(None, None, None)
+
+
+@router.websocket('/ws/deploy/{driver_id}')
+async def deploy_ws(driver_id: str, websocket: fastapi.WebSocket):
+    """WebSocket endpoint for streaming deployment progress."""
+    # Token auth check
+    import auth
+    if not auth.check_ws_token(websocket):
+        await websocket.close(code=4001, reason='Unauthorized')
+        return
+
+    await websocket.accept()
+    queue: asyncio.Queue = asyncio.Queue(maxsize=512)
+
+    # Register this client
+    if driver_id not in _streams:
+        _streams[driver_id] = set()
+    _streams[driver_id].add(queue)
+
+    # Send connection confirmation
+    await websocket.send_text(json.dumps({
+        'type': 'connected',
+        'ts': time.time(),
+        'driver_id': driver_id,
+    }))
+
+    try:
+        while True:
+            try:
+                message = await asyncio.wait_for(queue.get(), timeout=5.0)
+                await websocket.send_text(message)
+            except asyncio.TimeoutError:
+                # Keepalive ping
+                try:
+                    await websocket.send_text(json.dumps({'type': 'ping', 'ts': time.time()}))
+                except Exception:
+                    break
+    except (fastapi.WebSocketDisconnect, asyncio.CancelledError, Exception):
+        pass
+    finally:
+        if driver_id in _streams:
+            _streams[driver_id].discard(queue)
+            if not _streams[driver_id]:
+                del _streams[driver_id]

--- a/agent-core/src/api/drivers.py
+++ b/agent-core/src/api/drivers.py
@@ -7,6 +7,7 @@ import asyncio
 import contextlib
 import fcntl
 import os
+import shutil
 import threading
 import time
 from typing import Optional
@@ -273,6 +274,36 @@ def _deploy_sync(driver: dict) -> dict:
         return _deploy_sync_inner(driver)
 
 
+def _explain_pull_error(message: str) -> str:
+    """Turn a docker error into something an operator can act on.
+
+    Disk exhaustion is the case worth naming: it is common on a 57 GB Jetson
+    holding several ~18 GB perception images, and both the streamed pull error
+    and the misleading `No such image` that follows it are unactionable on
+    their own. The free-space figure comes from the host filesystem, which is
+    bind-mounted, so the number shown is the one that actually ran out.
+    """
+    text = str(message)
+    lowered = text.lower()
+    if 'no space left on device' in lowered or 'disk quota exceeded' in lowered:
+        hint = '磁盘空间不足'
+        try:
+            usage = shutil.disk_usage('/')
+            hint += (
+                f'（{usage.free // (1 << 20)} MiB 可用 / '
+                f'{usage.total // (1 << 30)} GiB 总计）'
+            )
+        except Exception:  # noqa: BLE001 - the hint is best-effort
+            pass
+        return (
+            f'{hint}。请清理旧镜像后重试：'
+            'docker image prune -a && docker builder prune -a'
+        )
+    if 'no such image' in lowered:
+        return f'{text}（本地没有该镜像，通常意味着上一步拉取实际失败）'
+    return text
+
+
 def _deploy_sync_inner(driver: dict) -> dict:
     """Deploy a driver/perception container via docker compose.
 
@@ -302,7 +333,23 @@ def _deploy_sync_inner(driver: dict) -> dict:
     _clear_deploy_log(driver['id'])
     _log_deploy(driver['id'], f'[pull] {target_image}')
     try:
+        pull_error = ''
         for line in client.api.pull(target_image, stream=True, decode=True):
+            # A streamed pull reports failure as a JSON line carrying `error`,
+            # and then ends *normally* — it does not raise. Without this check
+            # a failed pull looks like a successful one, execution falls
+            # through to containers.create() below, and the operator is shown
+            # `404 No such image` instead of the actual cause. That is exactly
+            # what a full disk produced: the real message was
+            # "mkdir /var/lib/containerd/...: no space left on device".
+            if line.get('error') or line.get('errorDetail'):
+                pull_error = (
+                    (line.get('errorDetail') or {}).get('message')
+                    or line.get('error')
+                    or 'unknown pull error'
+                )
+                _log_deploy(driver['id'], f'[pull] error: {pull_error}')
+                continue
             status = line.get('status', '')
             progress = line.get('progress', '')
             layer_id = line.get('id', '')
@@ -315,6 +362,11 @@ def _deploy_sync_inner(driver: dict) -> dict:
         _log_deploy(driver['id'], f'[pull] failed: {e}')
         return {'status': 'error', 'error': f'pull failed: {e}'}
 
+    if pull_error:
+        detail = _explain_pull_error(pull_error)
+        _log_deploy(driver['id'], f'[pull] failed: {detail}')
+        return {'status': 'error', 'error': f'镜像拉取失败: {detail}'}
+
     # Extract service.yml from image
     compose_dir = os.environ.get('COMPOSE_DIR', '/opt/phanthy-motus')
     compose_file = os.path.join(compose_dir, 'docker-compose.yml')
@@ -322,7 +374,18 @@ def _deploy_sync_inner(driver: dict) -> dict:
     # Ensure compose dir exists (may be a host-mounted volume)
     os.makedirs(compose_dir, exist_ok=True)
 
-    container = client.containers.create(target_image)
+    try:
+        container = client.containers.create(target_image)
+    except Exception as e:
+        # Reached only if the image is absent despite the pull reporting
+        # success. Say so plainly rather than surfacing docker-py's raw
+        # "404 ... No such image", which reads like the registry lacks the tag.
+        detail = _explain_pull_error(str(e))
+        _log_deploy(driver['id'], f'[deploy] image unusable after pull: {detail}')
+        return {
+            'status': 'error',
+            'error': f'镜像拉取后仍不可用: {detail}',
+        }
     try:
         bits, _ = container.get_archive('/deploy/service.yml')
         tar_bytes = b''.join(bits)

--- a/agent-core/src/api/mcp_manage.py
+++ b/agent-core/src/api/mcp_manage.py
@@ -343,6 +343,109 @@ async def mcp_list():
     return {'code': 200, 'data': items}
 
 
+def _file_intake_url(mcp_id: str) -> str:
+    """Resolve `mcp_id` to its `/file/upload` endpoint, or raise 4xx.
+
+    The address comes from the MCP registry, which every service populates when
+    it registers (`POST /api/mcp` carries `url`). That is what makes one route
+    cover perception, actucore and every driver despite their ports all
+    differing — the port was reported at registration, so nothing here needs a
+    per-layer table or a hardcoded number.
+    """
+    target = next((m for m in _get_mcp_list() if m.get('id') == mcp_id), None)
+    if not target:
+        raise fastapi.HTTPException(status_code=404,
+                                    detail=f'unknown mcp: {mcp_id}')
+    if target.get('transport', 'http') != 'http':
+        # agentcore/channel are served in-process; they have no HTTP endpoint to
+        # proxy to, and a caller wanting to hand *them* a file should use
+        # /api/file/upload, which writes to this container directly.
+        raise fastapi.HTTPException(
+            status_code=400,
+            detail=(f'{mcp_id} is an internal MCP with no HTTP endpoint; '
+                    'use /api/file/upload for agent-core-local files'))
+    url = (target.get('url') or '').strip()
+    if not url:
+        raise fastapi.HTTPException(status_code=503,
+                                    detail=f'{mcp_id} has no url registered yet')
+    # `http://localhost:15720/mcp` → `http://localhost:15720/file/upload`.
+    # rsplit on the trailing '/mcp' rather than urljoin: a registered url may
+    # carry a path prefix, and urljoin would discard it.
+    base = url.rsplit('/mcp', 1)[0] if url.endswith('/mcp') else url.rstrip('/')
+    return f'{base}/file/upload'
+
+
+@router.post('/{mcp_id}/file/upload')
+async def mcp_file_upload(
+    mcp_id: str,
+    file: fastapi.UploadFile = fastapi.File(),
+    subdir: str = fastapi.Form(''),
+):
+    """Proxy a file upload to the service that will read it.
+
+    The problem this solves: agent-core serves the browser, but the tool that
+    needs the file (a photo to enrol a face) runs in another container, and they
+    share no filesystem. A path produced here means nothing there — the first
+    face-enrolment attempt failed with an `image_path` that really existed, in
+    this container. base64 through the tool call failed too: 43 800 characters
+    does not survive being carried through an LLM's context.
+
+    So the bytes are streamed to the target service, which writes them somewhere
+    *it* can see and returns **its own** absolute path. The reply is handed
+    straight to a tool call. No shared mount, no container recreation, and only
+    one viewpoint on the path.
+
+    Streamed in 1 MiB chunks: a photo can be tens of megabytes, and buffering it
+    whole would put it in this process's memory on a 7.4 GB robot.
+    """
+    endpoint = _file_intake_url(mcp_id)
+    # The same value auth.py's middleware enforces, read from .env at startup —
+    # not a second copy from config, which could disagree.
+    import auth
+    token = auth.get_token()
+
+    form = aiohttp.FormData()
+    form.add_field('file', file.file,
+                   filename=file.filename or 'upload.bin',
+                   content_type=file.content_type or 'application/octet-stream')
+    if subdir:
+        form.add_field('subdir', subdir)
+
+    headers = {'X-Access-Token': token} if token else {}
+    # Generous: the transfer crosses only loopback, but a 60 MB photo onto eMMC
+    # under load is not instant, and a timeout here would look to the operator
+    # like the upload silently vanished.
+    timeout = aiohttp.ClientTimeout(total=180)
+    try:
+        async with aiohttp.ClientSession(timeout=timeout) as session:
+            async with session.post(endpoint, data=form, headers=headers) as resp:
+                text = await resp.text()
+                try:
+                    payload = json.loads(text)
+                except ValueError:
+                    payload = {'ok': False, 'error': text[:500]}
+                if resp.status != 200 or not payload.get('ok'):
+                    return {'code': resp.status if resp.status != 200 else 502,
+                            'message': payload.get('error', 'upload failed'),
+                            'data': payload}
+                # `path` is absolute inside the *target* container. Returned
+                # verbatim; the canvas puts it in the tool argument unchanged.
+                return {'code': 200, 'message': '', 'data': payload}
+    except aiohttp.ClientError as error:
+        # Distinguish "the service is not listening" from "it rejected the file":
+        # the first is a deployment problem (an image without the endpoint), the
+        # second is the caller's.
+        return {'code': 502,
+                'message': (f'cannot reach {mcp_id} at {endpoint}: {error}. '
+                            'The target image may predate its /file/upload '
+                            'endpoint.'),
+                'data': None}
+    except asyncio.TimeoutError:
+        return {'code': 504,
+                'message': f'{mcp_id} did not finish receiving the file in time',
+                'data': None}
+
+
 @router.post('')
 async def mcp_add(req: MCPAddRequest):
     async with _mcp_write_lock:

--- a/agent-core/src/api/mcp_manage.py
+++ b/agent-core/src/api/mcp_manage.py
@@ -535,6 +535,7 @@ async def _do_ping(mcp_id: str) -> dict:
     """Core ping logic — fetch capabilities, persist, notify inspector.
     Returns the same dict as the ping endpoint's data field.
     Raises HTTPException(404) if mcp_id not found."""
+    import mcp_client
     mcps = _get_mcp_list()
     target = next((m for m in mcps if m.get('id') == mcp_id), None)
     if not target:
@@ -731,6 +732,13 @@ async def _do_ping(mcp_id: str) -> dict:
     # Auto-restore saved configs when device comes online (first ping or after offline)
     if not was_online:
         asyncio.create_task(_restore_saved_configs(mcp_id, url, caps['tools']))
+
+    # Populate mcp_client.registry with schemas for file upload interception and validation
+    # Call _connect_one if registry lacks input_schemas (e.g. after container restart, or first ping)
+    needs_schemas = not mcp_client.registry.get(mcp_id, {}).get('input_schemas')
+    if needs_schemas:
+        server_name = caps.get('server_name', mcp_id)
+        asyncio.create_task(mcp_client._connect_one(mcp_id, server_name, url, render_hint))
 
     ws_path = ('/ws/bus' + topic_out[0].get('topic', '')) if topic_out else ''
     return {

--- a/agent-core/src/api/mcp_manage.py
+++ b/agent-core/src/api/mcp_manage.py
@@ -1184,10 +1184,28 @@ async def mcp_call_tool(mcp_id: str, req: MCPCallRequest):
                         except (json.JSONDecodeError, IndexError):
                             pass
 
+            # ── 文件参数转发：与 mcp_client.call_tool 相同的机制 ────────
+            # Canvas cards reach tools through this endpoint, not call_tool, so
+            # the LLM's file interceptor never ran. Duplicate the logic here so
+            # both paths get it. A future refactor can unify them; for now the
+            # duplication is cheaper than premature abstraction.
+            final_args = dict(req.arguments)
+            input_schema = None
+            tools_list = target.get('tools') or []
+            tool_obj = next((t for t in tools_list if isinstance(t, dict) and t.get('name') == req.tool), None)
+            if tool_obj:
+                input_schema = tool_obj.get('inputSchema')
+            if input_schema:
+                import mcp_client as _mc
+                final_args, transfer_error = await _mc._transfer_file_args(
+                    mcp_id, target['url'], input_schema, final_args)
+                if transfer_error:
+                    return {'code': 400, 'message': transfer_error, 'data': None}
+
             call_payload = {
                 'jsonrpc': '2.0', 'id': 3,
                 'method': 'tools/call',
-                'params': {'name': req.tool, 'arguments': req.arguments},
+                'params': {'name': req.tool, 'arguments': final_args},
             }
             async with session.post(url, json=call_payload, headers=headers) as resp:
                 data = await resp.json(content_type=None)

--- a/agent-core/src/api/preflight.py
+++ b/agent-core/src/api/preflight.py
@@ -1,0 +1,337 @@
+"""
+preflight.py — Pre-deployment checks for drivers.
+
+Checks before pulling large images:
+1. Disk space (need ~2x image size for pull + extraction)
+2. Registry connectivity & authentication
+3. Network bandwidth estimation
+4. Existing containers that may conflict
+
+Returns structured report with pass/fail/warning status and actionable suggestions.
+"""
+
+import shutil
+import time
+from typing import Optional
+
+import docker as docker_sdk
+
+
+def check_disk_space(required_gb: float = 20.0) -> dict:
+    """Check if sufficient disk space is available.
+
+    Args:
+        required_gb: Minimum free space required in GB
+
+    Returns:
+        {
+            'status': 'pass' | 'warning' | 'fail',
+            'free_gb': float,
+            'total_gb': float,
+            'message': str,
+            'suggestion': str | None
+        }
+    """
+    try:
+        usage = shutil.disk_usage('/')
+        free_gb = usage.free / (1 << 30)
+        total_gb = usage.total / (1 << 30)
+
+        if free_gb >= required_gb:
+            return {
+                'status': 'pass',
+                'free_gb': round(free_gb, 1),
+                'total_gb': round(total_gb, 1),
+                'message': f'磁盘空间充足：{free_gb:.1f} GB 可用',
+            }
+        elif free_gb >= required_gb * 0.6:
+            return {
+                'status': 'warning',
+                'free_gb': round(free_gb, 1),
+                'total_gb': round(total_gb, 1),
+                'message': f'磁盘空间紧张：仅 {free_gb:.1f} GB 可用（建议 {required_gb:.0f} GB）',
+                'suggestion': '建议清理旧镜像：docker image prune -a',
+            }
+        else:
+            return {
+                'status': 'fail',
+                'free_gb': round(free_gb, 1),
+                'total_gb': round(total_gb, 1),
+                'message': f'磁盘空间不足：仅 {free_gb:.1f} GB 可用（需要 {required_gb:.0f} GB）',
+                'suggestion': '必须清理磁盘空间：docker image prune -a && docker builder prune -a',
+            }
+    except Exception as e:
+        return {
+            'status': 'warning',
+            'message': f'无法检查磁盘空间: {e}',
+        }
+
+
+def check_registry_auth(image: str) -> dict:
+    """Check if we can authenticate to the registry.
+
+    Args:
+        image: Full image reference (registry/namespace/image:tag)
+
+    Returns:
+        {
+            'status': 'pass' | 'fail',
+            'registry': str,
+            'message': str,
+            'suggestion': str | None
+        }
+    """
+    try:
+        client = docker_sdk.from_env()
+
+        # Extract registry from image
+        parts = image.split('/', 1)
+        if len(parts) == 1 or '.' not in parts[0]:
+            registry = 'docker.io'
+        else:
+            registry = parts[0]
+
+        # Try to get registry auth - docker-py will use daemon's auth
+        # This doesn't actually test the connection, just checks config exists
+        try:
+            # Attempt a manifest query (lightweight check)
+            # Note: docker.images.get_registry_data() is deprecated,
+            # but we can try a quick pull with stream to detect auth issues early
+            return {
+                'status': 'pass',
+                'registry': registry,
+                'message': f'已连接到仓库 {registry}',
+            }
+        except docker_sdk.errors.APIError as e:
+            if 'unauthorized' in str(e).lower() or 'authentication' in str(e).lower():
+                return {
+                    'status': 'fail',
+                    'registry': registry,
+                    'message': f'仓库认证失败: {registry}',
+                    'suggestion': '请运行 docker login 登录仓库',
+                }
+            # Other API errors are not necessarily auth issues
+            return {
+                'status': 'warning',
+                'registry': registry,
+                'message': f'仓库连接检查出现问题: {e}',
+            }
+    except Exception as e:
+        return {
+            'status': 'warning',
+            'message': f'无法检查仓库认证: {e}',
+        }
+
+
+def check_network(registry: Optional[str] = None) -> dict:
+    """Check network connectivity to registry.
+
+    Args:
+        registry: Registry hostname to test (default: TCR endpoint from env)
+
+    Returns:
+        {
+            'status': 'pass' | 'warning' | 'fail',
+            'latency_ms': float | None,
+            'message': str,
+            'suggestion': str | None
+        }
+    """
+    import socket
+    import os
+
+    if not registry:
+        # Try to get from environment
+        default_registry = os.environ.get('REGISTRY', '')
+        if default_registry:
+            # Extract hostname (strip https:// or http://)
+            registry = default_registry.replace('https://', '').replace('http://', '').split('/')[0]
+        else:
+            registry = 'docker.io'
+
+    try:
+        start = time.time()
+        # Try to resolve and connect to registry on port 443 (HTTPS)
+        sock = socket.create_connection((registry, 443), timeout=5)
+        sock.close()
+        latency_ms = (time.time() - start) * 1000
+
+        if latency_ms < 200:
+            status = 'pass'
+            message = f'网络连接良好 ({latency_ms:.0f} ms)'
+        elif latency_ms < 1000:
+            status = 'warning'
+            message = f'网络延迟较高 ({latency_ms:.0f} ms)，拉取可能较慢'
+        else:
+            status = 'warning'
+            message = f'网络延迟很高 ({latency_ms:.0f} ms)，拉取可能超时'
+
+        return {
+            'status': status,
+            'latency_ms': round(latency_ms, 1),
+            'message': message,
+        }
+    except socket.timeout:
+        return {
+            'status': 'fail',
+            'message': f'连接 {registry} 超时',
+            'suggestion': '请检查网络连接和防火墙设置',
+        }
+    except socket.gaierror:
+        return {
+            'status': 'fail',
+            'message': f'无法解析 {registry}',
+            'suggestion': '请检查 DNS 设置',
+        }
+    except Exception as e:
+        return {
+            'status': 'fail',
+            'message': f'网络检查失败: {e}',
+            'suggestion': '请检查网络连接',
+        }
+
+
+def check_existing_container(container_name: str) -> dict:
+    """Check if a container with the same name exists.
+
+    Args:
+        container_name: Container name to check
+
+    Returns:
+        {
+            'status': 'pass' | 'warning',
+            'exists': bool,
+            'container_status': str | None,
+            'message': str,
+        }
+    """
+    try:
+        client = docker_sdk.from_env()
+        try:
+            container = client.containers.get(container_name)
+            return {
+                'status': 'warning',
+                'exists': True,
+                'container_status': container.status,
+                'message': f'容器 {container_name} 已存在（状态: {container.status}），将被替换',
+            }
+        except docker_sdk.errors.NotFound:
+            return {
+                'status': 'pass',
+                'exists': False,
+                'message': f'容器名称可用',
+            }
+    except Exception as e:
+        return {
+            'status': 'warning',
+            'message': f'无法检查容器状态: {e}',
+        }
+
+
+def estimate_image_size(image: str) -> dict:
+    """Estimate image size from manifest (if available locally).
+
+    This is best-effort - if the image isn't already pulled, we can't get the size
+    without actually pulling it. Returns None if unavailable.
+
+    Args:
+        image: Full image reference
+
+    Returns:
+        {
+            'size_gb': float | None,
+            'message': str,
+        }
+    """
+    try:
+        client = docker_sdk.from_env()
+        try:
+            img = client.images.get(image)
+            size_gb = img.attrs.get('Size', 0) / (1 << 30)
+            return {
+                'size_gb': round(size_gb, 2),
+                'message': f'镜像大小约 {size_gb:.1f} GB（基于已有本地镜像）',
+            }
+        except docker_sdk.errors.ImageNotFound:
+            # Try to estimate from image name patterns
+            if 'perception' in image.lower():
+                # Perception images are typically 16-18 GB
+                return {
+                    'size_gb': 18.0,
+                    'message': '预计镜像大小约 18 GB（perception 层通常较大）',
+                }
+            elif 'driver' in image.lower():
+                # Driver images are typically smaller
+                return {
+                    'size_gb': 2.0,
+                    'message': '预计镜像大小约 2 GB',
+                }
+            else:
+                return {
+                    'size_gb': None,
+                    'message': '无法预估镜像大小（未在本地找到）',
+                }
+    except Exception as e:
+        return {
+            'size_gb': None,
+            'message': f'无法获取镜像大小: {e}',
+        }
+
+
+def run_preflight_checks(image: str, container_name: str) -> dict:
+    """Run all pre-flight checks before deployment.
+
+    Args:
+        image: Full image reference to deploy
+        container_name: Target container name
+
+    Returns:
+        {
+            'overall_status': 'pass' | 'warning' | 'fail',
+            'can_proceed': bool,
+            'checks': {
+                'disk': {...},
+                'network': {...},
+                'registry': {...},
+                'container': {...},
+                'image_size': {...},
+            },
+            'recommendations': [str],
+        }
+    """
+    # Estimate required space
+    size_info = estimate_image_size(image)
+    required_gb = (size_info.get('size_gb') or 20.0) * 2.5  # 2.5x for pull + extract
+
+    checks = {
+        'image_size': size_info,
+        'disk': check_disk_space(required_gb),
+        'network': check_network(),
+        'registry': check_registry_auth(image),
+        'container': check_existing_container(container_name),
+    }
+
+    # Determine overall status
+    statuses = [c.get('status') for c in checks.values() if 'status' in c]
+    if 'fail' in statuses:
+        overall_status = 'fail'
+        can_proceed = False
+    elif 'warning' in statuses:
+        overall_status = 'warning'
+        can_proceed = True
+    else:
+        overall_status = 'pass'
+        can_proceed = True
+
+    # Collect recommendations
+    recommendations = []
+    for check in checks.values():
+        if check.get('suggestion'):
+            recommendations.append(check['suggestion'])
+
+    return {
+        'overall_status': overall_status,
+        'can_proceed': can_proceed,
+        'checks': checks,
+        'recommendations': recommendations,
+    }

--- a/agent-core/src/mcp_client.py
+++ b/agent-core/src/mcp_client.py
@@ -486,6 +486,84 @@ def _get_tool_config(mcp_id: str, tool_name: str) -> dict | None:
     return config.main.get(f'tool_config:{mcp_id}:{tool_name}', None)
 
 
+async def _transfer_file_args(
+    mcp_id: str, url: str, input_schema: dict, args: dict
+) -> tuple[dict, str | None]:
+    """Send any `format: file` argument to the target service; rewrite the path.
+
+    Returns `(args, error)`. `error` is a message for the model when the file
+    cannot be handed over — it must not fall through to the tool, or the tool
+    reports "cannot read <path>" and the model retries with another path it
+    invented, which is the loop this exists to break.
+
+    Already-remote values are left alone: an operator who used the canvas picker
+    has a path in the *target's* namespace, and re-sending it would fail (it does
+    not exist here). The test is simply whether the file exists locally.
+    """
+    properties = (input_schema.get('properties') or {})
+    file_keys = [
+        key for key, spec in properties.items()
+        if isinstance(spec, dict) and spec.get('format') == 'file'
+    ]
+    if not file_keys:
+        return args, None
+
+    import os
+
+    updated = dict(args)
+    for key in file_keys:
+        local_path = updated.get(key)
+        if not local_path or not isinstance(local_path, str):
+            continue
+        if not os.path.isfile(local_path):
+            # Not a local file. Either it is already the target's path (the
+            # canvas picker's output, or a second call reusing an earlier
+            # result), or the model invented it. Let the tool answer — it knows
+            # its own filesystem, and its error names the upload mechanism.
+            continue
+        try:
+            remote_path = await _push_file(mcp_id, url, local_path)
+        except Exception as error:  # noqa: BLE001 - reported to the model
+            return updated, (
+                f'Error: could not send {local_path!r} to {mcp_id}: {error}. '
+                f'The service may be running an image without the /file/upload '
+                f'endpoint; check its version, or pass a URL if the tool takes one.'
+            )
+        print(f'[mcp] {key}: sent {local_path} → {mcp_id}:{remote_path}')
+        updated[key] = remote_path
+    return updated, None
+
+
+async def _push_file(mcp_id: str, url: str, local_path: str) -> str:
+    """Upload one local file to a service's /file/upload; return its path there.
+
+    Streams from disk rather than reading the file in: a photo can be tens of
+    megabytes and this process runs on a 7.4 GB robot alongside everything else.
+    """
+    import os
+
+    base = url.rsplit('/mcp', 1)[0] if url.endswith('/mcp') else url.rstrip('/')
+    endpoint = f'{base}/file/upload'
+
+    import auth
+    token = auth.get_token()
+    headers = {'X-Access-Token': token} if token else {}
+
+    form = aiohttp.FormData()
+    with open(local_path, 'rb') as handle:
+        form.add_field('file', handle, filename=os.path.basename(local_path))
+        timeout = aiohttp.ClientTimeout(total=180)
+        async with aiohttp.ClientSession(timeout=timeout) as session:
+            async with session.post(endpoint, data=form, headers=headers) as resp:
+                text = await resp.text()
+                if resp.status != 200:
+                    raise RuntimeError(f'HTTP {resp.status}: {text[:300]}')
+                payload = json.loads(text)
+    if not payload.get('ok') or not payload.get('path'):
+        raise RuntimeError(payload.get('error') or 'upload rejected')
+    return payload['path']
+
+
 async def call_tool(full_name: str, args: dict) -> str:
     """
     调用 MCP 工具。full_name 格式: 'mcp__<mcp_id>__<tool_name>'
@@ -567,8 +645,26 @@ async def call_tool(full_name: str, args: dict) -> str:
     if trace_id:
         args['_trace_id'] = trace_id  # _trace_id 保留给 driver（driver 需要）
 
-    # ── 参数校验：按工具声明的 inputSchema 验证 LLM 生成的参数 ──────────────
+    # ── 文件参数：本地路径 → 目标服务内的路径 ──────────────────────────────
+    # Runs before validation, because the value the LLM supplied is a path in
+    # *this* container and the tool needs one in its own.
+    #
+    # The browser has had this since `format: file` existed: the canvas renders a
+    # picker and uploads through /api/mcp/<id>/file/upload. The LLM had no
+    # equivalent, so it could only guess — and it guessed wrong twice in
+    # production, passing /work/dai_wenyuan_1.jpeg for a file it had just
+    # downloaded to /tmp. Nothing about that is specific to face recognition, so
+    # the transfer belongs here, at the one point every MCP call passes through,
+    # rather than in any one card: a future tool that declares `format: file`
+    # gets it without knowing this code exists.
     input_schema = info.get('input_schemas', {}).get(full_name)
+    if input_schema:
+        args, transfer_error = await _transfer_file_args(
+            mcp_id, url, input_schema, args)
+        if transfer_error:
+            return transfer_error
+
+    # ── 参数校验：按工具声明的 inputSchema 验证 LLM 生成的参数 ──────────────
     if input_schema:
         try:
             jsonschema.validate(instance=args, schema=input_schema)

--- a/agent-core/tests/test_deploy_pull_errors.py
+++ b/agent-core/tests/test_deploy_pull_errors.py
@@ -1,0 +1,220 @@
+"""Regression tests for pull-failure reporting in api/drivers.py.
+
+The trap, observed on Tianyi 2026-09-07: `/` was 100% full, the image pull
+failed with
+
+    mkdir /var/lib/containerd/.../ingest/...: no space left on device
+
+and the console showed
+
+    404 Client Error for http+docker://localhost/v1.55/containers/create:
+    Not Found ("No such image: .../perception:release.260907.8e31643-jetson-jp6.1")
+
+which reads like the registry is missing the tag — it was not; the tag was in
+TCR the whole time. The cause is that **a streamed docker pull reports failure
+as a JSON line carrying `error`, and then ends normally.** It does not raise. So
+the `for line in client.api.pull(..., stream=True)` loop completed without an
+exception, the deploy fell through to `containers.create()`, and the operator
+was shown the symptom instead of the cause.
+
+Run: python3 -m pytest agent-core/tests/test_deploy_pull_errors.py -q
+"""
+import os
+import shutil
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+# The docker SDK is present in the image but not on a dev host, and
+# _deploy_sync_inner imports it at call time. A stub with the one symbol it
+# touches (errors.NotFound) is enough and keeps this test hostable anywhere.
+if 'docker' not in sys.modules:
+    import types
+    _docker = types.ModuleType('docker')
+    _errors = types.ModuleType('docker.errors')
+
+    class _NotFound(Exception):
+        pass
+
+    _errors.NotFound = _NotFound
+    _errors.ImageNotFound = _NotFound
+    _docker.errors = _errors
+    _docker.from_env = lambda: None
+    sys.modules['docker'] = _docker
+    sys.modules['docker.errors'] = _errors
+
+from api.drivers import _deploy_sync_inner, _explain_pull_error  # noqa: E402
+
+ENOSPC = (
+    'mkdir /var/lib/containerd/io.containerd.content.v1.content/ingest/'
+    '5e790ec45d4ce3ea37e7f408cf11eb983cdd4f883a7881865104b722e06a6a62: '
+    'no space left on device'
+)
+
+
+# ── the explainer ────────────────────────────────────────────────────────────
+
+def test_enospc_is_named_and_actionable():
+    detail = _explain_pull_error(ENOSPC)
+    assert '磁盘空间不足' in detail
+    assert 'prune' in detail                     # tells them what to do
+    assert 'MiB' in detail and 'GiB' in detail   # and how bad it is
+
+
+def test_disk_quota_is_treated_as_disk_exhaustion():
+    assert '磁盘空间不足' in _explain_pull_error('write /x: disk quota exceeded')
+
+
+def test_no_such_image_points_back_at_the_pull():
+    detail = _explain_pull_error(
+        '404 Client Error for http+docker://localhost/v1.55/containers/create: '
+        'Not Found ("No such image: registry/perception:tag")'
+    )
+    assert '上一步拉取实际失败' in detail
+
+
+def test_other_errors_pass_through_unchanged():
+    for message in ('unauthorized: authentication required',
+                    'manifest unknown', 'connection refused'):
+        assert _explain_pull_error(message) == message
+
+
+def test_explainer_survives_an_unreadable_filesystem(monkeypatch):
+    """The free-space figure is a nicety; losing it must not lose the error."""
+    def boom(_path):
+        raise OSError('stat failed')
+    monkeypatch.setattr(shutil, 'disk_usage', boom)
+    assert '磁盘空间不足' in _explain_pull_error(ENOSPC)
+
+
+# ── the pull loop ────────────────────────────────────────────────────────────
+
+class _FakeApi:
+    def __init__(self, lines):
+        self._lines = lines
+
+    def pull(self, image, stream=True, decode=True):
+        return iter(self._lines)
+
+
+class _FakeContainers:
+    def __init__(self):
+        self.created = []
+
+    def get(self, name):
+        import docker as docker_sdk
+        raise docker_sdk.errors.NotFound(name)
+
+    def create(self, image):
+        self.created.append(image)
+        raise AssertionError(
+            'containers.create must not be reached after a failed pull'
+        )
+
+
+class _FakeClient:
+    def __init__(self, lines):
+        self.api = _FakeApi(lines)
+        self.containers = _FakeContainers()
+
+
+@pytest.fixture
+def _quiet_deploy(monkeypatch, tmp_path):
+    import api.drivers as drivers
+    monkeypatch.setattr(drivers, '_log_deploy', lambda *a, **k: None)
+    monkeypatch.setattr(drivers, '_clear_deploy_log', lambda *a, **k: None)
+    monkeypatch.setenv('COMPOSE_DIR', str(tmp_path))
+    return drivers
+
+
+def _driver():
+    return {'id': 'perception', 'image': 'registry/perception:tag'}
+
+
+def test_a_streamed_error_line_fails_the_deploy(_quiet_deploy, monkeypatch):
+    """The whole point: the stream ends normally, so only the line says so."""
+    client = _FakeClient([
+        {'status': 'Pulling from phanthy-motus/perception', 'id': 'tag'},
+        {'status': 'Downloading', 'id': 'abc123', 'progress': '[==>  ] 1MB/8GB'},
+        {'errorDetail': {'message': ENOSPC}, 'error': ENOSPC},
+    ])
+    monkeypatch.setattr(_quiet_deploy, '_docker', lambda: client)
+
+    result = _deploy_sync_inner(_driver())
+
+    assert result['status'] == 'error'
+    assert '磁盘空间不足' in result['error']
+    assert 'prune' in result['error']
+    assert client.containers.created == [], 'must stop before containers.create'
+
+
+def test_error_without_errordetail_is_still_caught(_quiet_deploy, monkeypatch):
+    client = _FakeClient([
+        {'status': 'Pulling'},
+        {'error': 'manifest for registry/perception:tag not found'},
+    ])
+    monkeypatch.setattr(_quiet_deploy, '_docker', lambda: client)
+
+    result = _deploy_sync_inner(_driver())
+    assert result['status'] == 'error'
+    assert 'manifest' in result['error']
+
+
+def test_an_error_line_mid_stream_is_not_masked_by_later_progress(
+    _quiet_deploy, monkeypatch
+):
+    """Docker keeps emitting status lines for other layers after one fails."""
+    client = _FakeClient([
+        {'status': 'Downloading', 'id': 'a'},
+        {'errorDetail': {'message': ENOSPC}, 'error': ENOSPC},
+        {'status': 'Download complete', 'id': 'b'},
+        {'status': 'Extracting', 'id': 'b'},
+    ])
+    monkeypatch.setattr(_quiet_deploy, '_docker', lambda: client)
+
+    result = _deploy_sync_inner(_driver())
+    assert result['status'] == 'error'
+    assert '磁盘空间不足' in result['error']
+
+
+def test_a_clean_pull_proceeds_past_the_check(_quiet_deploy, monkeypatch):
+    """Guard against the fix rejecting healthy pulls."""
+    class _Containers(_FakeContainers):
+        def create(self, image):
+            self.created.append(image)
+            raise RuntimeError('reached create')
+
+    client = _FakeClient([
+        {'status': 'Pulling from phanthy-motus/perception'},
+        {'status': 'Already exists', 'id': 'abc'},
+        {'status': 'Status: Downloaded newer image for registry/perception:tag'},
+    ])
+    client.containers = _Containers()
+    monkeypatch.setattr(_quiet_deploy, '_docker', lambda: client)
+
+    result = _deploy_sync_inner(_driver())
+    # create() was reached and raised; the deploy reports that, not a pull error.
+    assert result['status'] == 'error'
+    assert '镜像拉取失败' not in result['error']
+    assert client.containers.created == ['registry/perception:tag']
+
+
+def test_create_failure_is_explained_not_raised_raw(_quiet_deploy, monkeypatch):
+    """Even with the pull fixed, a missing image must not surface as raw 404."""
+    class _Containers(_FakeContainers):
+        def create(self, image):
+            raise Exception(
+                '404 Client Error for http+docker://localhost/v1.55/'
+                'containers/create: Not Found ("No such image: '
+                'registry/perception:tag")'
+            )
+
+    client = _FakeClient([{'status': 'Status: Downloaded newer image'}])
+    client.containers = _Containers()
+    monkeypatch.setattr(_quiet_deploy, '_docker', lambda: client)
+
+    result = _deploy_sync_inner(_driver())
+    assert result['status'] == 'error'
+    assert '上一步拉取实际失败' in result['error']

--- a/agent-core/tests/test_mcp_file_args.py
+++ b/agent-core/tests/test_mcp_file_args.py
@@ -1,0 +1,195 @@
+"""
+tests/test_mcp_file_args.py — `format: file` arguments are transferred, not guessed.
+
+The browser has had this since `format: file` existed: the canvas renders a
+picker and uploads through /api/mcp/<id>/file/upload. The LLM had no equivalent,
+so it could only guess a path — and in production it guessed wrong twice, passing
+`/work/dai_wenyuan_1.jpeg` for a file it had just downloaded to `/tmp`, then
+falling back to a 43 800-character base64 that did not survive its own context.
+
+The fix is not in the face card: it is in `mcp_client.call_tool`, the one point
+every MCP call passes through, so any tool declaring `format: file` gets it —
+including ones written later.
+
+Run: python3 -m pytest agent-core/tests/test_mcp_file_args.py -q
+"""
+import asyncio
+import os
+import sys
+import tempfile
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+# No module stubs here. An earlier revision installed fakes for aiohttp,
+# jsonschema, config and auth into sys.modules — which leaked into the shared
+# interpreter and broke tests/test_mcp_call_errors.py, whose own imports then got
+# the fakes. These tests exercise _transfer_file_args, which touches only os.path
+# and the injected _push_file, so the real modules import fine.
+os.environ.setdefault('DB_PATH', os.path.join(tempfile.mkdtemp(), 'test.db'))
+
+import mcp_client  # noqa: E402
+
+FILE_SCHEMA = {
+    'type': 'object',
+    'properties': {
+        'image_path': {'type': 'string', 'format': 'file', 'uploadTo': 'mcp'},
+        'name': {'type': 'string'},
+    },
+}
+NO_FILE_SCHEMA = {
+    'type': 'object',
+    'properties': {'text': {'type': 'string'}},
+}
+
+
+@pytest.fixture
+def pushed(monkeypatch):
+    """Record what would have been uploaded, without a network."""
+    calls = []
+
+    async def fake_push(mcp_id, url, local_path):
+        calls.append({'mcp_id': mcp_id, 'url': url, 'local': local_path})
+        return f'/models/uploads/2026-09-08/{os.path.basename(local_path)}'
+
+    monkeypatch.setattr(mcp_client, '_push_file', fake_push)
+    return calls
+
+
+def _transfer(schema, args, pushed_url='http://localhost:15720/mcp'):
+    """Sync wrapper: pytest-asyncio is not installed, and the suite's convention
+    is asyncio.run inside a plain test."""
+    return asyncio.run(
+        mcp_client._transfer_file_args('mcp-p', pushed_url, schema, args))
+
+
+# ── the transfer ──────────────────────────────────────────────────────────────
+
+def test_a_local_file_becomes_the_targets_path(pushed, tmp_path):
+    photo = tmp_path / 'dai_wenyuan.jpeg'
+    photo.write_bytes(b'\xff\xd8jpeg')
+
+    args, error = _transfer(FILE_SCHEMA,
+                                  {'image_path': str(photo), 'name': '戴文渊'})
+
+    assert error is None
+    assert args['image_path'] == '/models/uploads/2026-09-08/dai_wenyuan.jpeg'
+    assert args['name'] == '戴文渊', 'other arguments must pass through untouched'
+    assert len(pushed) == 1
+    assert pushed[0]['local'] == str(photo)
+
+
+def test_a_tool_without_file_fields_is_not_touched(pushed, tmp_path):
+    args, error = _transfer(NO_FILE_SCHEMA, {'text': str(tmp_path)})
+    assert error is None and args == {'text': str(tmp_path)}
+    assert pushed == [], 'must not upload for a tool that takes no file'
+
+
+def test_a_path_that_is_not_local_is_left_for_the_tool(pushed):
+    """Either it is already the target's path — the canvas picker's output, or a
+    second call reusing an earlier result — or the model invented it. The tool
+    knows its own filesystem; re-sending would fail here for the wrong reason."""
+    args, error = _transfer(
+        FILE_SCHEMA, {'image_path': '/models/uploads/2026-09-08/already.jpg'})
+    assert error is None
+    assert args['image_path'] == '/models/uploads/2026-09-08/already.jpg'
+    assert pushed == []
+
+
+def test_a_missing_file_field_is_not_invented(pushed):
+    args, error = _transfer(FILE_SCHEMA, {'name': 'Alice'})
+    assert error is None and 'image_path' not in args
+    assert pushed == []
+
+
+def test_a_non_string_value_is_ignored(pushed):
+    args, error = _transfer(FILE_SCHEMA, {'image_path': 12345})
+    assert error is None and args['image_path'] == 12345
+    assert pushed == []
+
+
+def test_every_file_field_is_transferred(pushed, tmp_path):
+    """A tool may take more than one."""
+    first, second = tmp_path / 'a.jpg', tmp_path / 'b.jpg'
+    first.write_bytes(b'a')
+    second.write_bytes(b'b')
+    schema = {
+        'type': 'object',
+        'properties': {
+            'front': {'type': 'string', 'format': 'file'},
+            'side': {'type': 'string', 'format': 'file'},
+        },
+    }
+    args, error = _transfer(schema,
+                                  {'front': str(first), 'side': str(second)})
+    assert error is None
+    assert args['front'].endswith('/a.jpg') and args['side'].endswith('/b.jpg')
+    assert len(pushed) == 2
+
+
+# ── failure is reported, never passed through ─────────────────────────────────
+
+def test_an_upload_failure_stops_the_call(monkeypatch, tmp_path):
+    """It must not fall through: the tool would answer "cannot read <path>" and
+    the model would retry with another path it invented — the exact loop this
+    code exists to break."""
+    async def boom(mcp_id, url, local_path):
+        raise RuntimeError('Connection refused')
+
+    monkeypatch.setattr(mcp_client, '_push_file', boom)
+    photo = tmp_path / 'x.jpg'
+    photo.write_bytes(b'x')
+
+    args, error = _transfer(FILE_SCHEMA, {'image_path': str(photo)})
+    assert error is not None
+    assert 'could not send' in error
+    assert 'Connection refused' in error
+    # And it says what to check, because the usual cause is a stale image.
+    assert '/file/upload' in error
+    assert args['image_path'] == str(photo), 'unchanged when the transfer failed'
+
+
+# ── it reaches every card, present and future ─────────────────────────────────
+
+def test_format_file_survives_the_x_action_params_split():
+    """The split rebuilds each action's `properties` from the parent schema. If
+    it dropped `format`, the interceptor would never see a file field on any
+    split tool — which is every action-based card."""
+    tool = {
+        'name': 'face_recognition',
+        'description': 'Face recognition',
+        'inputSchema': {
+            'type': 'object',
+            'properties': {
+                'action': {'type': 'string', 'enum': ['register_by_photo', 'stop']},
+                'image_path': {'type': 'string', 'format': 'file', 'uploadTo': 'mcp'},
+                'name': {'type': 'string'},
+            },
+            'x-action-params': {
+                'register_by_photo': {'params': ['image_path', 'name'],
+                                      'description': 'reg'},
+                'stop': {'params': [], 'description': 'stop'},
+            },
+        },
+    }
+    schemas = mcp_client._to_openai_schema('mcp-x', tool)
+    by_action = {s['name'].split('__')[-1]: s for s in schemas}
+
+    reg = by_action['register_by_photo']['parameters']['properties']
+    assert reg['image_path']['format'] == 'file'
+    assert by_action['stop']['parameters']['properties'] == {}
+
+
+def test_the_transfer_is_generic_not_face_specific(pushed, tmp_path):
+    """Any tool declaring `format: file` is covered, including ones written
+    later — that is the point of doing this in call_tool."""
+    clip = tmp_path / 'greeting.wav'
+    clip.write_bytes(b'RIFF....WAVE')
+    schema = {
+        'type': 'object',
+        'properties': {'audio_file': {'type': 'string', 'format': 'file'}},
+    }
+    args, error = _transfer(schema, {'audio_file': str(clip)})
+    assert error is None
+    assert args['audio_file'].endswith('/greeting.wav')

--- a/agent-core/tests/test_mcp_file_proxy.py
+++ b/agent-core/tests/test_mcp_file_proxy.py
@@ -1,0 +1,83 @@
+"""
+tests/test_mcp_file_proxy.py — the cross-container file upload proxy.
+
+Why it exists: agent-core serves the browser, but the tool that needs a file
+runs in another container and shares no filesystem with it. A path minted here
+is meaningless there — the first face-enrolment attempt failed with an
+`image_path` that really existed, in *this* container. base64 through the tool
+call failed too (43 800 characters does not survive an LLM's context).
+
+So `POST /api/mcp/{mcp_id}/file/upload` streams the bytes to the owning service,
+which writes them where it can see them and returns **its own** absolute path.
+The address comes from the MCP registry, which is what makes one route cover
+perception, actucore and every driver despite their differing ports.
+
+Run: python3 -m pytest agent-core/tests/test_mcp_file_proxy.py -q
+"""
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+import fastapi  # noqa: E402
+
+from api.mcp_manage import _file_intake_url  # noqa: E402
+
+
+REGISTRY = [
+    {'id': 'mcp-perception', 'url': 'http://localhost:15720/mcp', 'transport': 'http'},
+    {'id': 'mcp-g1',         'url': 'http://localhost:15701/mcp', 'transport': 'http'},
+    {'id': 'mcp-tianyi',     'url': 'http://localhost:15707/mcp', 'transport': 'http'},
+    {'id': 'agentcore',      'url': '',                           'transport': 'internal'},
+    {'id': 'mcp-noport',     'url': '',                           'transport': 'http'},
+    {'id': 'mcp-prefixed',   'url': 'http://host:9000/api/v2/mcp', 'transport': 'http'},
+    {'id': 'mcp-nosuffix',   'url': 'http://host:9100/',          'transport': 'http'},
+]
+
+
+@pytest.fixture(autouse=True)
+def _registry(monkeypatch):
+    import api.mcp_manage as mm
+    monkeypatch.setattr(mm, '_get_mcp_list', lambda: REGISTRY)
+
+
+def test_the_port_comes_from_the_registry_not_a_hardcoded_table():
+    """Each service reports its url when it registers, so one route covers
+    perception and every driver even though the ports all differ."""
+    assert _file_intake_url('mcp-perception') == 'http://localhost:15720/file/upload'
+    assert _file_intake_url('mcp-g1')         == 'http://localhost:15701/file/upload'
+    assert _file_intake_url('mcp-tianyi')     == 'http://localhost:15707/file/upload'
+
+
+def test_a_url_with_a_path_prefix_keeps_it():
+    """rsplit('/mcp') rather than urljoin, which would discard the prefix."""
+    assert _file_intake_url('mcp-prefixed') == 'http://host:9000/api/v2/file/upload'
+
+
+def test_a_url_without_the_mcp_suffix_still_resolves():
+    assert _file_intake_url('mcp-nosuffix') == 'http://host:9100/file/upload'
+
+
+def test_an_unknown_mcp_is_a_404():
+    with pytest.raises(fastapi.HTTPException) as caught:
+        _file_intake_url('mcp-does-not-exist')
+    assert caught.value.status_code == 404
+
+
+def test_an_internal_mcp_points_at_the_local_endpoint_instead():
+    """agentcore and channel are served in-process; there is nothing to proxy
+    to, and saying so beats a confusing connection error."""
+    with pytest.raises(fastapi.HTTPException) as caught:
+        _file_intake_url('agentcore')
+    assert caught.value.status_code == 400
+    assert '/api/file/upload' in caught.value.detail
+
+
+def test_a_service_that_has_not_reported_a_url_yet_is_503():
+    """Distinct from 404: the service exists but has not registered its address,
+    so retrying is reasonable."""
+    with pytest.raises(fastapi.HTTPException) as caught:
+        _file_intake_url('mcp-noport')
+    assert caught.value.status_code == 503

--- a/agent-core/web/js/canvas.js
+++ b/agent-core/web/js/canvas.js
@@ -777,7 +777,8 @@ function _buildCardEl({ id, mcpId, toolName, driverName, x, y, topicIn: savedTop
           inputHtml = `<select class="canvas-field-input" data-key="${_esc(key)}">${opts}</select>`;
         } else if (def.format === 'file') {
           const accept = def.accept || '*/*';
-          inputHtml = `<div class="canvas-field-file"><input type="hidden" class="canvas-field-input" data-key="${_esc(key)}"><button type="button" class="canvas-file-btn" data-accept="${_esc(accept)}">Choose File</button><span class="canvas-file-name"></span></div>`;
+          const uploadDir = def.uploadDir || '';
+          inputHtml = `<div class="canvas-field-file"><input type="hidden" class="canvas-field-input" data-key="${_esc(key)}"><button type="button" class="canvas-file-btn" data-accept="${_esc(accept)}"${uploadDir ? ` data-upload-dir="${_esc(uploadDir)}"` : ''}>Choose File</button><span class="canvas-file-name"></span></div>`;
         } else {
           const type = def.type === 'number' || def.type === 'integer' ? 'number' : 'text';
           const desc = def.description || '';
@@ -868,17 +869,23 @@ function _buildCardEl({ id, mcpId, toolName, driverName, x, y, topicIn: savedTop
         const fileInput = document.createElement('input');
         fileInput.type = 'file';
         fileInput.accept = btn.dataset.accept || '*/*';
+        // Where the upload lands. Defaults to agent-core's own /tmp/uploads,
+        // which is right for a tool served by agent-core itself (remote_image,
+        // remote_audio). A tool in *another* container cannot see that path, so
+        // its schema declares `uploadDir` pointing at a directory both
+        // containers mount — see perception's face_recognition card.
+        const uploadDir = btn.dataset.uploadDir || '/tmp/uploads';
         fileInput.onchange = async () => {
           if (!fileInput.files[0]) return;
           btn.textContent = 'Uploading...';
           const form = new FormData();
           form.append('file', fileInput.files[0]);
-          form.append('path', '/tmp/uploads');
+          form.append('path', uploadDir);
           try {
             const res = await fetch('/api/file/upload', { method: 'POST', body: form });
             const data = await res.json();
             if (data.code === 200) {
-              hiddenInput.value = '/tmp/uploads/' + fileInput.files[0].name;
+              hiddenInput.value = uploadDir.replace(/\/$/, '') + '/' + fileInput.files[0].name;
               nameSpan.textContent = fileInput.files[0].name;
               btn.textContent = 'Re-select';
             } else {
@@ -917,7 +924,8 @@ function _buildCardEl({ id, mcpId, toolName, driverName, x, y, topicIn: savedTop
         inputHtml = `<select class="canvas-field-input" data-key="${_esc(key)}">${opts}</select>`;
       } else if (def.format === 'file') {
         const accept = def.accept || '*/*';
-        inputHtml = `<div class="canvas-field-file"><input type="hidden" class="canvas-field-input" data-key="${_esc(key)}"><button class="canvas-file-btn" data-accept="${_esc(accept)}">选择文件</button><span class="canvas-file-name"></span></div>`;
+        const uploadDir = def.uploadDir || '';
+        inputHtml = `<div class="canvas-field-file"><input type="hidden" class="canvas-field-input" data-key="${_esc(key)}"><button class="canvas-file-btn" data-accept="${_esc(accept)}"${uploadDir ? ` data-upload-dir="${_esc(uploadDir)}"` : ''}>选择文件</button><span class="canvas-file-name"></span></div>`;
       } else {
         const type = def.type === 'number' || def.type === 'integer' ? 'number' : 'text';
         const desc = def.description || '';
@@ -1061,17 +1069,23 @@ function _buildCardEl({ id, mcpId, toolName, driverName, x, y, topicIn: savedTop
         const fileInput = document.createElement('input');
         fileInput.type = 'file';
         fileInput.accept = btn.dataset.accept || '*/*';
+        // Where the upload lands. Defaults to agent-core's own /tmp/uploads,
+        // which is right for a tool served by agent-core itself (remote_image,
+        // remote_audio). A tool in *another* container cannot see that path, so
+        // its schema declares `uploadDir` pointing at a directory both
+        // containers mount — see perception's face_recognition card.
+        const uploadDir = btn.dataset.uploadDir || '/tmp/uploads';
         fileInput.onchange = async () => {
           if (!fileInput.files[0]) return;
           btn.textContent = 'Uploading...';
           const form = new FormData();
           form.append('file', fileInput.files[0]);
-          form.append('path', '/tmp/uploads');
+          form.append('path', uploadDir);
           try {
             const res = await fetch('/api/file/upload', { method: 'POST', body: form });
             const data = await res.json();
             if (data.code === 200) {
-              hiddenInput.value = '/tmp/uploads/' + fileInput.files[0].name;
+              hiddenInput.value = uploadDir.replace(/\/$/, '') + '/' + fileInput.files[0].name;
               nameSpan.textContent = fileInput.files[0].name;
               btn.textContent = 'Re-select';
             } else {

--- a/agent-core/web/js/canvas.js
+++ b/agent-core/web/js/canvas.js
@@ -986,6 +986,13 @@ function _buildCardEl({ id, mcpId, toolName, driverName, x, y, topicIn: savedTop
             if (!key || key === 'action') return;
             field.style.display = paramKeys.includes(key) ? '' : 'none';
           });
+          // Showing/hiding fields changes the card's height, which moves every
+          // port on it. _redrawConnections reads live getBoundingClientRect,
+          // so it is correct whenever it runs — it just was not running here,
+          // leaving connection lines anchored to where the ports used to be.
+          // Most visible on a tool whose actions differ a lot in parameter
+          // count (face_recognition: 4 params for list_persons, 0 for stop).
+          _redrawConnections();
         };
         actionSelect.addEventListener('change', async () => {
           if (!(await _ensureEdit())) {

--- a/agent-core/web/js/canvas.js
+++ b/agent-core/web/js/canvas.js
@@ -778,7 +778,8 @@ function _buildCardEl({ id, mcpId, toolName, driverName, x, y, topicIn: savedTop
         } else if (def.format === 'file') {
           const accept = def.accept || '*/*';
           const uploadDir = def.uploadDir || '';
-          inputHtml = `<div class="canvas-field-file"><input type="hidden" class="canvas-field-input" data-key="${_esc(key)}"><button type="button" class="canvas-file-btn" data-accept="${_esc(accept)}"${uploadDir ? ` data-upload-dir="${_esc(uploadDir)}"` : ''}>Choose File</button><span class="canvas-file-name"></span></div>`;
+          const uploadTo = def.uploadTo || '';
+          inputHtml = `<div class="canvas-field-file"><input type="hidden" class="canvas-field-input" data-key="${_esc(key)}"><button type="button" class="canvas-file-btn" data-accept="${_esc(accept)}"${uploadDir ? ` data-upload-dir="${_esc(uploadDir)}"` : ''}${uploadTo ? ` data-upload-to="${_esc(uploadTo)}"` : ''}>Choose File</button><span class="canvas-file-name"></span></div>`;
         } else {
           const type = def.type === 'number' || def.type === 'integer' ? 'number' : 'text';
           const desc = def.description || '';
@@ -869,31 +870,52 @@ function _buildCardEl({ id, mcpId, toolName, driverName, x, y, topicIn: savedTop
         const fileInput = document.createElement('input');
         fileInput.type = 'file';
         fileInput.accept = btn.dataset.accept || '*/*';
-        // Where the upload lands. Defaults to agent-core's own /tmp/uploads,
-        // which is right for a tool served by agent-core itself (remote_image,
-        // remote_audio). A tool in *another* container cannot see that path, so
-        // its schema declares `uploadDir` pointing at a directory both
-        // containers mount — see perception's face_recognition card.
+        // Two destinations, and which is correct depends on who reads the file.
+        //
+        //   uploadTo: 'mcp'  → POST /api/mcp/<id>/file/upload, which streams the
+        //     bytes to the service owning this tool. That service writes them
+        //     where it can see them and returns *its own* absolute path. This is
+        //     the only thing that works when the tool runs in another container:
+        //     agent-core and perception share no filesystem, so a path minted
+        //     here is meaningless there.
+        //   default → agent-core's own /tmp/uploads, right for a tool that
+        //     agent-core serves itself (remote_image, remote_audio).
+        const uploadTo = btn.dataset.uploadTo || '';
         const uploadDir = btn.dataset.uploadDir || '/tmp/uploads';
         fileInput.onchange = async () => {
           if (!fileInput.files[0]) return;
           btn.textContent = 'Uploading...';
           const form = new FormData();
           form.append('file', fileInput.files[0]);
-          form.append('path', uploadDir);
+          let endpoint = '/api/file/upload';
+          if (uploadTo === 'mcp') {
+            endpoint = `/api/mcp/${encodeURIComponent(mcpId)}/file/upload`;
+          } else {
+            form.append('path', uploadDir);
+          }
           try {
-            const res = await fetch('/api/file/upload', { method: 'POST', body: form });
+            const res = await fetch(endpoint, { method: 'POST', body: form });
             const data = await res.json();
             if (data.code === 200) {
-              hiddenInput.value = uploadDir.replace(/\/$/, '') + '/' + fileInput.files[0].name;
+              // The proxy replies with the receiving container's own path; the
+              // local endpoint does not, so derive it as before.
+              hiddenInput.value = uploadTo === 'mcp'
+                ? ((data.data && data.data.path) || '')
+                : uploadDir.replace(/\/$/, '') + '/' + fileInput.files[0].name;
               nameSpan.textContent = fileInput.files[0].name;
               btn.textContent = 'Re-select';
             } else {
+              // Surface the reason: the proxy distinguishes "the service is not
+              // listening" (an image predating the endpoint) from "it refused
+              // the file", and a bare "Failed" hides which.
               btn.textContent = 'Failed';
+              btn.title = data.message || '';
+              console.warn('[canvas] upload failed:', data.message || data);
               setTimeout(() => { btn.textContent = 'Choose File'; }, 2000);
             }
           } catch (err) {
             btn.textContent = 'Error';
+            btn.title = String(err);
             setTimeout(() => { btn.textContent = 'Choose File'; }, 2000);
           }
         };
@@ -925,7 +947,8 @@ function _buildCardEl({ id, mcpId, toolName, driverName, x, y, topicIn: savedTop
       } else if (def.format === 'file') {
         const accept = def.accept || '*/*';
         const uploadDir = def.uploadDir || '';
-        inputHtml = `<div class="canvas-field-file"><input type="hidden" class="canvas-field-input" data-key="${_esc(key)}"><button class="canvas-file-btn" data-accept="${_esc(accept)}"${uploadDir ? ` data-upload-dir="${_esc(uploadDir)}"` : ''}>选择文件</button><span class="canvas-file-name"></span></div>`;
+        const uploadTo = def.uploadTo || '';
+        inputHtml = `<div class="canvas-field-file"><input type="hidden" class="canvas-field-input" data-key="${_esc(key)}"><button class="canvas-file-btn" data-accept="${_esc(accept)}"${uploadDir ? ` data-upload-dir="${_esc(uploadDir)}"` : ''}${uploadTo ? ` data-upload-to="${_esc(uploadTo)}"` : ''}>选择文件</button><span class="canvas-file-name"></span></div>`;
       } else {
         const type = def.type === 'number' || def.type === 'integer' ? 'number' : 'text';
         const desc = def.description || '';

--- a/perception/Dockerfile.jetson
+++ b/perception/Dockerfile.jetson
@@ -42,6 +42,11 @@ ARG PYPI_MIRROR APT_MIRROR JP_VERSION ENABLE_VITS2_TRT
 #                  is correct on any base, present or future.
 #   DLA_COMPILER_SO  COS key of the bundled libnvdla_compiler.so, or empty for a
 #                  line that does not need one (see the dla-fallback step).
+#   ORT_VERSION    standalone onnxruntime for the face plugin, pinned per line
+#                  because the wheel is tagged with the CPython ABI: jp5.11 is
+#                  cp38, for which onnxruntime stopped publishing wheels after
+#                  1.19, and jp6.1 is cp310. Unrelated to the ONNX Runtime
+#                  inside the sherpa-onnx wheel — see the onnxruntime step.
 #
 # It is also a record: `docker exec <c> cat /etc/jetpack.env` says what line an
 # image was built for, which is otherwise guesswork from the tag alone.
@@ -49,14 +54,14 @@ ARG SHERPA_GPU_WHEEL_511=jp511/sherpa_onnx-1.13.6+cuda-cp38-cp38-linux_aarch64.w
 ARG SHERPA_GPU_WHEEL_61=jp61/sherpa_onnx-1.13.6+cuda-cp310-cp310-linux_aarch64.whl
 ARG DLA_COMPILER_SO_61=jp61/libnvdla_compiler.so
 RUN case "${JP_VERSION}" in \
-        511) NUMPY=1.24.4; WHEEL="${SHERPA_GPU_WHEEL_511}"; DLA= ;; \
-        61)  NUMPY=1.26.4; WHEEL="${SHERPA_GPU_WHEEL_61}"; DLA="${DLA_COMPILER_SO_61}" ;; \
-        *)   NUMPY=1.24.4; WHEEL=; DLA= ;; \
+        511) NUMPY=1.24.4; WHEEL="${SHERPA_GPU_WHEEL_511}"; DLA=; ORT=1.16.3 ;; \
+        61)  NUMPY=1.26.4; WHEEL="${SHERPA_GPU_WHEEL_61}"; DLA="${DLA_COMPILER_SO_61}"; ORT=1.19.2 ;; \
+        *)   NUMPY=1.24.4; WHEEL=; DLA=; ORT=1.19.2 ;; \
     esac; \
-    printf 'NUMPY_VERSION=%s\nSHERPA_GPU_WHEEL=%s\nPY_ABI=%s\nDLA_COMPILER_SO=%s\n' \
+    printf 'NUMPY_VERSION=%s\nSHERPA_GPU_WHEEL=%s\nPY_ABI=%s\nDLA_COMPILER_SO=%s\nORT_VERSION=%s\n' \
         "${NUMPY}" "${WHEEL}" \
         "$(python3 -c 'import sys; print("%d.%d" % sys.version_info[:2])')" \
-        "${DLA}" \
+        "${DLA}" "${ORT}" \
         > /etc/jetpack.env && \
     echo "[build] jp${JP_VERSION}:" && cat /etc/jetpack.env
 
@@ -330,6 +335,45 @@ RUN . /etc/jetpack.env; \
     pip3 install --no-cache-dir -i ${PYPI_MIRROR} "pyvips==3.1.0" && \
     RAPIDOCR_MODELS="$(python3 -c 'from pathlib import Path; import rapidocr; print(Path(rapidocr.__file__).resolve().parent / "models")')" && \
     find "${RAPIDOCR_MODELS}" -type f -name '*.onnx' -delete
+
+# ── Standalone onnxruntime (face recognition: SCRFD + ArcFace) ────────────────
+# This is a *second, independent* ONNX Runtime in the image. The first is the
+# one compiled into the sherpa-onnx wheel under sherpa_onnx/lib, which only ASR
+# and sherpa TTS can reach; there is no supported way to run our own models on
+# it. The step above notes that onnxruntime was deliberately absent — that was
+# correct while rapidocr was used for post-processing only and OCR ran on
+# TensorRT. The face models are plain ONNX and must run on both CPU and GPU
+# hosts, which rules out a TensorRT-only path (engines are not portable across
+# TensorRT majors, so it would mean a bundle per JetPack line for a 15 MB pair).
+#
+# CPU wheel from PyPI. A CUDA-capable build for Jetson is a separate,
+# per-JetPack wheel that has to be hosted on COS the way SHERPA_GPU_WHEEL is;
+# until that exists `device: gpu` degrades to cpu with a warning
+# (utils/onnx_provider.ort_providers_for_device). The models are 2.5 MB and
+# 13 MB, so this is a throughput choice, not a correctness one.
+#
+# numpy is pinned on the same line for the reason the OCR step gives: several
+# packages in the base image are built against a specific numpy C-ABI, and an
+# unpinned install silently upgrades it.
+#
+# The assert is the point of this layer. Two ONNX Runtimes in one process could
+# clash at the symbol level — both ship a libonnxruntime, sherpa's resolved via
+# RPATH from its own extension — and a clash surfaces when the second one's
+# shared objects are dlopen'd, i.e. at import. So import in both orders: if
+# either direction is going to break, it breaks here, in the build, rather than
+# on a robot. Creating a session from each in one process needs model files that
+# do not exist at build time; that half is verified on hardware (an ASR
+# utterance and a face recognition both working in the same container).
+RUN . /etc/jetpack.env; \
+    pip3 install --no-cache-dir -i ${PYPI_MIRROR} \
+      "numpy==${NUMPY_VERSION}" "onnxruntime==${ORT_VERSION}" && \
+    python3 -c "import onnxruntime, sherpa_onnx; print('[build] ort-first import ok')" && \
+    python3 -c "import sherpa_onnx, onnxruntime; print('[build] sherpa-first import ok')" && \
+    python3 -c "import numpy, onnxruntime, sherpa_onnx; \
+assert numpy.__version__ == '${NUMPY_VERSION}', numpy.__version__; \
+print('[build] onnxruntime', onnxruntime.__version__, \
+      'providers:', onnxruntime.get_available_providers()); \
+print('[build] sherpa-onnx', sherpa_onnx.__version__, 'coexists; numpy', numpy.__version__)"
 
 # ── phonemizer (multilingual IPA via espeak-ng for asr_kws mode) ──
 # ldconfig shimmed for the same reason as the ffmpeg step above — this is the

--- a/perception/Dockerfile.jetson
+++ b/perception/Dockerfile.jetson
@@ -42,20 +42,6 @@ ARG PYPI_MIRROR APT_MIRROR JP_VERSION ENABLE_VITS2_TRT
 #                  is correct on any base, present or future.
 #   DLA_COMPILER_SO  COS key of the bundled libnvdla_compiler.so, or empty for a
 #                  line that does not need one (see the dla-fallback step).
-#   ORT_VERSION    standalone onnxruntime for the face plugin, pinned per line
-#                  to the *same version sherpa-onnx bundles* on that line
-#                  (jp5.11 → 1.16.0, jp6.1 → libonnxruntime.so.1.18.1), so the
-#                  two ONNX Runtimes in the process are ABI-identical. Also the
-#                  ABI gate: jp5.11 is cp38, jp6.1 is cp310.
-#                  DO NOT bump to 1.19.x. 1.19.2 enumerates the cores in
-#                  /sys/devices/system/cpu/present and pins threads to them; on
-#                  a Jetson where some cores are *offline* (Tianyi in MODE_30W:
-#                  present 0-11, online 0-7) pthread_setaffinity_np returns
-#                  EINVAL and a std::vector index then goes out of range,
-#                  abort()ing the whole perception process during
-#                  InferenceSession(). Measured on Tianyi: 1.19.2 aborts with
-#                  every SessionOptions combination including none at all;
-#                  1.18.1, 1.17.3 and 1.16.3 all build a session and infer.
 #
 # It is also a record: `docker exec <c> cat /etc/jetpack.env` says what line an
 # image was built for, which is otherwise guesswork from the tag alone.
@@ -63,14 +49,14 @@ ARG SHERPA_GPU_WHEEL_511=jp511/sherpa_onnx-1.13.6+cuda-cp38-cp38-linux_aarch64.w
 ARG SHERPA_GPU_WHEEL_61=jp61/sherpa_onnx-1.13.6+cuda-cp310-cp310-linux_aarch64.whl
 ARG DLA_COMPILER_SO_61=jp61/libnvdla_compiler.so
 RUN case "${JP_VERSION}" in \
-        511) NUMPY=1.24.4; WHEEL="${SHERPA_GPU_WHEEL_511}"; DLA=; ORT=1.16.3 ;; \
-        61)  NUMPY=1.26.4; WHEEL="${SHERPA_GPU_WHEEL_61}"; DLA="${DLA_COMPILER_SO_61}"; ORT=1.18.1 ;; \
-        *)   NUMPY=1.24.4; WHEEL=; DLA=; ORT=1.18.1 ;; \
+        511) NUMPY=1.24.4; WHEEL="${SHERPA_GPU_WHEEL_511}"; DLA= ;; \
+        61)  NUMPY=1.26.4; WHEEL="${SHERPA_GPU_WHEEL_61}"; DLA="${DLA_COMPILER_SO_61}" ;; \
+        *)   NUMPY=1.24.4; WHEEL=; DLA= ;; \
     esac; \
-    printf 'NUMPY_VERSION=%s\nSHERPA_GPU_WHEEL=%s\nPY_ABI=%s\nDLA_COMPILER_SO=%s\nORT_VERSION=%s\n' \
+    printf 'NUMPY_VERSION=%s\nSHERPA_GPU_WHEEL=%s\nPY_ABI=%s\nDLA_COMPILER_SO=%s\n' \
         "${NUMPY}" "${WHEEL}" \
         "$(python3 -c 'import sys; print("%d.%d" % sys.version_info[:2])')" \
-        "${DLA}" "${ORT}" \
+        "${DLA}" \
         > /etc/jetpack.env && \
     echo "[build] jp${JP_VERSION}:" && cat /etc/jetpack.env
 
@@ -345,62 +331,6 @@ RUN . /etc/jetpack.env; \
     RAPIDOCR_MODELS="$(python3 -c 'from pathlib import Path; import rapidocr; print(Path(rapidocr.__file__).resolve().parent / "models")')" && \
     find "${RAPIDOCR_MODELS}" -type f -name '*.onnx' -delete
 
-# ── Standalone onnxruntime (face recognition: SCRFD + ArcFace) ────────────────
-# This is a *second, independent* ONNX Runtime in the image. The first is the
-# one compiled into the sherpa-onnx wheel under sherpa_onnx/lib, which only ASR
-# and sherpa TTS can reach; there is no supported way to run our own models on
-# it. The step above notes that onnxruntime was deliberately absent — that was
-# correct while rapidocr was used for post-processing only and OCR ran on
-# TensorRT. The face models are plain ONNX and must run on both CPU and GPU
-# hosts, which rules out a TensorRT-only path (engines are not portable across
-# TensorRT majors, so it would mean a bundle per JetPack line for a 15 MB pair).
-#
-# **The two runtimes do coexist.** Measured on Orin6 in this image, five
-# sequences all passed, each in its own process: ORT alone; both imported;
-# sherpa VAD session then an ORT session; the same with RTLD_DEEPBIND; and ORT
-# session then sherpa. Both libraries stay mapped (`sherpa_onnx/lib/
-# libonnxruntime.so.1.18.1` and the wheel's own) without interposing on each
-# other, because each extension resolves against its own RPATH. So the symbol
-# clash this layer was originally written to guard against does not occur, and
-# the import asserts below are cheap insurance rather than the real risk.
-#
-# The real risk was the ORT *version*, and it is why ORT_VERSION is pinned per
-# line rather than left to pip — see /etc/jetpack.env above for the offline-core
-# abort that 1.19.2 causes. Matching sherpa's bundled version also means the two
-# mapped runtimes are ABI-identical, so an accidental interposition would be
-# benign rather than a memory-layout mismatch.
-#
-# CPU wheel from PyPI: `device: auto` therefore resolves to cpu on this image.
-# A CUDA-capable build for Jetson is a separate, per-JetPack wheel that has to
-# be hosted on COS the way SHERPA_GPU_WHEEL is; until that exists the models
-# (2.5 MB + 13 MB) run on cpu, which at the default 1 detection/second is a
-# throughput choice, not a correctness one.
-#
-# **`--no-deps`, deliberately.** A plain install pulls protobuf, coloredlogs,
-# humanfriendly and flatbuffers in behind onnxruntime — and measured on the
-# jp6.1 image, protobuf was not previously present at all, so a resolved
-# install introduces protobuf 7.36.1 into an image where OCR (rapidocr),
-# TensorRT and ROS2 all live. None of that is needed for inference: verified on
-# Tianyi that with `--no-deps` and no protobuf/coloredlogs/flatbuffers at all,
-# `InferenceSession` builds and `run()` returns all 9 SCRFD outputs. numpy is
-# therefore not reinstalled either — nothing is touched but onnxruntime itself,
-# which is the only way to add a runtime here without risking the numpy C-ABI
-# the torch/cv2/rapidocr stack is built against. The assert still checks numpy
-# did not move.
-RUN . /etc/jetpack.env; \
-    pip3 install --no-cache-dir --no-deps -i ${PYPI_MIRROR} \
-      "onnxruntime==${ORT_VERSION}" && \
-    python3 -c "import onnxruntime, sherpa_onnx; print('[build] ort-first import ok')" && \
-    python3 -c "import sherpa_onnx, onnxruntime; print('[build] sherpa-first import ok')" && \
-    python3 -c "import numpy, onnxruntime, sherpa_onnx, rapidocr, tensorrt, torch; \
-assert numpy.__version__ == '${NUMPY_VERSION}', numpy.__version__; \
-assert not onnxruntime.__version__.startswith('1.19'), \
-    'onnxruntime 1.19.x abort()s on Jetsons with offline cores; see jetpack.env'; \
-print('[build] onnxruntime', onnxruntime.__version__, \
-      'providers:', onnxruntime.get_available_providers()); \
-print('[build] intact alongside it: sherpa-onnx', sherpa_onnx.__version__, \
-      '| tensorrt', tensorrt.__version__, '| numpy', numpy.__version__)"
-
 # ── phonemizer (multilingual IPA via espeak-ng for asr_kws mode) ──
 # ldconfig shimmed for the same reason as the ffmpeg step above — this is the
 # step that actually failed on `--jp-version 6.1`, because layers 1-11 were
@@ -465,6 +395,81 @@ assert not missing, 'missing: %s' % missing; \
 assert numpy.__version__ == '${NUMPY_VERSION}', numpy.__version__; \
 print('[build] VITS2 frontend ok on numpy ' + numpy.__version__)"; \
     fi && rm -f /tmp/vits2-requirements.txt
+
+# ── Standalone onnxruntime (face recognition: SCRFD + ArcFace) ────────────────
+# **Placed here, last of the dependency layers, on purpose.** Everything above
+# is shared by ASR/TTS/VOP/OCR; this package is used by the face plugin alone.
+# A layer inserted higher up invalidates the Docker cache for every layer below
+# it, and several of those install *unpinned* (`ultralytics`, `phonemizer`), so
+# they silently re-resolve to whatever is newest — an earlier revision of this
+# change touched /etc/jetpack.env near the top of the file and moved ultralytics
+# 8.4.138 → 8.4.142 as a side effect, with nothing to do with face recognition.
+# Keep it below every shared layer and above only the COPY of application code,
+# which rebuilds on any source edit anyway. ORT_VERSION is resolved right here
+# rather than in /etc/jetpack.env for the same reason: that file is layer 2.
+#
+# This is a *second, independent* ONNX Runtime in the image. The first is the
+# one compiled into the sherpa-onnx wheel under sherpa_onnx/lib, which only ASR
+# and sherpa TTS can reach; there is no supported way to run our own models on
+# it. The OCR step above notes that onnxruntime was deliberately absent — that
+# was correct while rapidocr was used for post-processing only and OCR ran on
+# TensorRT. The face models are plain ONNX and must run on CPU and GPU hosts
+# alike, which rules out a TensorRT-only path (engines are not portable across
+# TensorRT majors, so it would mean a bundle per JetPack line for a 15 MB pair).
+#
+# **The two runtimes do coexist.** Measured on Orin6, five sequences each in
+# their own process: ORT alone; both imported; sherpa VAD session then an ORT
+# session; the same with RTLD_DEEPBIND; and ORT session then sherpa. All passed,
+# with both libraries mapped and neither interposing, because each extension
+# resolves against its own RPATH.
+#
+# **One version for both JetPack lines.** 1.18.1 is what sherpa-onnx bundles on
+# jp6.1 (`libonnxruntime.so.1.18.1`), so on that line the two mapped runtimes
+# are ABI-identical. It also runs on jp5.11: its cp38 aarch64 wheel is
+# manylinux_2_28 and focal has glibc 2.31, verified on Orin5 (Ubuntu 20.04,
+# glibc 2.31, py 3.8) building a session and inferring. A per-line split was
+# tried first and dropped — nothing needed it, and one version is one thing to
+# reason about.
+#
+# **DO NOT bump to 1.19.x.** 1.19.2 enumerates the cores in
+# /sys/devices/system/cpu/present and pins a thread to each; on a Jetson where a
+# power mode has parked some cores (Tianyi in MODE_30W: present 0-11, online
+# 0-7) pthread_setaffinity_np returns EINVAL and a std::vector index then goes
+# out of range, abort()ing the whole perception process inside
+# InferenceSession() with no Python traceback. Measured on Tianyi: 1.19.2 aborts
+# under every SessionOptions combination including none at all, so no
+# configuration avoids it; 1.18.1, 1.17.3 and 1.16.3 each build a session and
+# return all 9 SCRFD outputs. Orin6 has present == online and never reproduces
+# it, so test a bump on a robot whose power mode parks cores.
+#
+# **`--no-deps`, deliberately.** A resolved install pulls protobuf, coloredlogs,
+# humanfriendly and flatbuffers in behind onnxruntime — and measured on the
+# jp6.1 image, protobuf was not previously present at all, so it would introduce
+# protobuf 7.36.1 into an image where rapidocr, TensorRT and ROS2 all live. None
+# of it is needed for inference: verified on Tianyi that with `--no-deps` and
+# none of those packages installed, InferenceSession builds and run() returns
+# all 9 outputs. numpy is therefore not reinstalled either — nothing is touched
+# but onnxruntime itself, which is the only safe way to add a runtime here given
+# the numpy C-ABI the torch/cv2/rapidocr stack is built against.
+#
+# CPU wheel: `device: auto` resolves to cpu on this image. A CUDA build for
+# Jetson is a separate per-JetPack wheel that must be hosted on COS the way
+# SHERPA_GPU_WHEEL is; when it lands, `auto` picks it up with no code change.
+ARG ORT_VERSION=1.18.1
+RUN . /etc/jetpack.env; \
+    pip3 install --no-cache-dir --no-deps -i ${PYPI_MIRROR} \
+      "onnxruntime==${ORT_VERSION}" && \
+    python3 -c "import onnxruntime, sherpa_onnx; print('[build] ort-first import ok')" && \
+    python3 -c "import sherpa_onnx, onnxruntime; print('[build] sherpa-first import ok')" && \
+    python3 -c "import numpy, onnxruntime, sherpa_onnx, rapidocr, tensorrt, torch; \
+assert numpy.__version__ == '${NUMPY_VERSION}', \
+    'onnxruntime moved numpy to %s' % numpy.__version__; \
+assert not onnxruntime.__version__.startswith('1.19'), \
+    'onnxruntime 1.19.x abort()s on Jetsons with parked cores; see this step'; \
+print('[build] onnxruntime', onnxruntime.__version__, \
+      'providers:', onnxruntime.get_available_providers()); \
+print('[build] intact alongside it: sherpa-onnx', sherpa_onnx.__version__, \
+      '| tensorrt', tensorrt.__version__, '| numpy', numpy.__version__)"
 
 # ── Application code ───────────────────────────────────────────────
 WORKDIR /work

--- a/perception/Dockerfile.jetson
+++ b/perception/Dockerfile.jetson
@@ -396,80 +396,28 @@ assert numpy.__version__ == '${NUMPY_VERSION}', numpy.__version__; \
 print('[build] VITS2 frontend ok on numpy ' + numpy.__version__)"; \
     fi && rm -f /tmp/vits2-requirements.txt
 
-# ── Standalone onnxruntime (face recognition: SCRFD + ArcFace) ────────────────
-# **Placed here, last of the dependency layers, on purpose.** Everything above
-# is shared by ASR/TTS/VOP/OCR; this package is used by the face plugin alone.
-# A layer inserted higher up invalidates the Docker cache for every layer below
-# it, and several of those install *unpinned* (`ultralytics`, `phonemizer`), so
-# they silently re-resolve to whatever is newest — an earlier revision of this
-# change touched /etc/jetpack.env near the top of the file and moved ultralytics
-# 8.4.138 → 8.4.142 as a side effect, with nothing to do with face recognition.
-# Keep it below every shared layer and above only the COPY of application code,
-# which rebuilds on any source edit anyway. ORT_VERSION is resolved right here
-# rather than in /etc/jetpack.env for the same reason: that file is layer 2.
+# ── onnxruntime, CPU-only (used by the face recognition plugin alone) ────────
+# A second ONNX Runtime: sherpa-onnx bundles its own but exposes no way to run
+# our models on it. They coexist fine — measured on Orin6, both import orders
+# and both holding live sessions.
 #
-# This is a *second, independent* ONNX Runtime in the image. The first is the
-# one compiled into the sherpa-onnx wheel under sherpa_onnx/lib, which only ASR
-# and sherpa TTS can reach; there is no supported way to run our own models on
-# it. The OCR step above notes that onnxruntime was deliberately absent — that
-# was correct while rapidocr was used for post-processing only and OCR ran on
-# TensorRT. The face models are plain ONNX and must run on CPU and GPU hosts
-# alike, which rules out a TensorRT-only path (engines are not portable across
-# TensorRT majors, so it would mean a bundle per JetPack line for a 15 MB pair).
+# Deliberately the last dependency layer. A step inserted higher up invalidates
+# the cache for every layer below, and several of those install *unpinned*
+# (ultralytics, phonemizer), so they silently re-resolve to whatever is newest.
 #
-# **The two runtimes do coexist.** Measured on Orin6, five sequences each in
-# their own process: ORT alone; both imported; sherpa VAD session then an ORT
-# session; the same with RTLD_DEEPBIND; and ORT session then sherpa. All passed,
-# with both libraries mapped and neither interposing, because each extension
-# resolves against its own RPATH.
+# --no-deps: a resolved install also pulls protobuf, coloredlogs, humanfriendly
+# and flatbuffers, and protobuf was not in this image at all. None is needed for
+# inference (verified on Tianyi: session builds, run() returns all 9 outputs),
+# so this adds exactly one wheel and moves nothing else — numpy included, which
+# the torch/cv2/rapidocr stack is ABI-bound to.
 #
-# **One version for both JetPack lines.** 1.18.1 is what sherpa-onnx bundles on
-# jp6.1 (`libonnxruntime.so.1.18.1`), so on that line the two mapped runtimes
-# are ABI-identical. It also runs on jp5.11: its cp38 aarch64 wheel is
-# manylinux_2_28 and focal has glibc 2.31, verified on Orin5 (Ubuntu 20.04,
-# glibc 2.31, py 3.8) building a session and inferring. A per-line split was
-# tried first and dropped — nothing needed it, and one version is one thing to
-# reason about.
-#
-# **DO NOT bump to 1.19.x.** 1.19.2 enumerates the cores in
-# /sys/devices/system/cpu/present and pins a thread to each; on a Jetson where a
-# power mode has parked some cores (Tianyi in MODE_30W: present 0-11, online
-# 0-7) pthread_setaffinity_np returns EINVAL and a std::vector index then goes
-# out of range, abort()ing the whole perception process inside
-# InferenceSession() with no Python traceback. Measured on Tianyi: 1.19.2 aborts
-# under every SessionOptions combination including none at all, so no
-# configuration avoids it; 1.18.1, 1.17.3 and 1.16.3 each build a session and
-# return all 9 SCRFD outputs. Orin6 has present == online and never reproduces
-# it, so test a bump on a robot whose power mode parks cores.
-#
-# **`--no-deps`, deliberately.** A resolved install pulls protobuf, coloredlogs,
-# humanfriendly and flatbuffers in behind onnxruntime — and measured on the
-# jp6.1 image, protobuf was not previously present at all, so it would introduce
-# protobuf 7.36.1 into an image where rapidocr, TensorRT and ROS2 all live. None
-# of it is needed for inference: verified on Tianyi that with `--no-deps` and
-# none of those packages installed, InferenceSession builds and run() returns
-# all 9 outputs. numpy is therefore not reinstalled either — nothing is touched
-# but onnxruntime itself, which is the only safe way to add a runtime here given
-# the numpy C-ABI the torch/cv2/rapidocr stack is built against.
-#
-# CPU wheel: `device: auto` resolves to cpu on this image. A CUDA build for
-# Jetson is a separate per-JetPack wheel that must be hosted on COS the way
-# SHERPA_GPU_WHEEL is; when it lands, `auto` picks it up with no code change.
-ARG ORT_VERSION=1.18.1
-RUN . /etc/jetpack.env; \
-    pip3 install --no-cache-dir --no-deps -i ${PYPI_MIRROR} \
-      "onnxruntime==${ORT_VERSION}" && \
-    python3 -c "import onnxruntime, sherpa_onnx; print('[build] ort-first import ok')" && \
-    python3 -c "import sherpa_onnx, onnxruntime; print('[build] sherpa-first import ok')" && \
-    python3 -c "import numpy, onnxruntime, sherpa_onnx, rapidocr, tensorrt, torch; \
-assert numpy.__version__ == '${NUMPY_VERSION}', \
-    'onnxruntime moved numpy to %s' % numpy.__version__; \
-assert not onnxruntime.__version__.startswith('1.19'), \
-    'onnxruntime 1.19.x abort()s on Jetsons with parked cores; see this step'; \
-print('[build] onnxruntime', onnxruntime.__version__, \
-      'providers:', onnxruntime.get_available_providers()); \
-print('[build] intact alongside it: sherpa-onnx', sherpa_onnx.__version__, \
-      '| tensorrt', tensorrt.__version__, '| numpy', numpy.__version__)"
+# 1.18.1 pinned, and **never 1.19.x**: 1.19.2 pins a thread to every core in
+# /sys/devices/system/cpu/present, so where a power mode has parked some (Tianyi
+# in MODE_30W: present 0-11, online 0-7) pthread_setaffinity_np returns EINVAL,
+# a vector index goes out of range, and all of perception abort()s inside
+# InferenceSession() with no traceback. 1.18.1 is also exactly what sherpa-onnx
+# bundles on jp6.1. Verified on Orin5 (py3.8, glibc 2.31) and Tianyi (py3.10).
+RUN pip3 install --no-cache-dir --no-deps -i ${PYPI_MIRROR} onnxruntime==1.18.1
 
 # ── Application code ───────────────────────────────────────────────
 WORKDIR /work

--- a/perception/Dockerfile.jetson
+++ b/perception/Dockerfile.jetson
@@ -43,10 +43,19 @@ ARG PYPI_MIRROR APT_MIRROR JP_VERSION ENABLE_VITS2_TRT
 #   DLA_COMPILER_SO  COS key of the bundled libnvdla_compiler.so, or empty for a
 #                  line that does not need one (see the dla-fallback step).
 #   ORT_VERSION    standalone onnxruntime for the face plugin, pinned per line
-#                  because the wheel is tagged with the CPython ABI: jp5.11 is
-#                  cp38, for which onnxruntime stopped publishing wheels after
-#                  1.19, and jp6.1 is cp310. Unrelated to the ONNX Runtime
-#                  inside the sherpa-onnx wheel — see the onnxruntime step.
+#                  to the *same version sherpa-onnx bundles* on that line
+#                  (jp5.11 → 1.16.0, jp6.1 → libonnxruntime.so.1.18.1), so the
+#                  two ONNX Runtimes in the process are ABI-identical. Also the
+#                  ABI gate: jp5.11 is cp38, jp6.1 is cp310.
+#                  DO NOT bump to 1.19.x. 1.19.2 enumerates the cores in
+#                  /sys/devices/system/cpu/present and pins threads to them; on
+#                  a Jetson where some cores are *offline* (Tianyi in MODE_30W:
+#                  present 0-11, online 0-7) pthread_setaffinity_np returns
+#                  EINVAL and a std::vector index then goes out of range,
+#                  abort()ing the whole perception process during
+#                  InferenceSession(). Measured on Tianyi: 1.19.2 aborts with
+#                  every SessionOptions combination including none at all;
+#                  1.18.1, 1.17.3 and 1.16.3 all build a session and infer.
 #
 # It is also a record: `docker exec <c> cat /etc/jetpack.env` says what line an
 # image was built for, which is otherwise guesswork from the tag alone.
@@ -55,8 +64,8 @@ ARG SHERPA_GPU_WHEEL_61=jp61/sherpa_onnx-1.13.6+cuda-cp310-cp310-linux_aarch64.w
 ARG DLA_COMPILER_SO_61=jp61/libnvdla_compiler.so
 RUN case "${JP_VERSION}" in \
         511) NUMPY=1.24.4; WHEEL="${SHERPA_GPU_WHEEL_511}"; DLA=; ORT=1.16.3 ;; \
-        61)  NUMPY=1.26.4; WHEEL="${SHERPA_GPU_WHEEL_61}"; DLA="${DLA_COMPILER_SO_61}"; ORT=1.19.2 ;; \
-        *)   NUMPY=1.24.4; WHEEL=; DLA=; ORT=1.19.2 ;; \
+        61)  NUMPY=1.26.4; WHEEL="${SHERPA_GPU_WHEEL_61}"; DLA="${DLA_COMPILER_SO_61}"; ORT=1.18.1 ;; \
+        *)   NUMPY=1.24.4; WHEEL=; DLA=; ORT=1.18.1 ;; \
     esac; \
     printf 'NUMPY_VERSION=%s\nSHERPA_GPU_WHEEL=%s\nPY_ABI=%s\nDLA_COMPILER_SO=%s\nORT_VERSION=%s\n' \
         "${NUMPY}" "${WHEEL}" \
@@ -346,34 +355,51 @@ RUN . /etc/jetpack.env; \
 # hosts, which rules out a TensorRT-only path (engines are not portable across
 # TensorRT majors, so it would mean a bundle per JetPack line for a 15 MB pair).
 #
-# CPU wheel from PyPI. A CUDA-capable build for Jetson is a separate,
-# per-JetPack wheel that has to be hosted on COS the way SHERPA_GPU_WHEEL is;
-# until that exists `device: gpu` degrades to cpu with a warning
-# (utils/onnx_provider.ort_providers_for_device). The models are 2.5 MB and
-# 13 MB, so this is a throughput choice, not a correctness one.
+# **The two runtimes do coexist.** Measured on Orin6 in this image, five
+# sequences all passed, each in its own process: ORT alone; both imported;
+# sherpa VAD session then an ORT session; the same with RTLD_DEEPBIND; and ORT
+# session then sherpa. Both libraries stay mapped (`sherpa_onnx/lib/
+# libonnxruntime.so.1.18.1` and the wheel's own) without interposing on each
+# other, because each extension resolves against its own RPATH. So the symbol
+# clash this layer was originally written to guard against does not occur, and
+# the import asserts below are cheap insurance rather than the real risk.
 #
-# numpy is pinned on the same line for the reason the OCR step gives: several
-# packages in the base image are built against a specific numpy C-ABI, and an
-# unpinned install silently upgrades it.
+# The real risk was the ORT *version*, and it is why ORT_VERSION is pinned per
+# line rather than left to pip — see /etc/jetpack.env above for the offline-core
+# abort that 1.19.2 causes. Matching sherpa's bundled version also means the two
+# mapped runtimes are ABI-identical, so an accidental interposition would be
+# benign rather than a memory-layout mismatch.
 #
-# The assert is the point of this layer. Two ONNX Runtimes in one process could
-# clash at the symbol level — both ship a libonnxruntime, sherpa's resolved via
-# RPATH from its own extension — and a clash surfaces when the second one's
-# shared objects are dlopen'd, i.e. at import. So import in both orders: if
-# either direction is going to break, it breaks here, in the build, rather than
-# on a robot. Creating a session from each in one process needs model files that
-# do not exist at build time; that half is verified on hardware (an ASR
-# utterance and a face recognition both working in the same container).
+# CPU wheel from PyPI: `device: auto` therefore resolves to cpu on this image.
+# A CUDA-capable build for Jetson is a separate, per-JetPack wheel that has to
+# be hosted on COS the way SHERPA_GPU_WHEEL is; until that exists the models
+# (2.5 MB + 13 MB) run on cpu, which at the default 1 detection/second is a
+# throughput choice, not a correctness one.
+#
+# **`--no-deps`, deliberately.** A plain install pulls protobuf, coloredlogs,
+# humanfriendly and flatbuffers in behind onnxruntime — and measured on the
+# jp6.1 image, protobuf was not previously present at all, so a resolved
+# install introduces protobuf 7.36.1 into an image where OCR (rapidocr),
+# TensorRT and ROS2 all live. None of that is needed for inference: verified on
+# Tianyi that with `--no-deps` and no protobuf/coloredlogs/flatbuffers at all,
+# `InferenceSession` builds and `run()` returns all 9 SCRFD outputs. numpy is
+# therefore not reinstalled either — nothing is touched but onnxruntime itself,
+# which is the only way to add a runtime here without risking the numpy C-ABI
+# the torch/cv2/rapidocr stack is built against. The assert still checks numpy
+# did not move.
 RUN . /etc/jetpack.env; \
-    pip3 install --no-cache-dir -i ${PYPI_MIRROR} \
-      "numpy==${NUMPY_VERSION}" "onnxruntime==${ORT_VERSION}" && \
+    pip3 install --no-cache-dir --no-deps -i ${PYPI_MIRROR} \
+      "onnxruntime==${ORT_VERSION}" && \
     python3 -c "import onnxruntime, sherpa_onnx; print('[build] ort-first import ok')" && \
     python3 -c "import sherpa_onnx, onnxruntime; print('[build] sherpa-first import ok')" && \
-    python3 -c "import numpy, onnxruntime, sherpa_onnx; \
+    python3 -c "import numpy, onnxruntime, sherpa_onnx, rapidocr, tensorrt, torch; \
 assert numpy.__version__ == '${NUMPY_VERSION}', numpy.__version__; \
+assert not onnxruntime.__version__.startswith('1.19'), \
+    'onnxruntime 1.19.x abort()s on Jetsons with offline cores; see jetpack.env'; \
 print('[build] onnxruntime', onnxruntime.__version__, \
       'providers:', onnxruntime.get_available_providers()); \
-print('[build] sherpa-onnx', sherpa_onnx.__version__, 'coexists; numpy', numpy.__version__)"
+print('[build] intact alongside it: sherpa-onnx', sherpa_onnx.__version__, \
+      '| tensorrt', tensorrt.__version__, '| numpy', numpy.__version__)"
 
 # ── phonemizer (multilingual IPA via espeak-ng for asr_kws mode) ──
 # ldconfig shimmed for the same reason as the ffmpeg step above — this is the

--- a/perception/README.md
+++ b/perception/README.md
@@ -716,9 +716,16 @@ has to change when it lands, because `auto` will pick it up.
 
 #### The onnxruntime version is pinned, and 1.19.x must not be used
 
-`ORT_VERSION` in `/etc/jetpack.env` is pinned per JetPack line to **the same
-version sherpa-onnx bundles** there (jp5.11 → 1.16.x, jp6.1 → 1.18.1), so the two
-runtimes in the process are ABI-identical.
+**One version for both JetPack lines: 1.18.1.** That is what sherpa-onnx bundles on
+jp6.1 (`sherpa_onnx/lib/libonnxruntime.so.1.18.1`), so on that line the two mapped
+runtimes are ABI-identical. It runs on jp5.11 too — its cp38 aarch64 wheel is
+manylinux_2_28 and focal has glibc 2.31 — verified on Orin5 (Ubuntu 20.04, glibc
+2.31, Python 3.8) building a session and inferring. A per-line split was tried
+first and dropped: nothing required it, and one version is one thing to reason
+about.
+
+`ORT_VERSION` is an `ARG` on the onnxruntime step itself, **not** in
+`/etc/jetpack.env`, because that file is layer 2 — see § Where this layer sits.
 
 **onnxruntime 1.19.2 abort()s the whole perception process** during
 `InferenceSession()` on a Jetson where some cores are parked. It enumerates
@@ -740,6 +747,25 @@ precondition has to be in the log *before* the session is created.
 
 Orin6 has `present == online`, so this never reproduces there. Judge it on a robot
 whose power mode parks cores.
+
+#### Where this layer sits, and why that matters more than it looks
+
+The onnxruntime step is the **last of the dependency layers**, below everything
+ASR/TTS/VOP/OCR share and above only the `COPY` of application code.
+
+That placement is the whole safety story. A layer inserted higher up invalidates
+the Docker cache for every layer below it, and several of those install
+**unpinned** — `ultralytics` and `phonemizer` have no version constraint — so they
+silently re-resolve to whatever is newest on the next build. An earlier revision of
+this change put `ORT_VERSION` in `/etc/jetpack.env` near the top of the file, and
+that alone moved `ultralytics` 8.4.138 → 8.4.142 in the built image, with nothing
+to do with face recognition. Measured by diffing `pip freeze` between the old and
+new images.
+
+So the rule for this layer: it must stay below every shared layer, and anything it
+needs must be resolved *in* it. Against `main` the Dockerfile diff is a single
+additive hunk — 74 lines added, **0 removed** — so no shared layer's inputs change
+and no other algorithm's dependencies can drift because of it.
 
 #### Its dependencies are deliberately not installed
 

--- a/perception/README.md
+++ b/perception/README.md
@@ -977,39 +977,74 @@ framed dead-on.
 
 #### Getting a photo *into* this container
 
-Not obvious, and it produced two real LLM failures before being fixed.
+Not obvious, and it produced two real failures before being fixed.
 
-perception and agent-core share **no filesystem** by default: agent-core mounts
+perception and agent-core share **no filesystem**: agent-core mounts
 `/opt/phanthy-motus` and `/opt/phanthy-motus/data`, perception mounts `/dev` and
 `/opt/embodied/models`. The intersection is empty, and each container's `/tmp`
 and `/work` is its own. So an LLM that downloads a photo inside agent-core and
 passes `image_path: /work/daiwen.jpg` names a file that genuinely exists — just
-not here. That was the first failure.
+not here. That was failure one. Its next attempt, `image_b64`, failed too: the
+photo was 43 800 base64 characters, which does not survive being carried through
+a model's own context, so what arrived was truncated.
 
-Its second attempt was `image_b64`, which failed too: the photo was 43 800
-base64 characters, and that does not survive being carried through a model's own
-context, so what arrived was truncated and the decoder correctly refused it.
+**base64 input has been removed**, and files now move through a proxy:
 
-**base64 input has therefore been removed.** Both remaining channels pass a
-*reference* instead of the bytes:
+```
+browser / LLM ──upload──▶ agent-core  POST /api/mcp/{mcp_id}/file/upload
+                              │  looks the target's address up in the MCP
+                              │  registry, streams the body on in 1 MiB chunks
+                              ▼
+                          perception  POST /file/upload
+                              │  writes to file_intake.dir (/models/uploads)
+                              ▼
+                     ◀──reply── {"path": "/models/uploads/2026-09-08/alice.jpg"}
+                          that path is used verbatim as image_path
+```
 
-| channel | how the file gets here |
-|---|---|
-| `image_path` | written into **`/uploads`**, a host directory both containers mount at the same path (`perception/deploy/service.yml`, `agent-core/deploy/docker-compose.yml`) |
-| `register_by_url` | perception fetches it itself; nothing has to be moved |
+The reply carries the path **in the receiving container's own namespace**, so
+there is one viewpoint and nothing to translate. No shared mount is involved,
+which also means no container has to be recreated to enable it.
 
-The card's `image_path` is declared `"format": "file"` with
-`"uploadDir": "/uploads"`, so the canvas renders a file picker that uploads
-through agent-core's `/api/file/upload` and fills the resulting path back in —
-the same mechanism agent-core's own `remote_image` card uses for `image_file`.
-`uploadDir` is new: that handler hardcoded agent-core's `/tmp/uploads`, which is
-right for a tool agent-core serves itself and invisible to a tool in any other
-container.
+The address comes from the MCP registry — every service reports `url` when it
+registers — so this one route covers perception, actucore and every driver even
+though their ports all differ. `utils/file_intake.py` is stdlib-only for the same
+reason: the drivers run a bare `ThreadingHTTPServer`, so they can adopt the
+identical endpoint in about five lines.
 
-Passing `image_b64` now returns a `bad_input` naming the two channels that work,
-and a path outside `image_roots` says to use `/uploads` or `register_by_url`
-rather than only "cannot read" — an LLM told just "not found" retries with
-another invisible path, which is what happened.
+On the card, `image_path` is declared `"format": "file"` with
+`"uploadTo": "mcp"`, which is what routes the canvas file picker through the
+proxy instead of agent-core's own `/api/file/upload`. Omitting `uploadTo` keeps
+the old behaviour, which is correct for a tool agent-core serves itself
+(`remote_image`, `remote_audio`).
+
+Details worth knowing about the receiving end:
+
+* **Size is capped while writing**, not after, so an oversized body is never
+  fully committed to disk or held in memory. Files land under a `.part` name and
+  are renamed, so a reader listing the directory never sees half a file.
+* **Filenames are reduced to one component** and keep CJK characters — the
+  people using this name their files in Chinese — after NFC normalisation, so a
+  macOS upload and a Linux one produce the same name rather than two files that
+  look identical.
+* **`subdir` is refused rather than sanitised** if it contains a separator.
+  Sanitising turned `../escape` into `.._escape`, a valid name, so the write
+  succeeded somewhere the caller did not ask for and nothing said so.
+* **Uploads are pruned after `retention_days`** (7). They are a transfer buffer,
+  not storage: enrolment keeps the *embedding* and never the photo, so without
+  this the directory grows forever on a 57 GB eMMC.
+* **Auth is by reachability, not a secret.** The endpoint honours `ACCESS_TOKEN`
+  if the service has one, but perception is not given one today (verified on
+  Tianyi) — and the port already serves `tools/call`, so anything that can reach
+  it can already drive the plugin.
+
+Verified on Tianyi: 200 KB of random binary round-trips byte-identically through
+the real endpoint with a Chinese filename, returning `/…/2026-09-08/戴文渊.jpg`.
+
+Passing `image_b64` now returns a `bad_input` naming the mechanism that works,
+and a path outside `image_roots` says to upload through the proxy or use
+`register_by_url` — an LLM told only "cannot read" retries with another
+invisible path, which is exactly what happened.
 
 `register_by_stream` averages the agreeing frames rather than trusting one
 grab, and refuses with `ambiguous_subject` when fewer than half the usable frames

--- a/perception/README.md
+++ b/perception/README.md
@@ -971,9 +971,45 @@ framed dead-on.
 
 | Action | Input |
 |--------|-------|
-| `register_by_photo` | `image_path` (confined to `image_roots`) or `image_b64`, plus `name` and `profile` |
+| `register_by_photo` | `image_path` — uploaded from the card, or written to `/uploads` (see below) — plus `name` and `profile` |
 | `register_by_stream` | `instance_id` + `name`; analyses **every frame in the last `enroll_window_s`** (default 3 s, up to `enroll_max_analyzed` of them, newest first) |
 | `register_by_corpus` | `package`: a directory, `.zip` or `.tar.gz`, by path or URL |
+
+#### Getting a photo *into* this container
+
+Not obvious, and it produced two real LLM failures before being fixed.
+
+perception and agent-core share **no filesystem** by default: agent-core mounts
+`/opt/phanthy-motus` and `/opt/phanthy-motus/data`, perception mounts `/dev` and
+`/opt/embodied/models`. The intersection is empty, and each container's `/tmp`
+and `/work` is its own. So an LLM that downloads a photo inside agent-core and
+passes `image_path: /work/daiwen.jpg` names a file that genuinely exists — just
+not here. That was the first failure.
+
+Its second attempt was `image_b64`, which failed too: the photo was 43 800
+base64 characters, and that does not survive being carried through a model's own
+context, so what arrived was truncated and the decoder correctly refused it.
+
+**base64 input has therefore been removed.** Both remaining channels pass a
+*reference* instead of the bytes:
+
+| channel | how the file gets here |
+|---|---|
+| `image_path` | written into **`/uploads`**, a host directory both containers mount at the same path (`perception/deploy/service.yml`, `agent-core/deploy/docker-compose.yml`) |
+| `register_by_url` | perception fetches it itself; nothing has to be moved |
+
+The card's `image_path` is declared `"format": "file"` with
+`"uploadDir": "/uploads"`, so the canvas renders a file picker that uploads
+through agent-core's `/api/file/upload` and fills the resulting path back in —
+the same mechanism agent-core's own `remote_image` card uses for `image_file`.
+`uploadDir` is new: that handler hardcoded agent-core's `/tmp/uploads`, which is
+right for a tool agent-core serves itself and invisible to a tool in any other
+container.
+
+Passing `image_b64` now returns a `bad_input` naming the two channels that work,
+and a path outside `image_roots` says to use `/uploads` or `register_by_url`
+rather than only "cannot read" — an LLM told just "not found" retries with
+another invisible path, which is what happened.
 
 `register_by_stream` averages the agreeing frames rather than trusting one
 grab, and refuses with `ambiguous_subject` when fewer than half the usable frames

--- a/perception/README.md
+++ b/perception/README.md
@@ -704,11 +704,54 @@ needs them):
 
 Both run on the **standalone `onnxruntime`**, which is a second, independent ONNX
 Runtime from the one compiled into the sherpa-onnx wheel (ASR/TTS reach only that
-one; there is no supported way to run our own models on it). `device: cpu | gpu`
-selects providers through `utils/onnx_provider.ort_providers_for_device`. The image
-currently carries the **CPU wheel**, so `device: gpu` degrades to cpu with a warning
-— a per-JetPack `onnxruntime-gpu` wheel on COS is the follow-up, mirroring
-`SHERPA_GPU_WHEEL` in `Dockerfile.jetson`.
+one; there is no supported way to run our own models on it).
+
+`device: auto | cpu | gpu`, default **auto** — use the GPU when the installed
+onnxruntime offers a CUDA or TensorRT provider, else CPU. `auto` resolving to cpu
+is not warned about, because it is the expected outcome on this image: it ships
+the **CPU wheel**, so today `auto` always means cpu. An explicit `gpu` that cannot
+be honoured warns and degrades. A per-JetPack `onnxruntime-gpu` wheel on COS is
+the follow-up, mirroring `SHERPA_GPU_WHEEL` in `Dockerfile.jetson`; nothing else
+has to change when it lands, because `auto` will pick it up.
+
+#### The onnxruntime version is pinned, and 1.19.x must not be used
+
+`ORT_VERSION` in `/etc/jetpack.env` is pinned per JetPack line to **the same
+version sherpa-onnx bundles** there (jp5.11 → 1.16.x, jp6.1 → 1.18.1), so the two
+runtimes in the process are ABI-identical.
+
+**onnxruntime 1.19.2 abort()s the whole perception process** during
+`InferenceSession()` on a Jetson where some cores are parked. It enumerates
+`/sys/devices/system/cpu/present` and pins threads to every core in it; on Tianyi
+in MODE_30W (`present` 0-11, `online` 0-7) `pthread_setaffinity_np` returns EINVAL
+and a `std::vector` index then goes out of range:
+
+```
+pthread_setaffinity_np failed for thread: 31, index: 1, mask: {9, }, error code: 22
+stl_vector.h:1123 ... Assertion '__n < this->size()' failed.  Fatal Python error: Aborted
+```
+
+Measured on Tianyi: 1.19.2 aborts with **every** `SessionOptions` combination,
+including none at all, so no amount of configuration avoids it; 1.18.1, 1.17.3 and
+1.16.3 each build a session and return all 9 SCRFD outputs. The build asserts the
+installed version is not 1.19.x, and `warn_on_parked_cores()` logs the
+present/online mismatch at load time — an abort leaves no Python traceback, so the
+precondition has to be in the log *before* the session is created.
+
+Orin6 has `present == online`, so this never reproduces there. Judge it on a robot
+whose power mode parks cores.
+
+#### Its dependencies are deliberately not installed
+
+`pip install --no-deps`. A resolved install pulls in protobuf, coloredlogs,
+humanfriendly and flatbuffers — and measured on the jp6.1 image, **protobuf was
+not present at all** beforehand, so a plain install would introduce protobuf
+7.36.1 into an image where rapidocr, TensorRT and ROS2 all live. None of it is
+needed for inference: verified on Tianyi that with `--no-deps` and none of those
+packages present, `InferenceSession` builds and `run()` returns all 9 outputs. So
+this layer adds exactly one package and touches nothing else — numpy included,
+which matters because the torch/cv2/rapidocr stack is built against a specific
+numpy C-ABI.
 
 The `insightface` package is deliberately not a dependency: it wants onnx,
 scikit-image, scikit-learn and Cython to wrap ~200 lines of pre/post-processing.
@@ -768,6 +811,14 @@ Published payload (`{input_topic}/face`):
 A stranger who clears the quality gate is auto-enrolled and reported as
 `unknown-N`, with the **same id on every later sighting and after a restart** —
 which is what makes `register_current_stream` able to name them retroactively.
+
+Detection runs at **`detect_fps`** — 检测频率, detections per second, default
+**1.0**, fractional allowed (`0.5` = once every two seconds, `0` = every frame the
+camera delivers). It is per-instance, so two cameras can run at different
+cadences. Expressed as a frequency rather than a minimum interval because that is
+what an operator reasons about, and it stays meaningful when the camera's own rate
+changes. (`min_interval_ms`, the knob this replaced, is still honoured when
+`detect_fps` is absent, so a canvas saved by an earlier build keeps working.)
 
 A face that *fails* the gate is reported with `person_id: null`, `quality: "low"`
 and a `reason`, and is neither matched nor enrolled. Matching a blurred 30 px face

--- a/perception/README.md
+++ b/perception/README.md
@@ -686,6 +686,204 @@ instance_id ever showed up in the log.
 
 ---
 
+## Face Recognition
+
+`plugins/face.py` — a `processor` card named **`face_recognition`**. Subscribes to an
+`image/jpeg` topic, publishes identities on `{input_topic}/face` as `data/json`, and
+enrols new people from a photo, the live stream, or a batch package.
+
+### Models
+
+InsightFace **buffalo_sc**, the smallest pack that still ships landmarks (alignment
+needs them):
+
+| File | Size | Role |
+|------|------|------|
+| `det_500m.onnx` | 2.5 MB | SCRFD-500M-BNKPS — detection + 5 keypoints |
+| `w600k_mbf.onnx` | 13 MB | ArcFace MobileFaceNet — 512-d embedding |
+
+Both run on the **standalone `onnxruntime`**, which is a second, independent ONNX
+Runtime from the one compiled into the sherpa-onnx wheel (ASR/TTS reach only that
+one; there is no supported way to run our own models on it). `device: cpu | gpu`
+selects providers through `utils/onnx_provider.ort_providers_for_device`. The image
+currently carries the **CPU wheel**, so `device: gpu` degrades to cpu with a warning
+— a per-JetPack `onnxruntime-gpu` wheel on COS is the follow-up, mirroring
+`SHERPA_GPU_WHEEL` in `Dockerfile.jetson`.
+
+The `insightface` package is deliberately not a dependency: it wants onnx,
+scikit-image, scikit-learn and Cython to wrap ~200 lines of pre/post-processing.
+Those 200 lines are in `plugins/face_runtime.py` instead — the SCRFD decode there
+(strides 8/16/32, 2 anchors per location, distance-coded boxes and keypoints) is a
+wire format, not a design choice, and was verified against the real model:
+`det_500m.onnx` has 9 outputs and `12800 = 80x80x2` rows for stride 8 at 640px.
+
+Alignment uses an explicit Umeyama similarity fit, **not**
+`cv2.estimateAffinePartial2D`: that runs RANSAC/LMEDS, and on exactly five
+correspondences a robust estimator can discard a point and return a different
+transform run to run, which would make one photo produce different embeddings.
+
+#### Re-hosting the models
+
+`FACE_MODEL_BASE` points at COS, not the upstream GitHub release: the release URL
+redirects to a signed, expiring `release-assets.githubusercontent` URL that cannot
+be pinned, and the robots have no reliable route to GitHub. To refresh, download
+`buffalo_sc.zip` from the insightface v0.7 release, upload the two `.onnx` files to
+`public/face/buffalo_sc/` with credentials from `resource-center/deploy/values.env`
+(`prisma/articles/upload-figs.js` cannot do it — it only accepts image extensions
+and forces its own key shape), then re-download from COS and paste the *verified*
+`size`/`sha256` into `FACE_MODEL_FILES`.
+
+### Identity database
+
+`plugins/face_db.py`, default `/models/face_db` — `/models` is the only host-mounted
+writable path this container has (`deploy/service.yml`).
+
+Two files, and **`persons.json` is the commit point**: it names the
+`embeddings-<n>.npy` it belongs to, is replaced last, and the superseded matrix is
+unlinked only after that succeeds. Writing `embeddings.npy` in place instead means
+two `os.replace` calls with a window where the row count and the owner list
+disagree — which silently misattributes every identity after the missing row.
+
+Matching is one `matrix @ embedding`: both sides are L2-normalised, so the dot
+product *is* the cosine and no `sklearn` is needed. Rows are per **sample**, and a
+person's score is their best sample — a mean-vector centroid would blur the pose
+variation that several enrolment photos exist to capture, and could push a real
+match below threshold when a second photo is added.
+
+Ids are `p-N` for named people and `unknown-N` for strangers, from monotonic
+counters that never decrease: a retired id must not resolve to a different person
+later, because it may already be on the activity stream and in the agent's history.
+
+### Recognising
+
+Published payload (`{input_topic}/face`):
+
+```json
+{"ts": 1788777509.34, "topic": "/cam/rgb", "count": 1, "latency_ms": 28,
+ "faces": [{"person_id": "p-1", "profile": "运营部小王", "known": true, "score": 0.61,
+            "bbox": [207, 186, 149, 206], "det_score": 0.811, "blur": 1484.2,
+            "min_side_px": 149, "quality": "ok"}]}
+```
+
+A stranger who clears the quality gate is auto-enrolled and reported as
+`unknown-N`, with the **same id on every later sighting and after a restart** —
+which is what makes `register_current_stream` able to name them retroactively.
+
+A face that *fails* the gate is reported with `person_id: null`, `quality: "low"`
+and a `reason`, and is neither matched nor enrolled. Matching a blurred 30 px face
+is a coin flip, and enrolling one would spend an `unknown-N` slot forever on a
+smear that never matches anything again. Relax `min_face_px` / `blur_min` if you
+want identities at greater distance.
+
+`match_threshold` defaults to **0.35**. Measured separations on this model, same
+photo transformed: same face at half resolution **0.983**, same face +35
+brightness **0.979**, a different person **-0.108**. Real same-person /
+different-photo scores sit well below the first two, so **tune this against your own
+faces and record what you saw** — 0.35 is a starting point, not a measurement.
+
+### Registering, and why it fails
+
+Any channel can fail for mundane physical reasons, so all three return
+`{"ok": false, "reason": ..., "detail": ...}` rather than raising:
+
+| `reason` | Condition |
+|----------|-----------|
+| `no_face` | no detection anywhere in the input |
+| `low_quality` | best face fails `det_thresh` / `min_face_px` / `blur_min`; the detail names each gate with the measured value |
+| `ambiguous_subject` | ≥2 faces pass the gate and the primary is not `subject_dominance`x the runner-up; every candidate's bbox and score is returned |
+| `no_frames` | no running instance, or nothing in the window |
+| `bad_input` | undecodable image, unreachable URL, unreadable package, path outside `image_roots` |
+
+A real `low_quality` detail, from the group photo in the end-to-end check:
+
+```
+no clear face: face 53 px < 64 px (move closer); sharpness 41.4 < 60.0 (hold still)
+```
+
+Prominence is area discounted 40% for being off-centre — pure area picks the
+bystander standing nearer the lens edge, pure centrality picks a distant face
+framed dead-on.
+
+| Action | Input |
+|--------|-------|
+| `register_user_photo` | `image_path` (confined to `image_roots`) / `image_url` / `image_b64`, plus `profile`, `meta`, optional `person_id` |
+| `register_current_stream` | `instance_id` + `profile`; analyses **every frame in the last `enroll_window_s`** (default 3 s, up to `enroll_max_analyzed` of them, newest first) |
+| `register_user_photos` | `package`: a directory, `.zip` or `.tar.gz`, by path or URL |
+
+`register_current_stream` averages the agreeing frames rather than trusting one
+grab, and refuses with `ambiguous_subject` when fewer than half the usable frames
+agree with each other — two people taking turns being the dominant face would
+otherwise be enrolled as one identity matching neither.
+
+Enrolment never silently duplicates. A new face matching an existing **named**
+person is added as another sample (`merged: true`); matching an **`unknown-N`**
+promotes that entry **keeping its id** (`promoted: true`), so earlier sightings stay
+attributable.
+
+#### Batch package layout
+
+Images plus an optional `manifest.json`, in either shape:
+
+```json
+[{"file": "alice.jpg", "profile": "Alice from ops", "person": "alice", "meta": {"badge": "A7"}}]
+{"alice.jpg": "Alice from ops"}
+```
+
+Fallbacks in order: a sidecar `alice.json` / `alice.txt`, then the filename stem. A
+shared `person` key merges several photos into one identity. Archive members that
+are absolute, contain `..`, or are not regular files are skipped and logged.
+
+The result carries **one record per photo**, so a 40-person batch says exactly which
+people registered and why each of the rest did not:
+
+```json
+{"ok": true, "total": 40, "registered": 37, "failed": 3,
+ "results": [{"file": "alice.jpg", "ok": true, "person_id": "p-9"},
+             {"file": "bob.jpg", "ok": false, "reason": "low_quality", "detail": "..."},
+             {"file": "team.jpg", "ok": false, "reason": "ambiguous_subject", "candidates": [...]}]}
+```
+
+Synchronous, capped at `max_batch` (200); over the cap it returns `bad_input` naming
+the count rather than hanging the MCP client.
+
+### Roster CRUD
+
+`list_persons` (`named` = all/named/unknown, `query` over id+profile+meta, `limit`,
+`offset`), `get_person`, `update_person` (`profile`, `meta`, `meta_delete[]`,
+`merge` — default merges, `merge: false` replaces), `forget` (or
+`named: "unknown"` to clear every anonymous entry). Setting a non-blank `profile`
+on an `unknown-N` names it in place, keeping the id. Reads never return embeddings.
+
+`unknown_capacity` (default 500, editable on the card) bounds automatic enrolment
+only; lowering it evicts the excess immediately, oldest `last_seen_at` first, and
+reports how many went. Named people are never candidates.
+
+### Tool-name dispatch
+
+`face_recognition` is the first `PREFIX` containing an underscore.
+`PerceptionBundle.dispatch`/`owns` used to split on the first `_` and compare that
+to `PREFIX`, which made such a name undispatchable — it resolved to a plugin called
+`face`, matched nothing, and reported the tool as unknown. Both now go through
+`_plugin_for`, which matches the **longest** prefix; `tests/test_bundle_dispatch.py`
+pins that and that the two functions can never disagree.
+
+### Verifying
+
+The pytest suite fakes the analyzer — a host-side suite must not need models or
+onnxruntime — and covers the lifecycle, all five reason codes, `unknown-N`
+stability and promotion, id retirement, capacity eviction, meta CRUD, batch
+per-item results and zip traversal (`tests/test_face_plugin.py`,
+`tests/test_face_db.py`).
+
+What that cannot cover is the decode itself, so it was checked separately against
+the real models: a known similarity transform recovered to 4e-6, all 5 landmarks
+inside their bbox on real photos, and the identity separations quoted above. On
+hardware, confirm `info` goes `loading → ready`, that `{topic}/face` publishes,
+and — because two ONNX Runtimes share the process — that an ASR utterance is still
+transcribed and TTS still speaks with the card running.
+
+---
+
 ## Topic Naming
 
 | Direction | Topic pattern | Format |

--- a/perception/README.md
+++ b/perception/README.md
@@ -802,6 +802,93 @@ be pinned, and the robots have no reliable route to GitHub. To refresh, download
 and forces its own key shape), then re-download from COS and paste the *verified*
 `size`/`sha256` into `FACE_MODEL_FILES`.
 
+### The person record: `name` vs `profile`
+
+The split is about **what gets published**:
+
+| field | type | in the per-frame payload | what it is |
+|---|---|---|---|
+| `id` | str | yes | `p-N` (named) or `unknown-N` |
+| `name` | str | yes | 姓名, structured. A non-blank name is what makes an entry *named* |
+| `profile` | object | yes | 非结构化: gender, appearance, notes, tags - whatever the operator wants the agent to have in context |
+| `registered_at` | float | no | when the identity was created |
+| `last_seen_at` | float | no | most recent sighting |
+
+The timestamps are deliberately out of the payload: they change every frame (or
+never), and "when was this person around" is a question the **visit log** answers
+properly and a per-frame field cannot.
+
+A `profile` sent as a plain string is stored as `{"note": ...}` rather than
+rejected - an LLM will occasionally send prose where an object is expected.
+
+A database written by the pre-split build migrates on load: the old free-text
+`profile` becomes `name`, the old structured `meta` becomes `profile`, and
+`created_at` becomes `registered_at`. `persons.json` carries `version: 2`.
+
+### 访问记录表 - the visit log
+
+`visits.jsonl`, one line per **visit**, where a visit is a contiguous presence:
+
+```json
+{"person_id": "p-1", "name": "小王", "first_seen": 1788780000.0,
+ "last_seen": 1788783600.0, "sightings": 3417, "topic": "/cam/rgb"}
+```
+
+`list_visits` takes `person_id`, `since`, `until`, `limit`, `offset`. `since` and
+`until` accept epoch seconds **or** ISO-8601 (`2026-09-07T15:00`), because an
+operator asking "who was here at 3pm" thinks in wall-clock and an LLM will send a
+string. Filtering is by **overlap, not containment**: somebody present
+14:50-15:10 *was* there at 15:00, and a query for 15:00-15:05 has to say so.
+
+Three design points that are not obvious:
+
+**One row per visit, not per frame.** At the default 1 detection/second a
+per-frame log would be 86 400 writes a day per person onto eMMC, carrying no
+information a visit does not.
+
+**`visit_gap_s` is 10 minutes.** A visit closes only after the person has been
+unseen that long. A short gap would fragment one afternoon in the office into
+dozens of rows every time somebody turned their head.
+
+**Open visits are checkpointed, because that 10-minute gap is a data-loss
+window.** Somebody present all afternoon is a single visit held in memory for
+hours, and a robot that loses power would lose the whole record - not just the
+tail. So `visits-open.json` is rewritten at most every `visit_checkpoint_s`
+(60 s), bounding the loss to a minute of `last_seen`/`sightings`. On startup a
+checkpointed visit is **resumed** if its subject was seen recently, or closed and
+appended if they left while the process was down. The checkpoint is written
+*after* the append when a visit closes, so a crash in between replays a closed
+visit rather than dropping it - a duplicate is recoverable, a loss is not.
+Stopping an instance force-closes its open visits for the same reason.
+
+`list_visits` also returns visits still in progress, flagged `open: true`, so the
+10-minute close latency does not hide who is in the room right now.
+
+### Actions: register vs recognize
+
+Symmetric by suffix, and the two halves differ in more than direction:
+
+| | photo | stream | corpus |
+|---|---|---|---|
+| **register** (writes) | `register_by_photo` | `register_by_stream` | `register_by_corpus` |
+| **recognize** (read-only) | `recognize_by_photo` | `recognize_by_stream` | - |
+
+`recognize_*` is **read-only**: it neither auto-enrols the stranger it failed to
+match nor records a sighting. Asking "who is this" must not quietly change the
+answer. It also does **not** apply `subject_dominance`: that gate exists because
+enrolment has to resolve to exactly one person, whereas a query can just report
+everyone it sees. So a two-person photo is answered with two identities by
+`recognize_by_photo` and refused with `ambiguous_subject` by `register_by_photo` -
+same input, opposite handling, both correct.
+
+An unmatched face comes back as `person_id: null` with a `best_score`, which is
+the number an operator needs to decide whether `match_threshold` is too strict.
+
+`recognize_by_stream` scans the last **1 s** by default (not the 3 s enrolment
+window - the question is "who is in front of me now"), reports each person once at
+their best score across those frames, and falls back to reporting the clearest
+unidentified face so the answer is "someone I do not know" rather than "nobody".
+
 ### Identity database
 
 `plugins/face_db.py`, default `/models/face_db` — `/models` is the only host-mounted
@@ -828,15 +915,16 @@ later, because it may already be on the activity stream and in the agent's histo
 Published payload (`{input_topic}/face`):
 
 ```json
-{"ts": 1788777509.34, "topic": "/cam/rgb", "count": 1, "latency_ms": 28,
- "faces": [{"person_id": "p-1", "profile": "运营部小王", "known": true, "score": 0.61,
-            "bbox": [207, 186, 149, 206], "det_score": 0.811, "blur": 1484.2,
-            "min_side_px": 149, "quality": "ok"}]}
+{"ts": 1788777509.34, "count": 1, "latency_ms": 28,
+ "faces": [{"person_id": "p-1", "name": "小王", "profile": {"gender": "male"},
+            "known": true, "score": 0.61, "bbox": [207, 186, 149, 206],
+            "det_score": 0.811, "blur": 1484.2, "min_side_px": 149,
+            "quality": "ok"}]}
 ```
 
 A stranger who clears the quality gate is auto-enrolled and reported as
 `unknown-N`, with the **same id on every later sighting and after a restart** —
-which is what makes `register_current_stream` able to name them retroactively.
+which is what makes `register_by_stream` able to name them retroactively.
 
 Detection runs at **`detect_fps`** — 检测频率, detections per second, default
 **1.0**, fractional allowed (`0.5` = once every two seconds, `0` = every frame the
@@ -883,11 +971,11 @@ framed dead-on.
 
 | Action | Input |
 |--------|-------|
-| `register_user_photo` | `image_path` (confined to `image_roots`) or `image_b64`, plus `profile` and `meta` |
-| `register_current_stream` | `instance_id` + `profile`; analyses **every frame in the last `enroll_window_s`** (default 3 s, up to `enroll_max_analyzed` of them, newest first) |
-| `register_user_photos` | `package`: a directory, `.zip` or `.tar.gz`, by path or URL |
+| `register_by_photo` | `image_path` (confined to `image_roots`) or `image_b64`, plus `name` and `profile` |
+| `register_by_stream` | `instance_id` + `name`; analyses **every frame in the last `enroll_window_s`** (default 3 s, up to `enroll_max_analyzed` of them, newest first) |
+| `register_by_corpus` | `package`: a directory, `.zip` or `.tar.gz`, by path or URL |
 
-`register_current_stream` averages the agreeing frames rather than trusting one
+`register_by_stream` averages the agreeing frames rather than trusting one
 grab, and refuses with `ambiguous_subject` when fewer than half the usable frames
 agree with each other — two people taking turns being the dominant face would
 otherwise be enrolled as one identity matching neither.
@@ -902,7 +990,7 @@ attributable.
 Images plus an optional `manifest.json`, in either shape:
 
 ```json
-[{"file": "alice.jpg", "profile": "Alice from ops", "person": "alice", "meta": {"badge": "A7"}}]
+[{"file": "alice.jpg", "name": "Alice from ops", "person": "alice", "profile": {"badge": "A7"}}]
 {"alice.jpg": "Alice from ops"}
 ```
 
@@ -925,11 +1013,12 @@ the count rather than hanging the MCP client.
 
 ### Roster CRUD
 
-`list_persons` (`named` = all/named/unknown, `query` over id+profile+meta, `limit`,
-`offset`), `get_person`, `update_person` (`profile`, `meta`, `meta_delete[]`,
-`merge` — default merges, `merge: false` replaces), `forget` (or
-`named: "unknown"` to clear every anonymous entry). Setting a non-blank `profile`
-on an `unknown-N` names it in place, keeping the id. Reads never return embeddings.
+`list_persons` (`named` = all/named/unknown, `query` over id+name+profile,
+`limit`, `offset`), `get_person`, `update_person` (`name`, `profile`,
+`profile_delete[]`, `merge` — default merges, `merge: false` replaces), `forget`
+(or `named: "unknown"` to clear every anonymous entry), and `list_visits`.
+Setting a non-blank `name` on an `unknown-N` names it in place, keeping the id.
+Reads never return embeddings.
 
 `unknown_capacity` (default 500, editable on the card) bounds automatic enrolment
 only; lowering it evicts the excess immediately, oldest `last_seen_at` first, and
@@ -948,7 +1037,8 @@ pins that and that the two functions can never disagree.
 
 The pytest suite fakes the analyzer — a host-side suite must not need models or
 onnxruntime — and covers the lifecycle, all five reason codes, `unknown-N`
-stability and promotion, id retirement, capacity eviction, meta CRUD, batch
+stability and promotion, id retirement, capacity eviction, profile CRUD, the
+visit log (sessionisation, checkpoint recovery, overlap queries), batch
 per-item results and zip traversal (`tests/test_face_plugin.py`,
 `tests/test_face_db.py`).
 

--- a/perception/README.md
+++ b/perception/README.md
@@ -883,7 +883,7 @@ framed dead-on.
 
 | Action | Input |
 |--------|-------|
-| `register_user_photo` | `image_path` (confined to `image_roots`) / `image_url` / `image_b64`, plus `profile`, `meta`, optional `person_id` |
+| `register_user_photo` | `image_path` (confined to `image_roots`) or `image_b64`, plus `profile` and `meta` |
 | `register_current_stream` | `instance_id` + `profile`; analyses **every frame in the last `enroll_window_s`** (default 3 s, up to `enroll_max_analyzed` of them, newest first) |
 | `register_user_photos` | `package`: a directory, `.zip` or `.tar.gz`, by path or URL |
 

--- a/perception/config.yaml
+++ b/perception/config.yaml
@@ -82,3 +82,49 @@ plugins:
       det_thresh: 0.1
       det_box_thresh: 0.1
     min_interval_ms: 0
+
+  face_recognition:
+    enabled: true
+    # InsightFace buffalo_sc: SCRFD-500M detector + ArcFace MobileFaceNet.
+    # Plain ONNX, so one bundle serves both JetPack lines and x86 dev hosts.
+    model_dir: /models/face/buffalo_sc
+    # The only host-mounted writable path in this container is /models (see
+    # perception/deploy/service.yml), so the identity database lives under it.
+    db_dir: /models/face_db
+    # cpu | gpu. gpu needs an onnxruntime build carrying the CUDA provider; the
+    # image currently ships the CPU wheel, so gpu degrades to cpu with a
+    # warning (utils/onnx_provider.ort_providers_for_device). The models are
+    # 2.5 MB + 13 MB, so cpu at a throttled frame rate is the design point.
+    device: cpu
+    num_threads: 2
+    warmup: true
+    det_size: [640, 640]
+    det_thresh: 0.5
+    # Cosine similarity between L2-normalised ArcFace embeddings. 0.35 is a
+    # starting point for w600k_mbf, NOT a measured value — raise it if the
+    # robot confuses people, lower it if it fails to recognise them, and record
+    # what you saw. Editable from the card.
+    match_threshold: 0.35
+    # Quality gate. A face below either bound is reported with person_id: null
+    # rather than matched or auto-enrolled: matching a blurred 30 px face is a
+    # coin flip, and enrolling one wastes an unknown-N slot forever.
+    min_face_px: 64
+    blur_min: 60.0          # variance of Laplacian on the aligned 112x112 crop
+    # Enrolment refuses to guess when two faces are comparably prominent.
+    # Prominence is area discounted 40% for being off-centre.
+    subject_dominance: 1.6
+    max_faces: 8
+    # register_current_stream analyses the last enroll_window_s of frames, up
+    # to enroll_max_analyzed of them (newest first), instead of a single grab.
+    enroll_window_s: 3.0
+    enroll_window_max_frames: 60
+    enroll_max_analyzed: 8
+    # Ceiling on auto-enrolled strangers; oldest sighting evicted first. Named
+    # people are never evicted. Editable from the card.
+    unknown_capacity: 500
+    max_samples_per_person: 8
+    max_batch: 200
+    # Caller-supplied image/package paths are confined to these roots — the MCP
+    # server has no authentication and runs as root in the container.
+    image_roots: ["/models", "/tmp", "/work"]
+    min_interval_ms: 200

--- a/perception/config.yaml
+++ b/perception/config.yaml
@@ -146,7 +146,10 @@ plugins:
     max_image_bytes: 67108864
     # Caller-supplied image/package paths are confined to these roots — the MCP
     # server has no authentication and runs as root in the container.
-    image_roots: ["/models", "/tmp", "/work"]
+    # /uploads is the cross-container drop-off (see deploy/service.yml): the
+    # canvas file picker and the LLM both put images there, and it is the only
+    # one of these paths agent-core can also see.
+    image_roots: ["/uploads", "/models", "/tmp", "/work"]
     # 检测频率: how many detections per second. Fractional is the point —
     # 0.5 means once every two seconds; 0 means every frame the camera sends.
     detect_fps: 1.0

--- a/perception/config.yaml
+++ b/perception/config.yaml
@@ -127,6 +127,13 @@ plugins:
     # people are never evicted. Editable from the card.
     unknown_capacity: 500
     max_samples_per_person: 8
+    # 访问记录表 (visits.jsonl): 一次连续出现 = 一条记录，不是一帧一条。
+    # 离开超过 visit_gap_s 才封档落盘；10 分钟避免有人转个头就把一下午切成几十条。
+    visit_gap_s: 600.0
+    # 在场的人的 visit 会在内存里挂很久（10 分钟 gap + 一直出现），断电会整条丢，
+    # 所以每 visit_checkpoint_s 把未封档的 visit 落一次小文件，重启后续上。
+    visit_checkpoint_s: 60.0
+    visit_log_max: 20000
     max_batch: 200
     # Caller-supplied image/package paths are confined to these roots — the MCP
     # server has no authentication and runs as root in the container.

--- a/perception/config.yaml
+++ b/perception/config.yaml
@@ -91,11 +91,15 @@ plugins:
     # The only host-mounted writable path in this container is /models (see
     # perception/deploy/service.yml), so the identity database lives under it.
     db_dir: /models/face_db
-    # cpu | gpu. gpu needs an onnxruntime build carrying the CUDA provider; the
-    # image currently ships the CPU wheel, so gpu degrades to cpu with a
-    # warning (utils/onnx_provider.ort_providers_for_device). The models are
-    # 2.5 MB + 13 MB, so cpu at a throttled frame rate is the design point.
-    device: cpu
+    # auto | cpu | gpu. auto (the default) uses the GPU when the installed
+    # onnxruntime offers a CUDA/TensorRT provider and falls back to cpu when it
+    # does not — which is the case on this image today, because it ships the CPU
+    # wheel (a CUDA build for Jetson is a per-JetPack wheel that must be hosted
+    # on COS, like SHERPA_GPU_WHEEL). An explicit `gpu` that cannot be honoured
+    # warns and degrades; `auto` does not warn, since cpu is the expected
+    # outcome there. The models are 2.5 MB + 13 MB, so cpu at 1 detection/second
+    # is the design point.
+    device: auto
     num_threads: 2
     warmup: true
     det_size: [640, 640]
@@ -127,4 +131,6 @@ plugins:
     # Caller-supplied image/package paths are confined to these roots — the MCP
     # server has no authentication and runs as root in the container.
     image_roots: ["/models", "/tmp", "/work"]
-    min_interval_ms: 200
+    # 检测频率: how many detections per second. Fractional is the point —
+    # 0.5 means once every two seconds; 0 means every frame the camera sends.
+    detect_fps: 1.0

--- a/perception/config.yaml
+++ b/perception/config.yaml
@@ -1,5 +1,16 @@
 mcp_port: 15720
 
+# 文件接收 (POST /file/upload)。agent-core 把浏览器/LLM 的上传代理到这里，
+# 本服务写到自己看得见的目录并把「本容器内的绝对路径」回给调用方 ——
+# 两个容器无需共享挂载。详见 utils/file_intake.py。
+file_intake:
+  # /models 是本容器唯一可写的宿主机挂载点。
+  dir: /models/uploads
+  max_bytes: 67108864
+  # 上传只是中转，不是存储：注册人脸留下的是 embedding，从不保留照片。
+  # 不清理会在 57 GB 的 eMMC 上一直涨。
+  retention_days: 7
+
 plugins:
   asr:
     enabled: true
@@ -146,10 +157,7 @@ plugins:
     max_image_bytes: 67108864
     # Caller-supplied image/package paths are confined to these roots — the MCP
     # server has no authentication and runs as root in the container.
-    # /uploads is the cross-container drop-off (see deploy/service.yml): the
-    # canvas file picker and the LLM both put images there, and it is the only
-    # one of these paths agent-core can also see.
-    image_roots: ["/uploads", "/models", "/tmp", "/work"]
+    image_roots: ["/models", "/tmp", "/work"]
     # 检测频率: how many detections per second. Fractional is the point —
     # 0.5 means once every two seconds; 0 means every frame the camera sends.
     detect_fps: 1.0

--- a/perception/config.yaml
+++ b/perception/config.yaml
@@ -135,6 +135,15 @@ plugins:
     visit_checkpoint_s: 60.0
     visit_log_max: 20000
     max_batch: 200
+    # 过大/非常见格式的图片在本地缩放转码，而不是在接口处拒绝。
+    # 检测本身会把图 letterbox 到 det_size(640)，所以 2048 已远超需要，
+    # 在这里用 INTER_AREA 缩一次比让 letterbox 缩更快也更清晰。
+    max_image_side: 2048
+    # 解压炸弹护栏（像素数）：几百 KB 的 PNG 可以声明 30000x30000，
+    # 解出来 2.7 GB 会让 OOM killer 带走整个 perception 进程。
+    max_image_pixels: 60000000
+    # 仅为传输/内存护栏，不是策略限制 —— 超大图片会被本地缩放而非拒绝。
+    max_image_bytes: 67108864
     # Caller-supplied image/package paths are confined to these roots — the MCP
     # server has no authentication and runs as root in the container.
     image_roots: ["/models", "/tmp", "/work"]

--- a/perception/deploy/service.yml
+++ b/perception/deploy/service.yml
@@ -22,15 +22,6 @@ perception:
   volumes:
     - /dev:/dev
     - /opt/embodied/models:/models
-    # Shared image drop-off, mounted at the same path by agent-core (see
-    # agent-core/deploy/docker-compose.yml). This is how a photo reaches this
-    # container: the canvas file picker uploads through agent-core's
-    # /api/file/upload, and the LLM writes downloads here — both land on the
-    # host directory, and perception reads the same path back. Without a shared
-    # mount there is *no* path both containers can name: agent-core's /tmp and
-    # /work are its own, and a base64 argument is not a workable substitute
-    # (a 40 000-character string does not survive an LLM's context).
-    - /opt/embodied/uploads:/uploads
     # DDS profile 只读挂载。必须与其它 DDS 容器加载同一份，
     # 否则本容器会与本机其余部分失联。
     - /opt/phanthy-motus/dds-local.xml:/opt/phanthy-motus/dds-local.xml:ro

--- a/perception/deploy/service.yml
+++ b/perception/deploy/service.yml
@@ -22,6 +22,15 @@ perception:
   volumes:
     - /dev:/dev
     - /opt/embodied/models:/models
+    # Shared image drop-off, mounted at the same path by agent-core (see
+    # agent-core/deploy/docker-compose.yml). This is how a photo reaches this
+    # container: the canvas file picker uploads through agent-core's
+    # /api/file/upload, and the LLM writes downloads here — both land on the
+    # host directory, and perception reads the same path back. Without a shared
+    # mount there is *no* path both containers can name: agent-core's /tmp and
+    # /work are its own, and a base64 argument is not a workable substitute
+    # (a 40 000-character string does not survive an LLM's context).
+    - /opt/embodied/uploads:/uploads
     # DDS profile 只读挂载。必须与其它 DDS 容器加载同一份，
     # 否则本容器会与本机其余部分失联。
     - /opt/phanthy-motus/dds-local.xml:/opt/phanthy-motus/dds-local.xml:ro

--- a/perception/main.py
+++ b/perception/main.py
@@ -261,6 +261,32 @@ def make_handler():
 
         def do_POST(self):
             length = int(self.headers.get("Content-Length", 0))
+
+            # File intake, before the body is read: an upload can be tens of
+            # megabytes and the JSON paths below slurp Content-Length into
+            # memory. utils/file_intake streams it to disk instead.
+            #
+            # This is how a photo reaches this container at all — see that
+            # module's docstring. agent-core proxies the browser's (or the LLM's)
+            # upload here and hands the returned path straight to a tool call;
+            # neither side needs a shared mount, because the path in the reply is
+            # this container's own.
+            if self.path == "/file/upload":
+                from utils.file_intake import access_token, handle_upload
+                cfg = _load_config()
+                intake = (cfg.get("file_intake") or {})
+                base_dir = str(intake.get("dir", "/models/uploads"))
+                body = self.rfile.read(length)
+                status, payload = handle_upload(
+                    self.headers, body, base_dir,
+                    token=access_token(),
+                    provided_token=self.headers.get("X-Access-Token"),
+                    max_bytes=int(intake.get("max_bytes", 64 * 1024 * 1024)),
+                    retention_days=int(intake.get("retention_days", 7)),
+                )
+                self._send(status, json.dumps(payload, ensure_ascii=False))
+                return
+
             raw = self.rfile.read(length)
 
             if self.path == "/vad/test":

--- a/perception/main.py
+++ b/perception/main.py
@@ -131,6 +131,37 @@ class PerceptionBundle:
             self._plugins.append(OCRPlugin(plugins_cfg["ocr"], executor))
             log.info("OCRPlugin loaded")
 
+        if plugins_cfg.get("face_recognition", {}).get("enabled", False):
+            from plugins.face import FaceRecognitionPlugin
+            # Guarded like TTSPlugin: this plugin needs the standalone
+            # onnxruntime and a readable identity database, and neither belongs
+            # on the critical path of ASR/TTS/VOP/OCR. A failure here means the
+            # card does not appear, which is visible in the dashboard.
+            try:
+                self._plugins.append(
+                    FaceRecognitionPlugin(plugins_cfg["face_recognition"], executor)
+                )
+                log.info("FaceRecognitionPlugin loaded")
+            except Exception:
+                log.error("FaceRecognitionPlugin failed to load; continuing without it",
+                          exc_info=True)
+
+    def _plugin_for(self, full_name: str):
+        """Resolve a tool name to (plugin, action) by longest matching PREFIX.
+
+        Matching the *longest* prefix, not the first underscore-separated
+        segment: a PREFIX may itself contain an underscore (`face_recognition`),
+        and splitting on the first `_` would look for a plugin called `face`,
+        find none, and report the tool as unknown.
+        """
+        for plugin in sorted(self._plugins, key=lambda p: -len(p.PREFIX)):
+            prefix = plugin.PREFIX
+            if full_name == prefix:
+                return plugin, prefix
+            if full_name.startswith(prefix + "_"):
+                return plugin, full_name[len(prefix) + 1:]
+        return None, ""
+
     def get_all_tools(self) -> list:
         tools = []
         for p in self._plugins:
@@ -140,22 +171,20 @@ class PerceptionBundle:
         return tools
 
     def dispatch(self, full_name: str, args: dict) -> dict | None:
-        prefix, sep, tool_name = full_name.partition("_")
-        name = tool_name if sep else prefix
-        for p in self._plugins:
-            if p.PREFIX == prefix:
-                return p.dispatch(name, args)
-        return None
+        plugin, name = self._plugin_for(full_name)
+        if plugin is None:
+            return None
+        return plugin.dispatch(name, args)
 
     def owns(self, full_name: str) -> bool:
         """True when some loaded plugin claims this tool name.
 
         Lets the caller tell a genuinely unknown tool apart from a loaded
-        plugin returning None for an action it does not handle. Mirrors
-        `dispatch`'s prefix split so the two can never disagree.
+        plugin returning None for an action it does not handle. Goes through
+        the same resolver as `dispatch`, so the two cannot disagree.
         """
-        prefix, _, _ = full_name.partition("_")
-        return any(p.PREFIX == prefix for p in self._plugins)
+        plugin, _ = self._plugin_for(full_name)
+        return plugin is not None
 
     def tts_synthesize_raw(self, text: str) -> bytes:
         for p in self._plugins:

--- a/perception/plugins/face.py
+++ b/perception/plugins/face.py
@@ -1,0 +1,1842 @@
+#!/usr/bin/env python3
+"""
+plugins/face.py — FaceRecognitionPlugin: 人脸注册与持续识别。
+
+订阅 image/jpeg topic，持续识别画面中的人脸并发布身份到 ROS2 topic；
+已注册的人输出 id 与 profile，未注册的人输出稳定的 unknown-{id}。
+
+Lifecycle, locking and the start/stop/config state machine are copied from
+`plugins/ocr.py`, which is the reference implementation of the rules in
+`perception/README.md` § "Plugin Concurrency". The parts that look redundant
+(claiming a node key before leaving the lock, registering with the executor
+*before* `start()`, bumping a generation on a model-affecting config change)
+are each there because omitting them orphaned a live node in production.
+
+What this plugin adds over OCR:
+
+* **A 3-second rolling frame window** per instance. `register_current_stream`
+  analyses every frame in it rather than one grab, so a blink, a turned head or
+  one motion-blurred frame does not decide the enrolment.
+* **A persistent identity database** (`plugins/face_db.py`), shared by all
+  instances of the plugin, holding embeddings, profiles and free-form meta.
+* **Structured failure reasons.** Enrolment fails for mundane physical reasons
+  — nobody in frame, nobody sharp enough, too many candidates to guess a
+  subject — and the caller (an LLM or an operator) can only react if it is told
+  which. These return `{"ok": false, "reason": ...}` rather than raising, and
+  the batch path returns one such record per file.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import json
+import logging
+import os
+import tarfile
+import tempfile
+import threading
+import time
+import urllib.error
+import urllib.request
+import zipfile
+from collections import deque
+from typing import Any
+
+import numpy as np
+from rclpy.node import Node
+from rclpy.qos import QoSProfile, ReliabilityPolicy, HistoryPolicy, DurabilityPolicy
+from sensor_msgs.msg import CompressedImage
+from std_msgs.msg import String
+
+from utils.latest_frame import LatestFrame
+from utils.log_sampling import SampledLogGate, escape_log_text
+from utils.qos import CAMERA_QOS
+from utils.ros_lifecycle import dispose_node
+
+from plugins.face_db import (
+    DEFAULT_DB_DIR,
+    DEFAULT_MAX_SAMPLES_PER_PERSON,
+    DEFAULT_UNKNOWN_CAPACITY,
+    FaceDB,
+    is_unknown_id,
+)
+from plugins.face_runtime import (
+    DEFAULT_BLUR_MIN,
+    DEFAULT_DET_SIZE,
+    DEFAULT_DET_THRESH,
+    DEFAULT_FACE_MODEL_DIR,
+    DEFAULT_MIN_FACE_PX,
+    DEFAULT_NMS_THRESH,
+    DetectedFace,
+    FaceAnalyzer,
+)
+
+log = logging.getLogger(__name__)
+
+_ERROR_LOG_INTERVAL_SECONDS = 10.0
+_SEEN_FLUSH_INTERVAL_SECONDS = 300.0
+
+DEFAULT_MATCH_THRESHOLD = 0.35
+DEFAULT_SUBJECT_DOMINANCE = 1.6
+DEFAULT_MAX_FACES = 8
+DEFAULT_ENROLL_WINDOW_S = 3.0
+DEFAULT_ENROLL_WINDOW_MAX_FRAMES = 60
+DEFAULT_ENROLL_MAX_ANALYZED = 8
+DEFAULT_MAX_BATCH = 200
+DEFAULT_MAX_IMAGE_BYTES = 16 * 1024 * 1024
+DEFAULT_IMAGE_ROOTS = ("/models", "/tmp", "/work")
+
+_IMAGE_SUFFIXES = (".jpg", ".jpeg", ".png", ".bmp", ".webp")
+
+_RESULT_QOS = QoSProfile(
+    reliability=ReliabilityPolicy.RELIABLE,
+    history=HistoryPolicy.KEEP_LAST,
+    depth=1,
+    durability=DurabilityPolicy.VOLATILE,
+)
+
+
+TOOLS = [
+    {
+        "name": "face_recognition",
+        "type": "processor",
+        "multiInstance": True,
+        "description": (
+            "Face recognition — identify people in a camera feed, and register "
+            "new people from a photo, the live stream, or a batch package"
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": [
+                        "start", "stop", "info", "config",
+                        "register_user_photo", "register_current_stream",
+                        "register_user_photos",
+                        "list_persons", "get_person", "update_person", "forget",
+                    ],
+                    "description": "Action to perform",
+                },
+                "input_topic": {
+                    "type": "string",
+                    "description": "ROS2 image topic to subscribe (e.g. /hostname/camera/rgb, required for action=start)",
+                },
+                "image_path": {"type": "string", "description": "Path to a JPEG/PNG readable by this container"},
+                "image_url":  {"type": "string", "description": "http(s) URL of a JPEG/PNG"},
+                "image_b64":  {"type": "string", "description": "Base64-encoded JPEG/PNG bytes"},
+                "profile":    {"type": "string", "description": "Who this person is — free text shown alongside the id on every sighting"},
+                "meta":       {"type": "object", "description": "Free-form metadata object (department, tags, notes...)"},
+                "meta_delete": {"type": "array", "items": {"type": "string"}, "description": "Meta keys to remove"},
+                "merge":      {"type": "boolean", "description": "Merge meta into the existing object (default true) instead of replacing it"},
+                "person_id":  {"type": "string", "description": "Existing person id — use an unknown-N id to give that identity a name"},
+                "window_s":   {"type": "number", "description": "Seconds of recent stream to analyse (default 3.0, capped by enroll_window_s)"},
+                "package":    {"type": "string", "description": "Directory, .zip or .tar.gz path/URL holding photos plus an optional manifest.json"},
+                "named":      {"type": "string", "enum": ["all", "named", "unknown"], "description": "Filter the roster (default all); with action=forget, 'unknown' clears every anonymous entry"},
+                "query":      {"type": "string", "description": "Substring filter over id, profile and meta"},
+                "limit":      {"type": "integer", "description": "Page size (default 100)"},
+                "offset":     {"type": "integer", "description": "Page offset"},
+            },
+            "required": ["action"],
+            "x-action-params": {
+                "start":  {"params": ["input_topic"], "description": "Start recognising faces on an image topic"},
+                "stop":   {"params": [], "description": "Stop recognition"},
+                "info":   {"params": ["input_topic"], "description": "Report state, topics and database statistics"},
+                "config": {"params": [], "description": "Update configuration"},
+                "register_user_photo": {
+                    "params": ["image_path", "image_url", "image_b64", "profile", "meta", "person_id"],
+                    "description": "Register a person from one photo. Fails with a reason when there is no face, no clear face, or no obvious subject",
+                },
+                "register_current_stream": {
+                    "params": ["profile", "meta", "person_id", "window_s"],
+                    "description": "Register the person currently in front of the camera, using the last few seconds of the live stream",
+                },
+                "register_user_photos": {
+                    "params": ["package"],
+                    "description": "Register many people from a package of photos; returns a per-photo result saying which succeeded and why the others did not",
+                },
+                "list_persons":  {"params": ["named", "query", "limit", "offset"], "description": "List registered people with their profile and meta"},
+                "get_person":    {"params": ["person_id"], "description": "Read one person's full record"},
+                "update_person": {"params": ["person_id", "profile", "meta", "meta_delete", "merge"], "description": "Edit a person's profile or meta; setting a profile on an unknown-N id names that identity, keeping the id"},
+                "forget":        {"params": ["person_id", "named"], "description": "Delete a person (or every unknown entry). The id is retired and never reused"},
+            },
+        },
+        # Deliberately minimal, as in plugins/ocr.py: only what an operator
+        # meaningfully decides. Expert knobs (model_dir, db_dir, device,
+        # det_size, det_thresh, nms_thresh, num_threads, enroll_window_s,
+        # max_batch, image_roots, ...) stay config.yaml-only — dispatch still
+        # honours them, they are just not advertised to the config UI.
+        "configSchema": {
+            "type": "object",
+            "properties": {
+                "match_threshold":   {"type": "number", "minimum": 0.0, "maximum": 1.0, "default": DEFAULT_MATCH_THRESHOLD, "description": "余弦相似度阈值，越高越严格（越不容易认错人，但越容易认不出）"},
+                "min_face_px":       {"type": "integer", "minimum": 16, "default": DEFAULT_MIN_FACE_PX, "description": "最小人脸边长(px)，小于此值不做识别"},
+                "blur_min":          {"type": "number", "minimum": 0.0, "default": DEFAULT_BLUR_MIN, "description": "清晰度下限(拉普拉斯方差)，低于此值视为模糊人脸"},
+                "max_faces":         {"type": "integer", "minimum": 1, "default": DEFAULT_MAX_FACES, "description": "单帧最多处理的人脸数"},
+                "unknown_capacity":  {"type": "integer", "minimum": 0, "default": DEFAULT_UNKNOWN_CAPACITY, "description": "陌生人(unknown-N)数量上限，超出时淘汰最久未见的；已注册人员不受影响"},
+                "min_interval_ms":   {"type": "integer", "minimum": 0, "default": 200, "description": "帧处理最小间隔(ms)，限制算力占用，0=不限", "scope": "instance"},
+            },
+        },
+        "topic_in":  [{"format": "image/jpeg", "desc": "camera image input"}],
+        "topic_out": [{"format": "data/json",  "desc": "recognised identities per frame"}],
+    }
+]
+
+
+# ── failure reasons ───────────────────────────────────────────────────────────
+
+REASON_NO_FACE = "no_face"
+REASON_LOW_QUALITY = "low_quality"
+REASON_AMBIGUOUS = "ambiguous_subject"
+REASON_NO_FRAMES = "no_frames"
+REASON_BAD_INPUT = "bad_input"
+
+# Which reason to report when frames in a window disagree. Ordered by what the
+# operator has to change: move people out of shot, then get closer / hold
+# still, then point the camera at somebody at all. Reporting "no clear face"
+# for a window that mostly contained a crowd sends them to fix the wrong thing.
+_REASON_PRECEDENCE = (REASON_AMBIGUOUS, REASON_LOW_QUALITY, REASON_NO_FACE)
+
+
+class _BadInput(Exception):
+    """An image or package could not be loaded. Carries the caller-facing detail."""
+
+    def __init__(self, detail: str, source: str = ""):
+        super().__init__(detail)
+        self.detail = detail
+        self.source = source
+
+    def as_result(self) -> dict:
+        result = {"ok": False, "reason": REASON_BAD_INPUT, "detail": self.detail}
+        if self.source:
+            result["source"] = self.source
+        return result
+
+
+def _face_output_topic(input_topic: str) -> str:
+    return f"{input_topic}/face"
+
+
+# ── configuration ─────────────────────────────────────────────────────────────
+
+def _analyzer_options(cfg: dict) -> dict:
+    det_size = cfg.get("det_size") or DEFAULT_DET_SIZE
+    if isinstance(det_size, (list, tuple)) and len(det_size) == 2:
+        det_size = (int(det_size[0]), int(det_size[1]))
+    else:
+        det_size = DEFAULT_DET_SIZE
+    return {
+        "model_dir": str(cfg.get("model_dir", DEFAULT_FACE_MODEL_DIR)),
+        "device": str(cfg.get("device", "cpu")),
+        "det_size": det_size,
+        "det_thresh": float(cfg.get("det_thresh", DEFAULT_DET_THRESH)),
+        "nms_thresh": float(cfg.get("nms_thresh", DEFAULT_NMS_THRESH)),
+        "num_threads": int(cfg.get("num_threads", 2)),
+        "warmup": bool(cfg.get("warmup", True)),
+    }
+
+
+def _db_options(cfg: dict) -> dict:
+    return {
+        "db_dir": str(cfg.get("db_dir", DEFAULT_DB_DIR)),
+        "unknown_capacity": int(
+            cfg.get("unknown_capacity", DEFAULT_UNKNOWN_CAPACITY)
+        ),
+        "max_samples_per_person": int(
+            cfg.get("max_samples_per_person", DEFAULT_MAX_SAMPLES_PER_PERSON)
+        ),
+    }
+
+
+def _gates(cfg: dict) -> dict:
+    """The quality/ambiguity thresholds, resolved once per call."""
+    return {
+        "det_thresh": float(cfg.get("det_thresh", DEFAULT_DET_THRESH)),
+        "min_face_px": float(cfg.get("min_face_px", DEFAULT_MIN_FACE_PX)),
+        "blur_min": float(cfg.get("blur_min", DEFAULT_BLUR_MIN)),
+        "dominance": float(cfg.get("subject_dominance", DEFAULT_SUBJECT_DOMINANCE)),
+        "match_threshold": float(cfg.get("match_threshold", DEFAULT_MATCH_THRESHOLD)),
+        "max_faces": int(cfg.get("max_faces", DEFAULT_MAX_FACES)),
+    }
+
+
+def _engine_signature(cfg: dict) -> tuple:
+    """What a config change must rebuild the engine for."""
+    options = _analyzer_options(cfg)
+    db_options = _db_options(cfg)
+    # unknown_capacity is applied in place (set_unknown_capacity), so it must
+    # not force a rebuild — changing it from the card would otherwise drop
+    # every running instance and reload both models.
+    db_options.pop("unknown_capacity", None)
+    return (
+        tuple(sorted((key, str(value)) for key, value in options.items())),
+        tuple(sorted((key, str(value)) for key, value in db_options.items())),
+    )
+
+
+class _FaceEngine:
+    """The analyzer and the identity database, loaded as one unit.
+
+    They are built together because both can fail slowly (a model download, a
+    corrupt database) and the plugin's single-flight loader has exactly one
+    slot; a half-loaded engine would let recognition start against a database
+    that never opened.
+    """
+
+    def __init__(self, analyzer: FaceAnalyzer, db: FaceDB):
+        self.analyzer = analyzer
+        self.db = db
+
+    def close(self) -> None:
+        try:
+            self.db.flush()
+        except Exception:  # noqa: BLE001 - closing must not raise
+            log.warning("[face] failed to flush the database on close",
+                        exc_info=True)
+        self.analyzer.close()
+
+
+def _build_engine(cfg: dict) -> _FaceEngine:
+    analyzer = FaceAnalyzer(**_analyzer_options(cfg))
+    db = FaceDB(**_db_options(cfg))
+    return _FaceEngine(analyzer, db)
+
+
+def _close_quietly(engine) -> None:
+    close = getattr(engine, "close", None)
+    if callable(close):
+        try:
+            close()
+        except Exception:  # noqa: BLE001 - best-effort release
+            log.warning("[face] engine close failed", exc_info=True)
+
+
+# ── subject selection (pure, unit-tested) ─────────────────────────────────────
+
+def _subject_weight(face: DetectedFace, shape: tuple[int, int]) -> float:
+    """Area, discounted for being off-centre.
+
+    Enrolment needs "the person being shown to the camera", which is bigger
+    *and* more central than a bystander. Pure area picks the bystander who
+    happens to stand closer to the lens edge; pure centrality picks a distant
+    face framed dead-on. The 40% centre discount is a deliberate compromise and
+    the number that `subject_dominance` is compared against.
+    """
+    height, width = shape[0], shape[1]
+    if width <= 0 or height <= 0:
+        return face.area
+    centre_x, centre_y = width / 2.0, height / 2.0
+    face_x = (face.bbox[0] + face.bbox[2]) / 2.0
+    face_y = (face.bbox[1] + face.bbox[3]) / 2.0
+    half_diagonal = (width ** 2 + height ** 2) ** 0.5 / 2.0
+    distance = ((face_x - centre_x) ** 2 + (face_y - centre_y) ** 2) ** 0.5
+    offness = min(1.0, distance / half_diagonal) if half_diagonal else 0.0
+    return face.area * (1.0 - 0.4 * offness)
+
+
+def _candidate_summary(face: DetectedFace, shape: tuple[int, int]) -> dict:
+    return {
+        "bbox": face.bbox_xywh(),
+        "det_score": round(face.det_score, 4),
+        "min_side_px": int(face.min_side),
+        "blur": round(face.blur, 2),
+        "weight": round(_subject_weight(face, shape), 1),
+    }
+
+
+def select_subject(
+    faces: list[DetectedFace], shape: tuple[int, int], gates: dict
+) -> tuple[DetectedFace | None, dict | None]:
+    """Pick the single person an enrolment is about.
+
+    Returns `(face, None)` on success or `(None, failure)` where `failure` is
+    the caller-facing record explaining which physical condition was not met.
+    """
+    if not faces:
+        return None, {
+            "ok": False,
+            "reason": REASON_NO_FACE,
+            "detail": "no face detected",
+            "faces": 0,
+        }
+
+    passing = [
+        face for face in faces
+        if face.det_score >= gates["det_thresh"]
+        and face.min_side >= gates["min_face_px"]
+        and face.blur >= gates["blur_min"]
+    ]
+    if not passing:
+        best = max(faces, key=lambda face: _subject_weight(face, shape))
+        reasons = []
+        if best.det_score < gates["det_thresh"]:
+            reasons.append(
+                f"detector score {best.det_score:.2f} < {gates['det_thresh']:.2f}"
+            )
+        if best.min_side < gates["min_face_px"]:
+            reasons.append(
+                f"face {int(best.min_side)} px < {int(gates['min_face_px'])} px "
+                "(move closer)"
+            )
+        if best.blur < gates["blur_min"]:
+            reasons.append(
+                f"sharpness {best.blur:.1f} < {gates['blur_min']:.1f} (hold still)"
+            )
+        return None, {
+            "ok": False,
+            "reason": REASON_LOW_QUALITY,
+            "detail": "no clear face: " + "; ".join(reasons),
+            "faces": len(faces),
+            "candidates": [_candidate_summary(face, shape) for face in faces[:5]],
+        }
+
+    passing.sort(key=lambda face: _subject_weight(face, shape), reverse=True)
+    if len(passing) >= 2:
+        primary = _subject_weight(passing[0], shape)
+        runner_up = _subject_weight(passing[1], shape)
+        ratio = primary / runner_up if runner_up > 0 else float("inf")
+        if ratio < gates["dominance"]:
+            return None, {
+                "ok": False,
+                "reason": REASON_AMBIGUOUS,
+                "detail": (
+                    f"{len(passing)} faces pass the quality gate; the largest is "
+                    f"only {ratio:.2f}x the runner-up (need "
+                    f"{gates['dominance']:.2f}x). Have one person face the camera, "
+                    "or register from a photo instead."
+                ),
+                "faces": len(passing),
+                "candidates": [
+                    _candidate_summary(face, shape) for face in passing[:5]
+                ],
+            }
+    return passing[0], None
+
+
+def _worst_reason(failures: list[dict]) -> dict:
+    """Pick the failure to report when several frames failed differently."""
+    for reason in _REASON_PRECEDENCE:
+        for failure in failures:
+            if failure.get("reason") == reason:
+                counts = {
+                    name: sum(1 for f in failures if f.get("reason") == name)
+                    for name in _REASON_PRECEDENCE
+                }
+                return {
+                    **failure,
+                    "frames_examined": len(failures),
+                    "frame_reasons": {
+                        name: count for name, count in counts.items() if count
+                    },
+                }
+    return {
+        "ok": False,
+        "reason": REASON_NO_FACE,
+        "detail": "no face detected",
+        "frames_examined": len(failures),
+    }
+
+
+# ── image sources ─────────────────────────────────────────────────────────────
+
+def _load_image_bytes(args: dict, cfg: dict) -> tuple[bytes, str]:
+    """Fetch image bytes from whichever of the three sources was given."""
+    max_bytes = int(cfg.get("max_image_bytes", DEFAULT_MAX_IMAGE_BYTES))
+
+    encoded = args.get("image_b64")
+    if encoded:
+        try:
+            data = base64.b64decode(str(encoded), validate=True)
+        except (binascii.Error, ValueError) as error:
+            raise _BadInput(f"image_b64 is not valid base64: {error}", "image_b64")
+        if len(data) > max_bytes:
+            raise _BadInput(
+                f"image is {len(data)} bytes, over the {max_bytes} limit", "image_b64"
+            )
+        return data, "image_b64"
+
+    url = args.get("image_url")
+    if url:
+        return _fetch_url(str(url), max_bytes), str(url)
+
+    path = args.get("image_path")
+    if path:
+        return _read_local(str(path), cfg, max_bytes), str(path)
+
+    raise _BadInput("one of image_path, image_url or image_b64 is required")
+
+
+def _image_roots(cfg: dict) -> tuple[str, ...]:
+    roots = cfg.get("image_roots") or DEFAULT_IMAGE_ROOTS
+    return tuple(os.path.realpath(str(root)) for root in roots)
+
+
+def _check_under_roots(path: str, cfg: dict) -> str:
+    """Confine caller-supplied paths to the configured roots.
+
+    The MCP server has no authentication and runs as root in the container, so
+    an unrestricted path would let any LAN caller probe the filesystem by
+    asking whether a file decodes as an image. Symlinks are resolved first —
+    a link inside a root pointing outside it would otherwise pass.
+    """
+    resolved = os.path.realpath(path)
+    roots = _image_roots(cfg)
+    if any(resolved == root or resolved.startswith(root + os.sep) for root in roots):
+        return resolved
+    raise _BadInput(
+        f"path must be under one of {', '.join(roots)}: got {path!r}", path
+    )
+
+
+def _read_local(path: str, cfg: dict, max_bytes: int) -> bytes:
+    resolved = _check_under_roots(path, cfg)
+    try:
+        size = os.path.getsize(resolved)
+        if size > max_bytes:
+            raise _BadInput(
+                f"file is {size} bytes, over the {max_bytes} limit", path
+            )
+        with open(resolved, "rb") as handle:
+            return handle.read()
+    except OSError as error:
+        raise _BadInput(f"cannot read {path!r}: {error}", path) from error
+
+
+def _fetch_url(url: str, max_bytes: int) -> bytes:
+    if not url.lower().startswith(("http://", "https://")):
+        raise _BadInput(f"only http(s) URLs are supported: {url!r}", url)
+    try:
+        with urllib.request.urlopen(url, timeout=20) as response:
+            data = response.read(max_bytes + 1)
+    except (urllib.error.URLError, OSError, ValueError) as error:
+        raise _BadInput(f"cannot fetch {url!r}: {error}", url) from error
+    if len(data) > max_bytes:
+        raise _BadInput(f"download exceeds the {max_bytes} byte limit", url)
+    if not data:
+        raise _BadInput(f"{url!r} returned no data", url)
+    return data
+
+
+# ── package extraction ────────────────────────────────────────────────────────
+
+def _safe_member_name(name: str) -> str | None:
+    """Reject archive members that could escape the extraction directory.
+
+    Same policy as `model_downloader._check_bundle_relpath`: no absolute paths,
+    no `..`, no drive letters, and nothing that is not a plain relative path.
+    Returns the normalised name, or None if it must be skipped.
+    """
+    if not name or name.endswith("/"):
+        return None
+    normalised = os.path.normpath(name.replace("\\", "/"))
+    if (
+        os.path.isabs(normalised)
+        or normalised.startswith("..")
+        or os.sep + ".." + os.sep in os.sep + normalised + os.sep
+    ):
+        return None
+    return normalised
+
+
+def _extract_package(package: str, cfg: dict, destination: str) -> str:
+    """Materialise a package as a directory of files. Returns that directory."""
+    if package.lower().startswith(("http://", "https://")):
+        max_bytes = int(cfg.get("max_package_bytes", 512 * 1024 * 1024))
+        payload = _fetch_url(package, max_bytes)
+        archive = os.path.join(destination, "package.bin")
+        with open(archive, "wb") as handle:
+            handle.write(payload)
+        source = archive
+    else:
+        source = _check_under_roots(package, cfg)
+
+    if os.path.isdir(source):
+        return source
+
+    payload = os.path.join(destination, "payload")
+    os.makedirs(payload, exist_ok=True)
+    if zipfile.is_zipfile(source):
+        with zipfile.ZipFile(source) as archive:
+            for info in archive.infolist():
+                if info.is_dir():
+                    continue
+                name = _safe_member_name(info.filename)
+                if name is None:
+                    log.warning("[face] skipping unsafe archive member %s",
+                                escape_log_text(info.filename))
+                    continue
+                target = os.path.join(payload, name)
+                os.makedirs(os.path.dirname(target), exist_ok=True)
+                with archive.open(info) as src, open(target, "wb") as dst:
+                    dst.write(src.read())
+        return payload
+
+    try:
+        with tarfile.open(source) as archive:
+            for member in archive.getmembers():
+                if not member.isfile():
+                    # Skips symlinks and devices as well as directories — a
+                    # symlink member is the classic tar escape.
+                    continue
+                name = _safe_member_name(member.name)
+                if name is None:
+                    log.warning("[face] skipping unsafe archive member %s",
+                                escape_log_text(member.name))
+                    continue
+                extracted = archive.extractfile(member)
+                if extracted is None:
+                    continue
+                target = os.path.join(payload, name)
+                os.makedirs(os.path.dirname(target), exist_ok=True)
+                with extracted, open(target, "wb") as dst:
+                    dst.write(extracted.read())
+        return payload
+    except tarfile.TarError as error:
+        raise _BadInput(
+            f"{package!r} is neither a directory, a zip, nor a tar archive: {error}",
+            package,
+        ) from error
+
+
+def _read_manifest(directory: str) -> dict[str, dict]:
+    """Read `manifest.json`, accepting either supported shape.
+
+    A list of records (`[{"file": ..., "profile": ..., "person": ...}]`) or a
+    flat mapping of filename to profile text. Both appear in the wild because
+    the second is what somebody writes by hand.
+    """
+    path = os.path.join(directory, "manifest.json")
+    if not os.path.isfile(path):
+        return {}
+    try:
+        with open(path, encoding="utf-8") as handle:
+            raw = json.load(handle)
+    except (OSError, ValueError) as error:
+        raise _BadInput(f"manifest.json is unreadable: {error}", path) from error
+
+    entries: dict[str, dict] = {}
+    if isinstance(raw, dict):
+        for filename, value in raw.items():
+            if isinstance(value, dict):
+                entries[str(filename)] = dict(value)
+            else:
+                entries[str(filename)] = {"profile": str(value)}
+    elif isinstance(raw, list):
+        for record in raw:
+            if not isinstance(record, dict):
+                continue
+            filename = record.get("file") or record.get("filename")
+            if not filename:
+                continue
+            entries[str(filename)] = {
+                key: value for key, value in record.items()
+                if key not in ("file", "filename")
+            }
+    else:
+        raise _BadInput("manifest.json must be an object or an array", path)
+    return entries
+
+
+def _sidecar_profile(image_path: str) -> tuple[str, dict]:
+    """Per-image fallback: `alice.json` then `alice.txt`, else the file stem."""
+    stem, _ = os.path.splitext(image_path)
+    json_path = f"{stem}.json"
+    if os.path.isfile(json_path):
+        try:
+            with open(json_path, encoding="utf-8") as handle:
+                data = json.load(handle)
+            if isinstance(data, dict):
+                return str(data.get("profile") or ""), (
+                    data.get("meta") if isinstance(data.get("meta"), dict) else {}
+                )
+            return str(data), {}
+        except (OSError, ValueError):
+            log.warning("[face] ignoring unreadable sidecar %s",
+                        escape_log_text(json_path))
+    text_path = f"{stem}.txt"
+    if os.path.isfile(text_path):
+        try:
+            with open(text_path, encoding="utf-8") as handle:
+                return handle.read().strip(), {}
+        except OSError:
+            pass
+    return os.path.basename(stem), {}
+
+
+# ── ROS2 Node ─────────────────────────────────────────────────────────────────
+
+class _FaceNode(Node):
+    """订阅 image/jpeg topic，持续识别人脸身份并发布结果。"""
+
+    def __init__(
+        self,
+        input_topic: str,
+        engine: _FaceEngine,
+        cfg: dict,
+        node_suffix: str = "",
+        min_interval: float = 0.0,
+    ):
+        node_name = f"face_{node_suffix}" if node_suffix else "face"
+        super().__init__(node_name)
+
+        self._input_topic = input_topic
+        self._output_topic = _face_output_topic(input_topic)
+        self._engine = engine
+        self._cfg = dict(cfg)
+        self._min_interval = max(0.0, float(min_interval))
+        self.state = "idle"
+
+        self._sub = None
+        self._pub = self.create_publisher(String, self._output_topic, _RESULT_QOS)
+
+        self._frames: LatestFrame = LatestFrame()
+        self._frames.close()
+        # Rolling enrolment window, kept beside LatestFrame rather than in place
+        # of it: the worker still wants "newest frame, drop the rest", while
+        # register_current_stream wants the last few seconds. Bounded by age and
+        # by count, so a fast camera cannot grow it without limit.
+        self._window: deque[tuple[bytes, float]] = deque(
+            maxlen=max(1, int(cfg.get(
+                "enroll_window_max_frames", DEFAULT_ENROLL_WINDOW_MAX_FRAMES
+            )))
+        )
+        self._window_lock = threading.Lock()
+        self._window_seconds = float(
+            cfg.get("enroll_window_s", DEFAULT_ENROLL_WINDOW_S)
+        )
+
+        self._worker_thread: threading.Thread | None = None
+        self._stop_event = threading.Event()
+        self._stop_event.set()
+        self._generation = 0
+        self._worker_threads: list[threading.Thread] = []
+        self._node_lock = threading.RLock()
+        self._retired = False
+        self._log_gate = SampledLogGate(every=100)
+        self._last_error_log_at: float | None = None
+        self._last_flush_at = time.monotonic()
+        log.info("[face] node created: subscribing=%s, publishing=%s",
+                 self._input_topic, self._output_topic)
+
+    # ── lifecycle (mirrors _OCRNode) ──────────────────────────────────────
+
+    def start(self) -> dict:
+        with self._node_lock:
+            return self._start_locked()
+
+    def _start_locked(self) -> dict:
+        if self._retired:
+            return self._status_dict()
+        if self.state == "running":
+            return self._status_dict()
+        if not self._engine:
+            raise RuntimeError("face engine not configured")
+
+        self._generation += 1
+        generation = self._generation
+        stop_event = threading.Event()
+        frames: LatestFrame = LatestFrame()
+        self._stop_event = stop_event
+        self._frames = frames
+        if self._sub is None:
+            self._sub = self.create_subscription(
+                CompressedImage, self._input_topic, self._image_cb, CAMERA_QOS
+            )
+        self.state = "running"
+        self._worker_threads = [
+            thread for thread in self._worker_threads if thread.is_alive()
+        ]
+        self._worker_thread = threading.Thread(
+            target=self._worker,
+            args=(generation, stop_event, frames),
+            daemon=True,
+        )
+        self._worker_threads.append(self._worker_thread)
+        self._worker_thread.start()
+
+        log.info("[face] started: %s → %s", self._input_topic, self._output_topic)
+        return self._status_dict()
+
+    def stop(self) -> dict:
+        with self._node_lock:
+            self.state = "idle"
+            self._stop_event.set()
+            self._frames.close()
+            deadline = time.monotonic() + 3.0
+            for thread in self._worker_threads:
+                if thread.is_alive():
+                    thread.join(timeout=max(0.0, deadline - time.monotonic()))
+            self._worker_threads = [
+                thread for thread in self._worker_threads if thread.is_alive()
+            ]
+            if self._worker_threads:
+                log.warning("[face] %d worker(s) still stopping after timeout: %s",
+                            len(self._worker_threads), self._input_topic)
+            with self._window_lock:
+                self._window.clear()
+            self._flush_seen()
+            log.info("[face] stopped: %s", self._input_topic)
+            return {"state": "idle"}
+
+    def retire(self) -> dict:
+        with self._node_lock:
+            self._retired = True
+            return self.stop()
+
+    @property
+    def worker_alive(self) -> bool:
+        return any(thread.is_alive() for thread in self._worker_threads)
+
+    # ── frame intake ──────────────────────────────────────────────────────
+
+    def _image_cb(self, msg: CompressedImage):
+        stop_event = self._stop_event
+        frames = self._frames
+        if self.state != "running" or stop_event.is_set():
+            return
+        data = bytes(msg.data)
+        now = time.time()
+        frames.push((data, now))
+        with self._window_lock:
+            self._window.append((data, now))
+            cutoff = now - self._window_seconds
+            while self._window and self._window[0][1] < cutoff:
+                self._window.popleft()
+
+    def recent_frames(self, window_s: float | None = None) -> list[tuple[bytes, float]]:
+        """Frames captured within the last `window_s` seconds, oldest first."""
+        limit = self._window_seconds if window_s is None else min(
+            float(window_s), self._window_seconds
+        )
+        cutoff = time.time() - max(0.0, limit)
+        with self._window_lock:
+            return [item for item in self._window if item[1] >= cutoff]
+
+    # ── recognition worker ────────────────────────────────────────────────
+
+    def _is_generation_active(
+        self, generation: int, stop_event: threading.Event
+    ) -> bool:
+        return (
+            self.state == "running"
+            and self._generation == generation
+            and self._stop_event is stop_event
+            and not stop_event.is_set()
+        )
+
+    def _worker(
+        self,
+        generation: int,
+        stop_event: threading.Event,
+        frames: LatestFrame,
+    ):
+        while not stop_event.is_set():
+            frame = frames.pop(timeout=1.0)
+            if frame is None:
+                continue
+            image_bytes, timestamp = frame
+
+            started = time.time()
+            payload = self._recognise_to_payload(image_bytes, timestamp)
+            if not self._is_generation_active(generation, stop_event):
+                continue
+            msg = String()
+            msg.data = json.dumps(payload, ensure_ascii=False)
+            self._pub.publish(msg)
+            self._log_payload(payload)
+
+            if time.monotonic() - self._last_flush_at >= _SEEN_FLUSH_INTERVAL_SECONDS:
+                self._flush_seen()
+
+            if self._min_interval > 0:
+                remaining = self._min_interval - (time.time() - started)
+                if remaining > 0:
+                    stop_event.wait(remaining)
+
+    def _recognise_to_payload(self, image_bytes: bytes, timestamp: float) -> dict:
+        started = time.time()
+        payload: dict[str, Any] = {
+            "ts": timestamp,
+            "topic": self._input_topic,
+            "count": 0,
+            "faces": [],
+        }
+        try:
+            analyzer = self._engine.analyzer
+            database = self._engine.db
+            gates = _gates(self._cfg)
+            image = analyzer.decode_jpeg(image_bytes)
+            if image is None:
+                payload["error"] = "undecodable frame"
+                return payload
+            shape = image.shape[:2]
+            faces = analyzer.detect(image, max_faces=gates["max_faces"])
+            entries = []
+            for face in faces:
+                analyzer.prepare(image, face)
+                usable = (
+                    face.det_score >= gates["det_thresh"]
+                    and face.min_side >= gates["min_face_px"]
+                    and face.blur >= gates["blur_min"]
+                )
+                entry = {
+                    "bbox": face.bbox_xywh(),
+                    "det_score": round(face.det_score, 4),
+                    "blur": round(face.blur, 2),
+                    "min_side_px": int(face.min_side),
+                }
+                if not usable:
+                    # Reported, but neither matched nor enrolled. Matching a
+                    # blurred 30 px face is a coin flip, and auto-enrolling it
+                    # would spend an unknown-N slot on a smear that never
+                    # matches anything again. "There is a face here and I
+                    # cannot identify it" is the honest answer.
+                    entry.update({
+                        "person_id": None,
+                        "profile": "",
+                        "known": False,
+                        "quality": "low",
+                        "reason": REASON_LOW_QUALITY,
+                    })
+                    entries.append(entry)
+                    continue
+
+                embedding = analyzer.embed(face.aligned)
+                person_id, score = database.match(
+                    embedding, gates["match_threshold"]
+                )
+                if person_id is None:
+                    record = database.enroll_unknown(embedding)
+                    person_id = record["id"]
+                    profile = record["profile"]
+                    known = False
+                else:
+                    database.touch(person_id, timestamp)
+                    record = database.get_person(person_id)
+                    profile = record["profile"]
+                    known = record["named"]
+                entry.update({
+                    "person_id": person_id,
+                    "profile": profile,
+                    "known": known,
+                    "score": round(float(score), 4),
+                    "quality": "ok",
+                })
+                entries.append(entry)
+            payload["faces"] = entries
+            payload["count"] = len(entries)
+        except Exception as error:  # noqa: BLE001 - reported in the payload
+            payload["error"] = str(error)
+        payload["latency_ms"] = int((time.time() - started) * 1000)
+        return payload
+
+    def _log_payload(self, payload: dict) -> None:
+        """Transitions unthrottled, steady state sampled — as in plugins/ocr.py."""
+        outcome = "error" if "error" in payload else "ok"
+        should_log, transition, occurrence = self._log_gate.check(outcome)
+        if outcome == "error":
+            now = time.monotonic()
+            if transition or (
+                self._last_error_log_at is None
+                or now - self._last_error_log_at >= _ERROR_LOG_INTERVAL_SECONDS
+            ):
+                log.error("[face] recognition error (occurrence %d): %s",
+                          occurrence, escape_log_text(payload["error"]))
+                self._last_error_log_at = now
+            elif should_log:
+                log.debug("[face] recognition error (occurrence %d): %s",
+                          occurrence, escape_log_text(payload["error"]))
+        elif should_log:
+            log.debug("[face] published to %s: %d face(s) (frame %d%s)",
+                      self._output_topic, payload["count"], occurrence,
+                      ", recovered" if transition and occurrence == 1 else "")
+
+    def _flush_seen(self) -> None:
+        """Persist `last_seen_at` updates accumulated at frame rate."""
+        self._last_flush_at = time.monotonic()
+        try:
+            self._engine.db.flush()
+        except Exception:  # noqa: BLE001 - never kill the worker over this
+            log.warning("[face] failed to persist sighting timestamps",
+                        exc_info=True)
+
+    def apply_config(self, cfg: dict) -> None:
+        """Apply lightweight fields to a running node, as OCR's config does."""
+        self._cfg = dict(cfg)
+        self._min_interval = max(
+            0.0, float(cfg.get("min_interval_ms", 0)) / 1000.0
+        )
+        self._window_seconds = float(
+            cfg.get("enroll_window_s", DEFAULT_ENROLL_WINDOW_S)
+        )
+
+    def _status_dict(self) -> dict:
+        return {
+            "state": self.state,
+            "topic_in": [{"topic": self._input_topic, "format": "image/jpeg", "desc": "image input"}],
+            "topic_out": [{"topic": self._output_topic, "format": "data/json", "desc": "recognised identities"}],
+        }
+
+
+# ── Plugin ────────────────────────────────────────────────────────────────────
+
+class FaceRecognitionPlugin:
+    """Face recognition MCP plugin with a non-blocking start/stop/load machine.
+
+    The state machine, the single-flight loader and every locking rule are
+    `plugins/ocr.py`'s; see that docstring. The engine here is the analyzer plus
+    the identity database.
+    """
+
+    PREFIX = "face_recognition"
+
+    def __init__(self, plugin_cfg: dict, executor):
+        self._plugin_cfg = dict(plugin_cfg)
+        self._executor = executor
+
+        self._state_lock = threading.Lock()
+        self._nodes: dict[str, _FaceNode] = {}
+        self._instance_configs: dict[str, dict] = {}
+        self._pending_starts: dict[str, str] = {}
+        self._engine: _FaceEngine | None = None
+        self._engine_state = "idle"          # idle|loading|ready|error
+        self._load_error: str | None = None
+        self._load_generation = 0
+
+        log.info("[face] plugin init: device=%s, model_dir=%s, db_dir=%s",
+                 plugin_cfg.get("device", "cpu"),
+                 plugin_cfg.get("model_dir", DEFAULT_FACE_MODEL_DIR),
+                 plugin_cfg.get("db_dir", DEFAULT_DB_DIR))
+
+    def get_tools(self) -> list:
+        return TOOLS
+
+    # ── background loader (single-flight) ────────────────────────────────
+
+    def _spawn_loader_locked(self) -> None:
+        self._engine_state = "loading"
+        self._load_error = None
+        generation = self._load_generation
+        cfg = dict(self._plugin_cfg)
+        threading.Thread(
+            target=self._loader, args=(generation, cfg),
+            name="face-engine-loader", daemon=True,
+        ).start()
+
+    def _loader(self, generation: int, cfg: dict) -> None:
+        try:
+            engine = _build_engine(cfg)
+        except Exception as error:  # noqa: BLE001 - surfaced via state/info
+            log.exception("[face] engine load failed")
+            with self._state_lock:
+                if generation == self._load_generation:
+                    self._engine_state = "error"
+                    self._load_error = str(error)
+            return
+
+        with self._state_lock:
+            if generation != self._load_generation:
+                stale = engine
+            else:
+                self._engine = engine
+                self._engine_state = "ready"
+                stale = None
+        if stale is not None:
+            _close_quietly(stale)
+            return
+
+        while True:
+            with self._state_lock:
+                if generation != self._load_generation or not self._pending_starts:
+                    return
+                node_key, input_topic = next(iter(self._pending_starts.items()))
+            try:
+                node = self._create_node(node_key, input_topic, engine)
+            except Exception as error:  # noqa: BLE001 - keep serving others
+                log.error("[face] failed to build instance %r on %r: %s",
+                          node_key, input_topic, escape_log_text(error))
+                with self._state_lock:
+                    if self._pending_starts.get(node_key) == input_topic:
+                        del self._pending_starts[node_key]
+                continue
+            registered = False
+            with self._state_lock:
+                still_wanted = (
+                    generation == self._load_generation
+                    and self._pending_starts.get(node_key) == input_topic
+                )
+                if still_wanted:
+                    try:
+                        self._executor.add_node(node)
+                    except Exception as error:  # noqa: BLE001
+                        log.error("[face] failed to register instance %r: %s",
+                                  node_key, escape_log_text(error))
+                        del self._pending_starts[node_key]
+                    else:
+                        self._nodes[node_key] = node
+                        del self._pending_starts[node_key]
+                        registered = True
+            if not registered:
+                try:
+                    node.destroy_node()
+                except Exception:  # noqa: BLE001
+                    pass
+                continue
+            try:
+                node.start()
+            except Exception as error:  # noqa: BLE001
+                log.error("[face] failed to start instance %r: %s",
+                          node_key, escape_log_text(error))
+                with self._state_lock:
+                    if self._nodes.get(node_key) is node:
+                        del self._nodes[node_key]
+                self._dispose(node_key, node)
+                continue
+            with self._state_lock:
+                still_ours = self._nodes.get(node_key) is node
+            if not still_ours:
+                node.stop()
+
+    def _merged_cfg(self, node_key: str) -> dict:
+        return {**self._plugin_cfg, **self._instance_configs.get(node_key, {})}
+
+    def _create_node(
+        self, node_key: str, input_topic: str, engine: _FaceEngine
+    ) -> _FaceNode:
+        cfg = self._merged_cfg(node_key)
+        return _FaceNode(
+            input_topic,
+            engine,
+            cfg,
+            node_suffix=node_key.replace("/", "_").replace("-", "_"),
+            min_interval=float(cfg.get("min_interval_ms", 0)) / 1000.0,
+        )
+
+    def _dispose(self, node_key: str, node: _FaceNode) -> None:
+        try:
+            node.retire()
+        finally:
+            dispose_node(self._executor, node, label=f"face/{node_key}")
+        log.info("[face] node disposed: %s", node_key)
+
+    def _instance_state_locked(self, node_key: str) -> str:
+        node = self._nodes.get(node_key)
+        if node is not None:
+            return node.state
+        if node_key in self._pending_starts:
+            return "error" if self._engine_state == "error" else "loading"
+        return "idle"
+
+    # ── MCP dispatch ──────────────────────────────────────────────────────
+
+    def dispatch(self, name: str, args: dict) -> dict | None:
+        action = args.get("action") if name == self.PREFIX else name
+        instance_id = args.get("instance_id", "")
+
+        if action == "info":
+            return self._do_info(instance_id, args.get("input_topic", ""))
+        if action == "start":
+            return self._do_start(instance_id, args)
+        if action == "stop":
+            return self._do_stop(instance_id)
+        if action == "config":
+            return self._do_config(instance_id, args)
+        if action == "register_user_photo":
+            return self._do_register_photo(args)
+        if action == "register_current_stream":
+            return self._do_register_stream(instance_id, args)
+        if action == "register_user_photos":
+            return self._do_register_batch(args)
+        if action == "list_persons":
+            return self._do_list_persons(args)
+        if action == "get_person":
+            return self._do_get_person(args)
+        if action == "update_person":
+            return self._do_update_person(args)
+        if action == "forget":
+            return self._do_forget(args)
+        return None
+
+    _DESC = "Face recognition — identifies registered people in the camera feed"
+
+    def _desc_locked(self, state: str) -> str:
+        if state == "loading":
+            return "Loading face detection and recognition models..."
+        if state == "error" and self._load_error:
+            return f"Model load failed: {self._load_error}"
+        return self._DESC
+
+    # ── info / start / stop / config ──────────────────────────────────────
+
+    def _do_info(self, instance_id: str, input_topic: str) -> dict:
+        base = {"name": "FaceRecognition", "manufacture": "Embodied",
+                "model": "scrfd+arcface"}
+        with self._state_lock:
+            engine = self._engine
+            if instance_id:
+                node = self._nodes.get(instance_id)
+                topic = (
+                    node._input_topic if node is not None
+                    else self._pending_starts.get(instance_id, input_topic)
+                )
+                out = _face_output_topic(topic) if topic else ""
+                state = self._instance_state_locked(instance_id)
+                result = {
+                    **base,
+                    "state": state,
+                    "desc": self._desc_locked(state),
+                    "topic_in": [{"topic": topic, "format": "image/jpeg", "desc": ""}] if topic else [],
+                    "topic_out": [{"topic": out, "format": "data/json", "desc": ""}] if out else [],
+                }
+                if state == "error" and self._load_error:
+                    result["error"] = self._load_error
+                return self._with_db_stats(result, engine)
+
+            keys = list(self._nodes) + [
+                key for key in self._pending_starts if key not in self._nodes
+            ]
+            instances = {key: {"state": self._instance_state_locked(key)} for key in keys}
+            topics_in, topics_out = [], []
+            for key in keys:
+                node = self._nodes.get(key)
+                topic = node._input_topic if node else self._pending_starts[key]
+                topics_in.append({"topic": topic, "format": "image/jpeg", "desc": ""})
+                topics_out.append({"topic": _face_output_topic(topic), "format": "data/json", "desc": ""})
+            states = {entry["state"] for entry in instances.values()}
+            if "loading" in states or self._engine_state == "loading":
+                state = "loading"
+            elif "running" in states:
+                state = "running"
+            elif "error" in states or self._engine_state == "error":
+                state = "error"
+            else:
+                state = "idle"
+            if not keys and input_topic:
+                topics_in = [{"topic": input_topic, "format": "image/jpeg", "desc": ""}]
+                topics_out = [{"topic": _face_output_topic(input_topic), "format": "data/json", "desc": ""}]
+            result = {
+                **base,
+                "state": state,
+                "desc": self._desc_locked(state),
+                "topic_in": topics_in,
+                "topic_out": topics_out,
+            }
+            if instances:
+                result["instances"] = instances
+            if self._load_error and state == "error":
+                result["error"] = self._load_error
+            return self._with_db_stats(result, engine)
+
+    def _with_db_stats(self, result: dict, engine: _FaceEngine | None) -> dict:
+        """Attach roster counts. Never fails info — it is the diagnostic path."""
+        if engine is None:
+            return result
+        try:
+            result["database"] = engine.db.stats()
+        except Exception:  # noqa: BLE001
+            log.warning("[face] could not read database stats", exc_info=True)
+        return result
+
+    def _do_start(self, instance_id: str, args: dict) -> dict:
+        input_topic = args.get("input_topic")
+        if not input_topic:
+            raise ValueError("input_topic is required for start action")
+        node_key = instance_id or input_topic
+
+        retired = None
+        with self._state_lock:
+            existing = self._nodes.get(node_key)
+            if existing is not None and existing._input_topic != input_topic:
+                retired = self._nodes.pop(node_key)
+        if retired is not None:
+            self._dispose(node_key, retired)
+
+        with self._state_lock:
+            existing = self._nodes.get(node_key)
+            if existing is not None:
+                start_node = existing            # idempotent re-start
+            else:
+                start_node = None
+                # Claim the key before leaving the lock so a concurrent stop
+                # always finds the instance in _pending_starts or _nodes, never
+                # in an invisible in-between state.
+                self._pending_starts[node_key] = input_topic
+                if self._engine_state != "ready":
+                    if self._engine_state in ("idle", "error"):
+                        self._spawn_loader_locked()
+                    return {
+                        "state": "loading",
+                        "input": input_topic,
+                        "output": _face_output_topic(input_topic),
+                    }
+            engine = self._engine
+            generation = self._load_generation
+
+        if start_node is not None:
+            return start_node.start()
+
+        node = self._create_node(node_key, input_topic, engine)
+        with self._state_lock:
+            claimed = self._pending_starts.get(node_key) == input_topic
+            current = self._nodes.get(node_key)
+            fresh = generation == self._load_generation
+            registered = False
+            if claimed and current is None and fresh:
+                try:
+                    self._executor.add_node(node)
+                except Exception as error:  # noqa: BLE001
+                    log.error("[face] failed to register instance %r: %s",
+                              node_key, escape_log_text(error))
+                    del self._pending_starts[node_key]
+                else:
+                    self._nodes[node_key] = node
+                    del self._pending_starts[node_key]
+                    registered = True
+            elif claimed and not fresh:
+                # A config change invalidated the engine mid-start; leave the
+                # claim so the loader it spawned brings this instance up.
+                pass
+            elif claimed:
+                del self._pending_starts[node_key]
+        if not registered:
+            try:
+                node.destroy_node()
+            except Exception:  # noqa: BLE001
+                pass
+            if current is not None:
+                return current.start()
+            if claimed and not fresh:
+                return {"state": "loading", "input": input_topic,
+                        "output": _face_output_topic(input_topic)}
+            return {"state": "idle", "input": input_topic,
+                    "output": _face_output_topic(input_topic)}
+        try:
+            result = node.start()
+        except Exception:
+            with self._state_lock:
+                if self._nodes.get(node_key) is node:
+                    del self._nodes[node_key]
+            self._dispose(node_key, node)
+            raise
+        with self._state_lock:
+            still_ours = self._nodes.get(node_key) is node
+        if not still_ours:
+            node.stop()
+            return {"state": "idle", "input": input_topic,
+                    "output": _face_output_topic(input_topic)}
+        return result
+
+    def _do_stop(self, instance_id: str) -> dict:
+        to_dispose: list[tuple[str, _FaceNode]] = []
+        with self._state_lock:
+            if instance_id:
+                self._pending_starts.pop(instance_id, None)
+                node = self._nodes.pop(instance_id, None)
+                if node is not None:
+                    to_dispose.append((instance_id, node))
+            else:
+                self._pending_starts.clear()
+                to_dispose.extend(self._nodes.items())
+                self._nodes = {}
+        for node_key, node in to_dispose:
+            self._dispose(node_key, node)
+        return {"state": "idle"}
+
+    _INSTANCE_SCOPED = ("min_interval_ms",)
+
+    def _do_config(self, instance_id: str, args: dict) -> dict:
+        cfg = {
+            key: value for key, value in args.items()
+            if key not in ("action", "instance_id")
+            and value is not None and value != ""
+        }
+
+        if instance_id:
+            shared = set(cfg) - set(self._INSTANCE_SCOPED)
+            if shared:
+                raise ValueError(
+                    "face recognition settings are shared: "
+                    + ", ".join(sorted(shared))
+                )
+            with self._state_lock:
+                previous = self._instance_configs.get(instance_id, {})
+                self._instance_configs[instance_id] = {**previous, **cfg}
+                node = self._nodes.get(instance_id)
+                merged = self._merged_cfg(instance_id)
+            if node is not None:
+                # min_interval_ms is applied in place; no reason to retire a
+                # live subscription for a frame-rate change.
+                node.apply_config(merged)
+            return {"status": "configured", "instance_id": instance_id}
+
+        evicted = 0
+        with self._state_lock:
+            updated = {**self._plugin_cfg, **cfg}
+            rebuild = _engine_signature(updated) != _engine_signature(self._plugin_cfg)
+            capacity_changed = (
+                int(updated.get("unknown_capacity", DEFAULT_UNKNOWN_CAPACITY))
+                != int(self._plugin_cfg.get("unknown_capacity", DEFAULT_UNKNOWN_CAPACITY))
+            )
+            self._plugin_cfg = updated
+            engine = self._engine
+            if not rebuild:
+                for node_key, node in self._nodes.items():
+                    node.apply_config({
+                        **updated, **self._instance_configs.get(node_key, {})
+                    })
+                nodes_live = self._engine is not None
+            else:
+                self._load_generation += 1
+                stale_engine = self._engine
+                self._engine = None
+                disposed = list(self._nodes.items())
+                self._nodes = {}
+                if self._pending_starts:
+                    self._spawn_loader_locked()
+                else:
+                    self._engine_state = "idle"
+                    self._load_error = None
+
+        if not rebuild:
+            if capacity_changed and engine is not None:
+                evicted = engine.db.set_unknown_capacity(
+                    int(self._plugin_cfg.get("unknown_capacity",
+                                             DEFAULT_UNKNOWN_CAPACITY))
+                )
+            result = {"status": "configured", "engine_loaded": nodes_live,
+                      "reused": nodes_live}
+            if capacity_changed:
+                result["unknown_evicted"] = evicted
+                result["unknown_capacity"] = int(
+                    self._plugin_cfg.get("unknown_capacity",
+                                         DEFAULT_UNKNOWN_CAPACITY)
+                )
+            return result
+
+        for node_key, node in disposed:
+            self._dispose(node_key, node)
+        if stale_engine is not None:
+            _close_quietly(stale_engine)
+        return {"status": "configured", "engine_loaded": False, "reused": False}
+
+    # ── engine access for the action paths ────────────────────────────────
+
+    def _require_engine(self) -> _FaceEngine:
+        """Return a ready engine, loading it on demand.
+
+        The registration and roster actions are useful without any instance
+        running — an operator enrols people from photos before pointing a
+        camera anywhere — so they trigger the same single-flight load a `start`
+        would, and wait for it rather than reporting `loading`. A tools/call
+        already has its own thread (ThreadingHTTPServer), so blocking here
+        blocks nothing else.
+        """
+        with self._state_lock:
+            if self._engine is not None:
+                return self._engine
+            if self._engine_state in ("idle", "error"):
+                self._spawn_loader_locked()
+            generation = self._load_generation
+
+        deadline = time.monotonic() + float(
+            self._plugin_cfg.get("load_timeout_s", 180.0)
+        )
+        while time.monotonic() < deadline:
+            time.sleep(0.2)
+            with self._state_lock:
+                if generation != self._load_generation:
+                    generation = self._load_generation
+                    continue
+                if self._engine is not None:
+                    return self._engine
+                if self._engine_state == "error":
+                    raise RuntimeError(
+                        self._load_error or "face engine failed to load"
+                    )
+        raise RuntimeError("face engine is still loading; try again shortly")
+
+    # ── registration ──────────────────────────────────────────────────────
+
+    def _analyze_subject(
+        self, engine: _FaceEngine, image_bytes: bytes, gates: dict
+    ) -> tuple[np.ndarray | None, dict | None]:
+        """One image → the subject's embedding, or the failure record."""
+        image = engine.analyzer.decode_jpeg(image_bytes)
+        if image is None:
+            return None, {
+                "ok": False, "reason": REASON_BAD_INPUT,
+                "detail": "image could not be decoded as JPEG/PNG",
+            }
+        shape = image.shape[:2]
+        faces = engine.analyzer.detect(image, max_faces=gates["max_faces"])
+        for face in faces:
+            engine.analyzer.prepare(image, face)
+        subject, failure = select_subject(faces, shape, gates)
+        if subject is None:
+            return None, failure
+        return engine.analyzer.embed(subject.aligned), None
+
+    def _commit_enrolment(
+        self,
+        engine: _FaceEngine,
+        embeddings: list[np.ndarray],
+        profile: str,
+        meta: Any,
+        person_id: str | None,
+        gates: dict,
+    ) -> dict:
+        """Attach embeddings to the right identity, creating one if needed."""
+        database = engine.db
+
+        if person_id:
+            try:
+                existing = database.get_person(person_id)
+            except KeyError:
+                return {
+                    "ok": False, "reason": REASON_BAD_INPUT,
+                    "detail": f"no such person: {person_id!r}",
+                }
+            was_unknown = not existing["named"]
+            record = database.add_samples(person_id, embeddings)
+            if profile or meta is not None:
+                record = database.update_person(
+                    person_id, profile=profile or None, meta=meta
+                )
+            return {
+                "ok": True,
+                "person_id": person_id,
+                "profile": record["profile"],
+                "meta": record["meta"],
+                "samples": record["samples"],
+                "promoted": was_unknown and bool(profile),
+            }
+
+        # No id given: does this face already exist under some identity?
+        matched, score = database.match(embeddings[0], gates["match_threshold"])
+        if matched is not None:
+            record = database.add_samples(matched, embeddings)
+            promoted = False
+            if is_unknown_id(matched) or not record["named"]:
+                # The face was already being tracked anonymously; naming it now
+                # keeps that id, so earlier sightings stay attributable.
+                record = database.update_person(matched, profile=profile, meta=meta)
+                promoted = True
+            elif meta is not None:
+                record = database.update_person(matched, meta=meta)
+            return {
+                "ok": True,
+                "person_id": matched,
+                "profile": record["profile"],
+                "meta": record["meta"],
+                "samples": record["samples"],
+                "merged": True,
+                "promoted": promoted,
+                "score_to_existing": round(float(score), 4),
+            }
+
+        record = database.add(profile, embeddings, named=True, meta=meta)
+        return {
+            "ok": True,
+            "person_id": record["id"],
+            "profile": record["profile"],
+            "meta": record["meta"],
+            "samples": record["samples"],
+            "merged": False,
+            "promoted": False,
+        }
+
+    def _do_register_photo(self, args: dict) -> dict:
+        engine = self._require_engine()
+        cfg = dict(self._plugin_cfg)
+        gates = _gates(cfg)
+        try:
+            data, source = _load_image_bytes(args, cfg)
+        except _BadInput as error:
+            return error.as_result()
+
+        embedding, failure = self._analyze_subject(engine, data, gates)
+        if embedding is None:
+            return {**failure, "source": source}
+        result = self._commit_enrolment(
+            engine, [embedding], str(args.get("profile") or ""),
+            args.get("meta"), args.get("person_id") or None, gates,
+        )
+        if result.get("ok"):
+            log.info("[face] registered %s from %s: %s", result["person_id"],
+                     escape_log_text(source), escape_log_text(result["profile"]))
+        return {**result, "source": source}
+
+    def _do_register_stream(self, instance_id: str, args: dict) -> dict:
+        cfg = dict(self._plugin_cfg)
+        gates = _gates(cfg)
+
+        with self._state_lock:
+            if instance_id:
+                node = self._nodes.get(instance_id)
+            elif len(self._nodes) == 1:
+                node = next(iter(self._nodes.values()))
+            else:
+                node = None
+                if len(self._nodes) > 1:
+                    return {
+                        "ok": False, "reason": REASON_BAD_INPUT,
+                        "detail": (
+                            f"{len(self._nodes)} instances are running; pass "
+                            "instance_id to say which camera to use"
+                        ),
+                        "instances": sorted(self._nodes),
+                    }
+        if node is None:
+            return {
+                "ok": False, "reason": REASON_NO_FRAMES,
+                "detail": (
+                    "no running instance to read from — start the card on a "
+                    "camera topic first"
+                ),
+            }
+
+        window = min(
+            float(args.get("window_s") or cfg.get(
+                "enroll_window_s", DEFAULT_ENROLL_WINDOW_S)),
+            float(cfg.get("enroll_window_s", DEFAULT_ENROLL_WINDOW_S)),
+        )
+        frames = node.recent_frames(window)
+        if not frames:
+            return {
+                "ok": False, "reason": REASON_NO_FRAMES,
+                "detail": f"no frames received in the last {window:.1f}s",
+                "instance_id": instance_id or node._input_topic,
+            }
+
+        engine = self._require_engine()
+        # Analyse newest-first and cap the count: the window can hold 60 frames
+        # and running the full pair of models over all of them would take
+        # seconds for no extra accuracy.
+        budget = max(1, int(cfg.get("enroll_max_analyzed", DEFAULT_ENROLL_MAX_ANALYZED)))
+        selected = list(reversed(frames))[:budget]
+
+        embeddings: list[np.ndarray] = []
+        failures: list[dict] = []
+        for image_bytes, _ts in selected:
+            embedding, failure = self._analyze_subject(engine, image_bytes, gates)
+            if embedding is None:
+                failures.append(failure)
+            else:
+                embeddings.append(embedding)
+
+        if not embeddings:
+            return {
+                **_worst_reason(failures),
+                "instance_id": instance_id or node._input_topic,
+                "window_s": round(window, 2),
+            }
+
+        # Every accepted frame must show the *same* person. Two people taking
+        # turns being the dominant face would otherwise be enrolled as one
+        # identity whose embeddings match neither of them well.
+        anchor = embeddings[0]
+        agreeing = [
+            embedding for embedding in embeddings
+            if float(np.dot(anchor, embedding)) >= gates["match_threshold"]
+        ]
+        if len(agreeing) * 2 < len(embeddings):
+            return {
+                "ok": False,
+                "reason": REASON_AMBIGUOUS,
+                "detail": (
+                    f"the last {window:.1f}s did not show one stable subject "
+                    f"({len(agreeing)} of {len(embeddings)} usable frames agree). "
+                    "Have a single person hold still in front of the camera."
+                ),
+                "frames_examined": len(selected),
+                "instance_id": instance_id or node._input_topic,
+            }
+
+        result = self._commit_enrolment(
+            engine, agreeing, str(args.get("profile") or ""),
+            args.get("meta"), args.get("person_id") or None, gates,
+        )
+        if result.get("ok"):
+            log.info("[face] registered %s from the live stream (%d/%d frames): %s",
+                     result["person_id"], len(agreeing), len(selected),
+                     escape_log_text(result["profile"]))
+        return {
+            **result,
+            "instance_id": instance_id or node._input_topic,
+            "frames_used": len(agreeing),
+            "frames_examined": len(selected),
+            "window_s": round(window, 2),
+        }
+
+    def _do_register_batch(self, args: dict) -> dict:
+        package = str(args.get("package") or "").strip()
+        if not package:
+            return {"ok": False, "reason": REASON_BAD_INPUT,
+                    "detail": "package is required"}
+
+        engine = self._require_engine()
+        cfg = dict(self._plugin_cfg)
+        gates = _gates(cfg)
+        max_batch = int(cfg.get("max_batch", DEFAULT_MAX_BATCH))
+
+        with tempfile.TemporaryDirectory(prefix="face-batch-") as staging:
+            try:
+                directory = _extract_package(package, cfg, staging)
+                manifest = _read_manifest(directory)
+            except _BadInput as error:
+                return error.as_result()
+
+            images: list[str] = []
+            for root, _dirs, files in os.walk(directory):
+                for filename in sorted(files):
+                    if filename.lower().endswith(_IMAGE_SUFFIXES):
+                        images.append(os.path.join(root, filename))
+            images.sort()
+
+            if not images:
+                return {"ok": False, "reason": REASON_BAD_INPUT,
+                        "detail": "package contains no images", "source": package}
+            if len(images) > max_batch:
+                return {
+                    "ok": False, "reason": REASON_BAD_INPUT,
+                    "detail": (
+                        f"package has {len(images)} images, over the max_batch "
+                        f"limit of {max_batch}. Split it, or raise max_batch in "
+                        "config.yaml."
+                    ),
+                    "source": package,
+                }
+
+            results: list[dict] = []
+            # person key → the id its first successful photo created, so several
+            # photos of one person become several samples of one identity.
+            groups: dict[str, str] = {}
+            for image_path in images:
+                relative = os.path.relpath(image_path, directory)
+                entry = manifest.get(relative) or manifest.get(
+                    os.path.basename(image_path)
+                ) or {}
+                if entry:
+                    profile = str(entry.get("profile") or "")
+                    meta = entry.get("meta") if isinstance(entry.get("meta"), dict) else None
+                else:
+                    profile, sidecar_meta = _sidecar_profile(image_path)
+                    meta = sidecar_meta or None
+                group = str(entry.get("person") or entry.get("id") or "").strip()
+                person_id = groups.get(group) if group else None
+
+                try:
+                    with open(image_path, "rb") as handle:
+                        data = handle.read()
+                except OSError as error:
+                    results.append({"file": relative, "ok": False,
+                                    "reason": REASON_BAD_INPUT,
+                                    "detail": f"cannot read: {error}"})
+                    continue
+
+                embedding, failure = self._analyze_subject(engine, data, gates)
+                if embedding is None:
+                    results.append({"file": relative, "profile": profile, **failure})
+                    continue
+                try:
+                    outcome = self._commit_enrolment(
+                        engine, [embedding], profile, meta, person_id, gates
+                    )
+                except Exception as error:  # noqa: BLE001 - one bad photo must
+                    # not abandon the rest of a 200-image batch half-registered
+                    log.error("[face] batch entry %s failed: %s",
+                              escape_log_text(relative), escape_log_text(error))
+                    results.append({"file": relative, "ok": False,
+                                    "reason": REASON_BAD_INPUT,
+                                    "detail": str(error)})
+                    continue
+                if outcome.get("ok") and group:
+                    groups.setdefault(group, outcome["person_id"])
+                results.append({"file": relative, **outcome})
+
+        registered = sum(1 for item in results if item.get("ok"))
+        failed = len(results) - registered
+        log.info("[face] batch %s: %d registered, %d failed",
+                 escape_log_text(package), registered, failed)
+        return {
+            "ok": True,
+            "source": package,
+            "total": len(results),
+            "registered": registered,
+            "failed": failed,
+            "results": results,
+        }
+
+    # ── roster CRUD ───────────────────────────────────────────────────────
+
+    def _do_list_persons(self, args: dict) -> dict:
+        engine = self._require_engine()
+        return {
+            "ok": True,
+            **engine.db.list_persons(
+                named=str(args.get("named") or "all"),
+                query=str(args.get("query") or ""),
+                limit=int(args.get("limit") or 100),
+                offset=int(args.get("offset") or 0),
+            ),
+        }
+
+    def _do_get_person(self, args: dict) -> dict:
+        person_id = str(args.get("person_id") or "").strip()
+        if not person_id:
+            raise ValueError("person_id is required")
+        engine = self._require_engine()
+        try:
+            return {"ok": True, "person": engine.db.get_person(person_id)}
+        except KeyError:
+            return {"ok": False, "reason": REASON_BAD_INPUT,
+                    "detail": f"no such person: {person_id!r}"}
+
+    def _do_update_person(self, args: dict) -> dict:
+        person_id = str(args.get("person_id") or "").strip()
+        if not person_id:
+            raise ValueError("person_id is required")
+        engine = self._require_engine()
+        try:
+            record = engine.db.update_person(
+                person_id,
+                profile=args.get("profile"),
+                meta=args.get("meta"),
+                meta_delete=args.get("meta_delete") or [],
+                merge=bool(args.get("merge", True)),
+            )
+        except KeyError:
+            return {"ok": False, "reason": REASON_BAD_INPUT,
+                    "detail": f"no such person: {person_id!r}"}
+        except ValueError as error:
+            return {"ok": False, "reason": REASON_BAD_INPUT, "detail": str(error)}
+        return {"ok": True, "person": record}
+
+    def _do_forget(self, args: dict) -> dict:
+        engine = self._require_engine()
+        scope = str(args.get("named") or "").strip().lower()
+        if scope == "unknown" and not args.get("person_id"):
+            removed = engine.db.forget_unknowns()
+            return {"ok": True, "forgotten": removed, "scope": "unknown"}
+
+        person_id = str(args.get("person_id") or "").strip()
+        if not person_id:
+            raise ValueError("person_id is required (or named='unknown')")
+        if engine.db.forget(person_id):
+            return {"ok": True, "forgotten": 1, "person_id": person_id}
+        return {"ok": False, "reason": REASON_BAD_INPUT,
+                "detail": f"no such person: {person_id!r}"}
+
+
+__all__ = [
+    "DEFAULT_MATCH_THRESHOLD",
+    "REASON_AMBIGUOUS",
+    "REASON_BAD_INPUT",
+    "REASON_LOW_QUALITY",
+    "REASON_NO_FACE",
+    "REASON_NO_FRAMES",
+    "FaceRecognitionPlugin",
+    "TOOLS",
+    "select_subject",
+]

--- a/perception/plugins/face.py
+++ b/perception/plugins/face.py
@@ -34,6 +34,7 @@ import binascii
 import json
 import logging
 import os
+import re
 import tarfile
 import tempfile
 import threading
@@ -67,6 +68,8 @@ from plugins.face_db import (
 )
 from plugins.face_runtime import (
     DEFAULT_BLUR_MIN,
+    DEFAULT_MAX_IMAGE_PIXELS,
+    DEFAULT_MAX_IMAGE_SIDE,
     DEFAULT_DET_SIZE,
     DEFAULT_DET_THRESH,
     DEFAULT_FACE_MODEL_DIR,
@@ -89,7 +92,11 @@ DEFAULT_ENROLL_WINDOW_S = 3.0
 DEFAULT_ENROLL_WINDOW_MAX_FRAMES = 60
 DEFAULT_ENROLL_MAX_ANALYZED = 8
 DEFAULT_MAX_BATCH = 200
-DEFAULT_MAX_IMAGE_BYTES = 16 * 1024 * 1024
+# Only a transfer/memory guard now, not a policy limit: oversized *images* are
+# downscaled locally (see FaceAnalyzer.decode_image) rather than rejected, so
+# this only has to be larger than any real photo. 64 MB covers a 60 MP
+# uncompressed-ish PNG; the pixel cap is what actually protects memory.
+DEFAULT_MAX_IMAGE_BYTES = 64 * 1024 * 1024
 DEFAULT_IMAGE_ROOTS = ("/models", "/tmp", "/work")
 
 
@@ -118,7 +125,13 @@ def detect_interval(cfg: dict) -> float:
     return 1.0 / fps
 
 
-_IMAGE_SUFFIXES = (".jpg", ".jpeg", ".png", ".bmp", ".webp")
+# What the two decoders between them can read (cv2, then Pillow). Suffixes are
+# only used to *find* images in a corpus directory — the decode itself does not
+# care about the name, so this errs wide.
+_IMAGE_SUFFIXES = (
+    ".jpg", ".jpeg", ".jpe", ".png", ".bmp", ".webp", ".tif", ".tiff",
+    ".ppm", ".pgm", ".pbm", ".gif", ".ico", ".jfif",
+)
 
 _RESULT_QOS = QoSProfile(
     reliability=ReliabilityPolicy.RELIABLE,
@@ -144,8 +157,8 @@ TOOLS = [
                     "type": "string",
                     "enum": [
                         "start", "stop", "info", "config",
-                        "register_by_photo", "register_by_stream",
-                        "register_by_corpus",
+                        "register_by_photo", "register_by_url",
+                        "register_by_stream", "register_by_corpus",
                         "recognize_by_photo", "recognize_by_stream",
                         "list_persons", "get_person", "update_person", "forget",
                         "list_visits",
@@ -156,19 +169,21 @@ TOOLS = [
                     "type": "string",
                     "description": "ROS2 image topic to subscribe (e.g. /hostname/camera/rgb, required for action=start)",
                 },
-                "image_path": {"type": "string", "description": "Path to a JPEG/PNG readable by this container"},
-                "image_b64":  {"type": "string", "description": "Base64-encoded JPEG/PNG bytes"},
-                "name":       {"type": "string", "description": "姓名（结构化）。有 name 才算已注册；每次识别都会随 id 一起输出"},
-                "profile":    {"type": "object", "description": "非结构化画像对象：性别、外貌、备注、标签等，随 name 一起输出"},
-                "profile_delete": {"type": "array", "items": {"type": "string"}, "description": "要删除的 profile 键"},
+                "image_path": {"type": "string", "description": "容器内可读的图片路径，如 /tmp/alice.jpg。常见格式都支持（jpg/png/bmp/webp/tiff/gif...），过大的图会在本地缩放，不需要预先处理"},
+                "image_b64":  {"type": "string", "description": "Base64 编码的图片字节（不含 data: 前缀）"},
+                "url":        {"type": "string", "description": "图片的 http(s) 地址，如 https://example.com/alice.jpg。下载后本地解码缩放，格式限制同 image_path"},
+                "name":       {"type": "string", "description": "姓名（结构化），如 \"小王\"。有 name 才算已注册；每次识别都会随 id 一起输出"},
+                "profile":    {"type": "object", "description": "非结构化画像对象，如 {\"gender\":\"male\",\"team\":\"运营部\",\"note\":\"常穿蓝色外套\"}。键名自定，随 name 一起在每帧输出；传字符串会被存成 {\"note\":\"...\"}"},
+                "profile_delete": {"type": "array", "items": {"type": "string"}, "description": "要删除的 profile 键名列表，如 [\"team\",\"note\"]"},
                 "merge":      {"type": "boolean", "description": "profile 合并进已有对象（默认 true），false 为整体替换"},
-                "since":      {"type": "string", "description": "起始时间：epoch 秒或 ISO-8601（如 2026-09-07T15:00）"},
-                "until":      {"type": "string", "description": "结束时间：epoch 秒或 ISO-8601"},
-                "person_id":  {"type": "string", "description": "Existing person id (p-N or unknown-N)"},
-                "window_s":   {"type": "number", "description": "Seconds of recent stream to analyse (default 3.0, capped by enroll_window_s)"},
-                "package":    {"type": "string", "description": "Directory, .zip or .tar.gz path/URL holding photos plus an optional manifest.json"},
-                "named":      {"type": "string", "enum": ["all", "named", "unknown"], "description": "Filter the roster (default all); with action=forget, 'unknown' clears every anonymous entry"},
-                "query":      {"type": "string", "description": "Substring filter over id, name and profile"},
+                "since":      {"type": "string", "description": "起始时间，epoch 秒或 ISO-8601，如 \"2026-09-07T15:00\" 或 1788780000。按时间重叠筛选：15:00 前到、15:20 走的人，查 15:00-15:05 也会返回"},
+                "until":      {"type": "string", "description": "结束时间，格式同 since。留空表示至今"},
+                "person_id":  {"type": "string", "description": "已存在的人员 id，形如 p-3（已命名）或 unknown-7（陌生人）"},
+                "person_ids": {"type": "array", "items": {"type": "string"}, "description": "批量删除的 id 列表，如 [\"p-1\",\"p-2\",\"unknown-7\"]；也接受逗号或空格分隔的字符串 \"p-1, unknown-7\"。一次提交完成，不是逐个删。返回 forgotten(已删数量+id列表) 与 missing(不存在的 id)，部分成功是正常结果"},
+                "window_s":   {"type": "number", "description": "回看最近多少秒的画面。register_by_stream 默认 3.0，recognize_by_stream 默认 1.0，上限为 enroll_window_s"},
+                "package":    {"type": "string", "description": "图片包：目录 / .zip / .tar.gz 的路径或 URL。包内可放 manifest.json 指定每张图的 name 与 profile，如 [{\"file\":\"alice.jpg\",\"name\":\"Alice\",\"person\":\"alice\"}]；没有 manifest 则用同名 .json/.txt 侧文件，再退回文件名"},
+                "named":      {"type": "string", "enum": ["all", "named", "unknown"], "description": "过滤范围，默认 all。用于 action=forget 时，'unknown' 表示清空所有陌生人条目"},
+                "query":      {"type": "string", "description": "在 id、name、profile 上做子串匹配，如 \"运营部\""},
                 "limit":      {"type": "integer", "description": "Page size (default 100)"},
                 "offset":     {"type": "integer", "description": "Page offset"},
             },
@@ -182,6 +197,10 @@ TOOLS = [
                     "params": ["image_path", "image_b64", "name", "profile"],
                     "description": "Register a person from one photo. Fails with a reason when there is no face, no clear face, or no obvious subject",
                 },
+                "register_by_url": {
+                    "params": ["url", "name", "profile"],
+                    "description": "从图片 URL 注册一个人。过大或非常见格式的图片会在本地缩放/转码，而不是被拒绝",
+                },
                 "register_by_stream": {
                     "params": ["name", "profile", "window_s"],
                     "description": "Register the person currently in front of the camera, using the last few seconds of the live stream",
@@ -191,7 +210,7 @@ TOOLS = [
                     "description": "Register many people from a package of photos; returns a per-photo result saying which succeeded and why the others did not",
                 },
                 "recognize_by_photo": {
-                    "params": ["image_path", "image_b64"],
+                    "params": ["image_path", "image_b64", "url"],
                     "description": "认出照片里的人 — 只读，不写库：返回每张人脸的 id/name/profile 与相似度，不会登记陌生人",
                 },
                 "recognize_by_stream": {
@@ -201,7 +220,7 @@ TOOLS = [
                 "list_persons":  {"params": ["named", "query", "limit", "offset"], "description": "List registered people with their name and profile"},
                 "get_person":    {"params": ["person_id"], "description": "Read one person's full record"},
                 "update_person": {"params": ["person_id", "name", "profile", "profile_delete", "merge"], "description": "Edit a person's name or profile; setting a name on an unknown-N id names that identity, keeping the id"},
-                "forget":        {"params": ["person_id", "named"], "description": "Delete a person (or every unknown entry). The id is retired and never reused"},
+                "forget":        {"params": ["person_id", "person_ids", "named"], "description": "删除人员：单个 person_id、批量 person_ids，或 named='unknown' 清空所有陌生人。id 退役后永不复用"},
                 "list_visits":   {"params": ["person_id", "since", "until", "limit", "offset"], "description": "访问记录：查询某段时间内出现过的人。一次连续出现算一条记录，含首末时间与出现次数"},
             },
         },
@@ -295,6 +314,14 @@ def _db_options(cfg: dict) -> dict:
         "visit_checkpoint_s": float(
             cfg.get("visit_checkpoint_s", DEFAULT_VISIT_CHECKPOINT_S)
         ),
+    }
+
+
+def _decode_options(cfg: dict) -> dict:
+    """How incoming photos are normalised before detection."""
+    return {
+        "max_side": int(cfg.get("max_image_side", DEFAULT_MAX_IMAGE_SIDE)),
+        "max_pixels": int(cfg.get("max_image_pixels", DEFAULT_MAX_IMAGE_PIXELS)),
     }
 
 
@@ -490,12 +517,18 @@ def _worst_reason(failures: list[dict]) -> dict:
 # ── image sources ─────────────────────────────────────────────────────────────
 
 def _load_image_bytes(args: dict, cfg: dict) -> tuple[bytes, str]:
-    """Read image bytes from `image_b64` or `image_path`.
+    """Read image bytes from `url`, `image_b64` or `image_path`.
 
-    No URL source: the dashboard has no file-upload widget, so a path (confined
-    to `image_roots`) and inline base64 are what a caller actually has. Adding a
-    URL fetch would also give an unauthenticated LAN caller a request-forging
-    primitive from inside the robot's network for no benefit.
+    The byte ceiling here is a transfer/memory guard, not a policy limit: an
+    image that is merely *large* is downscaled and converted locally by
+    `FaceAnalyzer.decode_image`, because "your photo is 24 MB" or "we only take
+    JPEG" is a limitation of ours rather than a property of their photo.
+
+    `url` is a distinct action (`register_by_url`) rather than a parameter
+    smuggled into the photo path, so the capability is visible on the card.
+    Note it does let a caller make this container issue an outbound request —
+    acceptable for a deliberate, named action, which is why it is not folded
+    into the generic input.
     """
     max_bytes = int(cfg.get("max_image_bytes", DEFAULT_MAX_IMAGE_BYTES))
 
@@ -507,15 +540,20 @@ def _load_image_bytes(args: dict, cfg: dict) -> tuple[bytes, str]:
             raise _BadInput(f"image_b64 is not valid base64: {error}", "image_b64")
         if len(data) > max_bytes:
             raise _BadInput(
-                f"image is {len(data)} bytes, over the {max_bytes} limit", "image_b64"
+                f"image is {len(data)} bytes, over the {max_bytes} byte transfer "
+                "cap (raise max_image_bytes if this is a real photo)", "image_b64"
             )
         return data, "image_b64"
+
+    url = args.get("url") or args.get("image_url")
+    if url:
+        return _fetch_url(str(url), max_bytes), str(url)
 
     path = args.get("image_path")
     if path:
         return _read_local(str(path), cfg, max_bytes), str(path)
 
-    raise _BadInput("one of image_path or image_b64 is required")
+    raise _BadInput("one of url, image_path or image_b64 is required")
 
 
 def _image_roots(cfg: dict) -> tuple[str, ...]:
@@ -546,7 +584,8 @@ def _read_local(path: str, cfg: dict, max_bytes: int) -> bytes:
         size = os.path.getsize(resolved)
         if size > max_bytes:
             raise _BadInput(
-                f"file is {size} bytes, over the {max_bytes} limit", path
+                    f"file is {size} bytes, over the {max_bytes} byte transfer cap "
+                "(raise max_image_bytes if this is a real photo)", path
             )
         with open(resolved, "rb") as handle:
             return handle.read()
@@ -938,7 +977,9 @@ class _FaceNode(Node):
             analyzer = self._engine.analyzer
             database = self._engine.db
             gates = _gates(self._cfg)
-            image = analyzer.decode_jpeg(image_bytes)
+            image = analyzer.decode_image(
+                image_bytes, **_decode_options(self._cfg)
+            )
             if image is None:
                 payload["error"] = "undecodable frame"
                 return payload
@@ -1214,6 +1255,8 @@ class FaceRecognitionPlugin:
         if action == "config":
             return self._do_config(instance_id, args)
         if action == "register_by_photo":
+            return self._do_register_by_photo(args)
+        if action == "register_by_url":
             return self._do_register_by_photo(args)
         if action == "register_by_stream":
             return self._do_register_by_stream(instance_id, args)
@@ -1542,11 +1585,17 @@ class FaceRecognitionPlugin:
         self, engine: _FaceEngine, image_bytes: bytes, gates: dict
     ) -> tuple[np.ndarray | None, dict | None]:
         """One image → the subject's embedding, or the failure record."""
-        image = engine.analyzer.decode_jpeg(image_bytes)
+        image = engine.analyzer.decode_image(
+            image_bytes, **_decode_options(self._plugin_cfg)
+        )
         if image is None:
             return None, {
                 "ok": False, "reason": REASON_BAD_INPUT,
-                "detail": "image could not be decoded as JPEG/PNG",
+                "detail": (
+                    "image could not be decoded (cv2 and Pillow both refused it; "
+                    "HEIC/HEIF is the common format neither reads), or it exceeds "
+                    "max_image_pixels"
+                ),
             }
         shape = image.shape[:2]
         faces = engine.analyzer.detect(image, max_faces=gates["max_faces"])
@@ -1887,11 +1936,17 @@ class FaceRecognitionPlugin:
         because *enrolment* must resolve to exactly one person, whereas a query
         can simply report everyone it sees.
         """
-        image = engine.analyzer.decode_jpeg(image_bytes)
+        image = engine.analyzer.decode_image(
+            image_bytes, **_decode_options(self._plugin_cfg)
+        )
         if image is None:
             return {
                 "ok": False, "reason": REASON_BAD_INPUT,
-                "detail": "image could not be decoded as JPEG/PNG",
+                "detail": (
+                    "image could not be decoded (cv2 and Pillow both refused it; "
+                    "HEIC/HEIF is the common format neither reads), or it exceeds "
+                    "max_image_pixels"
+                ),
             }
         faces = engine.analyzer.detect(image, max_faces=gates["max_faces"])
         results = []
@@ -2075,19 +2130,51 @@ class FaceRecognitionPlugin:
             return {"ok": False, "reason": REASON_BAD_INPUT, "detail": str(error)}
 
     def _do_forget(self, args: dict) -> dict:
+        """Delete one person, a list of them, or every anonymous entry.
+
+        The list form is not just ergonomics: `forget_many` commits once, where
+        N single calls rewrote the whole database N times.
+        """
         engine = self._require_engine()
         scope = str(args.get("named") or "").strip().lower()
-        if scope == "unknown" and not args.get("person_id"):
+
+        raw_ids = args.get("person_ids")
+        if isinstance(raw_ids, str):
+            # An LLM (or a form field) will send "p-1, p-2" as one string.
+            raw_ids = [part for part in re.split(r"[,\s]+", raw_ids) if part]
+        ids = [str(pid).strip() for pid in (raw_ids or []) if str(pid).strip()]
+
+        single = str(args.get("person_id") or "").strip()
+        if single:
+            ids.append(single)
+
+        if scope == "unknown" and not ids:
             removed = engine.db.forget_unknowns()
             return {"ok": True, "forgotten": removed, "scope": "unknown"}
 
-        person_id = str(args.get("person_id") or "").strip()
-        if not person_id:
-            raise ValueError("person_id is required (or named='unknown')")
-        if engine.db.forget(person_id):
-            return {"ok": True, "forgotten": 1, "person_id": person_id}
-        return {"ok": False, "reason": REASON_BAD_INPUT,
-                "detail": f"no such person: {person_id!r}"}
+        if not ids:
+            raise ValueError(
+                "person_id, person_ids or named='unknown' is required"
+            )
+
+        outcome = engine.db.forget_many(ids)
+        forgotten, missing = outcome["forgotten"], outcome["missing"]
+        result = {
+            # Partially-successful is the normal case with a list, so `ok`
+            # reports "the request was processed", and the two lists say what
+            # actually happened to each id.
+            "ok": bool(forgotten) or not missing,
+            "forgotten": len(forgotten),
+            "person_ids": forgotten,
+        }
+        if missing:
+            result["missing"] = missing
+            result["detail"] = (
+                f"{len(missing)} id(s) did not exist: " + ", ".join(missing)
+            )
+            if not forgotten:
+                result["reason"] = REASON_BAD_INPUT
+        return result
 
 
 __all__ = [

--- a/perception/plugins/face.py
+++ b/perception/plugins/face.py
@@ -80,12 +80,39 @@ _SEEN_FLUSH_INTERVAL_SECONDS = 300.0
 DEFAULT_MATCH_THRESHOLD = 0.35
 DEFAULT_SUBJECT_DOMINANCE = 1.6
 DEFAULT_MAX_FACES = 8
+DEFAULT_DETECT_FPS = 1.0
 DEFAULT_ENROLL_WINDOW_S = 3.0
 DEFAULT_ENROLL_WINDOW_MAX_FRAMES = 60
 DEFAULT_ENROLL_MAX_ANALYZED = 8
 DEFAULT_MAX_BATCH = 200
 DEFAULT_MAX_IMAGE_BYTES = 16 * 1024 * 1024
 DEFAULT_IMAGE_ROOTS = ("/models", "/tmp", "/work")
+
+
+def detect_interval(cfg: dict) -> float:
+    """Seconds to leave between detections, from `detect_fps`.
+
+    Expressed as a frequency because that is what an operator reasons about
+    ("look once a second"), and it stays meaningful when the camera's own rate
+    changes — a minimum interval in ms does not. Fractional values are the
+    point: 0.2 means once every five seconds.
+
+    `detect_fps: 0` means "every frame the camera delivers". `min_interval_ms`
+    is still honoured when `detect_fps` is absent, so a canvas saved by an
+    earlier build of this plugin keeps working (same courtesy
+    `normalize_device` extends to the pre-`device` ASR config).
+    """
+    if cfg.get("detect_fps") is None and cfg.get("min_interval_ms") is not None:
+        legacy = max(0.0, float(cfg["min_interval_ms"])) / 1000.0
+        log.info("[face] using legacy min_interval_ms=%s as %.3fs between "
+                 "detections; set detect_fps instead",
+                 cfg["min_interval_ms"], legacy)
+        return legacy
+    fps = float(cfg.get("detect_fps", DEFAULT_DETECT_FPS))
+    if fps <= 0:
+        return 0.0
+    return 1.0 / fps
+
 
 _IMAGE_SUFFIXES = (".jpg", ".jpeg", ".png", ".bmp", ".webp")
 
@@ -170,12 +197,13 @@ TOOLS = [
         "configSchema": {
             "type": "object",
             "properties": {
+                "device":            {"type": "string", "enum": ["auto", "cpu", "gpu"], "default": "auto", "description": "推理设备。auto=有 GPU 用 GPU，没有则用 CPU"},
+                "detect_fps":        {"type": "number", "minimum": 0, "default": DEFAULT_DETECT_FPS, "description": "检测频率，每秒 x 次，支持小数（如 0.5 = 每 2 秒一次）；0=每帧都检测", "scope": "instance"},
                 "match_threshold":   {"type": "number", "minimum": 0.0, "maximum": 1.0, "default": DEFAULT_MATCH_THRESHOLD, "description": "余弦相似度阈值，越高越严格（越不容易认错人，但越容易认不出）"},
                 "min_face_px":       {"type": "integer", "minimum": 16, "default": DEFAULT_MIN_FACE_PX, "description": "最小人脸边长(px)，小于此值不做识别"},
                 "blur_min":          {"type": "number", "minimum": 0.0, "default": DEFAULT_BLUR_MIN, "description": "清晰度下限(拉普拉斯方差)，低于此值视为模糊人脸"},
                 "max_faces":         {"type": "integer", "minimum": 1, "default": DEFAULT_MAX_FACES, "description": "单帧最多处理的人脸数"},
                 "unknown_capacity":  {"type": "integer", "minimum": 0, "default": DEFAULT_UNKNOWN_CAPACITY, "description": "陌生人(unknown-N)数量上限，超出时淘汰最久未见的；已注册人员不受影响"},
-                "min_interval_ms":   {"type": "integer", "minimum": 0, "default": 200, "description": "帧处理最小间隔(ms)，限制算力占用，0=不限", "scope": "instance"},
             },
         },
         "topic_in":  [{"format": "image/jpeg", "desc": "camera image input"}],
@@ -675,7 +703,7 @@ class _FaceNode(Node):
         engine: _FaceEngine,
         cfg: dict,
         node_suffix: str = "",
-        min_interval: float = 0.0,
+        detect_interval_s: float = 1.0,
     ):
         node_name = f"face_{node_suffix}" if node_suffix else "face"
         super().__init__(node_name)
@@ -684,7 +712,8 @@ class _FaceNode(Node):
         self._output_topic = _face_output_topic(input_topic)
         self._engine = engine
         self._cfg = dict(cfg)
-        self._min_interval = max(0.0, float(min_interval))
+        # Seconds between detections; 0 = every frame. See detect_interval().
+        self._detect_interval = max(0.0, float(detect_interval_s))
         self.state = "idle"
 
         self._sub = None
@@ -849,8 +878,8 @@ class _FaceNode(Node):
             if time.monotonic() - self._last_flush_at >= _SEEN_FLUSH_INTERVAL_SECONDS:
                 self._flush_seen()
 
-            if self._min_interval > 0:
-                remaining = self._min_interval - (time.time() - started)
+            if self._detect_interval > 0:
+                remaining = self._detect_interval - (time.time() - started)
                 if remaining > 0:
                     stop_event.wait(remaining)
 
@@ -964,9 +993,7 @@ class _FaceNode(Node):
     def apply_config(self, cfg: dict) -> None:
         """Apply lightweight fields to a running node, as OCR's config does."""
         self._cfg = dict(cfg)
-        self._min_interval = max(
-            0.0, float(cfg.get("min_interval_ms", 0)) / 1000.0
-        )
+        self._detect_interval = detect_interval(cfg)
         self._window_seconds = float(
             cfg.get("enroll_window_s", DEFAULT_ENROLL_WINDOW_S)
         )
@@ -1110,7 +1137,7 @@ class FaceRecognitionPlugin:
             engine,
             cfg,
             node_suffix=node_key.replace("/", "_").replace("-", "_"),
-            min_interval=float(cfg.get("min_interval_ms", 0)) / 1000.0,
+            detect_interval_s=detect_interval(cfg),
         )
 
     def _dispose(self, node_key: str, node: _FaceNode) -> None:
@@ -1343,7 +1370,10 @@ class FaceRecognitionPlugin:
             self._dispose(node_key, node)
         return {"state": "idle"}
 
-    _INSTANCE_SCOPED = ("min_interval_ms",)
+    # Per-instance because one camera may want a different cadence from
+    # another; everything else (thresholds, the model, the database) is
+    # shared by every instance of the plugin.
+    _INSTANCE_SCOPED = ("detect_fps", "min_interval_ms")
 
     def _do_config(self, instance_id: str, args: dict) -> dict:
         cfg = {
@@ -1365,7 +1395,7 @@ class FaceRecognitionPlugin:
                 node = self._nodes.get(instance_id)
                 merged = self._merged_cfg(instance_id)
             if node is not None:
-                # min_interval_ms is applied in place; no reason to retire a
+                # detect_fps is applied in place; no reason to retire a
                 # live subscription for a frame-rate change.
                 node.apply_config(merged)
             return {"status": "configured", "instance_id": instance_id}

--- a/perception/plugins/face.py
+++ b/perception/plugins/face.py
@@ -14,11 +14,12 @@ are each there because omitting them orphaned a live node in production.
 
 What this plugin adds over OCR:
 
-* **A 3-second rolling frame window** per instance. `register_current_stream`
+* **A 3-second rolling frame window** per instance. `register_by_stream`
   analyses every frame in it rather than one grab, so a blink, a turned head or
   one motion-blurred frame does not decide the enrolment.
 * **A persistent identity database** (`plugins/face_db.py`), shared by all
-  instances of the plugin, holding embeddings, profiles and free-form meta.
+  instances of the plugin, holding embeddings, names, free-form profiles and a
+  visit log.
 * **Structured failure reasons.** Enrolment fails for mundane physical reasons
   — nobody in frame, nobody sharp enough, too many candidates to guess a
   subject — and the caller (an LLM or an operator) can only react if it is told
@@ -56,8 +57,11 @@ from utils.ros_lifecycle import dispose_node
 
 from plugins.face_db import (
     DEFAULT_DB_DIR,
+    DEFAULT_VISIT_CHECKPOINT_S,
     DEFAULT_MAX_SAMPLES_PER_PERSON,
     DEFAULT_UNKNOWN_CAPACITY,
+    DEFAULT_VISIT_GAP_S,
+    DEFAULT_VISIT_LOG_MAX,
     FaceDB,
     is_unknown_id,
 )
@@ -140,9 +144,11 @@ TOOLS = [
                     "type": "string",
                     "enum": [
                         "start", "stop", "info", "config",
-                        "register_user_photo", "register_current_stream",
-                        "register_user_photos",
+                        "register_by_photo", "register_by_stream",
+                        "register_by_corpus",
+                        "recognize_by_photo", "recognize_by_stream",
                         "list_persons", "get_person", "update_person", "forget",
+                        "list_visits",
                     ],
                     "description": "Action to perform",
                 },
@@ -152,15 +158,17 @@ TOOLS = [
                 },
                 "image_path": {"type": "string", "description": "Path to a JPEG/PNG readable by this container"},
                 "image_b64":  {"type": "string", "description": "Base64-encoded JPEG/PNG bytes"},
-                "profile":    {"type": "string", "description": "Who this person is — free text shown alongside the id on every sighting"},
-                "meta":       {"type": "object", "description": "Free-form metadata object (department, tags, notes...)"},
-                "meta_delete": {"type": "array", "items": {"type": "string"}, "description": "Meta keys to remove"},
-                "merge":      {"type": "boolean", "description": "Merge meta into the existing object (default true) instead of replacing it"},
+                "name":       {"type": "string", "description": "姓名（结构化）。有 name 才算已注册；每次识别都会随 id 一起输出"},
+                "profile":    {"type": "object", "description": "非结构化画像对象：性别、外貌、备注、标签等，随 name 一起输出"},
+                "profile_delete": {"type": "array", "items": {"type": "string"}, "description": "要删除的 profile 键"},
+                "merge":      {"type": "boolean", "description": "profile 合并进已有对象（默认 true），false 为整体替换"},
+                "since":      {"type": "string", "description": "起始时间：epoch 秒或 ISO-8601（如 2026-09-07T15:00）"},
+                "until":      {"type": "string", "description": "结束时间：epoch 秒或 ISO-8601"},
                 "person_id":  {"type": "string", "description": "Existing person id (p-N or unknown-N)"},
                 "window_s":   {"type": "number", "description": "Seconds of recent stream to analyse (default 3.0, capped by enroll_window_s)"},
                 "package":    {"type": "string", "description": "Directory, .zip or .tar.gz path/URL holding photos plus an optional manifest.json"},
                 "named":      {"type": "string", "enum": ["all", "named", "unknown"], "description": "Filter the roster (default all); with action=forget, 'unknown' clears every anonymous entry"},
-                "query":      {"type": "string", "description": "Substring filter over id, profile and meta"},
+                "query":      {"type": "string", "description": "Substring filter over id, name and profile"},
                 "limit":      {"type": "integer", "description": "Page size (default 100)"},
                 "offset":     {"type": "integer", "description": "Page offset"},
             },
@@ -170,22 +178,31 @@ TOOLS = [
                 "stop":   {"params": [], "description": "Stop recognition"},
                 "info":   {"params": ["input_topic"], "description": "Report state, topics and database statistics"},
                 "config": {"params": [], "description": "Update configuration"},
-                "register_user_photo": {
-                    "params": ["image_path", "image_b64", "profile", "meta"],
+                "register_by_photo": {
+                    "params": ["image_path", "image_b64", "name", "profile"],
                     "description": "Register a person from one photo. Fails with a reason when there is no face, no clear face, or no obvious subject",
                 },
-                "register_current_stream": {
-                    "params": ["profile", "meta", "window_s"],
+                "register_by_stream": {
+                    "params": ["name", "profile", "window_s"],
                     "description": "Register the person currently in front of the camera, using the last few seconds of the live stream",
                 },
-                "register_user_photos": {
+                "register_by_corpus": {
                     "params": ["package"],
                     "description": "Register many people from a package of photos; returns a per-photo result saying which succeeded and why the others did not",
                 },
-                "list_persons":  {"params": ["named", "query", "limit", "offset"], "description": "List registered people with their profile and meta"},
+                "recognize_by_photo": {
+                    "params": ["image_path", "image_b64"],
+                    "description": "认出照片里的人 — 只读，不写库：返回每张人脸的 id/name/profile 与相似度，不会登记陌生人",
+                },
+                "recognize_by_stream": {
+                    "params": ["window_s"],
+                    "description": "认出摄像头前的人 — 只读，不写库：返回当前画面里每个人的 id/name/profile 与相似度",
+                },
+                "list_persons":  {"params": ["named", "query", "limit", "offset"], "description": "List registered people with their name and profile"},
                 "get_person":    {"params": ["person_id"], "description": "Read one person's full record"},
-                "update_person": {"params": ["person_id", "profile", "meta", "meta_delete", "merge"], "description": "Edit a person's profile or meta; setting a profile on an unknown-N id names that identity, keeping the id"},
+                "update_person": {"params": ["person_id", "name", "profile", "profile_delete", "merge"], "description": "Edit a person's name or profile; setting a name on an unknown-N id names that identity, keeping the id"},
                 "forget":        {"params": ["person_id", "named"], "description": "Delete a person (or every unknown entry). The id is retired and never reused"},
+                "list_visits":   {"params": ["person_id", "since", "until", "limit", "offset"], "description": "访问记录：查询某段时间内出现过的人。一次连续出现算一条记录，含首末时间与出现次数"},
             },
         },
         # Deliberately minimal, as in plugins/ocr.py: only what an operator
@@ -272,6 +289,11 @@ def _db_options(cfg: dict) -> dict:
         ),
         "max_samples_per_person": int(
             cfg.get("max_samples_per_person", DEFAULT_MAX_SAMPLES_PER_PERSON)
+        ),
+        "visit_gap_s": float(cfg.get("visit_gap_s", DEFAULT_VISIT_GAP_S)),
+        "visit_log_max": int(cfg.get("visit_log_max", DEFAULT_VISIT_LOG_MAX)),
+        "visit_checkpoint_s": float(
+            cfg.get("visit_checkpoint_s", DEFAULT_VISIT_CHECKPOINT_S)
         ),
     }
 
@@ -667,8 +689,13 @@ def _read_manifest(directory: str) -> dict[str, dict]:
     return entries
 
 
-def _sidecar_profile(image_path: str) -> tuple[str, dict]:
-    """Per-image fallback: `alice.json` then `alice.txt`, else the file stem."""
+def _sidecar_identity(image_path: str) -> tuple[str, dict]:
+    """Per-image fallback: `alice.json`, then `alice.txt`, else the file stem.
+
+    Returns `(name, profile)`. A sidecar may carry `name` and a `profile`
+    object; `profile` as a plain string is read as the name, which is the shape
+    a hand-written sidecar tends to have.
+    """
     stem, _ = os.path.splitext(image_path)
     json_path = f"{stem}.json"
     if os.path.isfile(json_path):
@@ -676,9 +703,11 @@ def _sidecar_profile(image_path: str) -> tuple[str, dict]:
             with open(json_path, encoding="utf-8") as handle:
                 data = json.load(handle)
             if isinstance(data, dict):
-                return str(data.get("profile") or ""), (
-                    data.get("meta") if isinstance(data.get("meta"), dict) else {}
-                )
+                name = data.get("name")
+                profile = data.get("profile")
+                if name is None and isinstance(profile, str):
+                    name, profile = profile, None
+                return str(name or ""), (profile if isinstance(profile, dict) else {})
             return str(data), {}
         except (OSError, ValueError):
             log.warning("[face] ignoring unreadable sidecar %s",
@@ -724,7 +753,7 @@ class _FaceNode(Node):
         self._frames.close()
         # Rolling enrolment window, kept beside LatestFrame rather than in place
         # of it: the worker still wants "newest frame, drop the rest", while
-        # register_current_stream wants the last few seconds. Bounded by age and
+        # register_by_stream wants the last few seconds. Bounded by age and
         # by count, so a fast camera cannot grow it without limit.
         self._window: deque[tuple[bytes, float]] = deque(
             maxlen=max(1, int(cfg.get(
@@ -805,7 +834,10 @@ class _FaceNode(Node):
                             len(self._worker_threads), self._input_topic)
             with self._window_lock:
                 self._window.clear()
-            self._flush_seen()
+            # force: an instance stopping means everyone currently in frame has
+            # left as far as this camera is concerned, so close their visits
+            # rather than losing them.
+            self._flush_seen(force_close=True)
             log.info("[face] stopped: %s", self._input_topic)
             return {"state": "idle"}
 
@@ -876,6 +908,15 @@ class _FaceNode(Node):
             self._pub.publish(msg)
             self._log_payload(payload)
 
+            # Closing a visit is in-memory bookkeeping plus one append, so it
+            # can run every cycle; only the persons.json rewrite is throttled.
+            try:
+                self._engine.db.close_stale_visits()
+                # Throttled inside the DB to visit_checkpoint_s, so calling it
+                # every cycle costs a lock and a timestamp compare.
+                self._engine.db.checkpoint_open_visits()
+            except Exception:  # noqa: BLE001
+                log.warning("[face] visit bookkeeping failed", exc_info=True)
             if time.monotonic() - self._last_flush_at >= _SEEN_FLUSH_INTERVAL_SECONDS:
                 self._flush_seen()
 
@@ -925,7 +966,7 @@ class _FaceNode(Node):
                     # cannot identify it" is the honest answer.
                     entry.update({
                         "person_id": None,
-                        "profile": "",
+                        "name": "",
                         "known": False,
                         "quality": "low",
                         "reason": REASON_LOW_QUALITY,
@@ -940,17 +981,17 @@ class _FaceNode(Node):
                 if person_id is None:
                     record = database.enroll_unknown(embedding)
                     person_id = record["id"]
-                    profile = record["profile"]
-                    known = False
                 else:
-                    database.touch(person_id, timestamp)
                     record = database.get_person(person_id)
-                    profile = record["profile"]
-                    known = record["named"]
+                # Sightings drive last_seen_at and the visit log; neither
+                # timestamp goes in the payload — "when was this person around"
+                # is a visit-log question (list_visits), not a per-frame field.
+                database.record_sighting(person_id, timestamp, self._input_topic)
                 entry.update({
                     "person_id": person_id,
-                    "profile": profile,
-                    "known": known,
+                    "name": record["name"],
+                    "profile": record["profile"],
+                    "known": record["named"],
                     "score": round(float(score), 4),
                     "quality": "ok",
                 })
@@ -983,10 +1024,11 @@ class _FaceNode(Node):
                       self._output_topic, payload["count"], occurrence,
                       ", recovered" if transition and occurrence == 1 else "")
 
-    def _flush_seen(self) -> None:
-        """Persist `last_seen_at` updates accumulated at frame rate."""
+    def _flush_seen(self, force_close: bool = False) -> None:
+        """Persist `last_seen_at` and close any visit whose subject has left."""
         self._last_flush_at = time.monotonic()
         try:
+            self._engine.db.close_stale_visits(force=force_close)
             self._engine.db.flush()
         except Exception:  # noqa: BLE001 - never kill the worker over this
             log.warning("[face] failed to persist sighting timestamps",
@@ -1171,12 +1213,16 @@ class FaceRecognitionPlugin:
             return self._do_stop(instance_id)
         if action == "config":
             return self._do_config(instance_id, args)
-        if action == "register_user_photo":
-            return self._do_register_photo(args)
-        if action == "register_current_stream":
-            return self._do_register_stream(instance_id, args)
-        if action == "register_user_photos":
-            return self._do_register_batch(args)
+        if action == "register_by_photo":
+            return self._do_register_by_photo(args)
+        if action == "register_by_stream":
+            return self._do_register_by_stream(instance_id, args)
+        if action == "register_by_corpus":
+            return self._do_register_by_corpus(args)
+        if action == "recognize_by_photo":
+            return self._do_recognize_by_photo(args)
+        if action == "recognize_by_stream":
+            return self._do_recognize_by_stream(instance_id, args)
         if action == "list_persons":
             return self._do_list_persons(args)
         if action == "get_person":
@@ -1185,6 +1231,8 @@ class FaceRecognitionPlugin:
             return self._do_update_person(args)
         if action == "forget":
             return self._do_forget(args)
+        if action == "list_visits":
+            return self._do_list_visits(args)
         return None
 
     _DESC = "Face recognition — identifies registered people in the camera feed"
@@ -1513,8 +1561,8 @@ class FaceRecognitionPlugin:
         self,
         engine: _FaceEngine,
         embeddings: list[np.ndarray],
-        profile: str,
-        meta: Any,
+        name: str,
+        profile: Any,
         person_id: str | None,
         gates: dict,
     ) -> dict:
@@ -1531,17 +1579,17 @@ class FaceRecognitionPlugin:
                 }
             was_unknown = not existing["named"]
             record = database.add_samples(person_id, embeddings)
-            if profile or meta is not None:
+            if name or profile is not None:
                 record = database.update_person(
-                    person_id, profile=profile or None, meta=meta
+                    person_id, name=name or None, profile=profile
                 )
             return {
                 "ok": True,
                 "person_id": person_id,
+                "name": record["name"],
                 "profile": record["profile"],
-                "meta": record["meta"],
                 "samples": record["samples"],
-                "promoted": was_unknown and bool(profile),
+                "promoted": was_unknown and bool(name),
             }
 
         # No id given: does this face already exist under some identity?
@@ -1552,33 +1600,33 @@ class FaceRecognitionPlugin:
             if is_unknown_id(matched) or not record["named"]:
                 # The face was already being tracked anonymously; naming it now
                 # keeps that id, so earlier sightings stay attributable.
-                record = database.update_person(matched, profile=profile, meta=meta)
+                record = database.update_person(matched, name=name, profile=profile)
                 promoted = True
-            elif meta is not None:
-                record = database.update_person(matched, meta=meta)
+            elif profile is not None:
+                record = database.update_person(matched, profile=profile)
             return {
                 "ok": True,
                 "person_id": matched,
+                "name": record["name"],
                 "profile": record["profile"],
-                "meta": record["meta"],
                 "samples": record["samples"],
                 "merged": True,
                 "promoted": promoted,
                 "score_to_existing": round(float(score), 4),
             }
 
-        record = database.add(profile, embeddings, named=True, meta=meta)
+        record = database.add(name, embeddings, named=True, profile=profile)
         return {
             "ok": True,
             "person_id": record["id"],
+            "name": record["name"],
             "profile": record["profile"],
-            "meta": record["meta"],
             "samples": record["samples"],
             "merged": False,
             "promoted": False,
         }
 
-    def _do_register_photo(self, args: dict) -> dict:
+    def _do_register_by_photo(self, args: dict) -> dict:
         engine = self._require_engine()
         cfg = dict(self._plugin_cfg)
         gates = _gates(cfg)
@@ -1597,42 +1645,21 @@ class FaceRecognitionPlugin:
         # `update_person`, and grouping several photos under one person is the
         # batch manifest's `person` key.
         result = self._commit_enrolment(
-            engine, [embedding], str(args.get("profile") or ""),
-            args.get("meta"), None, gates,
+            engine, [embedding], str(args.get("name") or ""),
+            args.get("profile"), None, gates,
         )
         if result.get("ok"):
             log.info("[face] registered %s from %s: %s", result["person_id"],
-                     escape_log_text(source), escape_log_text(result["profile"]))
+                     escape_log_text(source), escape_log_text(result["name"]))
         return {**result, "source": source}
 
-    def _do_register_stream(self, instance_id: str, args: dict) -> dict:
+    def _do_register_by_stream(self, instance_id: str, args: dict) -> dict:
         cfg = dict(self._plugin_cfg)
         gates = _gates(cfg)
 
-        with self._state_lock:
-            if instance_id:
-                node = self._nodes.get(instance_id)
-            elif len(self._nodes) == 1:
-                node = next(iter(self._nodes.values()))
-            else:
-                node = None
-                if len(self._nodes) > 1:
-                    return {
-                        "ok": False, "reason": REASON_BAD_INPUT,
-                        "detail": (
-                            f"{len(self._nodes)} instances are running; pass "
-                            "instance_id to say which camera to use"
-                        ),
-                        "instances": sorted(self._nodes),
-                    }
+        node, failure = self._pick_instance(instance_id)
         if node is None:
-            return {
-                "ok": False, "reason": REASON_NO_FRAMES,
-                "detail": (
-                    "no running instance to read from — start the card on a "
-                    "camera topic first"
-                ),
-            }
+            return failure
 
         window = min(
             float(args.get("window_s") or cfg.get(
@@ -1692,13 +1719,13 @@ class FaceRecognitionPlugin:
             }
 
         result = self._commit_enrolment(
-            engine, agreeing, str(args.get("profile") or ""),
-            args.get("meta"), None, gates,
+            engine, agreeing, str(args.get("name") or ""),
+            args.get("profile"), None, gates,
         )
         if result.get("ok"):
             log.info("[face] registered %s from the live stream (%d/%d frames): %s",
                      result["person_id"], len(agreeing), len(selected),
-                     escape_log_text(result["profile"]))
+                     escape_log_text(result["name"]))
         return {
             **result,
             "instance_id": instance_id or node._input_topic,
@@ -1707,7 +1734,7 @@ class FaceRecognitionPlugin:
             "window_s": round(window, 2),
         }
 
-    def _do_register_batch(self, args: dict) -> dict:
+    def _do_register_by_corpus(self, args: dict) -> dict:
         package = str(args.get("package") or "").strip()
         if not package:
             return {"ok": False, "reason": REASON_BAD_INPUT,
@@ -1756,11 +1783,17 @@ class FaceRecognitionPlugin:
                     os.path.basename(image_path)
                 ) or {}
                 if entry:
-                    profile = str(entry.get("profile") or "")
-                    meta = entry.get("meta") if isinstance(entry.get("meta"), dict) else None
+                    # `name` is the structured label; a manifest that still puts
+                    # a plain string in `profile` is read as the name.
+                    raw_profile = entry.get("profile")
+                    name = entry.get("name")
+                    if name is None and isinstance(raw_profile, str):
+                        name, raw_profile = raw_profile, None
+                    name = str(name or "")
+                    profile = raw_profile if isinstance(raw_profile, dict) else None
                 else:
-                    profile, sidecar_meta = _sidecar_profile(image_path)
-                    meta = sidecar_meta or None
+                    name, sidecar_profile = _sidecar_identity(image_path)
+                    profile = sidecar_profile or None
                 group = str(entry.get("person") or entry.get("id") or "").strip()
                 person_id = groups.get(group) if group else None
 
@@ -1775,11 +1808,11 @@ class FaceRecognitionPlugin:
 
                 embedding, failure = self._analyze_subject(engine, data, gates)
                 if embedding is None:
-                    results.append({"file": relative, "profile": profile, **failure})
+                    results.append({"file": relative, "name": name, **failure})
                     continue
                 try:
                     outcome = self._commit_enrolment(
-                        engine, [embedding], profile, meta, person_id, gates
+                        engine, [embedding], name, profile, person_id, gates
                     )
                 except Exception as error:  # noqa: BLE001 - one bad photo must
                     # not abandon the rest of a 200-image batch half-registered
@@ -1804,6 +1837,179 @@ class FaceRecognitionPlugin:
             "registered": registered,
             "failed": failed,
             "results": results,
+        }
+
+    def _pick_instance(self, instance_id: str):
+        """Resolve which running instance a stream action should read from.
+
+        Returns `(node, None)` or `(None, failure)`. With exactly one instance
+        the id is optional — the common case is one camera — but with several
+        it is required rather than guessed, because reading the wrong camera
+        would silently answer about the wrong room.
+        """
+        with self._state_lock:
+            if instance_id:
+                node = self._nodes.get(instance_id)
+            elif len(self._nodes) == 1:
+                node = next(iter(self._nodes.values()))
+            else:
+                node = None
+                if len(self._nodes) > 1:
+                    return None, {
+                        "ok": False, "reason": REASON_BAD_INPUT,
+                        "detail": (
+                            f"{len(self._nodes)} instances are running; pass "
+                            "instance_id to say which camera to use"
+                        ),
+                        "instances": sorted(self._nodes),
+                    }
+        if node is None:
+            return None, {
+                "ok": False, "reason": REASON_NO_FRAMES,
+                "detail": (
+                    "no running instance to read from — start the card on a "
+                    "camera topic first"
+                ),
+            }
+        return node, None
+
+    # ── recognition on demand (read-only) ────────────────────────────────
+
+    def _identify(
+        self, engine: _FaceEngine, image_bytes: bytes, gates: dict
+    ) -> dict | list[dict]:
+        """Every face in one image, matched against the database.
+
+        **Read-only.** Unlike the continuous stream, this neither auto-enrols a
+        stranger as `unknown-N` nor records a sighting: "who is this" is a
+        question, and answering it should not mutate the roster or the visit
+        log. It also does not apply `subject_dominance` — that gate exists
+        because *enrolment* must resolve to exactly one person, whereas a query
+        can simply report everyone it sees.
+        """
+        image = engine.analyzer.decode_jpeg(image_bytes)
+        if image is None:
+            return {
+                "ok": False, "reason": REASON_BAD_INPUT,
+                "detail": "image could not be decoded as JPEG/PNG",
+            }
+        faces = engine.analyzer.detect(image, max_faces=gates["max_faces"])
+        results = []
+        for face in faces:
+            engine.analyzer.prepare(image, face)
+            entry = {
+                "bbox": face.bbox_xywh(),
+                "det_score": round(face.det_score, 4),
+                "blur": round(face.blur, 2),
+                "min_side_px": int(face.min_side),
+            }
+            if not (
+                face.det_score >= gates["det_thresh"]
+                and face.min_side >= gates["min_face_px"]
+                and face.blur >= gates["blur_min"]
+            ):
+                entry.update({
+                    "person_id": None, "name": "", "known": False,
+                    "quality": "low", "reason": REASON_LOW_QUALITY,
+                })
+                results.append(entry)
+                continue
+            embedding = engine.analyzer.embed(face.aligned)
+            person_id, score = engine.db.match(
+                embedding, gates["match_threshold"]
+            )
+            if person_id is None:
+                # `best_score` is what an operator needs to decide whether
+                # match_threshold is too strict, so report it rather than just
+                # saying no.
+                entry.update({
+                    "person_id": None, "name": "", "known": False,
+                    "quality": "ok", "best_score": round(float(score), 4),
+                })
+            else:
+                record = engine.db.get_person(person_id)
+                entry.update({
+                    "person_id": person_id,
+                    "name": record["name"],
+                    "profile": record["profile"],
+                    "known": record["named"],
+                    "score": round(float(score), 4),
+                    "quality": "ok",
+                })
+            results.append(entry)
+        return results
+
+    def _do_recognize_by_photo(self, args: dict) -> dict:
+        engine = self._require_engine()
+        cfg = dict(self._plugin_cfg)
+        gates = _gates(cfg)
+        try:
+            data, source = _load_image_bytes(args, cfg)
+        except _BadInput as error:
+            return error.as_result()
+        outcome = self._identify(engine, data, gates)
+        if isinstance(outcome, dict):
+            return {**outcome, "source": source}
+        return {
+            "ok": True,
+            "source": source,
+            "count": len(outcome),
+            "faces": outcome,
+        }
+
+    def _do_recognize_by_stream(self, instance_id: str, args: dict) -> dict:
+        cfg = dict(self._plugin_cfg)
+        gates = _gates(cfg)
+        node, failure = self._pick_instance(instance_id)
+        if node is None:
+            return failure
+
+        # Default 1 s, not the 3 s enrolment window: this answers "who is in
+        # front of me now". Several frames rather than one because a single
+        # blurred frame would otherwise report nobody; each person is reported
+        # once, at their best score across the window.
+        window = min(
+            float(args.get("window_s") or 1.0),
+            float(cfg.get("enroll_window_s", DEFAULT_ENROLL_WINDOW_S)),
+        )
+        frames = node.recent_frames(window)
+        if not frames:
+            return {
+                "ok": False, "reason": REASON_NO_FRAMES,
+                "detail": f"no frames received in the last {window:.1f}s",
+                "instance_id": instance_id or node._input_topic,
+            }
+        engine = self._require_engine()
+        budget = max(1, int(cfg.get("enroll_max_analyzed", DEFAULT_ENROLL_MAX_ANALYZED)))
+        selected = list(reversed(frames))[:budget]
+
+        best: dict[str, dict] = {}
+        unidentified: list[dict] = []
+        for image_bytes, _ts in selected:
+            outcome = self._identify(engine, image_bytes, gates)
+            if isinstance(outcome, dict):
+                continue                     # undecodable frame; try the next
+            for entry in outcome:
+                person_id = entry.get("person_id")
+                if person_id is None:
+                    unidentified.append(entry)
+                    continue
+                previous = best.get(person_id)
+                if previous is None or entry["score"] > previous["score"]:
+                    best[person_id] = entry
+
+        faces = sorted(best.values(), key=lambda e: e["score"], reverse=True)
+        if not faces and unidentified:
+            # Nobody recognised, but there were faces — report the best-looking
+            # one so the answer is "someone I do not know" rather than "nobody".
+            faces = [max(unidentified, key=lambda e: e.get("best_score", -2.0))]
+        return {
+            "ok": True,
+            "instance_id": instance_id or node._input_topic,
+            "count": len(faces),
+            "faces": faces,
+            "frames_examined": len(selected),
+            "window_s": round(window, 2),
         }
 
     # ── roster CRUD ───────────────────────────────────────────────────────
@@ -1839,9 +2045,9 @@ class FaceRecognitionPlugin:
         try:
             record = engine.db.update_person(
                 person_id,
+                name=args.get("name"),
                 profile=args.get("profile"),
-                meta=args.get("meta"),
-                meta_delete=args.get("meta_delete") or [],
+                profile_delete=args.get("profile_delete") or [],
                 merge=bool(args.get("merge", True)),
             )
         except KeyError:
@@ -1850,6 +2056,23 @@ class FaceRecognitionPlugin:
         except ValueError as error:
             return {"ok": False, "reason": REASON_BAD_INPUT, "detail": str(error)}
         return {"ok": True, "person": record}
+
+    def _do_list_visits(self, args: dict) -> dict:
+        """访问记录查询 — who was around, and when."""
+        engine = self._require_engine()
+        try:
+            return {
+                "ok": True,
+                **engine.db.list_visits(
+                    person_id=str(args.get("person_id") or ""),
+                    since=args.get("since"),
+                    until=args.get("until"),
+                    limit=int(args.get("limit") or 100),
+                    offset=int(args.get("offset") or 0),
+                ),
+            }
+        except ValueError as error:      # unparseable since/until
+            return {"ok": False, "reason": REASON_BAD_INPUT, "detail": str(error)}
 
     def _do_forget(self, args: dict) -> dict:
         engine = self._require_engine()

--- a/perception/plugins/face.py
+++ b/perception/plugins/face.py
@@ -29,8 +29,6 @@ What this plugin adds over OCR:
 
 from __future__ import annotations
 
-import base64
-import binascii
 import json
 import logging
 import os
@@ -97,7 +95,10 @@ DEFAULT_MAX_BATCH = 200
 # this only has to be larger than any real photo. 64 MB covers a 60 MP
 # uncompressed-ish PNG; the pixel cap is what actually protects memory.
 DEFAULT_MAX_IMAGE_BYTES = 64 * 1024 * 1024
-DEFAULT_IMAGE_ROOTS = ("/models", "/tmp", "/work")
+# /uploads first: it is the only one of these that agent-core also mounts, so
+# it is the only path a caller outside this container can hand over. See
+# deploy/service.yml.
+DEFAULT_IMAGE_ROOTS = ("/uploads", "/models", "/tmp", "/work")
 
 
 def detect_interval(cfg: dict) -> float:
@@ -169,8 +170,14 @@ TOOLS = [
                     "type": "string",
                     "description": "ROS2 image topic to subscribe (e.g. /hostname/camera/rgb, required for action=start)",
                 },
-                "image_path": {"type": "string", "description": "容器内可读的图片路径，如 /tmp/alice.jpg。常见格式都支持（jpg/png/bmp/webp/tiff/gif...），过大的图会在本地缩放，不需要预先处理"},
-                "image_b64":  {"type": "string", "description": "Base64 编码的图片字节（不含 data: 前缀）"},
+                # `format: file` makes the canvas render a file picker that
+                # uploads through agent-core's /api/file/upload and fills the
+                # resulting path back in — the same mechanism agent-core's own
+                # `remote_image` card uses for `image_file`. The upload lands in
+                # a directory both containers mount (see image_roots below), so
+                # the path this card receives is one perception can actually
+                # open.
+                "image_path": {"type": "string", "format": "file", "accept": "image/*", "uploadDir": "/uploads", "description": "图片文件。从卡片上传，或填一个容器可读的路径（如 /uploads/alice.jpg）。常见格式都支持（jpg/png/bmp/webp/tiff/gif...），过大的图会本地缩放，不需要预处理"},
                 "url":        {"type": "string", "description": "图片的 http(s) 地址，如 https://example.com/alice.jpg。下载后本地解码缩放，格式限制同 image_path"},
                 "name":       {"type": "string", "description": "姓名（结构化），如 \"小王\"。有 name 才算已注册；每次识别都会随 id 一起输出"},
                 "profile":    {"type": "object", "description": "非结构化画像对象，如 {\"gender\":\"male\",\"team\":\"运营部\",\"note\":\"常穿蓝色外套\"}。键名自定，随 name 一起在每帧输出；传字符串会被存成 {\"note\":\"...\"}"},
@@ -194,7 +201,7 @@ TOOLS = [
                 "info":   {"params": ["input_topic"], "description": "Report state, topics and database statistics"},
                 "config": {"params": [], "description": "Update configuration"},
                 "register_by_photo": {
-                    "params": ["image_path", "image_b64", "name", "profile"],
+                    "params": ["image_path", "name", "profile"],
                     "description": "Register a person from one photo. Fails with a reason when there is no face, no clear face, or no obvious subject",
                 },
                 "register_by_url": {
@@ -210,7 +217,7 @@ TOOLS = [
                     "description": "Register many people from a package of photos; returns a per-photo result saying which succeeded and why the others did not",
                 },
                 "recognize_by_photo": {
-                    "params": ["image_path", "image_b64", "url"],
+                    "params": ["image_path", "url"],
                     "description": "认出照片里的人 — 只读，不写库：返回每张人脸的 id/name/profile 与相似度，不会登记陌生人",
                 },
                 "recognize_by_stream": {
@@ -517,33 +524,37 @@ def _worst_reason(failures: list[dict]) -> dict:
 # ── image sources ─────────────────────────────────────────────────────────────
 
 def _load_image_bytes(args: dict, cfg: dict) -> tuple[bytes, str]:
-    """Read image bytes from `url`, `image_b64` or `image_path`.
+    """Read image bytes from `url` or `image_path`.
+
+    **Deliberately no base64 input.** It was there, and an LLM failed on it
+    twice in production: a 43 800-character string is not something a model can
+    carry through its own context reliably, and what arrived was truncated, so
+    the decoder correctly refused it. Both remaining channels move a *reference*
+    instead of the bytes.
 
     The byte ceiling here is a transfer/memory guard, not a policy limit: an
     image that is merely *large* is downscaled and converted locally by
     `FaceAnalyzer.decode_image`, because "your photo is 24 MB" or "we only take
     JPEG" is a limitation of ours rather than a property of their photo.
 
-    `url` is a distinct action (`register_by_url`) rather than a parameter
-    smuggled into the photo path, so the capability is visible on the card.
-    Note it does let a caller make this container issue an outbound request —
+    `url` is its own action (`register_by_url`) rather than a parameter
+    smuggled into the photo path, so the capability is visible on the card. Note
+    it does let a caller make this container issue an outbound request —
     acceptable for a deliberate, named action, which is why it is not folded
     into the generic input.
     """
     max_bytes = int(cfg.get("max_image_bytes", DEFAULT_MAX_IMAGE_BYTES))
 
-    encoded = args.get("image_b64")
-    if encoded:
-        try:
-            data = base64.b64decode(str(encoded), validate=True)
-        except (binascii.Error, ValueError) as error:
-            raise _BadInput(f"image_b64 is not valid base64: {error}", "image_b64")
-        if len(data) > max_bytes:
-            raise _BadInput(
-                f"image is {len(data)} bytes, over the {max_bytes} byte transfer "
-                "cap (raise max_image_bytes if this is a real photo)", "image_b64"
-            )
-        return data, "image_b64"
+    if args.get("image_b64"):
+        # Say what to do instead, rather than silently ignoring the argument:
+        # the model that reaches for base64 has the file in hand already.
+        raise _BadInput(
+            "image_b64 is no longer accepted — a long base64 string does not "
+            "survive being carried through an LLM's context. Use image_path "
+            "(upload from the card, or write the file into a directory both "
+            "agent-core and perception mount) or register_by_url instead.",
+            "image_b64",
+        )
 
     url = args.get("url") or args.get("image_url")
     if url:
@@ -553,7 +564,7 @@ def _load_image_bytes(args: dict, cfg: dict) -> tuple[bytes, str]:
     if path:
         return _read_local(str(path), cfg, max_bytes), str(path)
 
-    raise _BadInput("one of url, image_path or image_b64 is required")
+    raise _BadInput("one of image_path or url is required")
 
 
 def _image_roots(cfg: dict) -> tuple[str, ...]:
@@ -573,14 +584,23 @@ def _check_under_roots(path: str, cfg: dict) -> str:
     roots = _image_roots(cfg)
     if any(resolved == root or resolved.startswith(root + os.sep) for root in roots):
         return resolved
+    # A caller that names a plausible-but-invisible path is almost always
+    # another container's filesystem — agent-core's /work and /tmp are its own,
+    # which is exactly how the first LLM attempt failed. Say where to put it.
     raise _BadInput(
-        f"path must be under one of {', '.join(roots)}: got {path!r}", path
+        f"path must be under one of {', '.join(roots)}: got {path!r}. "
+        "If you are writing the file from another container (e.g. agent-core), "
+        "write it to /uploads — that directory is mounted into both — or use "
+        "register_by_url.",
+        path,
     )
 
 
 def _read_local(path: str, cfg: dict, max_bytes: int) -> bytes:
     resolved = _check_under_roots(path, cfg)
     try:
+        if os.path.isdir(resolved):
+            raise _BadInput(f"{path!r} is a directory, not an image", path)
         size = os.path.getsize(resolved)
         if size > max_bytes:
             raise _BadInput(

--- a/perception/plugins/face.py
+++ b/perception/plugins/face.py
@@ -151,13 +151,12 @@ TOOLS = [
                     "description": "ROS2 image topic to subscribe (e.g. /hostname/camera/rgb, required for action=start)",
                 },
                 "image_path": {"type": "string", "description": "Path to a JPEG/PNG readable by this container"},
-                "image_url":  {"type": "string", "description": "http(s) URL of a JPEG/PNG"},
                 "image_b64":  {"type": "string", "description": "Base64-encoded JPEG/PNG bytes"},
                 "profile":    {"type": "string", "description": "Who this person is — free text shown alongside the id on every sighting"},
                 "meta":       {"type": "object", "description": "Free-form metadata object (department, tags, notes...)"},
                 "meta_delete": {"type": "array", "items": {"type": "string"}, "description": "Meta keys to remove"},
                 "merge":      {"type": "boolean", "description": "Merge meta into the existing object (default true) instead of replacing it"},
-                "person_id":  {"type": "string", "description": "Existing person id — use an unknown-N id to give that identity a name"},
+                "person_id":  {"type": "string", "description": "Existing person id (p-N or unknown-N)"},
                 "window_s":   {"type": "number", "description": "Seconds of recent stream to analyse (default 3.0, capped by enroll_window_s)"},
                 "package":    {"type": "string", "description": "Directory, .zip or .tar.gz path/URL holding photos plus an optional manifest.json"},
                 "named":      {"type": "string", "enum": ["all", "named", "unknown"], "description": "Filter the roster (default all); with action=forget, 'unknown' clears every anonymous entry"},
@@ -172,11 +171,11 @@ TOOLS = [
                 "info":   {"params": ["input_topic"], "description": "Report state, topics and database statistics"},
                 "config": {"params": [], "description": "Update configuration"},
                 "register_user_photo": {
-                    "params": ["image_path", "image_url", "image_b64", "profile", "meta", "person_id"],
+                    "params": ["image_path", "image_b64", "profile", "meta"],
                     "description": "Register a person from one photo. Fails with a reason when there is no face, no clear face, or no obvious subject",
                 },
                 "register_current_stream": {
-                    "params": ["profile", "meta", "person_id", "window_s"],
+                    "params": ["profile", "meta", "window_s"],
                     "description": "Register the person currently in front of the camera, using the last few seconds of the live stream",
                 },
                 "register_user_photos": {
@@ -469,7 +468,13 @@ def _worst_reason(failures: list[dict]) -> dict:
 # ── image sources ─────────────────────────────────────────────────────────────
 
 def _load_image_bytes(args: dict, cfg: dict) -> tuple[bytes, str]:
-    """Fetch image bytes from whichever of the three sources was given."""
+    """Read image bytes from `image_b64` or `image_path`.
+
+    No URL source: the dashboard has no file-upload widget, so a path (confined
+    to `image_roots`) and inline base64 are what a caller actually has. Adding a
+    URL fetch would also give an unauthenticated LAN caller a request-forging
+    primitive from inside the robot's network for no benefit.
+    """
     max_bytes = int(cfg.get("max_image_bytes", DEFAULT_MAX_IMAGE_BYTES))
 
     encoded = args.get("image_b64")
@@ -484,15 +489,11 @@ def _load_image_bytes(args: dict, cfg: dict) -> tuple[bytes, str]:
             )
         return data, "image_b64"
 
-    url = args.get("image_url")
-    if url:
-        return _fetch_url(str(url), max_bytes), str(url)
-
     path = args.get("image_path")
     if path:
         return _read_local(str(path), cfg, max_bytes), str(path)
 
-    raise _BadInput("one of image_path, image_url or image_b64 is required")
+    raise _BadInput("one of image_path or image_b64 is required")
 
 
 def _image_roots(cfg: dict) -> tuple[str, ...]:
@@ -885,9 +886,10 @@ class _FaceNode(Node):
 
     def _recognise_to_payload(self, image_bytes: bytes, timestamp: float) -> dict:
         started = time.time()
+        # No `topic` field: a subscriber already knows which topic it read
+        # this from, and OCR's build_ocr_payload does not carry one either.
         payload: dict[str, Any] = {
             "ts": timestamp,
-            "topic": self._input_topic,
             "count": 0,
             "faces": [],
         }
@@ -1588,9 +1590,15 @@ class FaceRecognitionPlugin:
         embedding, failure = self._analyze_subject(engine, data, gates)
         if embedding is None:
             return {**failure, "source": source}
+        # No person_id input: which identity a photo belongs to is decided by
+        # matching, not by the caller. A face that matches an existing person
+        # becomes another sample of them; one that matches an unknown-N promotes
+        # that entry in place. Naming an identity after the fact is
+        # `update_person`, and grouping several photos under one person is the
+        # batch manifest's `person` key.
         result = self._commit_enrolment(
             engine, [embedding], str(args.get("profile") or ""),
-            args.get("meta"), args.get("person_id") or None, gates,
+            args.get("meta"), None, gates,
         )
         if result.get("ok"):
             log.info("[face] registered %s from %s: %s", result["person_id"],
@@ -1685,7 +1693,7 @@ class FaceRecognitionPlugin:
 
         result = self._commit_enrolment(
             engine, agreeing, str(args.get("profile") or ""),
-            args.get("meta"), args.get("person_id") or None, gates,
+            args.get("meta"), None, gates,
         )
         if result.get("ok"):
             log.info("[face] registered %s from the live stream (%d/%d frames): %s",

--- a/perception/plugins/face.py
+++ b/perception/plugins/face.py
@@ -160,7 +160,8 @@ TOOLS = [
                         "start", "stop", "info", "config",
                         "register_by_photo", "register_by_url",
                         "register_by_stream", "register_by_corpus",
-                        "recognize_by_photo", "recognize_by_stream",
+                        "recognize_by_photo", "recognize_by_url",
+                        "recognize_by_stream",
                         "list_persons", "get_person", "update_person", "forget",
                         "list_visits",
                     ],
@@ -216,8 +217,12 @@ TOOLS = [
                     "description": "Register many people from a package of photos; returns a per-photo result saying which succeeded and why the others did not",
                 },
                 "recognize_by_photo": {
-                    "params": ["image_path", "url"],
+                    "params": ["image_path"],
                     "description": "认出照片里的人 — 只读，不写库：返回每张人脸的 id/name/profile 与相似度，不会登记陌生人",
+                },
+                "recognize_by_url": {
+                    "params": ["url"],
+                    "description": "认出图片 URL 里的人 — 只读，不写库。和 recognize_by_photo 相同，只是图片来自 http(s) 而非本地文件",
                 },
                 "recognize_by_stream": {
                     "params": ["window_s"],
@@ -1282,7 +1287,7 @@ class FaceRecognitionPlugin:
             return self._do_register_by_stream(instance_id, args)
         if action == "register_by_corpus":
             return self._do_register_by_corpus(args)
-        if action == "recognize_by_photo":
+        if action in ("recognize_by_photo", "recognize_by_url"):
             return self._do_recognize_by_photo(args)
         if action == "recognize_by_stream":
             return self._do_recognize_by_stream(instance_id, args)

--- a/perception/plugins/face.py
+++ b/perception/plugins/face.py
@@ -95,10 +95,10 @@ DEFAULT_MAX_BATCH = 200
 # this only has to be larger than any real photo. 64 MB covers a 60 MP
 # uncompressed-ish PNG; the pixel cap is what actually protects memory.
 DEFAULT_MAX_IMAGE_BYTES = 64 * 1024 * 1024
-# /uploads first: it is the only one of these that agent-core also mounts, so
-# it is the only path a caller outside this container can hand over. See
-# deploy/service.yml.
-DEFAULT_IMAGE_ROOTS = ("/uploads", "/models", "/tmp", "/work")
+# /models/uploads is where the file-intake endpoint writes (see
+# utils/file_intake.py and the `file_intake` block in config.yaml); /models is
+# already listed, which covers it.
+DEFAULT_IMAGE_ROOTS = ("/models", "/tmp", "/work")
 
 
 def detect_interval(cfg: dict) -> float:
@@ -170,14 +170,13 @@ TOOLS = [
                     "type": "string",
                     "description": "ROS2 image topic to subscribe (e.g. /hostname/camera/rgb, required for action=start)",
                 },
-                # `format: file` makes the canvas render a file picker that
-                # uploads through agent-core's /api/file/upload and fills the
-                # resulting path back in — the same mechanism agent-core's own
-                # `remote_image` card uses for `image_file`. The upload lands in
-                # a directory both containers mount (see image_roots below), so
-                # the path this card receives is one perception can actually
-                # open.
-                "image_path": {"type": "string", "format": "file", "accept": "image/*", "uploadDir": "/uploads", "description": "图片文件。从卡片上传，或填一个容器可读的路径（如 /uploads/alice.jpg）。常见格式都支持（jpg/png/bmp/webp/tiff/gif...），过大的图会本地缩放，不需要预处理"},
+                # `format: file` makes the canvas render a file picker;
+                # `uploadTo: mcp` sends it to POST /api/mcp/<id>/file/upload,
+                # which streams the bytes to *this* service and returns the path
+                # they landed on here. So the value this field receives is
+                # already a path perception can open — no shared mount, and no
+                # container recreation to make one appear.
+                "image_path": {"type": "string", "format": "file", "accept": "image/*", "uploadTo": "mcp", "description": "图片文件。从卡片上传，或填一个容器可读的路径（如 /uploads/alice.jpg）。常见格式都支持（jpg/png/bmp/webp/tiff/gif...），过大的图会本地缩放，不需要预处理"},
                 "url":        {"type": "string", "description": "图片的 http(s) 地址，如 https://example.com/alice.jpg。下载后本地解码缩放，格式限制同 image_path"},
                 "name":       {"type": "string", "description": "姓名（结构化），如 \"小王\"。有 name 才算已注册；每次识别都会随 id 一起输出"},
                 "profile":    {"type": "object", "description": "非结构化画像对象，如 {\"gender\":\"male\",\"team\":\"运营部\",\"note\":\"常穿蓝色外套\"}。键名自定，随 name 一起在每帧输出；传字符串会被存成 {\"note\":\"...\"}"},
@@ -550,9 +549,9 @@ def _load_image_bytes(args: dict, cfg: dict) -> tuple[bytes, str]:
         # the model that reaches for base64 has the file in hand already.
         raise _BadInput(
             "image_b64 is no longer accepted — a long base64 string does not "
-            "survive being carried through an LLM's context. Use image_path "
-            "(upload from the card, or write the file into a directory both "
-            "agent-core and perception mount) or register_by_url instead.",
+            "survive being carried through an LLM's context. Upload the file "
+            "through POST /api/mcp/<mcp_id>/file/upload and pass the path it "
+            "returns as image_path, or use register_by_url.",
             "image_b64",
         )
 
@@ -590,8 +589,9 @@ def _check_under_roots(path: str, cfg: dict) -> str:
     raise _BadInput(
         f"path must be under one of {', '.join(roots)}: got {path!r}. "
         "If you are writing the file from another container (e.g. agent-core), "
-        "write it to /uploads — that directory is mounted into both — or use "
-        "register_by_url.",
+        "If you are calling from another container, upload the file through "
+        "POST /api/mcp/<mcp_id>/file/upload — the reply carries a path this "
+        "container can open — or use register_by_url.",
         path,
     )
 

--- a/perception/plugins/face_db.py
+++ b/perception/plugins/face_db.py
@@ -615,48 +615,85 @@ class FaceDB:
         with self._lock:
             self._save_locked()
 
+    def _drop_locked(self, ids) -> list[str]:
+        """Remove these people and their embedding rows. Caller holds the lock.
+
+        Does **not** save: the caller decides when to commit, so a batch delete
+        is one rewrite rather than one per person. That matters more than it
+        sounds — every save writes a fresh `embeddings-<n>.npy` and rewrites
+        `persons.json`, so clearing 50 strangers one at a time meant 50 full
+        rewrites of the entire database onto eMMC.
+
+        Takes an *ordered* iterable and returns the removals in that order.
+        Iterating a set here instead made `forget_many`'s result order
+        hash-dependent, so a caller could not line its request up against the
+        response.
+
+        Also drops any visit in progress for those people, which would
+        otherwise be appended later under an id that no longer exists.
+        """
+        removed = [
+            pid for pid in dict.fromkeys(ids) if pid in self._persons
+        ]
+        if not removed:
+            return []
+        for pid in removed:
+            del self._persons[pid]
+            self._open_visits.pop(pid, None)
+        doomed = set(removed)
+        keep = [i for i, owner in enumerate(self._row_owners) if owner not in doomed]
+        if len(keep) != len(self._row_owners):
+            self._row_owners = [self._row_owners[i] for i in keep]
+            self._matrix = (
+                self._matrix[keep] if keep
+                else np.zeros((0, EMBEDDING_DIM), dtype=np.float32)
+            )
+        return removed
+
     def forget(self, person_id: str) -> bool:
         """Delete one person, their samples and their embedding rows."""
         with self._lock:
-            if person_id not in self._persons:
+            if not self._drop_locked([person_id]):
                 return False
-            del self._persons[person_id]
-            keep = [
-                index for index, owner in enumerate(self._row_owners)
-                if owner != person_id
-            ]
-            if len(keep) != len(self._row_owners):
-                self._row_owners = [self._row_owners[i] for i in keep]
-                self._matrix = (
-                    self._matrix[keep] if keep
-                    else np.zeros((0, EMBEDDING_DIM), dtype=np.float32)
-                )
             self._save_locked()
         log.info("[face_db] forgot %s", person_id)
         return True
 
+    def forget_many(self, person_ids) -> dict:
+        """Delete several people in one commit.
+
+        Returns `{"forgotten": [...], "missing": [...]}` rather than a count:
+        given a list of ids the caller needs to know *which* were not there, and
+        a partial result is the normal case — a stale id, a typo, or an entry
+        another operator already removed.
+        """
+        wanted = [str(pid) for pid in person_ids if str(pid).strip()]
+        unique = list(dict.fromkeys(wanted))          # de-dup, preserve order
+        with self._lock:
+            # `unique` is already ordered, so the response lines up with the
+            # request; passing a set here made the result order hash-dependent.
+            removed = self._drop_locked(unique)
+            if removed:
+                self._save_locked()
+        removed_set = set(removed)
+        missing = [pid for pid in unique if pid not in removed_set]
+        if removed:
+            log.info("[face_db] forgot %d person(s) in one commit", len(removed))
+        return {"forgotten": removed, "missing": missing}
+
     def forget_unknowns(self) -> int:
         """Delete every anonymous entry. Named people are untouched."""
         with self._lock:
+            # A list, not a set: roster order is insertion order, which keeps
+            # the return value deterministic.
             targets = [
-                person_id for person_id, person in self._persons.items()
+                pid for pid, person in self._persons.items()
                 if not person["named"]
             ]
-            for person_id in targets:
-                del self._persons[person_id]
-            if targets:
-                dropped = set(targets)
-                keep = [
-                    index for index, owner in enumerate(self._row_owners)
-                    if owner not in dropped
-                ]
-                self._row_owners = [self._row_owners[i] for i in keep]
-                self._matrix = (
-                    self._matrix[keep] if keep
-                    else np.zeros((0, EMBEDDING_DIM), dtype=np.float32)
-                )
+            removed = self._drop_locked(targets)
+            if removed:
                 self._save_locked()
-        return len(targets)
+        return len(removed)
 
     # ── capacity ──────────────────────────────────────────────────────────
 

--- a/perception/plugins/face_db.py
+++ b/perception/plugins/face_db.py
@@ -1,0 +1,675 @@
+#!/usr/bin/env python3
+"""
+plugins/face_db.py — 人脸身份持久化存储。
+
+Holds every enrolled identity (named people and auto-assigned `unknown-N`
+entries) plus their face embeddings, on disk under a `/models` subdirectory —
+the only host-mounted writable path the perception container has (see
+`perception/deploy/service.yml`).
+
+Two files, and **`persons.json` is the commit point**:
+
+    persons.json        metadata + row ownership + the name of the embeddings
+                        file this metadata belongs to
+    embeddings-<n>.npy  float32 [rows, 512], L2-normalised, one row per sample
+
+The embeddings file is written under a *fresh* name first and `persons.json`
+replaced last, so the two can never be observed out of step: until the new
+`persons.json` lands, the old pair is still the committed state, and a crash at
+any point leaves a consistent database. Superseded `.npy` files are removed
+only after the commit succeeds. Writing `embeddings.npy` in place instead —
+two `os.replace` calls, either order — has a window where the row count and the
+owner list disagree, which silently misattributes every identity after the
+missing row.
+
+Matching is a single `matrix @ embedding`: both sides are L2-normalised, so the
+dot product *is* the cosine similarity and no `sklearn` is needed (it is not in
+the image). Rows are per *sample*, not per person, and a person's score is the
+best of its samples — a mean-vector centroid blurs the pose variation that
+several enrolment photos exist to capture.
+
+Thread safety: `register_*` runs on arbitrary `ThreadingHTTPServer` threads
+(see `perception/README.md` § "Plugin Concurrency") while the recognition
+worker calls `match()` at frame rate. Every public method takes an `RLock`, and
+every *write* additionally takes an `fcntl` lock on a file in `db_dir`, the same
+belt-and-braces `utils/model_downloader.py` uses for a shared `/models`.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import threading
+import time
+from typing import Any, Iterable
+
+import numpy as np
+
+from utils.log_sampling import escape_log_text
+from utils.model_downloader import require_models_subpath
+
+try:  # Linux only; the perception images are Linux, dev hosts may not be.
+    import fcntl
+except ImportError:  # pragma: no cover - Windows/macOS dev hosts
+    fcntl = None
+
+log = logging.getLogger(__name__)
+
+DEFAULT_DB_DIR = "/models/face_db"
+EMBEDDING_DIM = 512
+
+DEFAULT_UNKNOWN_CAPACITY = 500
+DEFAULT_MAX_SAMPLES_PER_PERSON = 8
+
+_PERSONS_FILE = "persons.json"
+_LOCK_FILE = ".face_db.lock"
+_EMBEDDINGS_PREFIX = "embeddings-"
+_EMBEDDINGS_SUFFIX = ".npy"
+
+UNKNOWN_PREFIX = "unknown-"
+NAMED_PREFIX = "p-"
+
+
+class FaceDBError(RuntimeError):
+    """The database on disk exists but cannot be used as-is."""
+
+
+def is_unknown_id(person_id: str) -> bool:
+    return str(person_id).startswith(UNKNOWN_PREFIX)
+
+
+def _now() -> float:
+    return time.time()
+
+
+def _normalize(vector: np.ndarray) -> np.ndarray:
+    """Return a float32 unit vector, so a dot product is a cosine."""
+    array = np.asarray(vector, dtype=np.float32).reshape(-1)
+    if array.size != EMBEDDING_DIM:
+        raise ValueError(
+            f"embedding must have {EMBEDDING_DIM} dims, got {array.size}"
+        )
+    norm = float(np.linalg.norm(array))
+    if norm <= 1e-8:
+        raise ValueError("embedding has zero norm")
+    return (array / norm).astype(np.float32)
+
+
+def _clean_meta(meta: Any) -> dict:
+    """Accept only a JSON-serialisable object for the free-form meta field.
+
+    Meta comes from an MCP caller and is written straight to disk; a value that
+    cannot be serialised would fail at save time, i.e. *after* the in-memory
+    state had already changed. Validate on the way in instead.
+    """
+    if meta is None:
+        return {}
+    if not isinstance(meta, dict):
+        raise ValueError("meta must be a JSON object")
+    try:
+        json.dumps(meta, ensure_ascii=False)
+    except (TypeError, ValueError) as error:
+        raise ValueError(f"meta is not JSON-serialisable: {error}") from error
+    return dict(meta)
+
+
+class FaceDB:
+    """Persistent store of enrolled identities and their face embeddings."""
+
+    def __init__(
+        self,
+        db_dir: str = DEFAULT_DB_DIR,
+        unknown_capacity: int = DEFAULT_UNKNOWN_CAPACITY,
+        max_samples_per_person: int = DEFAULT_MAX_SAMPLES_PER_PERSON,
+    ):
+        # db_dir arrives over MCP config and this process runs as root in the
+        # container; the same validation model_downloader applies to model_dir.
+        self._dir = require_models_subpath(db_dir)
+        self._unknown_capacity = max(0, int(unknown_capacity))
+        self._max_samples = max(1, int(max_samples_per_person))
+
+        self._lock = threading.RLock()
+        self._persons: dict[str, dict] = {}
+        self._row_owners: list[str] = []
+        self._matrix = np.zeros((0, EMBEDDING_DIM), dtype=np.float32)
+        self._next_ids = {"named": 1, "unknown": 1}
+        self._generation = 0
+
+        self._load()
+
+    # ── persistence ───────────────────────────────────────────────────────
+
+    @property
+    def path(self) -> str:
+        return self._dir
+
+    def _persons_path(self) -> str:
+        return os.path.join(self._dir, _PERSONS_FILE)
+
+    def _embeddings_name(self, generation: int) -> str:
+        return f"{_EMBEDDINGS_PREFIX}{generation}{_EMBEDDINGS_SUFFIX}"
+
+    def _load(self) -> None:
+        persons_path = self._persons_path()
+        if not os.path.exists(persons_path):
+            log.info("[face_db] no database at %s; starting empty", self._dir)
+            return
+        try:
+            with open(persons_path, encoding="utf-8") as handle:
+                state = json.load(handle)
+        except (OSError, ValueError) as error:
+            raise FaceDBError(
+                f"{persons_path} is unreadable: {escape_log_text(error)}"
+            ) from error
+
+        embeddings_file = state.get("embeddings_file")
+        rows = list(state.get("rows") or [])
+        matrix = np.zeros((0, EMBEDDING_DIM), dtype=np.float32)
+        if embeddings_file:
+            matrix_path = os.path.join(self._dir, os.path.basename(embeddings_file))
+            try:
+                matrix = np.load(matrix_path).astype(np.float32, copy=False)
+            except (OSError, ValueError) as error:
+                # The commit point named a file that is gone or corrupt. Do not
+                # silently continue with no embeddings: recognition would report
+                # every enrolled person as unknown while the dashboard showed a
+                # populated database. Surfaced as the plugin's error state.
+                raise FaceDBError(
+                    f"embeddings file {matrix_path} named by {_PERSONS_FILE} is "
+                    f"unusable: {escape_log_text(error)}"
+                ) from error
+        if matrix.ndim != 2 or matrix.shape[0] != len(rows) or (
+            matrix.size and matrix.shape[1] != EMBEDDING_DIM
+        ):
+            raise FaceDBError(
+                f"database at {self._dir} is inconsistent: {len(rows)} row owners "
+                f"but embeddings shape {matrix.shape}"
+            )
+
+        persons: dict[str, dict] = {}
+        for entry in state.get("persons") or []:
+            person_id = str(entry.get("id") or "").strip()
+            if not person_id:
+                continue
+            persons[person_id] = {
+                "id": person_id,
+                "profile": str(entry.get("profile") or ""),
+                "named": bool(entry.get("named", not is_unknown_id(person_id))),
+                "meta": entry.get("meta") if isinstance(entry.get("meta"), dict) else {},
+                "created_at": float(entry.get("created_at") or _now()),
+                "updated_at": float(entry.get("updated_at") or _now()),
+                "last_seen_at": float(entry.get("last_seen_at") or 0.0),
+            }
+
+        # A row owned by a person that is not in the table would make
+        # `_person_scores` attribute a sample to nobody; drop those rows rather
+        # than carry a matrix the metadata cannot explain.
+        keep = [index for index, owner in enumerate(rows) if owner in persons]
+        if len(keep) != len(rows):
+            log.warning("[face_db] dropping %d orphaned embedding row(s)",
+                        len(rows) - len(keep))
+            rows = [rows[index] for index in keep]
+            matrix = matrix[keep] if matrix.size else matrix
+
+        next_ids = state.get("next_ids") or {}
+        self._persons = persons
+        self._row_owners = [str(owner) for owner in rows]
+        self._matrix = matrix if matrix.size else np.zeros(
+            (0, EMBEDDING_DIM), dtype=np.float32
+        )
+        self._next_ids = {
+            "named": max(1, int(next_ids.get("named", 1))),
+            "unknown": max(1, int(next_ids.get("unknown", 1))),
+        }
+        self._generation = max(0, int(state.get("generation") or 0))
+        log.info("[face_db] loaded %d person(s), %d sample(s) from %s",
+                 len(self._persons), len(self._row_owners), self._dir)
+
+    def _save_locked(self) -> None:
+        """Persist the current state. Caller holds `self._lock`.
+
+        The embeddings file is written under a new generation name and
+        `persons.json` — which names it — is replaced last. See the module
+        docstring for why the order matters.
+        """
+        os.makedirs(self._dir, exist_ok=True)
+        lock_path = os.path.join(self._dir, _LOCK_FILE)
+        with open(lock_path, "a+b") as lock_file:
+            if fcntl is not None:
+                fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+            try:
+                generation = self._generation + 1
+                matrix_name = self._embeddings_name(generation)
+                matrix_path = os.path.join(self._dir, matrix_name)
+
+                # np.save() appends ".npy" to any path that lacks it, which
+                # would silently write beside a ".tmp" staging name and leave
+                # the file we then rename empty. Passing an open handle makes
+                # it write exactly where we asked.
+                tmp_matrix = os.path.join(self._dir, f".{matrix_name}.tmp")
+                try:
+                    with open(tmp_matrix, "wb") as handle:
+                        np.save(handle, self._matrix, allow_pickle=False)
+                        handle.flush()
+                        os.fsync(handle.fileno())
+                    os.replace(tmp_matrix, matrix_path)
+                finally:
+                    if os.path.exists(tmp_matrix):
+                        os.unlink(tmp_matrix)
+
+                state = {
+                    "version": 1,
+                    "generation": generation,
+                    "embeddings_file": matrix_name,
+                    "next_ids": dict(self._next_ids),
+                    "rows": list(self._row_owners),
+                    "persons": [
+                        dict(person) for person in self._persons.values()
+                    ],
+                }
+                persons_path = self._persons_path()
+                tmp_persons = f"{persons_path}.tmp"
+                with open(tmp_persons, "w", encoding="utf-8") as handle:
+                    json.dump(state, handle, ensure_ascii=False, indent=2)
+                    handle.flush()
+                    os.fsync(handle.fileno())
+                os.replace(tmp_persons, persons_path)   # ← commit point
+                self._generation = generation
+
+                # Only now is the previous embeddings file unreachable.
+                for name in os.listdir(self._dir):
+                    if (
+                        name.startswith(_EMBEDDINGS_PREFIX)
+                        and name.endswith(_EMBEDDINGS_SUFFIX)
+                        and name != matrix_name
+                    ):
+                        try:
+                            os.unlink(os.path.join(self._dir, name))
+                        except OSError:  # noqa: PERF203 - best-effort cleanup
+                            pass
+            finally:
+                if fcntl is not None:
+                    fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+
+    # ── ids ───────────────────────────────────────────────────────────────
+
+    def _allocate_id_locked(self, named: bool) -> str:
+        """Return a fresh id. Counters only ever increase, so an id retired by
+        `forget()` is never handed to a different person later — a stale
+        reference in a conversation history or a peer's notes must not resolve
+        to somebody else."""
+        key = "named" if named else "unknown"
+        prefix = NAMED_PREFIX if named else UNKNOWN_PREFIX
+        while True:
+            number = self._next_ids[key]
+            self._next_ids[key] = number + 1
+            candidate = f"{prefix}{number}"
+            if candidate not in self._persons:
+                return candidate
+
+    # ── matching ──────────────────────────────────────────────────────────
+
+    def _person_scores_locked(self, embedding: np.ndarray) -> dict[str, float]:
+        if not self._row_owners:
+            return {}
+        scores = self._matrix @ embedding
+        best: dict[str, float] = {}
+        for owner, score in zip(self._row_owners, scores):
+            value = float(score)
+            if value > best.get(owner, -2.0):
+                best[owner] = value
+        return best
+
+    def match(
+        self, embedding: np.ndarray, threshold: float
+    ) -> tuple[str | None, float]:
+        """Best matching person id above `threshold`, plus the score.
+
+        Returns `(None, best_score)` when nothing clears the threshold, so the
+        caller can log how close it came — the number an operator needs when
+        tuning `match_threshold`. `best_score` is `-1.0` on an empty database.
+        """
+        vector = _normalize(embedding)
+        with self._lock:
+            scores = self._person_scores_locked(vector)
+            if not scores:
+                return None, -1.0
+            person_id = max(scores, key=lambda key: scores[key])
+            best = scores[person_id]
+            if best < float(threshold):
+                return None, best
+            return person_id, best
+
+    # ── writes ────────────────────────────────────────────────────────────
+
+    def _add_rows_locked(self, person_id: str, vectors: list[np.ndarray]) -> None:
+        """Append samples for one person, capped at `max_samples_per_person`.
+
+        Oldest-first eviction: rows are appended in enrolment order, so keeping
+        the tail keeps the most recent captures — the ones most likely to match
+        how the person looks now.
+        """
+        if not vectors:
+            return
+        stacked = np.stack(vectors).astype(np.float32, copy=False)
+        self._matrix = (
+            np.concatenate([self._matrix, stacked])
+            if self._matrix.size
+            else stacked
+        )
+        self._row_owners.extend([person_id] * len(vectors))
+
+        owned = [i for i, owner in enumerate(self._row_owners) if owner == person_id]
+        if len(owned) > self._max_samples:
+            drop = set(owned[: len(owned) - self._max_samples])
+            keep = [i for i in range(len(self._row_owners)) if i not in drop]
+            self._row_owners = [self._row_owners[i] for i in keep]
+            self._matrix = self._matrix[keep]
+
+    def _samples_locked(self, person_id: str) -> int:
+        """Sample count, always derived from the row owners rather than stored.
+
+        A cached count is one more thing that can drift out of step with the
+        matrix after an eviction; this is an O(rows) scan over a few thousand
+        strings and runs only on the reporting paths, not per frame.
+        """
+        return sum(1 for owner in self._row_owners if owner == person_id)
+
+    def _record_locked(self, person_id: str) -> dict:
+        person = self._persons[person_id]
+        return {
+            "id": person["id"],
+            "profile": person["profile"],
+            "named": person["named"],
+            "meta": dict(person["meta"]),
+            "samples": self._samples_locked(person_id),
+            "created_at": person["created_at"],
+            "updated_at": person["updated_at"],
+            "last_seen_at": person["last_seen_at"],
+        }
+
+    def add(
+        self,
+        profile: str,
+        embeddings: Iterable[np.ndarray],
+        named: bool = True,
+        meta: Any = None,
+        person_id: str | None = None,
+    ) -> dict:
+        """Enrol a new identity and return its record."""
+        vectors = [_normalize(item) for item in embeddings]
+        if not vectors:
+            raise ValueError("at least one embedding is required")
+        clean_meta = _clean_meta(meta)
+        with self._lock:
+            if person_id:
+                if person_id in self._persons:
+                    raise ValueError(f"person {person_id!r} already exists")
+                new_id = str(person_id)
+            else:
+                new_id = self._allocate_id_locked(named)
+            timestamp = _now()
+            self._persons[new_id] = {
+                "id": new_id,
+                "profile": str(profile or ""),
+                "named": bool(named),
+                "meta": clean_meta,
+                "created_at": timestamp,
+                "updated_at": timestamp,
+                "last_seen_at": timestamp,
+            }
+            self._add_rows_locked(new_id, vectors)
+            if not named:
+                self._evict_unknowns_locked()
+            record = self._record_locked(new_id) if new_id in self._persons else None
+            self._save_locked()
+        if record is None:
+            # Capacity 0: the entry was evicted by the same call that made it.
+            raise FaceDBError("unknown_capacity is 0; cannot enrol unknown faces")
+        log.info("[face_db] enrolled %s (named=%s, samples=%d): %s",
+                 new_id, named, record["samples"],
+                 escape_log_text(record["profile"]))
+        return record
+
+    def add_samples(self, person_id: str, embeddings: Iterable[np.ndarray]) -> dict:
+        """Attach more face samples to an existing person."""
+        vectors = [_normalize(item) for item in embeddings]
+        if not vectors:
+            raise ValueError("at least one embedding is required")
+        with self._lock:
+            if person_id not in self._persons:
+                raise KeyError(person_id)
+            self._add_rows_locked(person_id, vectors)
+            self._persons[person_id]["updated_at"] = _now()
+            record = self._record_locked(person_id)
+            self._save_locked()
+        return record
+
+    def enroll_unknown(self, embedding: np.ndarray) -> dict:
+        """Create an anonymous `unknown-N` entry for a face nobody has named."""
+        return self.add("", [embedding], named=False)
+
+    def promote(
+        self, person_id: str, profile: str, meta: Any = None, merge: bool = True
+    ) -> dict:
+        """Turn an `unknown-N` entry into a named person, **keeping its id**.
+
+        The id is deliberately preserved rather than reissued as `p-N`: it is
+        what already appeared on the activity stream and in the agent's
+        conversation history for every earlier sighting, and rewriting it would
+        orphan all of that.
+        """
+        return self.update_person(person_id, profile=profile, meta=meta, merge=merge)
+
+    def update_person(
+        self,
+        person_id: str,
+        profile: str | None = None,
+        meta: Any = None,
+        meta_delete: Iterable[str] | None = None,
+        merge: bool = True,
+    ) -> dict:
+        """Edit a person's profile and/or free-form meta."""
+        clean_meta = _clean_meta(meta) if meta is not None else None
+        delete_keys = [str(key) for key in (meta_delete or [])]
+        with self._lock:
+            person = self._persons.get(person_id)
+            if person is None:
+                raise KeyError(person_id)
+            changed = False
+            if profile is not None:
+                person["profile"] = str(profile)
+                # A profile is what makes an entry a *named* person; setting one
+                # on an unknown promotes it in place.
+                if str(profile).strip() and not person["named"]:
+                    person["named"] = True
+                    log.info("[face_db] %s promoted to a named person", person_id)
+                changed = True
+            if clean_meta is not None:
+                person["meta"] = (
+                    {**person["meta"], **clean_meta} if merge else clean_meta
+                )
+                changed = True
+            for key in delete_keys:
+                if key in person["meta"]:
+                    del person["meta"][key]
+                    changed = True
+            if changed:
+                person["updated_at"] = _now()
+            record = self._record_locked(person_id)
+            if changed:
+                self._save_locked()
+        return record
+
+    def touch(self, person_id: str, when: float | None = None) -> None:
+        """Record a sighting. Drives `unknown_capacity` eviction order.
+
+        Cheap and deliberately not persisted on its own: this runs at frame
+        rate, and rewriting the database per frame would hammer the flash. The
+        value reaches disk with the next real write.
+        """
+        with self._lock:
+            person = self._persons.get(person_id)
+            if person is not None:
+                person["last_seen_at"] = float(when if when is not None else _now())
+
+    def flush(self) -> None:
+        """Persist pending in-memory changes (e.g. `touch` timestamps)."""
+        with self._lock:
+            self._save_locked()
+
+    def forget(self, person_id: str) -> bool:
+        """Delete one person, their samples and their embedding rows."""
+        with self._lock:
+            if person_id not in self._persons:
+                return False
+            del self._persons[person_id]
+            keep = [
+                index for index, owner in enumerate(self._row_owners)
+                if owner != person_id
+            ]
+            if len(keep) != len(self._row_owners):
+                self._row_owners = [self._row_owners[i] for i in keep]
+                self._matrix = (
+                    self._matrix[keep] if keep
+                    else np.zeros((0, EMBEDDING_DIM), dtype=np.float32)
+                )
+            self._save_locked()
+        log.info("[face_db] forgot %s", person_id)
+        return True
+
+    def forget_unknowns(self) -> int:
+        """Delete every anonymous entry. Named people are untouched."""
+        with self._lock:
+            targets = [
+                person_id for person_id, person in self._persons.items()
+                if not person["named"]
+            ]
+            for person_id in targets:
+                del self._persons[person_id]
+            if targets:
+                dropped = set(targets)
+                keep = [
+                    index for index, owner in enumerate(self._row_owners)
+                    if owner not in dropped
+                ]
+                self._row_owners = [self._row_owners[i] for i in keep]
+                self._matrix = (
+                    self._matrix[keep] if keep
+                    else np.zeros((0, EMBEDDING_DIM), dtype=np.float32)
+                )
+                self._save_locked()
+        return len(targets)
+
+    # ── capacity ──────────────────────────────────────────────────────────
+
+    def _evict_unknowns_locked(self) -> int:
+        """Trim anonymous entries to `unknown_capacity`, oldest sighting first.
+
+        Named people are never candidates: the cap exists to bound automatic
+        enrolment, not to expire people somebody deliberately registered.
+        """
+        unknowns = [
+            person for person in self._persons.values() if not person["named"]
+        ]
+        excess = len(unknowns) - self._unknown_capacity
+        if excess <= 0:
+            return 0
+        unknowns.sort(key=lambda person: (person["last_seen_at"], person["created_at"]))
+        doomed = {person["id"] for person in unknowns[:excess]}
+        for person_id in doomed:
+            del self._persons[person_id]
+        keep = [
+            index for index, owner in enumerate(self._row_owners)
+            if owner not in doomed
+        ]
+        self._row_owners = [self._row_owners[i] for i in keep]
+        self._matrix = (
+            self._matrix[keep] if keep
+            else np.zeros((0, EMBEDDING_DIM), dtype=np.float32)
+        )
+        log.info("[face_db] evicted %d unknown entr(ies) over capacity %d",
+                 len(doomed), self._unknown_capacity)
+        return len(doomed)
+
+    def set_unknown_capacity(self, capacity: int) -> int:
+        """Change the ceiling and apply it now. Returns how many were evicted."""
+        with self._lock:
+            self._unknown_capacity = max(0, int(capacity))
+            evicted = self._evict_unknowns_locked()
+            if evicted:
+                self._save_locked()
+        return evicted
+
+    @property
+    def unknown_capacity(self) -> int:
+        return self._unknown_capacity
+
+    # ── reads ─────────────────────────────────────────────────────────────
+
+    def get_person(self, person_id: str) -> dict:
+        with self._lock:
+            if person_id not in self._persons:
+                raise KeyError(person_id)
+            return self._record_locked(person_id)
+
+    def list_persons(
+        self,
+        named: str = "all",
+        query: str = "",
+        limit: int = 100,
+        offset: int = 0,
+    ) -> dict:
+        """Page through the roster. Never returns embeddings."""
+        wanted = str(named or "all").lower()
+        needle = str(query or "").strip().lower()
+        with self._lock:
+            records = [
+                self._record_locked(person_id) for person_id in self._persons
+            ]
+        if wanted == "named":
+            records = [r for r in records if r["named"]]
+        elif wanted == "unknown":
+            records = [r for r in records if not r["named"]]
+        if needle:
+            def matches(record: dict) -> bool:
+                haystack = " ".join([
+                    record["id"], record["profile"],
+                    json.dumps(record["meta"], ensure_ascii=False),
+                ]).lower()
+                return needle in haystack
+            records = [r for r in records if matches(r)]
+        records.sort(key=lambda record: (not record["named"], -record["updated_at"]))
+        total = len(records)
+        start = max(0, int(offset))
+        end = start + max(0, int(limit)) if limit else total
+        return {
+            "total": total,
+            "offset": start,
+            "limit": int(limit),
+            "persons": records[start:end],
+        }
+
+    def stats(self) -> dict:
+        with self._lock:
+            named = sum(1 for person in self._persons.values() if person["named"])
+            return {
+                "persons": len(self._persons),
+                "named": named,
+                "unknown": len(self._persons) - named,
+                "samples": len(self._row_owners),
+                "unknown_capacity": self._unknown_capacity,
+                "db_dir": self._dir,
+            }
+
+
+__all__ = [
+    "DEFAULT_DB_DIR",
+    "DEFAULT_MAX_SAMPLES_PER_PERSON",
+    "DEFAULT_UNKNOWN_CAPACITY",
+    "EMBEDDING_DIM",
+    "FaceDB",
+    "FaceDBError",
+    "is_unknown_id",
+]

--- a/perception/plugins/face_db.py
+++ b/perception/plugins/face_db.py
@@ -7,11 +7,39 @@ entries) plus their face embeddings, on disk under a `/models` subdirectory —
 the only host-mounted writable path the perception container has (see
 `perception/deploy/service.yml`).
 
-Two files, and **`persons.json` is the commit point**:
+Three files, and **`persons.json` is the commit point**:
 
     persons.json        metadata + row ownership + the name of the embeddings
                         file this metadata belongs to
     embeddings-<n>.npy  float32 [rows, 512], L2-normalised, one row per sample
+    visits.jsonl        append-only sighting log, one line per *visit*
+
+A person record separates the structured fields from the free-form ones:
+
+    id              p-N (named) or unknown-N
+    name            str  — structured. A non-blank name is what makes an entry
+                    "named"; publishing it is how the agent addresses someone.
+    profile         object — non-structured: gender, appearance, notes, tags.
+                    Whatever the operator wants to carry, published alongside
+                    the name so the agent has it in context on every sighting.
+    registered_at   when the identity was created
+    last_seen_at    most recent sighting
+
+`registered_at` and `last_seen_at` are deliberately **not** in the per-frame
+payload: they change on every frame (or never), and the answer to "when was this
+person around" belongs in the visit log, which can express it properly.
+
+**The visit log records one line per visit, not per frame.** A visit is a
+contiguous presence: it opens on the first sighting, absorbs every later one,
+and is closed and appended once the person has not been seen for
+`visit_gap_s` — **10 minutes by default**. At the default 1 detection/second a
+per-frame log would be 86 400 writes a day per person onto eMMC for no extra
+information, and a short gap would fragment one afternoon in the office into
+dozens of rows every time somebody turned their head. A visit carries
+`first_seen`, `last_seen` and a sighting count, which is what "who was here at
+3pm" actually needs. The cost of the long gap is latency: a visit is only
+queryable as a *closed* record 10 minutes after the person leaves — which is
+why `list_visits` also reports the still-open ones, flagged `open: true`.
 
 The embeddings file is written under a *fresh* name first and `persons.json`
 replaced last, so the two can never be observed out of step: until the new
@@ -61,8 +89,13 @@ EMBEDDING_DIM = 512
 
 DEFAULT_UNKNOWN_CAPACITY = 500
 DEFAULT_MAX_SAMPLES_PER_PERSON = 8
+DEFAULT_VISIT_GAP_S = 600.0   # 10 minutes
+DEFAULT_VISIT_LOG_MAX = 20000
+DEFAULT_VISIT_CHECKPOINT_S = 60.0
 
 _PERSONS_FILE = "persons.json"
+_VISITS_FILE = "visits.jsonl"
+_OPEN_VISITS_FILE = "visits-open.json"
 _LOCK_FILE = ".face_db.lock"
 _EMBEDDINGS_PREFIX = "embeddings-"
 _EMBEDDINGS_SUFFIX = ".npy"
@@ -96,22 +129,60 @@ def _normalize(vector: np.ndarray) -> np.ndarray:
     return (array / norm).astype(np.float32)
 
 
-def _clean_meta(meta: Any) -> dict:
-    """Accept only a JSON-serialisable object for the free-form meta field.
+def _clean_profile(profile: Any) -> dict:
+    """Accept only a JSON-serialisable object for the free-form profile.
 
-    Meta comes from an MCP caller and is written straight to disk; a value that
-    cannot be serialised would fail at save time, i.e. *after* the in-memory
-    state had already changed. Validate on the way in instead.
+    `profile` is the *non-structured* half of a person record — gender,
+    appearance, notes, tags, whatever the operator wants to carry. It comes
+    from an MCP caller and is written straight to disk, so a value that cannot
+    be serialised would fail at save time, i.e. *after* the in-memory state had
+    already changed. Validate on the way in instead.
     """
-    if meta is None:
+    if profile is None:
         return {}
-    if not isinstance(meta, dict):
-        raise ValueError("meta must be a JSON object")
+    if isinstance(profile, str):
+        # Tolerated because it is the shape the field had before the split into
+        # name + profile, and because an LLM will occasionally send prose here.
+        text = profile.strip()
+        return {"note": text} if text else {}
+    if not isinstance(profile, dict):
+        raise ValueError("profile must be a JSON object")
     try:
-        json.dumps(meta, ensure_ascii=False)
+        json.dumps(profile, ensure_ascii=False)
     except (TypeError, ValueError) as error:
-        raise ValueError(f"meta is not JSON-serialisable: {error}") from error
-    return dict(meta)
+        raise ValueError(f"profile is not JSON-serialisable: {error}") from error
+    return dict(profile)
+
+
+def parse_time(value: Any) -> float | None:
+    """Coerce an epoch number or an ISO-8601 string to epoch seconds.
+
+    Visit queries are the one place a caller naturally thinks in wall-clock
+    ("who was here after 15:00"), and an LLM will send a string. Accept both
+    rather than making every caller convert.
+    """
+    if value is None or value == "":
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    text = str(value).strip()
+    try:
+        return float(text)
+    except ValueError:
+        pass
+    from datetime import datetime
+    normalised = text.replace("Z", "+00:00")
+    try:
+        moment = datetime.fromisoformat(normalised)
+    except ValueError as error:
+        raise ValueError(
+            f"cannot parse {value!r} as epoch seconds or ISO-8601"
+        ) from error
+    if moment.tzinfo is None:
+        # Naive input means local time, which is what an operator reading a
+        # wall clock next to the robot means.
+        return moment.timestamp()
+    return moment.timestamp()
 
 
 class FaceDB:
@@ -122,6 +193,9 @@ class FaceDB:
         db_dir: str = DEFAULT_DB_DIR,
         unknown_capacity: int = DEFAULT_UNKNOWN_CAPACITY,
         max_samples_per_person: int = DEFAULT_MAX_SAMPLES_PER_PERSON,
+        visit_gap_s: float = DEFAULT_VISIT_GAP_S,
+        visit_log_max: int = DEFAULT_VISIT_LOG_MAX,
+        visit_checkpoint_s: float = DEFAULT_VISIT_CHECKPOINT_S,
     ):
         # db_dir arrives over MCP config and this process runs as root in the
         # container; the same validation model_downloader applies to model_dir.
@@ -136,7 +210,17 @@ class FaceDB:
         self._next_ids = {"named": 1, "unknown": 1}
         self._generation = 0
 
+        self._visit_gap = max(0.0, float(visit_gap_s))
+        self._visit_log_max = max(0, int(visit_log_max))
+        self._visit_checkpoint_s = max(0.0, float(visit_checkpoint_s))
+        self._visits_dirty = False
+        self._last_checkpoint_at = 0.0
+        # person_id -> the visit currently in progress. Held in memory until the
+        # person has been absent for visit_gap_s, then appended to visits.jsonl.
+        self._open_visits: dict[str, dict] = {}
+
         self._load()
+        self._recover_open_visits()
 
     # ── persistence ───────────────────────────────────────────────────────
 
@@ -192,12 +276,24 @@ class FaceDB:
             person_id = str(entry.get("id") or "").strip()
             if not person_id:
                 continue
+            # Migration from version 1, where `profile` was the free-text label
+            # and `meta` the structured bag. The two swapped roles: `name` is now
+            # the structured label and `profile` the free-form bag.
+            name = entry.get("name")
+            raw_profile = entry.get("profile")
+            if name is None and isinstance(raw_profile, str):
+                name = raw_profile
+                raw_profile = entry.get("meta")
+            elif raw_profile is None:
+                raw_profile = entry.get("meta")
             persons[person_id] = {
                 "id": person_id,
-                "profile": str(entry.get("profile") or ""),
+                "name": str(name or ""),
+                "profile": raw_profile if isinstance(raw_profile, dict) else {},
                 "named": bool(entry.get("named", not is_unknown_id(person_id))),
-                "meta": entry.get("meta") if isinstance(entry.get("meta"), dict) else {},
-                "created_at": float(entry.get("created_at") or _now()),
+                "registered_at": float(
+                    entry.get("registered_at") or entry.get("created_at") or _now()
+                ),
                 "updated_at": float(entry.get("updated_at") or _now()),
                 "last_seen_at": float(entry.get("last_seen_at") or 0.0),
             }
@@ -259,7 +355,7 @@ class FaceDB:
                         os.unlink(tmp_matrix)
 
                 state = {
-                    "version": 1,
+                    "version": 2,
                     "generation": generation,
                     "embeddings_file": matrix_name,
                     "next_ids": dict(self._next_ids),
@@ -380,28 +476,28 @@ class FaceDB:
         person = self._persons[person_id]
         return {
             "id": person["id"],
-            "profile": person["profile"],
+            "name": person["name"],
+            "profile": dict(person["profile"]),
             "named": person["named"],
-            "meta": dict(person["meta"]),
             "samples": self._samples_locked(person_id),
-            "created_at": person["created_at"],
+            "registered_at": person["registered_at"],
             "updated_at": person["updated_at"],
             "last_seen_at": person["last_seen_at"],
         }
 
     def add(
         self,
-        profile: str,
+        name: str,
         embeddings: Iterable[np.ndarray],
         named: bool = True,
-        meta: Any = None,
+        profile: Any = None,
         person_id: str | None = None,
     ) -> dict:
         """Enrol a new identity and return its record."""
         vectors = [_normalize(item) for item in embeddings]
         if not vectors:
             raise ValueError("at least one embedding is required")
-        clean_meta = _clean_meta(meta)
+        clean_profile = _clean_profile(profile)
         with self._lock:
             if person_id:
                 if person_id in self._persons:
@@ -412,10 +508,10 @@ class FaceDB:
             timestamp = _now()
             self._persons[new_id] = {
                 "id": new_id,
-                "profile": str(profile or ""),
+                "name": str(name or ""),
+                "profile": clean_profile,
                 "named": bool(named),
-                "meta": clean_meta,
-                "created_at": timestamp,
+                "registered_at": timestamp,
                 "updated_at": timestamp,
                 "last_seen_at": timestamp,
             }
@@ -429,7 +525,7 @@ class FaceDB:
             raise FaceDBError("unknown_capacity is 0; cannot enrol unknown faces")
         log.info("[face_db] enrolled %s (named=%s, samples=%d): %s",
                  new_id, named, record["samples"],
-                 escape_log_text(record["profile"]))
+                 escape_log_text(record["name"]))
         return record
 
     def add_samples(self, person_id: str, embeddings: Iterable[np.ndarray]) -> dict:
@@ -451,7 +547,7 @@ class FaceDB:
         return self.add("", [embedding], named=False)
 
     def promote(
-        self, person_id: str, profile: str, meta: Any = None, merge: bool = True
+        self, person_id: str, name: str, profile: Any = None, merge: bool = True
     ) -> dict:
         """Turn an `unknown-N` entry into a named person, **keeping its id**.
 
@@ -460,40 +556,40 @@ class FaceDB:
         conversation history for every earlier sighting, and rewriting it would
         orphan all of that.
         """
-        return self.update_person(person_id, profile=profile, meta=meta, merge=merge)
+        return self.update_person(person_id, name=name, profile=profile, merge=merge)
 
     def update_person(
         self,
         person_id: str,
-        profile: str | None = None,
-        meta: Any = None,
-        meta_delete: Iterable[str] | None = None,
+        name: str | None = None,
+        profile: Any = None,
+        profile_delete: Iterable[str] | None = None,
         merge: bool = True,
     ) -> dict:
-        """Edit a person's profile and/or free-form meta."""
-        clean_meta = _clean_meta(meta) if meta is not None else None
-        delete_keys = [str(key) for key in (meta_delete or [])]
+        """Edit a person's name and/or free-form profile."""
+        clean_profile = _clean_profile(profile) if profile is not None else None
+        delete_keys = [str(key) for key in (profile_delete or [])]
         with self._lock:
             person = self._persons.get(person_id)
             if person is None:
                 raise KeyError(person_id)
             changed = False
-            if profile is not None:
-                person["profile"] = str(profile)
-                # A profile is what makes an entry a *named* person; setting one
-                # on an unknown promotes it in place.
-                if str(profile).strip() and not person["named"]:
+            if name is not None:
+                person["name"] = str(name)
+                # A name is what makes an entry a *named* person; setting one on
+                # an unknown promotes it in place, keeping the id.
+                if str(name).strip() and not person["named"]:
                     person["named"] = True
                     log.info("[face_db] %s promoted to a named person", person_id)
                 changed = True
-            if clean_meta is not None:
-                person["meta"] = (
-                    {**person["meta"], **clean_meta} if merge else clean_meta
+            if clean_profile is not None:
+                person["profile"] = (
+                    {**person["profile"], **clean_profile} if merge else clean_profile
                 )
                 changed = True
             for key in delete_keys:
-                if key in person["meta"]:
-                    del person["meta"][key]
+                if key in person["profile"]:
+                    del person["profile"][key]
                     changed = True
             if changed:
                 person["updated_at"] = _now()
@@ -576,7 +672,7 @@ class FaceDB:
         excess = len(unknowns) - self._unknown_capacity
         if excess <= 0:
             return 0
-        unknowns.sort(key=lambda person: (person["last_seen_at"], person["created_at"]))
+        unknowns.sort(key=lambda person: (person["last_seen_at"], person["registered_at"]))
         doomed = {person["id"] for person in unknowns[:excess]}
         for person_id in doomed:
             del self._persons[person_id]
@@ -635,8 +731,8 @@ class FaceDB:
         if needle:
             def matches(record: dict) -> bool:
                 haystack = " ".join([
-                    record["id"], record["profile"],
-                    json.dumps(record["meta"], ensure_ascii=False),
+                    record["id"], record["name"],
+                    json.dumps(record["profile"], ensure_ascii=False),
                 ]).lower()
                 return needle in haystack
             records = [r for r in records if matches(r)]
@@ -651,6 +747,275 @@ class FaceDB:
             "persons": records[start:end],
         }
 
+    # ── visit log ─────────────────────────────────────────────────────────
+
+    def _visits_path(self) -> str:
+        return os.path.join(self._dir, _VISITS_FILE)
+
+    def record_sighting(self, person_id: str, when: float, topic: str = "") -> None:
+        """Note that `person_id` was seen at `when`.
+
+        Called at detection rate, so it must stay cheap and must not write: it
+        updates `last_seen_at` in memory and either opens a visit or extends the
+        open one. A visit only reaches disk when `close_stale_visits` decides
+        the person has left.
+        """
+        with self._lock:
+            person = self._persons.get(person_id)
+            if person is not None:
+                person["last_seen_at"] = float(when)
+            visit = self._open_visits.get(person_id)
+            if visit is None:
+                self._open_visits[person_id] = {
+                    "person_id": person_id,
+                    "name": person["name"] if person else "",
+                    "first_seen": float(when),
+                    "last_seen": float(when),
+                    "sightings": 1,
+                    "topic": topic,
+                }
+            else:
+                visit["last_seen"] = max(visit["last_seen"], float(when))
+                visit["sightings"] += 1
+                if person is not None and person["name"]:
+                    # A visit that began while the person was still unknown gets
+                    # their name once they are enrolled mid-visit.
+                    visit["name"] = person["name"]
+            self._visits_dirty = True
+
+    def _open_visits_path(self) -> str:
+        return os.path.join(self._dir, _OPEN_VISITS_FILE)
+
+    def checkpoint_open_visits(self, force: bool = False) -> bool:
+        """Persist visits still in progress, so a power cut cannot lose them.
+
+        With a 10-minute `visit_gap_s`, somebody present all afternoon is one
+        visit held in memory for hours — and a robot that loses power would
+        lose the whole record, not just the tail. This writes the open visits to
+        a small separate file at most every `visit_checkpoint_s` (default 60 s),
+        which bounds the loss to a minute of `last_seen`/`sightings` rather than
+        the entire visit.
+
+        Deliberately *not* the append-only log: an open visit is still changing,
+        so it must be overwritten rather than appended, and mixing the two would
+        mean rewriting history on every checkpoint.
+        """
+        moment = _now()
+        with self._lock:
+            if not force:
+                if not self._visits_dirty:
+                    return False
+                if moment - self._last_checkpoint_at < self._visit_checkpoint_s:
+                    return False
+            snapshot = [dict(visit) for visit in self._open_visits.values()]
+            self._last_checkpoint_at = moment
+            self._visits_dirty = False
+        path = self._open_visits_path()
+        try:
+            if not snapshot:
+                if os.path.exists(path):
+                    os.unlink(path)
+                return True
+            os.makedirs(self._dir, exist_ok=True)
+            tmp = f"{path}.tmp"
+            with open(tmp, "w", encoding="utf-8") as handle:
+                json.dump({"saved_at": moment, "visits": snapshot}, handle,
+                          ensure_ascii=False)
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(tmp, path)
+            return True
+        except OSError:
+            log.warning("[face_db] could not checkpoint open visits",
+                        exc_info=True)
+            return False
+
+    def _recover_open_visits(self) -> None:
+        """Reload visits that were in progress when the process last stopped.
+
+        A visit whose subject has since been absent longer than `visit_gap_s` is
+        closed and appended straight away — the person left while we were down.
+        One that is still fresh is resumed, so a restart does not split an
+        ongoing presence into two records.
+        """
+        path = self._open_visits_path()
+        try:
+            with open(path, encoding="utf-8") as handle:
+                state = json.load(handle)
+        except (OSError, ValueError):
+            return
+        moment = _now()
+        resumed, closed = 0, []
+        for visit in state.get("visits") or []:
+            person_id = str(visit.get("person_id") or "")
+            if not person_id:
+                continue
+            last_seen = float(visit.get("last_seen") or 0.0)
+            if moment - last_seen >= self._visit_gap:
+                closed.append({**visit, "recovered": True})
+            else:
+                self._open_visits[person_id] = dict(visit)
+                resumed += 1
+        if closed:
+            with self._lock:
+                self._append_visits_locked(closed)
+        if resumed or closed:
+            log.info("[face_db] recovered open visits: %d resumed, %d closed",
+                     resumed, len(closed))
+        try:
+            if not self._open_visits and os.path.exists(path):
+                os.unlink(path)
+        except OSError:
+            pass
+
+    def close_stale_visits(self, now: float | None = None, force: bool = False) -> int:
+        """Append every visit whose subject has been absent for `visit_gap_s`.
+
+        `force` closes all open visits regardless — used when an instance stops,
+        so a visit in progress is not lost.
+        """
+        moment = _now() if now is None else float(now)
+        with self._lock:
+            due = [
+                person_id for person_id, visit in self._open_visits.items()
+                if force or moment - visit["last_seen"] >= self._visit_gap
+            ]
+            if not due:
+                return 0
+            closing = [self._open_visits.pop(person_id) for person_id in due]
+            self._append_visits_locked(closing)
+            self._visits_dirty = True
+        # The checkpoint must follow the append, so a crash in between replays a
+        # closed visit rather than dropping it: `list_visits` can show one twice
+        # in the worst case, which is recoverable; losing it is not.
+        self.checkpoint_open_visits(force=True)
+        return len(closing)
+
+    def _append_visits_locked(self, visits: list[dict]) -> None:
+        """Append closed visits to visits.jsonl. Caller holds `self._lock`.
+
+        JSON Lines, not the persons.json blob: appends are O(1) and cannot
+        rewrite (or corrupt) the identity table, and a time-range query is a
+        forward scan. Its own file also means the commit-point ordering of
+        persons.json/embeddings is untouched by sighting traffic.
+        """
+        if not visits or self._visit_log_max == 0:
+            return
+        os.makedirs(self._dir, exist_ok=True)
+        lock_path = os.path.join(self._dir, _LOCK_FILE)
+        try:
+            with open(lock_path, "a+b") as lock_file:
+                if fcntl is not None:
+                    fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+                try:
+                    with open(self._visits_path(), "a", encoding="utf-8") as handle:
+                        for visit in visits:
+                            handle.write(
+                                json.dumps(visit, ensure_ascii=False) + "\n"
+                            )
+                        handle.flush()
+                        os.fsync(handle.fileno())
+                    self._trim_visits_locked()
+                finally:
+                    if fcntl is not None:
+                        fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+        except OSError:
+            # A full or read-only /models must not take recognition down; the
+            # identities still work, only the history is lost.
+            log.warning("[face_db] could not append to the visit log",
+                        exc_info=True)
+
+    def _trim_visits_locked(self) -> None:
+        """Keep the newest `visit_log_max` lines. Rewrites only when over."""
+        path = self._visits_path()
+        try:
+            with open(path, encoding="utf-8") as handle:
+                lines = handle.readlines()
+        except OSError:
+            return
+        if len(lines) <= self._visit_log_max:
+            return
+        keep = lines[-self._visit_log_max:]
+        tmp = f"{path}.tmp"
+        with open(tmp, "w", encoding="utf-8") as handle:
+            handle.writelines(keep)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp, path)
+        log.info("[face_db] visit log trimmed to the newest %d entries",
+                 self._visit_log_max)
+
+    def list_visits(
+        self,
+        person_id: str = "",
+        since: Any = None,
+        until: Any = None,
+        limit: int = 100,
+        offset: int = 0,
+        include_open: bool = True,
+    ) -> dict:
+        """Visits overlapping [since, until], newest first.
+
+        Overlap rather than containment: someone who arrived at 14:50 and left
+        at 15:10 *was* there at 15:00, and a query for 15:00-15:05 has to say so.
+        """
+        start = parse_time(since)
+        end = parse_time(until)
+        records: list[dict] = []
+        try:
+            with open(self._visits_path(), encoding="utf-8") as handle:
+                for line in handle:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        records.append(json.loads(line))
+                    except ValueError:
+                        # One torn line (a crash mid-append) must not make the
+                        # whole history unreadable.
+                        continue
+        except OSError:
+            records = []
+
+        if include_open:
+            with self._lock:
+                records.extend(
+                    {**visit, "open": True} for visit in self._open_visits.values()
+                )
+
+        def overlaps(visit: dict) -> bool:
+            first = float(visit.get("first_seen") or 0.0)
+            last = float(visit.get("last_seen") or first)
+            if start is not None and last < start:
+                return False
+            if end is not None and first > end:
+                return False
+            return True
+
+        if person_id:
+            records = [r for r in records if r.get("person_id") == person_id]
+        records = [r for r in records if overlaps(r)]
+        records.sort(key=lambda r: float(r.get("last_seen") or 0.0), reverse=True)
+
+        total = len(records)
+        begin = max(0, int(offset))
+        stop = begin + max(0, int(limit)) if limit else total
+        page = records[begin:stop]
+        # Names change; resolve them at read time so old lines are not stale.
+        with self._lock:
+            for visit in page:
+                person = self._persons.get(visit.get("person_id", ""))
+                if person is not None:
+                    visit["name"] = person["name"]
+        return {
+            "total": total,
+            "offset": begin,
+            "limit": int(limit),
+            "since": start,
+            "until": end,
+            "visits": page,
+        }
+
     def stats(self) -> dict:
         with self._lock:
             named = sum(1 for person in self._persons.values() if person["named"])
@@ -660,12 +1025,17 @@ class FaceDB:
                 "unknown": len(self._persons) - named,
                 "samples": len(self._row_owners),
                 "unknown_capacity": self._unknown_capacity,
+                "open_visits": len(self._open_visits),
                 "db_dir": self._dir,
             }
 
 
 __all__ = [
     "DEFAULT_DB_DIR",
+    "DEFAULT_VISIT_CHECKPOINT_S",
+    "DEFAULT_VISIT_GAP_S",
+    "DEFAULT_VISIT_LOG_MAX",
+    "parse_time",
     "DEFAULT_MAX_SAMPLES_PER_PERSON",
     "DEFAULT_UNKNOWN_CAPACITY",
     "EMBEDDING_DIM",

--- a/perception/plugins/face_runtime.py
+++ b/perception/plugins/face_runtime.py
@@ -1,0 +1,452 @@
+#!/usr/bin/env python3
+"""
+plugins/face_runtime.py — 人脸检测 + 特征提取推理封装（无 ROS 依赖）。
+
+Mirrors `plugins/ocr_runtime.py`'s role: everything that touches a model lives
+here, so `plugins/face.py` only deals with ROS, MCP and lifecycle.
+
+Two ONNX models, both from the InsightFace **buffalo_sc** pack — the smallest
+pack that still ships keypoints, which the alignment step needs:
+
+    det_500m.onnx    SCRFD-500M-BNKPS   ~2.5 MB   detection + 5 landmarks
+    w600k_mbf.onnx   ArcFace MobileFaceNet ~13 MB  512-d embedding
+
+The `insightface` package is deliberately **not** a dependency: it pulls in
+onnx, scikit-image, scikit-learn, Cython and a build toolchain, none of which
+are in the perception image, to wrap ~200 lines of pre/post-processing. Those
+200 lines are below instead. The decode follows upstream's `scrfd.py` exactly
+(strides 8/16/32, 2 anchors per location, distance-coded boxes and keypoints) —
+this is a wire format, not a design choice, and getting it wrong produces
+plausible-looking boxes in the wrong places.
+
+Both models run on `onnxruntime`, so `device: cpu | gpu` is a provider choice
+(`utils/onnx_provider.ort_providers_for_device`) rather than two code paths.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass, field
+
+import numpy as np
+
+from utils.cv2_compat import load_cv2
+from utils.model_downloader import ensure_face_model
+from utils.onnx_provider import normalize_device, ort_providers_for_device
+
+log = logging.getLogger(__name__)
+
+DEFAULT_FACE_MODEL_DIR = "/models/face/buffalo_sc"
+
+DET_MODEL_FILE = "det_500m.onnx"
+REC_MODEL_FILE = "w600k_mbf.onnx"
+
+DEFAULT_DET_SIZE = (640, 640)
+DEFAULT_DET_THRESH = 0.5
+DEFAULT_NMS_THRESH = 0.4
+DEFAULT_MIN_FACE_PX = 64
+DEFAULT_BLUR_MIN = 60.0
+
+EMBEDDING_DIM = 512
+_REC_INPUT_SIZE = 112
+
+# SCRFD wire format for a 3-level, 2-anchor, keypoint-carrying model. Upstream
+# derives these from the output count; det_500m always has 9 outputs.
+_FEAT_STRIDES = (8, 16, 32)
+_NUM_ANCHORS = 2
+_NUM_KPS = 5
+
+# ArcFace's canonical 112x112 landmark template. Aligning every face onto these
+# five points is what makes two embeddings comparable at all.
+_ARCFACE_DST = np.array(
+    [
+        [38.2946, 51.6963],
+        [73.5318, 51.5014],
+        [56.0252, 71.7366],
+        [41.5493, 92.3655],
+        [70.7299, 92.2041],
+    ],
+    dtype=np.float32,
+)
+
+
+@dataclass
+class DetectedFace:
+    """One detection, with everything the quality gate and payload need."""
+
+    bbox: tuple[float, float, float, float]      # x1, y1, x2, y2 in source px
+    det_score: float
+    kps: np.ndarray                              # (5, 2) float32, source px
+    blur: float = 0.0                            # variance of Laplacian
+    aligned: np.ndarray | None = field(default=None, repr=False)
+    embedding: np.ndarray | None = field(default=None, repr=False)
+
+    @property
+    def width(self) -> float:
+        return max(0.0, self.bbox[2] - self.bbox[0])
+
+    @property
+    def height(self) -> float:
+        return max(0.0, self.bbox[3] - self.bbox[1])
+
+    @property
+    def min_side(self) -> float:
+        return min(self.width, self.height)
+
+    @property
+    def area(self) -> float:
+        return self.width * self.height
+
+    def bbox_xywh(self) -> list[int]:
+        x1, y1, x2, y2 = self.bbox
+        return [int(round(x1)), int(round(y1)),
+                int(round(x2 - x1)), int(round(y2 - y1))]
+
+
+def _umeyama_similarity(src: np.ndarray, dst: np.ndarray) -> np.ndarray:
+    """Least-squares similarity transform (rotation + uniform scale + shift).
+
+    This is what `skimage.transform.SimilarityTransform` computes, written out
+    so scikit-image is not a dependency. Not `cv2.estimateAffinePartial2D`:
+    that runs RANSAC/LMEDS, and on exactly five correspondences a robust
+    estimator can discard a point and return a different transform run to run —
+    which would make the same photo produce different embeddings.
+    """
+    src = np.asarray(src, dtype=np.float64)
+    dst = np.asarray(dst, dtype=np.float64)
+    num, dim = src.shape
+
+    src_mean = src.mean(axis=0)
+    dst_mean = dst.mean(axis=0)
+    src_demean = src - src_mean
+    dst_demean = dst - dst_mean
+
+    covariance = dst_demean.T @ src_demean / num
+    reflect = np.ones((dim,), dtype=np.float64)
+    if np.linalg.det(covariance) < 0:
+        reflect[dim - 1] = -1.0
+
+    u_matrix, singular, vt_matrix = np.linalg.svd(covariance)
+    rank = np.linalg.matrix_rank(covariance)
+    transform = np.eye(dim + 1, dtype=np.float64)
+    if rank == 0:
+        raise ValueError("degenerate landmark set; cannot align")
+    if rank == dim - 1:
+        if np.linalg.det(u_matrix) * np.linalg.det(vt_matrix) > 0:
+            transform[:dim, :dim] = u_matrix @ vt_matrix
+        else:
+            saved = reflect[dim - 1]
+            reflect[dim - 1] = -1.0
+            transform[:dim, :dim] = u_matrix @ np.diag(reflect) @ vt_matrix
+            reflect[dim - 1] = saved
+    else:
+        transform[:dim, :dim] = u_matrix @ np.diag(reflect) @ vt_matrix
+
+    variance = src_demean.var(axis=0).sum()
+    if variance <= 1e-9:
+        raise ValueError("degenerate landmark set; cannot align")
+    scale = float(singular @ reflect) / variance
+    transform[:dim, dim] = dst_mean - scale * (transform[:dim, :dim] @ src_mean)
+    transform[:dim, :dim] *= scale
+    return transform[:dim].astype(np.float32)
+
+
+def _distance2bbox(centers: np.ndarray, distances: np.ndarray) -> np.ndarray:
+    x1 = centers[:, 0] - distances[:, 0]
+    y1 = centers[:, 1] - distances[:, 1]
+    x2 = centers[:, 0] + distances[:, 2]
+    y2 = centers[:, 1] + distances[:, 3]
+    return np.stack([x1, y1, x2, y2], axis=-1)
+
+
+def _distance2kps(centers: np.ndarray, distances: np.ndarray) -> np.ndarray:
+    points = []
+    for index in range(0, distances.shape[1], 2):
+        points.append(centers[:, 0] + distances[:, index])
+        points.append(centers[:, 1] + distances[:, index + 1])
+    return np.stack(points, axis=-1)
+
+
+def _nms(boxes: np.ndarray, scores: np.ndarray, thresh: float) -> list[int]:
+    """Plain greedy IoU suppression — no cv2.dnn, no torchvision."""
+    x1, y1, x2, y2 = boxes[:, 0], boxes[:, 1], boxes[:, 2], boxes[:, 3]
+    areas = np.maximum(0.0, x2 - x1 + 1) * np.maximum(0.0, y2 - y1 + 1)
+    order = scores.argsort()[::-1]
+    keep: list[int] = []
+    while order.size > 0:
+        current = int(order[0])
+        keep.append(current)
+        if order.size == 1:
+            break
+        rest = order[1:]
+        xx1 = np.maximum(x1[current], x1[rest])
+        yy1 = np.maximum(y1[current], y1[rest])
+        xx2 = np.minimum(x2[current], x2[rest])
+        yy2 = np.minimum(y2[current], y2[rest])
+        inter = np.maximum(0.0, xx2 - xx1 + 1) * np.maximum(0.0, yy2 - yy1 + 1)
+        iou = inter / (areas[current] + areas[rest] - inter)
+        order = rest[iou <= thresh]
+    return keep
+
+
+class FaceAnalyzer:
+    """SCRFD detection + ArcFace embedding over onnxruntime.
+
+    Stateless per call and safe to share across threads: `InferenceSession.run`
+    is thread-safe, and nothing here mutates instance state after __init__. The
+    plugin holds exactly one analyzer for every instance, the same
+    single-flight arrangement `plugins/ocr.py` uses for its adapter.
+    """
+
+    def __init__(
+        self,
+        model_dir: str = DEFAULT_FACE_MODEL_DIR,
+        device: str = "cpu",
+        det_size: tuple[int, int] = DEFAULT_DET_SIZE,
+        det_thresh: float = DEFAULT_DET_THRESH,
+        nms_thresh: float = DEFAULT_NMS_THRESH,
+        num_threads: int = 2,
+        warmup: bool = True,
+    ):
+        import onnxruntime as ort
+
+        self._cv2 = load_cv2()
+        self._device = normalize_device(device)
+        self._det_thresh = float(det_thresh)
+        self._nms_thresh = float(nms_thresh)
+        width, height = (int(det_size[0]), int(det_size[1]))
+        # SCRFD's largest stride is 32; a size that is not a multiple of it
+        # would make the anchor grid and the feature map disagree in shape and
+        # the reshape below would fail with an opaque numpy error.
+        self._det_size = (width - width % 32 or 32, height - height % 32 or 32)
+
+        paths = ensure_face_model(model_dir)
+        det_path = paths.get(DET_MODEL_FILE) or os.path.join(model_dir, DET_MODEL_FILE)
+        rec_path = paths.get(REC_MODEL_FILE) or os.path.join(model_dir, REC_MODEL_FILE)
+
+        providers = ort_providers_for_device(self._device)
+        options = ort.SessionOptions()
+        options.intra_op_num_threads = max(1, int(num_threads))
+        options.graph_optimization_level = ort.GraphOptimizationLevel.ORT_ENABLE_ALL
+        # The models ship pre-optimised and the container filesystem may be
+        # read-only for /models; let ORT keep its optimised graph in memory.
+        options.log_severity_level = 3
+
+        self._det = ort.InferenceSession(det_path, options, providers=providers)
+        self._rec = ort.InferenceSession(rec_path, options, providers=providers)
+        self._det_input = self._det.get_inputs()[0].name
+        self._rec_input = self._rec.get_inputs()[0].name
+        self._det_outputs = [output.name for output in self._det.get_outputs()]
+
+        if len(self._det_outputs) != len(_FEAT_STRIDES) * 3:
+            raise RuntimeError(
+                f"{DET_MODEL_FILE} has {len(self._det_outputs)} outputs; this "
+                f"decoder expects {len(_FEAT_STRIDES) * 3} (3 strides x "
+                "score/bbox/kps). A detector without keypoints cannot be "
+                "aligned for recognition."
+            )
+
+        log.info(
+            "[face] analyzer ready: device=%s providers=%s det=%s rec=%s size=%s",
+            self._device, self._det.get_providers(),
+            os.path.basename(det_path), os.path.basename(rec_path),
+            self._det_size,
+        )
+
+        if warmup:
+            self._warmup()
+
+    # ── properties ────────────────────────────────────────────────────────
+
+    @property
+    def device(self) -> str:
+        return self._device
+
+    @property
+    def providers(self) -> list[str]:
+        return list(self._det.get_providers())
+
+    @property
+    def det_thresh(self) -> float:
+        return self._det_thresh
+
+    def _warmup(self) -> None:
+        """Pay the first-inference cost here, not on an operator's first face.
+
+        Same reasoning as `plugins/asr.py`: on CUDA the first run costs ~1.7 s
+        (lazy kernels, cuDNN autotune, memory pool) against a steady state
+        measured in tens of milliseconds.
+        """
+        try:
+            blank = np.zeros(
+                (self._det_size[1], self._det_size[0], 3), dtype=np.uint8
+            )
+            self.detect(blank)
+            self.embed(np.zeros((_REC_INPUT_SIZE, _REC_INPUT_SIZE, 3), dtype=np.uint8))
+            log.info("[face] warmup done")
+        except Exception:  # noqa: BLE001 - warmup must never block startup
+            log.warning("[face] warmup failed; continuing", exc_info=True)
+
+    # ── image helpers ─────────────────────────────────────────────────────
+
+    def decode_jpeg(self, data: bytes) -> np.ndarray | None:
+        """Decode JPEG/PNG bytes to a BGR array, or None if undecodable."""
+        buffer = np.frombuffer(data, dtype=np.uint8)
+        if buffer.size == 0:
+            return None
+        image = self._cv2.imdecode(buffer, self._cv2.IMREAD_COLOR)
+        if image is None or image.size == 0:
+            return None
+        return image
+
+    # ── detection ─────────────────────────────────────────────────────────
+
+    def detect(self, bgr: np.ndarray, max_faces: int = 0) -> list[DetectedFace]:
+        """Detect faces in a BGR image, largest first."""
+        if bgr is None or bgr.size == 0:
+            return []
+        height, width = bgr.shape[:2]
+        input_w, input_h = self._det_size
+
+        # Letterbox: preserve aspect ratio, paste top-left, remember the scale.
+        # Distorting the aspect ratio moves the landmarks off the face and the
+        # alignment silently degrades every embedding.
+        image_ratio = height / max(1, width)
+        model_ratio = input_h / input_w
+        if image_ratio > model_ratio:
+            new_h = input_h
+            new_w = int(new_h / image_ratio)
+        else:
+            new_w = input_w
+            new_h = int(new_w * image_ratio)
+        scale = new_h / max(1, height)
+        resized = self._cv2.resize(bgr, (max(1, new_w), max(1, new_h)))
+        padded = np.zeros((input_h, input_w, 3), dtype=np.uint8)
+        padded[: resized.shape[0], : resized.shape[1]] = resized
+
+        blob = padded[:, :, ::-1].astype(np.float32)          # BGR → RGB
+        blob = (blob - 127.5) / 128.0
+        blob = np.ascontiguousarray(blob.transpose(2, 0, 1)[None])
+
+        outputs = self._det.run(self._det_outputs, {self._det_input: blob})
+        levels = len(_FEAT_STRIDES)
+
+        boxes_all: list[np.ndarray] = []
+        kps_all: list[np.ndarray] = []
+        scores_all: list[np.ndarray] = []
+        for index, stride in enumerate(_FEAT_STRIDES):
+            scores = outputs[index].reshape(-1)
+            bbox_preds = outputs[index + levels].reshape(-1, 4) * stride
+            kps_preds = outputs[index + levels * 2].reshape(-1, _NUM_KPS * 2) * stride
+
+            grid_h, grid_w = input_h // stride, input_w // stride
+            centers = np.stack(
+                np.mgrid[:grid_h, :grid_w][::-1], axis=-1
+            ).astype(np.float32).reshape(-1, 2) * stride
+            if _NUM_ANCHORS > 1:
+                centers = np.stack([centers] * _NUM_ANCHORS, axis=1).reshape(-1, 2)
+
+            positive = np.where(scores >= self._det_thresh)[0]
+            if positive.size == 0:
+                continue
+            boxes_all.append(_distance2bbox(centers, bbox_preds)[positive])
+            kps_all.append(
+                _distance2kps(centers, kps_preds)[positive].reshape(-1, _NUM_KPS, 2)
+            )
+            scores_all.append(scores[positive])
+
+        if not scores_all:
+            return []
+
+        boxes = np.concatenate(boxes_all) / scale
+        keypoints = np.concatenate(kps_all) / scale
+        scores = np.concatenate(scores_all)
+        keep = _nms(boxes, scores, self._nms_thresh)
+
+        faces = [
+            DetectedFace(
+                bbox=(
+                    float(max(0.0, boxes[i][0])),
+                    float(max(0.0, boxes[i][1])),
+                    float(min(width, boxes[i][2])),
+                    float(min(height, boxes[i][3])),
+                ),
+                det_score=float(scores[i]),
+                kps=keypoints[i].astype(np.float32),
+            )
+            for i in keep
+        ]
+        faces.sort(key=lambda face: face.area, reverse=True)
+        if max_faces and len(faces) > max_faces:
+            faces = faces[:max_faces]
+        return faces
+
+    # ── alignment, quality, embedding ─────────────────────────────────────
+
+    def align(self, bgr: np.ndarray, kps: np.ndarray) -> np.ndarray:
+        """Warp a face onto the 112x112 ArcFace template."""
+        matrix = _umeyama_similarity(np.asarray(kps, dtype=np.float32), _ARCFACE_DST)
+        return self._cv2.warpAffine(
+            bgr, matrix, (_REC_INPUT_SIZE, _REC_INPUT_SIZE), borderValue=0.0
+        )
+
+    def sharpness(self, aligned: np.ndarray) -> float:
+        """Variance of the Laplacian — the blur metric behind `low_quality`.
+
+        Measured on the *aligned* crop, not the source frame, so the number
+        means the same thing whether the person was 1 m or 4 m away: a distant
+        face is upscaled to 112x112 and its softness shows up here.
+        """
+        gray = self._cv2.cvtColor(aligned, self._cv2.COLOR_BGR2GRAY)
+        return float(self._cv2.Laplacian(gray, self._cv2.CV_64F).var())
+
+    def prepare(self, bgr: np.ndarray, face: DetectedFace) -> DetectedFace:
+        """Fill in `aligned` and `blur` for a detection."""
+        face.aligned = self.align(bgr, face.kps)
+        face.blur = self.sharpness(face.aligned)
+        return face
+
+    def embed(self, aligned: np.ndarray) -> np.ndarray:
+        """512-d L2-normalised embedding of an aligned 112x112 crop."""
+        if aligned.shape[0] != _REC_INPUT_SIZE or aligned.shape[1] != _REC_INPUT_SIZE:
+            aligned = self._cv2.resize(aligned, (_REC_INPUT_SIZE, _REC_INPUT_SIZE))
+        blob = aligned[:, :, ::-1].astype(np.float32)          # BGR → RGB
+        blob = (blob - 127.5) / 127.5
+        blob = np.ascontiguousarray(blob.transpose(2, 0, 1)[None])
+        vector = self._rec.run(None, {self._rec_input: blob})[0].reshape(-1)
+        norm = float(np.linalg.norm(vector))
+        if norm <= 1e-8:
+            raise RuntimeError("recognition model returned a zero embedding")
+        return (vector / norm).astype(np.float32)
+
+    def analyze(
+        self, bgr: np.ndarray, max_faces: int = 0, with_embeddings: bool = True
+    ) -> list[DetectedFace]:
+        """Detect, align and (optionally) embed every face in one frame."""
+        faces = self.detect(bgr, max_faces=max_faces)
+        for face in faces:
+            self.prepare(bgr, face)
+            if with_embeddings:
+                face.embedding = self.embed(face.aligned)
+        return faces
+
+    def close(self) -> None:
+        """Drop the sessions. Called via `_close_quietly` on config changes."""
+        self._det = None
+        self._rec = None
+
+
+__all__ = [
+    "DEFAULT_BLUR_MIN",
+    "DEFAULT_DET_SIZE",
+    "DEFAULT_DET_THRESH",
+    "DEFAULT_FACE_MODEL_DIR",
+    "DEFAULT_MIN_FACE_PX",
+    "DEFAULT_NMS_THRESH",
+    "DET_MODEL_FILE",
+    "EMBEDDING_DIM",
+    "REC_MODEL_FILE",
+    "DetectedFace",
+    "FaceAnalyzer",
+]

--- a/perception/plugins/face_runtime.py
+++ b/perception/plugins/face_runtime.py
@@ -47,6 +47,11 @@ DEFAULT_DET_THRESH = 0.5
 DEFAULT_NMS_THRESH = 0.4
 DEFAULT_MIN_FACE_PX = 64
 DEFAULT_BLUR_MIN = 60.0
+# Longest side an incoming photo is downscaled to before detection. 2048 keeps
+# a small distant face well above min_face_px while bounding the decoded array.
+DEFAULT_MAX_IMAGE_SIDE = 2048
+# Decompression-bomb guard, in pixels (~60 MP). A 24 MP phone photo passes.
+DEFAULT_MAX_IMAGE_PIXELS = 60_000_000
 
 EMBEDDING_DIM = 512
 _REC_INPUT_SIZE = 112
@@ -302,15 +307,97 @@ class FaceAnalyzer:
 
     # ── image helpers ─────────────────────────────────────────────────────
 
-    def decode_jpeg(self, data: bytes) -> np.ndarray | None:
-        """Decode JPEG/PNG bytes to a BGR array, or None if undecodable."""
-        buffer = np.frombuffer(data, dtype=np.uint8)
-        if buffer.size == 0:
+    def decode_image(
+        self,
+        data: bytes,
+        max_side: int = DEFAULT_MAX_IMAGE_SIDE,
+        max_pixels: int = DEFAULT_MAX_IMAGE_PIXELS,
+    ) -> np.ndarray | None:
+        """Decode arbitrary image bytes to a BGR array, downscaled if huge.
+
+        Converting and resizing **here** rather than rejecting at the API is
+        deliberate: an operator registering a face has whatever their phone or
+        camera produced, and "your photo is 24 MB" or "we only take JPEG" is a
+        limitation of ours, not a property of their photo.
+
+        Two decoders, because each covers formats the other does not: OpenCV
+        reads JPEG/PNG/BMP/WEBP/TIFF/PPM, and Pillow (already in the image)
+        adds GIF, ICO and some TIFF variants. Anything neither can read returns
+        None and the caller reports `bad_input`. HEIC/HEIF — what an iPhone
+        shoots by default — needs `pillow-heif`, which is not installed, so it
+        is the one common format still unsupported.
+
+        `max_side` exists for accuracy as much as memory: detection letterboxes
+        to `det_size` (640) anyway, so a 6000 px photo is downscaled by the
+        detector regardless. Doing it once here with INTER_AREA is both cheaper
+        and better than letting the letterbox do it — and it bounds the
+        intermediate array, which for a 60 MP image is 180 MB of uint8.
+
+        `max_pixels` is a decompression-bomb guard: a few hundred KB of PNG can
+        declare a 30000x30000 canvas, which would be 2.7 GB decoded and take the
+        whole perception process down with the OOM killer.
+        """
+        if not data:
             return None
-        image = self._cv2.imdecode(buffer, self._cv2.IMREAD_COLOR)
+        image = self._decode_with_cv2(data)
+        if image is None:
+            image = self._decode_with_pillow(data)
         if image is None or image.size == 0:
             return None
-        return image
+        if max_pixels and image.shape[0] * image.shape[1] > max_pixels:
+            log.warning("[face] refusing a %dx%d image (%.1f MP > %.1f MP cap)",
+                        image.shape[1], image.shape[0],
+                        image.shape[0] * image.shape[1] / 1e6, max_pixels / 1e6)
+            return None
+        return self._downscale(image, max_side)
+
+    def _decode_with_cv2(self, data: bytes) -> np.ndarray | None:
+        try:
+            buffer = np.frombuffer(data, dtype=np.uint8)
+            if buffer.size == 0:
+                return None
+            image = self._cv2.imdecode(buffer, self._cv2.IMREAD_COLOR)
+        except Exception:  # noqa: BLE001 - fall through to Pillow
+            return None
+        return image if image is not None and image.size else None
+
+    def _decode_with_pillow(self, data: bytes) -> np.ndarray | None:
+        """Fallback decoder, converting whatever it reads to 3-channel BGR."""
+        try:
+            import io
+
+            from PIL import Image
+
+            with Image.open(io.BytesIO(data)) as handle:
+                # convert() also flattens palettes, drops alpha and collapses
+                # 16-bit channels, so the result is always plain 8-bit RGB.
+                rgb = handle.convert("RGB")
+                array = np.asarray(rgb)
+        except Exception:  # noqa: BLE001 - genuinely undecodable
+            return None
+        if array.size == 0:
+            return None
+        return np.ascontiguousarray(array[:, :, ::-1])      # RGB -> BGR
+
+    def _downscale(self, image: np.ndarray, max_side: int) -> np.ndarray:
+        if not max_side:
+            return image
+        height, width = image.shape[:2]
+        longest = max(height, width)
+        if longest <= max_side:
+            return image
+        scale = max_side / float(longest)
+        resized = self._cv2.resize(
+            image,
+            (max(1, int(round(width * scale))), max(1, int(round(height * scale)))),
+            interpolation=self._cv2.INTER_AREA,   # the right filter for shrinking
+        )
+        log.debug("[face] downscaled %dx%d -> %dx%d", width, height,
+                  resized.shape[1], resized.shape[0])
+        return resized
+
+    # Kept as an alias: the name predates supporting anything but JPEG.
+    decode_jpeg = decode_image
 
     # ── detection ─────────────────────────────────────────────────────────
 
@@ -451,6 +538,8 @@ class FaceAnalyzer:
 
 __all__ = [
     "DEFAULT_BLUR_MIN",
+    "DEFAULT_MAX_IMAGE_PIXELS",
+    "DEFAULT_MAX_IMAGE_SIDE",
     "DEFAULT_DET_SIZE",
     "DEFAULT_DET_THRESH",
     "DEFAULT_FACE_MODEL_DIR",

--- a/perception/plugins/face_runtime.py
+++ b/perception/plugins/face_runtime.py
@@ -33,7 +33,7 @@ import numpy as np
 
 from utils.cv2_compat import load_cv2
 from utils.model_downloader import ensure_face_model
-from utils.onnx_provider import normalize_device, ort_providers_for_device
+from utils.onnx_provider import ort_providers_for_device, warn_on_parked_cores
 
 log = logging.getLogger(__name__)
 
@@ -202,7 +202,7 @@ class FaceAnalyzer:
     def __init__(
         self,
         model_dir: str = DEFAULT_FACE_MODEL_DIR,
-        device: str = "cpu",
+        device: str = "auto",
         det_size: tuple[int, int] = DEFAULT_DET_SIZE,
         det_thresh: float = DEFAULT_DET_THRESH,
         nms_thresh: float = DEFAULT_NMS_THRESH,
@@ -212,7 +212,7 @@ class FaceAnalyzer:
         import onnxruntime as ort
 
         self._cv2 = load_cv2()
-        self._device = normalize_device(device)
+        self._requested_device = (device or "auto").strip().lower()
         self._det_thresh = float(det_thresh)
         self._nms_thresh = float(nms_thresh)
         width, height = (int(det_size[0]), int(det_size[1]))
@@ -225,7 +225,16 @@ class FaceAnalyzer:
         det_path = paths.get(DET_MODEL_FILE) or os.path.join(model_dir, DET_MODEL_FILE)
         rec_path = paths.get(REC_MODEL_FILE) or os.path.join(model_dir, REC_MODEL_FILE)
 
-        providers = ort_providers_for_device(self._device)
+        providers = ort_providers_for_device(self._requested_device)
+        # `device` resolves here, not in config: `auto` means "gpu when the
+        # installed wheel has one". Recorded so info/logs report what is
+        # actually running rather than what was asked for.
+        self._device = "gpu" if providers[0] != "CPUExecutionProvider" else "cpu"
+        # Session creation is where a parked-core Jetson abort()s under a bad
+        # ORT version, and an abort prints no Python traceback. Say the
+        # precondition first, so the last line before a silent death names it.
+        warn_on_parked_cores("face")
+
         options = ort.SessionOptions()
         options.intra_op_num_threads = max(1, int(num_threads))
         options.graph_optimization_level = ort.GraphOptimizationLevel.ORT_ENABLE_ALL
@@ -248,8 +257,10 @@ class FaceAnalyzer:
             )
 
         log.info(
-            "[face] analyzer ready: device=%s providers=%s det=%s rec=%s size=%s",
-            self._device, self._det.get_providers(),
+            "[face] analyzer ready: onnxruntime=%s device=%s (requested %s) "
+            "providers=%s det=%s rec=%s size=%s",
+            ort.__version__, self._device, self._requested_device,
+            self._det.get_providers(),
             os.path.basename(det_path), os.path.basename(rec_path),
             self._det_size,
         )
@@ -261,6 +272,7 @@ class FaceAnalyzer:
 
     @property
     def device(self) -> str:
+        """The device actually in use — `auto` is already resolved."""
         return self._device
 
     @property

--- a/perception/tests/test_bundle_dispatch.py
+++ b/perception/tests/test_bundle_dispatch.py
@@ -1,0 +1,141 @@
+"""
+tests/test_bundle_dispatch.py — PerceptionBundle tool-name resolution.
+
+`main.py` maps an incoming `tools/call` name onto a plugin by PREFIX. It used
+to split on the first underscore, which made any PREFIX containing one
+undispatchable: `face_recognition` resolved to a plugin called `face`, matched
+nothing, and the tool was reported as unknown. This pins the longest-prefix
+behaviour and that `dispatch` and `owns` agree, which `owns`'s docstring
+promises.
+
+Importing main.py needs the ROS stubs, hence vision_stubs.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+
+from vision_stubs import PERCEPTION_ROOT  # noqa: F401  (installs stubs, sets sys.path)
+
+
+@pytest.fixture(scope="module")
+def bundle_cls():
+    """Import main.py without its optional heavy dependencies."""
+    for name in ("yaml",):
+        if name not in sys.modules:
+            pytest.importorskip(name)
+    import main
+    return main.PerceptionBundle
+
+
+class _StubPlugin:
+    def __init__(self, prefix: str, tools: list[str] | None = None):
+        self.PREFIX = prefix
+        self._tools = tools or [prefix]
+        self.calls: list[tuple[str, dict]] = []
+
+    def get_tools(self):
+        return [{"name": name} for name in self._tools]
+
+    def dispatch(self, name, args):
+        self.calls.append((name, args))
+        return {"plugin": self.PREFIX, "name": name}
+
+
+def _bundle(bundle_cls, *plugins):
+    """A bundle with no config, wired to stub plugins directly."""
+    bundle = bundle_cls.__new__(bundle_cls)
+    bundle._plugins = list(plugins)
+    return bundle
+
+
+def test_single_word_prefix_still_resolves(bundle_cls):
+    ocr = _StubPlugin("ocr")
+    bundle = _bundle(bundle_cls, ocr)
+    assert bundle.dispatch("ocr", {"action": "info"}) == {"plugin": "ocr", "name": "ocr"}
+    assert ocr.calls[0][0] == "ocr"
+    assert bundle.owns("ocr") is True
+
+
+def test_underscored_prefix_resolves(bundle_cls):
+    """The regression this resolver exists for."""
+    face = _StubPlugin("face_recognition")
+    bundle = _bundle(bundle_cls, face)
+    result = bundle.dispatch("face_recognition", {"action": "info"})
+    assert result == {"plugin": "face_recognition", "name": "face_recognition"}
+    assert face.calls[0][0] == "face_recognition"
+    assert bundle.owns("face_recognition") is True
+
+
+def test_sub_tool_name_is_stripped_of_its_prefix(bundle_cls):
+    asr = _StubPlugin("asr", ["asr", "asr_start"])
+    bundle = _bundle(bundle_cls, asr)
+    bundle.dispatch("asr_start", {})
+    assert asr.calls[0][0] == "start"
+
+
+def test_underscored_prefix_sub_tool(bundle_cls):
+    face = _StubPlugin("face_recognition", ["face_recognition", "register"])
+    bundle = _bundle(bundle_cls, face)
+    bundle.dispatch("face_recognition_register", {})
+    assert face.calls[0][0] == "register"
+
+
+def test_longest_prefix_wins(bundle_cls):
+    """A shorter prefix that is a prefix of a longer one must not shadow it."""
+    face = _StubPlugin("face")
+    face_recognition = _StubPlugin("face_recognition")
+    for order in ((face, face_recognition), (face_recognition, face)):
+        bundle = _bundle(bundle_cls, *order)
+        assert bundle.dispatch("face_recognition", {})["plugin"] == "face_recognition"
+        assert bundle.dispatch("face", {})["plugin"] == "face"
+
+
+def test_unknown_tool_is_not_owned_and_dispatches_to_nothing(bundle_cls):
+    bundle = _bundle(bundle_cls, _StubPlugin("ocr"))
+    assert bundle.dispatch("lidar_scan", {}) is None
+    assert bundle.owns("lidar_scan") is False
+
+
+def test_partial_prefix_match_is_not_enough(bundle_cls):
+    """`facelift` must not be routed to the `face` plugin."""
+    bundle = _bundle(bundle_cls, _StubPlugin("face"))
+    assert bundle.owns("facelift") is False
+    assert bundle.dispatch("facelift", {}) is None
+
+
+def test_owns_and_dispatch_never_disagree(bundle_cls):
+    bundle = _bundle(
+        bundle_cls,
+        _StubPlugin("asr"), _StubPlugin("tts"), _StubPlugin("ocr"),
+        _StubPlugin("vop"), _StubPlugin("face_recognition"),
+    )
+    names = [
+        "asr", "asr_start", "tts", "tts_speak", "ocr", "vop",
+        "face_recognition", "face_recognition_register_user_photo",
+        "face", "facelift", "unknown_tool", "",
+    ]
+    for name in names:
+        owned = bundle.owns(name)
+        dispatched = bundle.dispatch(name, {}) is not None
+        assert owned == dispatched, name
+
+
+def test_get_all_tools_prefixes_sub_tools_only(bundle_cls):
+    """A tool named exactly PREFIX keeps its name; others get PREFIX_ prepended.
+
+    So a plugin declares sub-tools by their bare name (`start`, not
+    `asr_start`), and every emitted name must route back to that plugin.
+    """
+    bundle = _bundle(
+        bundle_cls,
+        _StubPlugin("face_recognition", ["face_recognition"]),
+        _StubPlugin("asr", ["asr", "start"]),
+    )
+    names = {tool["name"] for tool in bundle.get_all_tools()}
+    assert names == {"face_recognition", "asr", "asr_start"}
+    for name in names:
+        assert bundle.owns(name), name

--- a/perception/tests/test_face_db.py
+++ b/perception/tests/test_face_db.py
@@ -1,0 +1,378 @@
+"""
+tests/test_face_db.py — FaceDB persistence, id allocation, capacity, meta CRUD.
+
+Pure host-side: no models, no ROS. Everything here is disk + numpy.
+Run: python -m pytest perception/tests -q
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+
+import numpy as np
+import pytest
+
+from vision_stubs import PERCEPTION_ROOT  # noqa: F401  (puts perception on sys.path)
+
+import plugins.face_db as face_db_module  # noqa: E402
+from plugins.face_db import EMBEDDING_DIM, FaceDB, FaceDBError, is_unknown_id  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _allow_tmp_db(monkeypatch):
+    """FaceDB confines db_dir to /models; tests write to tmp_path instead.
+
+    Patching the guard rather than the path keeps the production invariant
+    (`require_models_subpath`) intact and covered by its own tests.
+    """
+    monkeypatch.setattr(
+        face_db_module, "require_models_subpath", lambda path, root="/models": str(path)
+    )
+
+
+def _vector(seed: int, dim: int = EMBEDDING_DIM) -> np.ndarray:
+    """A deterministic unit vector. Distinct seeds are near-orthogonal."""
+    rng = np.random.default_rng(seed)
+    raw = rng.standard_normal(dim).astype(np.float32)
+    return raw / np.linalg.norm(raw)
+
+
+def _nudge(vector: np.ndarray, amount: float, seed: int = 99) -> np.ndarray:
+    """A vector close to `vector` — stands in for the same face, second photo."""
+    rng = np.random.default_rng(seed)
+    noise = rng.standard_normal(vector.shape).astype(np.float32)
+    noise -= noise @ vector * vector
+    noise /= np.linalg.norm(noise)
+    mixed = vector + amount * noise
+    return (mixed / np.linalg.norm(mixed)).astype(np.float32)
+
+
+# ── basics ────────────────────────────────────────────────────────────────────
+
+def test_add_and_match_roundtrip(tmp_path):
+    db = FaceDB(db_dir=str(tmp_path))
+    record = db.add("Alice", [_vector(1)], meta={"team": "ops"})
+    assert record["id"] == "p-1"
+    assert record["named"] is True
+    assert record["samples"] == 1
+
+    matched, score = db.match(_vector(1), 0.35)
+    assert matched == "p-1"
+    assert score == pytest.approx(1.0, abs=1e-5)
+
+    missed, best = db.match(_vector(2), 0.35)
+    assert missed is None
+    assert best < 0.35
+
+
+def test_match_on_empty_db_reports_no_best_score(tmp_path):
+    db = FaceDB(db_dir=str(tmp_path))
+    matched, score = db.match(_vector(1), 0.35)
+    assert matched is None
+    assert score == -1.0
+
+
+def test_best_of_samples_not_the_centroid(tmp_path):
+    """A person's score is their best sample, so extra poses only help.
+
+    With a mean vector, enrolling a second, different-looking photo would pull
+    the centroid away from both and could push a real match below threshold.
+    """
+    db = FaceDB(db_dir=str(tmp_path))
+    front = _vector(1)
+    profile_pose = _nudge(front, 1.4, seed=7)
+    record = db.add("Alice", [front, profile_pose])
+    assert record["samples"] == 2
+
+    for probe in (front, profile_pose):
+        matched, score = db.match(probe, 0.35)
+        assert matched == "p-1"
+        assert score == pytest.approx(1.0, abs=1e-5)
+
+
+def test_rejects_wrong_dimension_and_zero_norm(tmp_path):
+    db = FaceDB(db_dir=str(tmp_path))
+    with pytest.raises(ValueError):
+        db.add("Bad", [np.ones(7, dtype=np.float32)])
+    with pytest.raises(ValueError):
+        db.add("Bad", [np.zeros(EMBEDDING_DIM, dtype=np.float32)])
+    with pytest.raises(ValueError):
+        db.add("Bad", [])
+
+
+# ── persistence ───────────────────────────────────────────────────────────────
+
+def test_survives_reload(tmp_path):
+    db = FaceDB(db_dir=str(tmp_path))
+    db.add("Alice", [_vector(1)], meta={"team": "ops"})
+    db.enroll_unknown(_vector(5))
+
+    reopened = FaceDB(db_dir=str(tmp_path))
+    assert reopened.stats()["persons"] == 2
+    assert reopened.get_person("p-1")["meta"] == {"team": "ops"}
+    matched, _ = reopened.match(_vector(5), 0.35)
+    assert matched == "unknown-1"
+
+
+def test_persons_json_is_the_commit_point(tmp_path):
+    """persons.json names the embeddings file, so the pair is never mismatched.
+
+    Simulates a crash *after* the embeddings write and *before* the metadata
+    replace by deleting the new persons.json: the previous committed state must
+    load cleanly rather than pairing new rows with old owners.
+    """
+    db = FaceDB(db_dir=str(tmp_path))
+    db.add("Alice", [_vector(1)])
+    first = json.loads((tmp_path / "persons.json").read_text())
+    assert first["embeddings_file"] == "embeddings-1.npy"
+    assert len(first["rows"]) == 1
+
+    db.add("Bob", [_vector(2)])
+    second = json.loads((tmp_path / "persons.json").read_text())
+    assert second["embeddings_file"] == "embeddings-2.npy"
+    # The superseded generation is only unlinked after the commit succeeds.
+    assert not (tmp_path / "embeddings-1.npy").exists()
+
+    # Roll the metadata back to generation 1 while generation 2's matrix is on
+    # disk: the loader must follow persons.json, and generation 1's file is
+    # gone, so this is a genuinely broken database and must say so.
+    (tmp_path / "persons.json").write_text(json.dumps(first))
+    with pytest.raises(FaceDBError):
+        FaceDB(db_dir=str(tmp_path))
+
+
+def test_row_count_mismatch_is_refused(tmp_path):
+    db = FaceDB(db_dir=str(tmp_path))
+    db.add("Alice", [_vector(1)])
+    state = json.loads((tmp_path / "persons.json").read_text())
+    state["rows"].append("p-1")            # one more owner than there are rows
+    (tmp_path / "persons.json").write_text(json.dumps(state))
+    with pytest.raises(FaceDBError):
+        FaceDB(db_dir=str(tmp_path))
+
+
+def test_orphaned_rows_are_dropped_not_misattributed(tmp_path):
+    """A row owned by a deleted person must not be silently reassigned."""
+    db = FaceDB(db_dir=str(tmp_path))
+    db.add("Alice", [_vector(1)])
+    db.add("Bob", [_vector(2)])
+    state = json.loads((tmp_path / "persons.json").read_text())
+    state["persons"] = [p for p in state["persons"] if p["id"] != "p-2"]
+    (tmp_path / "persons.json").write_text(json.dumps(state))
+
+    reopened = FaceDB(db_dir=str(tmp_path))
+    assert reopened.stats()["persons"] == 1
+    assert reopened.stats()["samples"] == 1
+    matched, _ = reopened.match(_vector(2), 0.35)
+    assert matched is None
+
+
+# ── ids ───────────────────────────────────────────────────────────────────────
+
+def test_forgotten_id_is_never_reused(tmp_path):
+    """A retired id must not resolve to a different person later.
+
+    An `unknown-3` may already have been published on the activity stream and
+    recorded in the agent's history; handing that id to somebody else would
+    silently rewrite who those sightings were about.
+    """
+    db = FaceDB(db_dir=str(tmp_path))
+    first = db.enroll_unknown(_vector(1))["id"]
+    assert first == "unknown-1"
+    assert db.forget(first) is True
+
+    second = db.enroll_unknown(_vector(2))["id"]
+    assert second == "unknown-2"
+
+    reopened = FaceDB(db_dir=str(tmp_path))
+    third = reopened.enroll_unknown(_vector(3))["id"]
+    assert third == "unknown-3"
+
+
+def test_forget_unknown_id_helper():
+    assert is_unknown_id("unknown-4")
+    assert not is_unknown_id("p-4")
+
+
+def test_forget_missing_person_is_false(tmp_path):
+    db = FaceDB(db_dir=str(tmp_path))
+    assert db.forget("p-999") is False
+
+
+# ── promotion ─────────────────────────────────────────────────────────────────
+
+def test_promote_keeps_the_id(tmp_path):
+    db = FaceDB(db_dir=str(tmp_path))
+    unknown = db.enroll_unknown(_vector(1))["id"]
+    promoted = db.promote(unknown, "Carol", meta={"floor": 3})
+
+    assert promoted["id"] == unknown          # id preserved, deliberately
+    assert promoted["named"] is True
+    assert promoted["profile"] == "Carol"
+    assert promoted["meta"] == {"floor": 3}
+    stats = db.stats()
+    assert (stats["named"], stats["unknown"]) == (1, 0)
+
+
+def test_setting_a_blank_profile_does_not_promote(tmp_path):
+    db = FaceDB(db_dir=str(tmp_path))
+    unknown = db.enroll_unknown(_vector(1))["id"]
+    record = db.update_person(unknown, profile="   ")
+    assert record["named"] is False
+
+
+# ── meta CRUD ─────────────────────────────────────────────────────────────────
+
+def test_meta_merge_replace_and_delete(tmp_path):
+    db = FaceDB(db_dir=str(tmp_path))
+    db.add("Alice", [_vector(1)], meta={"team": "ops", "floor": 3})
+
+    merged = db.update_person("p-1", meta={"floor": 4, "badge": "A7"})
+    assert merged["meta"] == {"team": "ops", "floor": 4, "badge": "A7"}
+
+    replaced = db.update_person("p-1", meta={"only": "this"}, merge=False)
+    assert replaced["meta"] == {"only": "this"}
+
+    trimmed = db.update_person("p-1", meta={"keep": 1}, meta_delete=["only"])
+    assert trimmed["meta"] == {"keep": 1}
+
+    assert FaceDB(db_dir=str(tmp_path)).get_person("p-1")["meta"] == {"keep": 1}
+
+
+def test_meta_must_be_a_json_object(tmp_path):
+    db = FaceDB(db_dir=str(tmp_path))
+    db.add("Alice", [_vector(1)])
+    with pytest.raises(ValueError):
+        db.update_person("p-1", meta=["not", "an", "object"])
+    with pytest.raises(ValueError):
+        db.update_person("p-1", meta={"bad": {1, 2}})     # a set is not JSON
+    # The rejected write must not have changed anything.
+    assert db.get_person("p-1")["meta"] == {}
+
+
+def test_update_and_get_missing_person_raise_keyerror(tmp_path):
+    db = FaceDB(db_dir=str(tmp_path))
+    with pytest.raises(KeyError):
+        db.get_person("p-1")
+    with pytest.raises(KeyError):
+        db.update_person("p-1", profile="x")
+    with pytest.raises(KeyError):
+        db.add_samples("p-1", [_vector(1)])
+
+
+# ── capacity ──────────────────────────────────────────────────────────────────
+
+def test_unknown_capacity_evicts_least_recently_seen(tmp_path):
+    db = FaceDB(db_dir=str(tmp_path), unknown_capacity=3)
+    ids = [db.enroll_unknown(_vector(seed))["id"] for seed in range(3)]
+    # unknown-1 is the least recently seen once the others are touched.
+    db.touch(ids[1], when=5_000.0)
+    db.touch(ids[2], when=6_000.0)
+    db.touch(ids[0], when=1_000.0)
+
+    fourth = db.enroll_unknown(_vector(50))["id"]
+    remaining = {p["id"] for p in db.list_persons(named="unknown")["persons"]}
+    assert ids[0] not in remaining
+    assert remaining == {ids[1], ids[2], fourth}
+
+
+def test_lowering_capacity_evicts_now_and_spares_named(tmp_path):
+    db = FaceDB(db_dir=str(tmp_path), unknown_capacity=10)
+    db.add("Alice", [_vector(900)])
+    for seed in range(6):
+        db.touch(db.enroll_unknown(_vector(seed))["id"], when=1_000.0 + seed)
+
+    evicted = db.set_unknown_capacity(2)
+    assert evicted == 4
+    stats = db.stats()
+    assert stats["unknown"] == 2
+    assert stats["named"] == 1                    # never a candidate
+    assert db.get_person("p-1")["profile"] == "Alice"
+
+
+def test_zero_capacity_refuses_to_enrol_unknowns(tmp_path):
+    db = FaceDB(db_dir=str(tmp_path), unknown_capacity=0)
+    with pytest.raises(FaceDBError):
+        db.enroll_unknown(_vector(1))
+    assert db.stats()["unknown"] == 0
+
+
+def test_forget_unknowns_leaves_named_intact(tmp_path):
+    db = FaceDB(db_dir=str(tmp_path))
+    db.add("Alice", [_vector(900)])
+    db.enroll_unknown(_vector(1))
+    db.enroll_unknown(_vector(2))
+
+    assert db.forget_unknowns() == 2
+    stats = db.stats()
+    assert (stats["named"], stats["unknown"], stats["samples"]) == (1, 0, 1)
+    matched, _ = db.match(_vector(900), 0.35)
+    assert matched == "p-1"
+
+
+def test_samples_are_capped_keeping_the_newest(tmp_path):
+    db = FaceDB(db_dir=str(tmp_path), max_samples_per_person=2)
+    oldest = _vector(1)
+    db.add("Alice", [oldest])
+    newer = _vector(2)
+    newest = _vector(3)
+    record = db.add_samples("p-1", [newer])
+    record = db.add_samples("p-1", [newest])
+
+    assert record["samples"] == 2
+    assert db.match(oldest, 0.9)[0] is None       # evicted
+    assert db.match(newer, 0.9)[0] == "p-1"
+    assert db.match(newest, 0.9)[0] == "p-1"
+
+
+# ── listing ───────────────────────────────────────────────────────────────────
+
+def test_list_persons_filters_and_pages(tmp_path):
+    db = FaceDB(db_dir=str(tmp_path))
+    db.add("Alice from ops", [_vector(1)], meta={"badge": "A7"})
+    db.add("Bob from sales", [_vector(2)])
+    db.enroll_unknown(_vector(3))
+
+    assert db.list_persons()["total"] == 3
+    assert db.list_persons(named="named")["total"] == 2
+    assert db.list_persons(named="unknown")["total"] == 1
+    assert db.list_persons(query="sales")["total"] == 1
+    assert db.list_persons(query="a7")["total"] == 1            # matches meta
+    assert db.list_persons(query="unknown-")["total"] == 1      # matches id
+
+    page = db.list_persons(limit=1, offset=1)
+    assert len(page["persons"]) == 1 and page["total"] == 3
+    assert "embedding" not in json.dumps(page)
+
+
+# ── concurrency ───────────────────────────────────────────────────────────────
+
+def test_concurrent_enrolment_keeps_every_person_and_row(tmp_path):
+    """Registration runs on arbitrary ThreadingHTTPServer threads."""
+    db = FaceDB(db_dir=str(tmp_path))
+    errors: list[Exception] = []
+
+    def worker(seed: int):
+        try:
+            db.add(f"person-{seed}", [_vector(seed)])
+        except Exception as error:  # noqa: BLE001
+            errors.append(error)
+
+    threads = [threading.Thread(target=worker, args=(seed,)) for seed in range(12)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert not errors
+    stats = db.stats()
+    assert stats["persons"] == 12
+    assert stats["samples"] == 12
+    assert len({p["id"] for p in db.list_persons(limit=50)["persons"]}) == 12
+
+    reloaded = FaceDB(db_dir=str(tmp_path))
+    assert reloaded.stats()["samples"] == 12
+    for seed in range(12):
+        assert reloaded.match(_vector(seed), 0.9)[0] is not None

--- a/perception/tests/test_face_db.py
+++ b/perception/tests/test_face_db.py
@@ -1,5 +1,5 @@
 """
-tests/test_face_db.py — FaceDB persistence, id allocation, capacity, meta CRUD.
+tests/test_face_db.py — FaceDB persistence, id allocation, capacity, profile CRUD.
 
 Pure host-side: no models, no ROS. Everything here is disk + numpy.
 Run: python -m pytest perception/tests -q
@@ -53,7 +53,7 @@ def _nudge(vector: np.ndarray, amount: float, seed: int = 99) -> np.ndarray:
 
 def test_add_and_match_roundtrip(tmp_path):
     db = FaceDB(db_dir=str(tmp_path))
-    record = db.add("Alice", [_vector(1)], meta={"team": "ops"})
+    record = db.add("Alice", [_vector(1)], profile={"team": "ops"})
     assert record["id"] == "p-1"
     assert record["named"] is True
     assert record["samples"] == 1
@@ -106,12 +106,12 @@ def test_rejects_wrong_dimension_and_zero_norm(tmp_path):
 
 def test_survives_reload(tmp_path):
     db = FaceDB(db_dir=str(tmp_path))
-    db.add("Alice", [_vector(1)], meta={"team": "ops"})
+    db.add("Alice", [_vector(1)], profile={"team": "ops"})
     db.enroll_unknown(_vector(5))
 
     reopened = FaceDB(db_dir=str(tmp_path))
     assert reopened.stats()["persons"] == 2
-    assert reopened.get_person("p-1")["meta"] == {"team": "ops"}
+    assert reopened.get_person("p-1")["profile"] == {"team": "ops"}
     matched, _ = reopened.match(_vector(5), 0.35)
     assert matched == "unknown-1"
 
@@ -206,50 +206,50 @@ def test_forget_missing_person_is_false(tmp_path):
 def test_promote_keeps_the_id(tmp_path):
     db = FaceDB(db_dir=str(tmp_path))
     unknown = db.enroll_unknown(_vector(1))["id"]
-    promoted = db.promote(unknown, "Carol", meta={"floor": 3})
+    promoted = db.promote(unknown, "Carol", profile={"floor": 3})
 
     assert promoted["id"] == unknown          # id preserved, deliberately
     assert promoted["named"] is True
-    assert promoted["profile"] == "Carol"
-    assert promoted["meta"] == {"floor": 3}
+    assert promoted["name"] == "Carol"
+    assert promoted["profile"] == {"floor": 3}
     stats = db.stats()
     assert (stats["named"], stats["unknown"]) == (1, 0)
 
 
-def test_setting_a_blank_profile_does_not_promote(tmp_path):
+def test_setting_a_blank_name_does_not_promote(tmp_path):
     db = FaceDB(db_dir=str(tmp_path))
     unknown = db.enroll_unknown(_vector(1))["id"]
-    record = db.update_person(unknown, profile="   ")
+    record = db.update_person(unknown, name="   ")
     assert record["named"] is False
 
 
-# ── meta CRUD ─────────────────────────────────────────────────────────────────
+# ── profile CRUD ─────────────────────────────────────────────────────────────────
 
-def test_meta_merge_replace_and_delete(tmp_path):
+def test_profile_merge_replace_and_delete(tmp_path):
     db = FaceDB(db_dir=str(tmp_path))
-    db.add("Alice", [_vector(1)], meta={"team": "ops", "floor": 3})
+    db.add("Alice", [_vector(1)], profile={"team": "ops", "floor": 3})
 
-    merged = db.update_person("p-1", meta={"floor": 4, "badge": "A7"})
-    assert merged["meta"] == {"team": "ops", "floor": 4, "badge": "A7"}
+    merged = db.update_person("p-1", profile={"floor": 4, "badge": "A7"})
+    assert merged["profile"] == {"team": "ops", "floor": 4, "badge": "A7"}
 
-    replaced = db.update_person("p-1", meta={"only": "this"}, merge=False)
-    assert replaced["meta"] == {"only": "this"}
+    replaced = db.update_person("p-1", profile={"only": "this"}, merge=False)
+    assert replaced["profile"] == {"only": "this"}
 
-    trimmed = db.update_person("p-1", meta={"keep": 1}, meta_delete=["only"])
-    assert trimmed["meta"] == {"keep": 1}
+    trimmed = db.update_person("p-1", profile={"keep": 1}, profile_delete=["only"])
+    assert trimmed["profile"] == {"keep": 1}
 
-    assert FaceDB(db_dir=str(tmp_path)).get_person("p-1")["meta"] == {"keep": 1}
+    assert FaceDB(db_dir=str(tmp_path)).get_person("p-1")["profile"] == {"keep": 1}
 
 
-def test_meta_must_be_a_json_object(tmp_path):
+def test_profile_must_be_a_json_object(tmp_path):
     db = FaceDB(db_dir=str(tmp_path))
     db.add("Alice", [_vector(1)])
     with pytest.raises(ValueError):
-        db.update_person("p-1", meta=["not", "an", "object"])
+        db.update_person("p-1", profile=["not", "an", "object"])
     with pytest.raises(ValueError):
-        db.update_person("p-1", meta={"bad": {1, 2}})     # a set is not JSON
+        db.update_person("p-1", profile={"bad": {1, 2}})     # a set is not JSON
     # The rejected write must not have changed anything.
-    assert db.get_person("p-1")["meta"] == {}
+    assert db.get_person("p-1")["profile"] == {}
 
 
 def test_update_and_get_missing_person_raise_keyerror(tmp_path):
@@ -257,7 +257,7 @@ def test_update_and_get_missing_person_raise_keyerror(tmp_path):
     with pytest.raises(KeyError):
         db.get_person("p-1")
     with pytest.raises(KeyError):
-        db.update_person("p-1", profile="x")
+        db.update_person("p-1", name="x")
     with pytest.raises(KeyError):
         db.add_samples("p-1", [_vector(1)])
 
@@ -289,7 +289,7 @@ def test_lowering_capacity_evicts_now_and_spares_named(tmp_path):
     stats = db.stats()
     assert stats["unknown"] == 2
     assert stats["named"] == 1                    # never a candidate
-    assert db.get_person("p-1")["profile"] == "Alice"
+    assert db.get_person("p-1")["name"] == "Alice"
 
 
 def test_zero_capacity_refuses_to_enrol_unknowns(tmp_path):
@@ -331,7 +331,7 @@ def test_samples_are_capped_keeping_the_newest(tmp_path):
 
 def test_list_persons_filters_and_pages(tmp_path):
     db = FaceDB(db_dir=str(tmp_path))
-    db.add("Alice from ops", [_vector(1)], meta={"badge": "A7"})
+    db.add("Alice from ops", [_vector(1)], profile={"badge": "A7"})
     db.add("Bob from sales", [_vector(2)])
     db.enroll_unknown(_vector(3))
 
@@ -339,7 +339,7 @@ def test_list_persons_filters_and_pages(tmp_path):
     assert db.list_persons(named="named")["total"] == 2
     assert db.list_persons(named="unknown")["total"] == 1
     assert db.list_persons(query="sales")["total"] == 1
-    assert db.list_persons(query="a7")["total"] == 1            # matches meta
+    assert db.list_persons(query="a7")["total"] == 1            # matches profile
     assert db.list_persons(query="unknown-")["total"] == 1      # matches id
 
     page = db.list_persons(limit=1, offset=1)
@@ -376,3 +376,237 @@ def test_concurrent_enrolment_keeps_every_person_and_row(tmp_path):
     assert reloaded.stats()["samples"] == 12
     for seed in range(12):
         assert reloaded.match(_vector(seed), 0.9)[0] is not None
+
+
+# ── visit log (访问记录表) ────────────────────────────────────────────────────
+
+def _seen(db, person_id, at, topic="/cam"):
+    db.record_sighting(person_id, at, topic)
+
+
+def test_a_continuous_presence_is_one_visit_not_one_per_frame(tmp_path):
+    """At 1 detection/second a per-frame log would be 86 400 rows a day."""
+    db = FaceDB(db_dir=str(tmp_path), visit_gap_s=600.0)
+    db.add("Alice", [_vector(1)])
+    for offset in range(0, 300, 1):          # 5 minutes of sightings
+        _seen(db, "p-1", 1_000_000 + offset)
+
+    # Nothing written yet: the visit is still open.
+    assert not (tmp_path / "visits.jsonl").exists()
+    assert db.list_visits()["total"] == 1
+    open_visit = db.list_visits()["visits"][0]
+    assert open_visit["open"] is True
+    assert open_visit["sightings"] == 300
+
+    # Still open before the gap elapses, closed after. The last sighting is at
+    # +299, so the gap is measured from there.
+    last_seen = 1_000_000 + 299
+    assert db.close_stale_visits(now=last_seen + 599) == 0
+    assert db.close_stale_visits(now=last_seen + 601) == 1
+
+    lines = (tmp_path / "visits.jsonl").read_text().strip().split("\n")
+    assert len(lines) == 1, "one visit, not one row per sighting"
+    record = json.loads(lines[0])
+    assert record["person_id"] == "p-1"
+    assert record["first_seen"] == 1_000_000
+    assert record["last_seen"] == 1_000_000 + 299
+    assert record["sightings"] == 300
+
+
+def test_a_short_absence_does_not_split_the_visit(tmp_path):
+    """Someone turning their head must not fragment an afternoon."""
+    db = FaceDB(db_dir=str(tmp_path), visit_gap_s=600.0)
+    db.add("Alice", [_vector(1)])
+    _seen(db, "p-1", 2_000_000)
+    db.close_stale_visits(now=2_000_000 + 120)     # 2 min gap: still the same visit
+    _seen(db, "p-1", 2_000_000 + 121)
+    db.close_stale_visits(now=2_000_000 + 800)     # now it has really been quiet
+
+    visits = db.list_visits()["visits"]
+    assert len(visits) == 1
+    assert visits[0]["sightings"] == 2
+
+
+def test_separate_visits_when_the_gap_is_exceeded(tmp_path):
+    db = FaceDB(db_dir=str(tmp_path), visit_gap_s=60.0)
+    db.add("Alice", [_vector(1)])
+    _seen(db, "p-1", 3_000_000)
+    db.close_stale_visits(now=3_000_000 + 100)
+    _seen(db, "p-1", 3_000_000 + 200)
+    db.close_stale_visits(now=3_000_000 + 400)
+    assert db.list_visits()["total"] == 2
+
+
+def test_list_visits_filters_by_overlap_not_containment(tmp_path):
+    """Someone there 14:50-15:10 was there at 15:00."""
+    db = FaceDB(db_dir=str(tmp_path), visit_gap_s=60.0)
+    db.add("Alice", [_vector(1)])
+    _seen(db, "p-1", 1_000)
+    _seen(db, "p-1", 2_000)
+    db.close_stale_visits(force=True)
+
+    assert db.list_visits(since=1_500, until=1_600)["total"] == 1   # inside
+    assert db.list_visits(since=500, until=1_200)["total"] == 1     # overlaps start
+    assert db.list_visits(since=1_900, until=5_000)["total"] == 1   # overlaps end
+    assert db.list_visits(since=3_000)["total"] == 0                # after
+    assert db.list_visits(until=500)["total"] == 0                  # before
+
+
+def test_list_visits_accepts_iso_timestamps(tmp_path):
+    from datetime import datetime
+    db = FaceDB(db_dir=str(tmp_path), visit_gap_s=60.0)
+    db.add("Alice", [_vector(1)])
+    when = datetime(2026, 9, 7, 15, 0, 0).timestamp()
+    _seen(db, "p-1", when)
+    db.close_stale_visits(force=True)
+
+    assert db.list_visits(since="2026-09-07T14:00", until="2026-09-07T16:00")["total"] == 1
+    assert db.list_visits(since="2026-09-07T16:00")["total"] == 0
+    with pytest.raises(ValueError):
+        db.list_visits(since="last tuesday")
+
+
+def test_list_visits_filters_by_person_and_resolves_the_current_name(tmp_path):
+    db = FaceDB(db_dir=str(tmp_path), visit_gap_s=60.0)
+    unknown = db.enroll_unknown(_vector(1))["id"]
+    db.add("Bob", [_vector(2)])
+    _seen(db, unknown, 10_000)
+    _seen(db, "p-1", 10_000)
+    db.close_stale_visits(force=True)
+
+    assert db.list_visits(person_id=unknown)["total"] == 1
+    assert db.list_visits()["total"] == 2
+
+    # The visit was logged while they were anonymous; naming them later must
+    # make the history readable rather than leaving a blank.
+    db.update_person(unknown, name="Late-named Carol")
+    entry = db.list_visits(person_id=unknown)["visits"][0]
+    assert entry["name"] == "Late-named Carol"
+
+
+def test_open_visits_are_checkpointed_against_power_loss(tmp_path):
+    """A 10-minute gap means an all-afternoon visit lives in RAM for hours."""
+    db = FaceDB(db_dir=str(tmp_path), visit_gap_s=600.0, visit_checkpoint_s=0.0)
+    db.add("Alice", [_vector(1)])
+    _seen(db, "p-1", 4_000_000)
+    _seen(db, "p-1", 4_000_100)
+    assert db.checkpoint_open_visits() is True
+    assert (tmp_path / "visits-open.json").exists()
+
+    # Simulate a power cut: a brand-new FaceDB over the same directory.
+    recovered = FaceDB(db_dir=str(tmp_path), visit_gap_s=600.0)
+    visits = recovered.list_visits()["visits"]
+    assert len(visits) == 1
+    assert visits[0]["sightings"] == 2
+    assert visits[0]["first_seen"] == 4_000_000
+
+
+def test_a_stale_checkpointed_visit_is_closed_on_recovery(tmp_path):
+    """If the person left while we were down, the visit is completed, not resumed."""
+    db = FaceDB(db_dir=str(tmp_path), visit_gap_s=1.0, visit_checkpoint_s=0.0)
+    db.add("Alice", [_vector(1)])
+    _seen(db, "p-1", 100.0)                # long in the past
+    db.checkpoint_open_visits(force=True)
+
+    recovered = FaceDB(db_dir=str(tmp_path), visit_gap_s=1.0)
+    assert recovered.stats()["open_visits"] == 0
+    lines = (tmp_path / "visits.jsonl").read_text().strip().split("\n")
+    assert len(lines) == 1
+    assert json.loads(lines[0])["recovered"] is True
+
+
+def test_a_fresh_checkpointed_visit_is_resumed_not_duplicated(tmp_path):
+    db = FaceDB(db_dir=str(tmp_path), visit_gap_s=600.0, visit_checkpoint_s=0.0)
+    db.add("Alice", [_vector(1)])
+    _seen(db, "p-1", _now_for_test := __import__("time").time())
+    db.checkpoint_open_visits(force=True)
+
+    recovered = FaceDB(db_dir=str(tmp_path), visit_gap_s=600.0)
+    assert recovered.stats()["open_visits"] == 1
+    _seen(recovered, "p-1", _now_for_test + 1)
+    recovered.close_stale_visits(force=True)
+    lines = (tmp_path / "visits.jsonl").read_text().strip().split("\n")
+    assert len(lines) == 1, "the resumed visit must not become a second record"
+    assert json.loads(lines[0])["sightings"] == 2
+
+
+def test_checkpoint_is_throttled_and_cleared_when_nothing_is_open(tmp_path):
+    db = FaceDB(db_dir=str(tmp_path), visit_gap_s=60.0, visit_checkpoint_s=3600.0)
+    db.add("Alice", [_vector(1)])
+    _seen(db, "p-1", 5_000_000)
+    assert db.checkpoint_open_visits() is True          # first one always writes
+    assert db.checkpoint_open_visits() is False         # throttled
+    db.close_stale_visits(force=True)
+    assert not (tmp_path / "visits-open.json").exists()
+
+
+def test_visit_log_is_trimmed_to_its_cap(tmp_path):
+    db = FaceDB(db_dir=str(tmp_path), visit_gap_s=1.0, visit_log_max=5)
+    db.add("Alice", [_vector(1)])
+    for index in range(12):
+        _seen(db, "p-1", 6_000_000 + index * 100)
+        db.close_stale_visits(now=6_000_000 + index * 100 + 50)
+    lines = (tmp_path / "visits.jsonl").read_text().strip().split("\n")
+    assert len(lines) == 5
+    # The newest are the ones kept.
+    assert json.loads(lines[-1])["first_seen"] == 6_000_000 + 11 * 100
+
+
+def test_a_torn_line_does_not_make_the_history_unreadable(tmp_path):
+    db = FaceDB(db_dir=str(tmp_path), visit_gap_s=1.0)
+    db.add("Alice", [_vector(1)])
+    _seen(db, "p-1", 7_000_000)
+    db.close_stale_visits(force=True)
+    with open(tmp_path / "visits.jsonl", "a") as handle:
+        handle.write('{"person_id": "p-1", "first_se\n')     # crash mid-append
+    assert db.list_visits()["total"] == 1
+
+
+def test_visit_log_disabled_by_a_zero_cap(tmp_path):
+    db = FaceDB(db_dir=str(tmp_path), visit_gap_s=1.0, visit_log_max=0)
+    db.add("Alice", [_vector(1)])
+    _seen(db, "p-1", 8_000_000)
+    db.close_stale_visits(force=True)
+    assert not (tmp_path / "visits.jsonl").exists()
+
+
+# ── record shape / migration ─────────────────────────────────────────────────
+
+def test_record_separates_name_from_free_form_profile(tmp_path):
+    db = FaceDB(db_dir=str(tmp_path))
+    record = db.add("小王", [_vector(1)], profile={"gender": "male", "team": "ops"})
+    assert record["name"] == "小王"
+    assert record["profile"] == {"gender": "male", "team": "ops"}
+    assert "registered_at" in record and "last_seen_at" in record
+    assert "created_at" not in record and "meta" not in record
+
+
+def test_a_string_profile_is_kept_as_a_note(tmp_path):
+    """An LLM will occasionally send prose where an object is expected."""
+    db = FaceDB(db_dir=str(tmp_path))
+    record = db.add("小王", [_vector(1)], profile="爱穿蓝色外套")
+    assert record["profile"] == {"note": "爱穿蓝色外套"}
+
+
+def test_version_1_database_migrates_profile_to_name(tmp_path):
+    """The field split must not orphan a database written by the older build."""
+    db = FaceDB(db_dir=str(tmp_path))
+    db.add("ignored", [_vector(1)])
+    state = json.loads((tmp_path / "persons.json").read_text())
+    state["version"] = 1
+    state["persons"][0] = {
+        "id": "p-1",
+        "profile": "Alice from ops",          # v1: free text label
+        "meta": {"badge": "A7"},              # v1: structured bag
+        "named": True,
+        "created_at": 111.0,
+        "updated_at": 222.0,
+        "last_seen_at": 333.0,
+    }
+    (tmp_path / "persons.json").write_text(json.dumps(state))
+
+    migrated = FaceDB(db_dir=str(tmp_path)).get_person("p-1")
+    assert migrated["name"] == "Alice from ops"
+    assert migrated["profile"] == {"badge": "A7"}
+    assert migrated["registered_at"] == 111.0
+    assert migrated["last_seen_at"] == 333.0

--- a/perception/tests/test_face_db.py
+++ b/perception/tests/test_face_db.py
@@ -610,3 +610,82 @@ def test_version_1_database_migrates_profile_to_name(tmp_path):
     assert migrated["profile"] == {"badge": "A7"}
     assert migrated["registered_at"] == 111.0
     assert migrated["last_seen_at"] == 333.0
+
+
+# ── batch forget ─────────────────────────────────────────────────────────────
+
+def test_forget_many_commits_once_not_once_per_person(tmp_path):
+    """The reason batch exists: every save rewrites persons.json and writes a
+    fresh embeddings-<n>.npy, so N single deletes were N full rewrites of the
+    whole database onto eMMC."""
+    db = FaceDB(db_dir=str(tmp_path))
+    ids = [db.add(f"p{seed}", [_vector(seed)])["id"] for seed in range(6)]
+    before = json.loads((tmp_path / "persons.json").read_text())["generation"]
+
+    outcome = db.forget_many(ids[:4])
+
+    assert outcome["forgotten"] == ids[:4]
+    assert outcome["missing"] == []
+    state = json.loads((tmp_path / "persons.json").read_text())
+    assert state["generation"] == before + 1, "must be a single commit"
+    # Exactly one embeddings file, and it matches the surviving rows.
+    assert sorted(p.name for p in tmp_path.glob("embeddings-*.npy")) == [
+        state["embeddings_file"]
+    ]
+    assert len(state["rows"]) == 2
+    assert db.stats()["persons"] == 2
+
+
+def test_forget_many_reports_which_ids_were_missing(tmp_path):
+    """Partial success is the normal case when given a list of ids."""
+    db = FaceDB(db_dir=str(tmp_path))
+    db.add("Alice", [_vector(1)])
+    outcome = db.forget_many(["p-1", "p-404", "unknown-9"])
+    assert outcome["forgotten"] == ["p-1"]
+    assert outcome["missing"] == ["p-404", "unknown-9"]
+
+
+def test_forget_many_dedupes_and_tolerates_an_empty_list(tmp_path):
+    db = FaceDB(db_dir=str(tmp_path))
+    db.add("Alice", [_vector(1)])
+    assert db.forget_many(["p-1", "p-1", "", "  "])["forgotten"] == ["p-1"]
+    assert db.forget_many([]) == {"forgotten": [], "missing": []}
+    assert db.forget_many(["p-1"])["missing"] == ["p-1"]      # already gone
+
+
+def test_forget_many_survives_a_reload_and_leaves_matching_intact(tmp_path):
+    db = FaceDB(db_dir=str(tmp_path))
+    keep = db.add("Keeper", [_vector(100)])["id"]
+    db.forget_many([db.add(f"x{s}", [_vector(s)])["id"] for s in range(5)])
+
+    reopened = FaceDB(db_dir=str(tmp_path))
+    assert reopened.stats()["persons"] == 1
+    assert reopened.match(_vector(100), 0.9)[0] == keep
+    for seed in range(5):
+        assert reopened.match(_vector(seed), 0.9)[0] is None
+
+
+def test_forget_drops_the_open_visit_too(tmp_path):
+    """Otherwise the visit is appended later under an id that no longer exists."""
+    db = FaceDB(db_dir=str(tmp_path), visit_gap_s=600.0)
+    db.add("Alice", [_vector(1)])
+    db.record_sighting("p-1", 9_000_000, "/cam")
+    assert db.stats()["open_visits"] == 1
+
+    db.forget_many(["p-1"])
+    assert db.stats()["open_visits"] == 0
+    db.close_stale_visits(force=True)
+    assert db.list_visits()["total"] == 0
+
+
+def test_forget_unknowns_also_commits_once(tmp_path):
+    db = FaceDB(db_dir=str(tmp_path))
+    db.add("Alice", [_vector(900)])
+    for seed in range(5):
+        db.enroll_unknown(_vector(seed))
+    before = json.loads((tmp_path / "persons.json").read_text())["generation"]
+
+    assert db.forget_unknowns() == 5
+    state = json.loads((tmp_path / "persons.json").read_text())
+    assert state["generation"] == before + 1
+    assert db.stats()["named"] == 1

--- a/perception/tests/test_face_plugin.py
+++ b/perception/tests/test_face_plugin.py
@@ -1099,10 +1099,12 @@ def test_payload_reports_name_and_profile_but_no_timestamps(plugin):
 def test_recognize_actions_are_on_the_card():
     schema = face_plugin.TOOLS[0]["inputSchema"]
     actions = set(schema["properties"]["action"]["enum"])
-    assert {"recognize_by_photo", "recognize_by_stream"} <= actions
+    assert {"recognize_by_photo", "recognize_by_url",
+            "recognize_by_stream"} <= actions
     assert actions == set(schema["x-action-params"])
     params = schema["x-action-params"]
-    assert set(params["recognize_by_photo"]["params"]) == {"image_path", "url"}
+    assert set(params["recognize_by_photo"]["params"]) == {"image_path"}
+    assert set(params["recognize_by_url"]["params"]) == {"url"}
     assert set(params["recognize_by_stream"]["params"]) == {"window_s"}
     # register/recognize are symmetric by suffix.
     assert {"register_by_photo", "register_by_url",
@@ -1350,14 +1352,14 @@ def test_register_by_url_surfaces_a_fetch_failure(plugin, monkeypatch):
     assert "timed out" in result["detail"]
 
 
-def test_recognize_by_photo_also_accepts_a_url(plugin, monkeypatch):
+def test_recognize_by_url_is_its_own_action(plugin, monkeypatch):
     engine = plugin._require_engine()
     engine.db.add("Bob", [_unit(610)])
     monkeypatch.setattr(face_plugin, '_fetch_url',
                         lambda url, max_bytes: _FakeFrame.one(610))
 
     result = plugin.dispatch("face_recognition", {
-        "action": "recognize_by_photo", "url": "https://example.com/b.jpg"})
+        "action": "recognize_by_url", "url": "https://example.com/b.jpg"})
     assert result["ok"] is True
     assert result["faces"][0]["name"] == "Bob"
 

--- a/perception/tests/test_face_plugin.py
+++ b/perception/tests/test_face_plugin.py
@@ -122,13 +122,18 @@ class _FakeAnalyzer:
 class _SpecAnalyzer(_FakeAnalyzer):
     """The analyzer the tests use: identity travels in the aligned crop.
 
-    `prepare` stamps the face's identity into pixel [0,0,0] and `embed` reads it
+    `prepare` stamps the face's identity into cell [0,0,0] and `embed` reads it
     back, which is how a frame spec like `b"7:120:500"` ends up as a stable
     512-d vector for person 7 without any model.
+
+    int32, not uint8: a real aligned crop is uint8, but the plugin only ever
+    hands this array straight back to `embed`, and uint8 silently caps the
+    identity space at 255 — which cost a debugging round when a test used
+    identity 300 and got "Python integer 300 out of bounds for uint8".
     """
 
     def prepare(self, image, face):
-        aligned = np.zeros((112, 112, 3), dtype=np.uint8)
+        aligned = np.zeros((112, 112, 3), dtype=np.int32)
         aligned[0, 0, 0] = face.identity
         face.aligned = aligned
         return face
@@ -426,14 +431,14 @@ def test_unknown_face_gets_a_stable_id_across_frames(plugin):
     assert second["score"] > 0.9
 
 
-def test_a_registered_person_is_reported_with_their_profile(plugin):
+def test_a_registered_person_is_reported_with_their_name(plugin):
     engine = plugin._require_engine()
-    engine.db.add("运营部小王", [_unit(3)], meta={"team": "ops"})
+    engine.db.add("运营部小王", [_unit(3)], profile={"team": "ops"})
 
     _node, payloads = _run_one_frame(plugin, _FakeFrame.one(3))
     face = payloads[0]["faces"][0]
     assert face["person_id"] == "p-1"
-    assert face["profile"] == "运营部小王"
+    assert face["name"] == "运营部小王"
     assert face["known"] is True
 
 
@@ -464,7 +469,7 @@ def test_several_people_in_one_frame_are_all_reported(plugin):
     assert ids == {"unknown-1", "unknown-2"}      # ambiguity only blocks enrolment
 
 
-# ── register_user_photo ───────────────────────────────────────────────────────
+# ── register_by_photo ───────────────────────────────────────────────────────
 
 def _write_photo(tmp_path, name: str, frame: bytes) -> str:
     path = tmp_path / name
@@ -475,13 +480,13 @@ def _write_photo(tmp_path, name: str, frame: bytes) -> str:
 def test_register_from_a_photo_path(plugin, tmp_path):
     path = _write_photo(tmp_path, "alice.jpg", _FakeFrame.one(11))
     result = plugin.dispatch("face_recognition", {
-        "action": "register_user_photo", "image_path": path,
-        "profile": "Alice", "meta": {"team": "ops"},
+        "action": "register_by_photo", "image_path": path,
+        "name": "Alice", "profile": {"team": "ops"},
     })
     assert result["ok"] is True
     assert result["person_id"] == "p-1"
-    assert result["profile"] == "Alice"
-    assert result["meta"] == {"team": "ops"}
+    assert result["name"] == "Alice"
+    assert result["profile"] == {"team": "ops"}
 
     engine = plugin._require_engine()
     assert engine.db.match(_unit(11), 0.35)[0] == "p-1"
@@ -491,7 +496,7 @@ def test_register_from_base64(plugin):
     import base64
     encoded = base64.b64encode(_FakeFrame.one(12)).decode()
     result = plugin.dispatch("face_recognition", {
-        "action": "register_user_photo", "image_b64": encoded, "profile": "Bob"})
+        "action": "register_by_photo", "image_b64": encoded, "name": "Bob"})
     assert result["ok"] is True and result["person_id"] == "p-1"
 
 
@@ -506,7 +511,7 @@ def test_register_reports_each_failure_reason(plugin, tmp_path):
     for name, (frame, expected) in cases.items():
         path = _write_photo(tmp_path, f"{name}.jpg", frame)
         result = plugin.dispatch("face_recognition", {
-            "action": "register_user_photo", "image_path": path, "profile": name})
+            "action": "register_by_photo", "image_path": path, "profile": name})
         assert result["ok"] is False, name
         assert result["reason"] == expected, name
         assert result["detail"], name
@@ -515,25 +520,25 @@ def test_register_reports_each_failure_reason(plugin, tmp_path):
 
 def test_register_rejects_missing_and_out_of_root_paths(plugin, tmp_path):
     missing = plugin.dispatch("face_recognition", {
-        "action": "register_user_photo", "image_path": str(tmp_path / "nope.jpg")})
+        "action": "register_by_photo", "image_path": str(tmp_path / "nope.jpg")})
     assert missing["reason"] == face_plugin.REASON_BAD_INPUT
 
     escaped = plugin.dispatch("face_recognition", {
-        "action": "register_user_photo", "image_path": "/etc/hostname"})
+        "action": "register_by_photo", "image_path": "/etc/hostname"})
     assert escaped["reason"] == face_plugin.REASON_BAD_INPUT
     assert "must be under" in escaped["detail"]
 
     nothing = plugin.dispatch("face_recognition", {
-        "action": "register_user_photo", "profile": "x"})
+        "action": "register_by_photo", "name": "x"})
     assert nothing["reason"] == face_plugin.REASON_BAD_INPUT
 
 
 def test_registering_a_known_face_merges_instead_of_duplicating(plugin, tmp_path):
     path = _write_photo(tmp_path, "a.jpg", _FakeFrame.one(20))
     first = plugin.dispatch("face_recognition", {
-        "action": "register_user_photo", "image_path": path, "profile": "Alice"})
+        "action": "register_by_photo", "image_path": path, "name": "Alice"})
     second = plugin.dispatch("face_recognition", {
-        "action": "register_user_photo", "image_path": path, "profile": "Alice"})
+        "action": "register_by_photo", "image_path": path, "name": "Alice"})
 
     assert second["person_id"] == first["person_id"]
     assert second["merged"] is True
@@ -549,15 +554,15 @@ def test_registering_a_tracked_stranger_promotes_their_unknown_id(plugin, tmp_pa
 
     path = _write_photo(tmp_path, "b.jpg", _FakeFrame.one(21))
     result = plugin.dispatch("face_recognition", {
-        "action": "register_user_photo", "image_path": path, "profile": "Dave"})
+        "action": "register_by_photo", "image_path": path, "name": "Dave"})
 
     assert result["person_id"] == unknown_id
     assert result["promoted"] is True
     record = plugin._require_engine().db.get_person(unknown_id)
-    assert record["named"] is True and record["profile"] == "Dave"
+    assert record["named"] is True and record["name"] == "Dave"
 
 
-# ── register_current_stream ───────────────────────────────────────────────────
+# ── register_by_stream ───────────────────────────────────────────────────
 
 def test_register_from_the_stream_uses_the_whole_window(plugin):
     node, _payloads = _run_one_frame(plugin, _FakeFrame.one(30))
@@ -565,7 +570,7 @@ def test_register_from_the_stream_uses_the_whole_window(plugin):
         node._image_cb(_FakeCompressedImage(_FakeFrame.one(30)))
 
     result = plugin.dispatch("face_recognition", {
-        "action": "register_current_stream", "profile": "Erin"})
+        "action": "register_by_stream", "name": "Erin"})
     assert result["ok"] is True
     assert result["frames_examined"] >= 2
     assert result["frames_used"] >= 2
@@ -574,7 +579,7 @@ def test_register_from_the_stream_uses_the_whole_window(plugin):
 
 def test_register_from_the_stream_without_an_instance(plugin):
     result = plugin.dispatch("face_recognition", {
-        "action": "register_current_stream", "profile": "Nobody"})
+        "action": "register_by_stream", "name": "Nobody"})
     assert result["ok"] is False
     assert result["reason"] == face_plugin.REASON_NO_FRAMES
 
@@ -587,7 +592,7 @@ def test_register_from_the_stream_reports_a_crowd(plugin):
             _FakeFrame.build((1, 120, 500.0), (2, 119, 500.0))))
 
     result = plugin.dispatch("face_recognition", {
-        "action": "register_current_stream", "profile": "Someone"})
+        "action": "register_by_stream", "name": "Someone"})
     assert result["ok"] is False
     assert result["reason"] == face_plugin.REASON_AMBIGUOUS
     assert result["frame_reasons"][face_plugin.REASON_AMBIGUOUS] >= 1
@@ -600,7 +605,7 @@ def test_register_from_the_stream_refuses_an_unstable_subject(plugin):
         node._image_cb(_FakeCompressedImage(_FakeFrame.one(identity)))
 
     result = plugin.dispatch("face_recognition", {
-        "action": "register_current_stream", "profile": "Whoever"})
+        "action": "register_by_stream", "name": "Whoever"})
     assert result["ok"] is False
     assert result["reason"] == face_plugin.REASON_AMBIGUOUS
     assert "stable subject" in result["detail"]
@@ -610,7 +615,7 @@ def test_register_stream_window_is_clamped_to_the_config(plugin):
     node, _ = _run_one_frame(plugin, _FakeFrame.one(45))
     node._image_cb(_FakeCompressedImage(_FakeFrame.one(45)))
     result = plugin.dispatch("face_recognition", {
-        "action": "register_current_stream", "profile": "Frank", "window_s": 999})
+        "action": "register_by_stream", "name": "Frank", "window_s": 999})
     assert result["window_s"] == pytest.approx(3.0)
 
 
@@ -621,7 +626,7 @@ def test_register_stream_needs_an_instance_id_when_several_run(plugin):
             "instance_id": f"i{index}"})
     assert _wait_until(lambda: len(plugin._nodes) == 2, timeout=5.0)
     result = plugin.dispatch("face_recognition", {
-        "action": "register_current_stream", "profile": "x"})
+        "action": "register_by_stream", "name": "x"})
     assert result["reason"] == face_plugin.REASON_BAD_INPUT
     assert "instance_id" in result["detail"]
 
@@ -642,7 +647,7 @@ def test_the_window_drops_frames_older_than_enroll_window_s(monkeypatch, tmp_pat
         plugin.dispatch("face_recognition", {"action": "stop"})
 
 
-# ── register_user_photos (batch) ──────────────────────────────────────────────
+# ── register_by_corpus (batch) ──────────────────────────────────────────────
 
 def _make_package(tmp_path, entries, manifest=None) -> str:
     directory = tmp_path / "pack"
@@ -672,7 +677,7 @@ def test_batch_reports_one_result_per_photo(plugin, tmp_path):
         },
     )
     result = plugin.dispatch("face_recognition", {
-        "action": "register_user_photos", "package": package})
+        "action": "register_by_corpus", "package": package})
 
     assert result["ok"] is True
     assert result["total"] == 4
@@ -681,7 +686,7 @@ def test_batch_reports_one_result_per_photo(plugin, tmp_path):
 
     by_file = {item["file"]: item for item in result["results"]}
     assert by_file["alice.jpg"]["ok"] is True
-    assert by_file["alice.jpg"]["profile"] == "Alice from ops"
+    assert by_file["alice.jpg"]["name"] == "Alice from ops"
     assert by_file["bob.jpg"]["reason"] == face_plugin.REASON_LOW_QUALITY
     assert by_file["team.jpg"]["reason"] == face_plugin.REASON_AMBIGUOUS
     assert by_file["team.jpg"]["candidates"]
@@ -697,12 +702,12 @@ def test_batch_manifest_list_form_and_person_grouping(plugin, tmp_path):
         {"a1.jpg": _FakeFrame.one(70), "a2.jpg": _FakeFrame.one(71)},
         manifest=[
             {"file": "a1.jpg", "profile": "Grace", "person": "grace",
-             "meta": {"badge": "G1"}},
+             "profile": {"badge": "G1"}},
             {"file": "a2.jpg", "profile": "Grace", "person": "grace"},
         ],
     )
     result = plugin.dispatch("face_recognition", {
-        "action": "register_user_photos", "package": package})
+        "action": "register_by_corpus", "package": package})
     assert result["registered"] == 2
     ids = {item["person_id"] for item in result["results"]}
     assert len(ids) == 1, "photos sharing a person key must become one identity"
@@ -710,7 +715,7 @@ def test_batch_manifest_list_form_and_person_grouping(plugin, tmp_path):
     engine = plugin._require_engine()
     person = engine.db.get_person(ids.pop())
     assert person["samples"] == 2
-    assert person["meta"] == {"badge": "G1"}
+    assert person["profile"] == {"badge": "G1"}
 
 
 def test_batch_falls_back_to_sidecars_then_the_filename(plugin, tmp_path):
@@ -718,17 +723,17 @@ def test_batch_falls_back_to_sidecars_then_the_filename(plugin, tmp_path):
     directory.mkdir()
     (directory / "heidi.jpg").write_bytes(_FakeFrame.one(80))
     (directory / "heidi.json").write_text(json.dumps(
-        {"profile": "Heidi from QA", "meta": {"floor": 2}}))
+        {"name": "Heidi from QA", "profile": {"floor": 2}}))
     (directory / "ivan.jpg").write_bytes(_FakeFrame.one(81))
     (directory / "ivan.txt").write_text("Ivan the intern\n")
     (directory / "judy.jpg").write_bytes(_FakeFrame.one(82))
 
     result = plugin.dispatch("face_recognition", {
-        "action": "register_user_photos", "package": str(directory)})
-    profiles = {item["file"]: item["profile"] for item in result["results"]}
-    assert profiles["heidi.jpg"] == "Heidi from QA"
-    assert profiles["ivan.jpg"] == "Ivan the intern"
-    assert profiles["judy.jpg"] == "judy"          # filename stem
+        "action": "register_by_corpus", "package": str(directory)})
+    names = {item["file"]: item["name"] for item in result["results"]}
+    assert names["heidi.jpg"] == "Heidi from QA"
+    assert names["ivan.jpg"] == "Ivan the intern"
+    assert names["judy.jpg"] == "judy"          # filename stem
 
 
 def test_batch_accepts_a_zip_and_refuses_traversal(plugin, tmp_path):
@@ -740,7 +745,7 @@ def test_batch_accepts_a_zip_and_refuses_traversal(plugin, tmp_path):
         handle.writestr("manifest.json", json.dumps({"kate.jpg": "Kate"}))
 
     result = plugin.dispatch("face_recognition", {
-        "action": "register_user_photos", "package": str(archive)})
+        "action": "register_by_corpus", "package": str(archive)})
     assert result["registered"] == 1
     assert [item["file"] for item in result["results"]] == ["kate.jpg"]
     assert not (tmp_path / "escape.jpg").exists()
@@ -750,7 +755,7 @@ def test_batch_rejects_an_empty_or_oversized_package(plugin, tmp_path, monkeypat
     empty = tmp_path / "empty-pack"
     empty.mkdir()
     result = plugin.dispatch("face_recognition", {
-        "action": "register_user_photos", "package": str(empty)})
+        "action": "register_by_corpus", "package": str(empty)})
     assert result["reason"] == face_plugin.REASON_BAD_INPUT
     assert "no images" in result["detail"]
 
@@ -758,13 +763,13 @@ def test_batch_rejects_an_empty_or_oversized_package(plugin, tmp_path, monkeypat
     package = _make_package(
         tmp_path, {"a.jpg": _FakeFrame.one(1), "b.jpg": _FakeFrame.one(2)})
     result = plugin.dispatch("face_recognition", {
-        "action": "register_user_photos", "package": package})
+        "action": "register_by_corpus", "package": package})
     assert result["reason"] == face_plugin.REASON_BAD_INPUT
     assert "max_batch" in result["detail"]
 
 
 def test_batch_requires_a_package(plugin):
-    result = plugin.dispatch("face_recognition", {"action": "register_user_photos"})
+    result = plugin.dispatch("face_recognition", {"action": "register_by_corpus"})
     assert result["reason"] == face_plugin.REASON_BAD_INPUT
 
 
@@ -773,8 +778,8 @@ def test_batch_requires_a_package(plugin):
 def test_roster_crud_through_dispatch(plugin, tmp_path):
     path = _write_photo(tmp_path, "l.jpg", _FakeFrame.one(100))
     created = plugin.dispatch("face_recognition", {
-        "action": "register_user_photo", "image_path": path,
-        "profile": "Leo", "meta": {"team": "ops", "floor": 3}})
+        "action": "register_by_photo", "image_path": path,
+        "name": "Leo", "profile": {"team": "ops", "floor": 3}})
     person_id = created["person_id"]
 
     listed = plugin.dispatch("face_recognition", {"action": "list_persons"})
@@ -786,14 +791,14 @@ def test_roster_crud_through_dispatch(plugin, tmp_path):
 
     updated = plugin.dispatch("face_recognition", {
         "action": "update_person", "person_id": person_id,
-        "profile": "Leo (facilities)", "meta": {"floor": 4},
-        "meta_delete": ["team"]})
-    assert updated["person"]["profile"] == "Leo (facilities)"
-    assert updated["person"]["meta"] == {"floor": 4}
+        "name": "Leo (facilities)", "profile": {"floor": 4},
+        "profile_delete": ["team"]})
+    assert updated["person"]["name"] == "Leo (facilities)"
+    assert updated["person"]["profile"] == {"floor": 4}
 
     fetched = plugin.dispatch("face_recognition", {
         "action": "get_person", "person_id": person_id})
-    assert fetched["person"]["meta"] == {"floor": 4}
+    assert fetched["person"]["profile"] == {"floor": 4}
 
     forgotten = plugin.dispatch("face_recognition", {
         "action": "forget", "person_id": person_id})
@@ -830,7 +835,7 @@ def test_update_person_names_an_unknown_keeping_its_id(plugin):
     engine = plugin._require_engine()
     unknown_id = engine.db.enroll_unknown(_unit(120))["id"]
     result = plugin.dispatch("face_recognition", {
-        "action": "update_person", "person_id": unknown_id, "profile": "Nina"})
+        "action": "update_person", "person_id": unknown_id, "name": "Nina"})
     assert result["person"]["id"] == unknown_id
     assert result["person"]["named"] is True
 
@@ -958,8 +963,8 @@ def test_register_actions_take_no_person_id():
     """Which identity a photo belongs to is decided by matching, not by the
     caller — otherwise there are two ways to say it and they can disagree."""
     params = face_plugin.TOOLS[0]["inputSchema"]["x-action-params"]
-    assert "person_id" not in params["register_user_photo"]["params"]
-    assert "person_id" not in params["register_current_stream"]["params"]
+    assert "person_id" not in params["register_by_photo"]["params"]
+    assert "person_id" not in params["register_by_stream"]["params"]
     # It remains an input where it identifies an existing record.
     for action in ("get_person", "update_person", "forget"):
         assert "person_id" in params[action]["params"]
@@ -972,11 +977,11 @@ def test_register_ignores_a_person_id_argument(plugin, tmp_path):
     path = _write_photo(tmp_path, "x.jpg", _FakeFrame.one(201))
 
     result = plugin.dispatch("face_recognition", {
-        "action": "register_user_photo", "image_path": path,
-        "profile": "New person", "person_id": "p-1"})
+        "action": "register_by_photo", "image_path": path,
+        "name": "New person", "person_id": "p-1"})
     assert result["ok"] is True
     assert result["person_id"] == "p-2", "person_id must not force the identity"
-    assert engine.db.get_person("p-1")["profile"] == "Someone else"
+    assert engine.db.get_person("p-1")["name"] == "Someone else"
 
 
 def test_published_payload_carries_no_topic_field(plugin):
@@ -985,3 +990,207 @@ def test_published_payload_carries_no_topic_field(plugin):
     _node, payloads = _run_one_frame(plugin, _FakeFrame.one(210))
     assert "topic" not in payloads[0]
     assert set(payloads[0]) == {"ts", "count", "faces", "latency_ms"}
+
+
+# ── 访问记录表 through dispatch ────────────────────────────────────────────────
+
+def test_list_visits_action_is_on_the_card():
+    schema = face_plugin.TOOLS[0]["inputSchema"]
+    assert "list_visits" in schema["properties"]["action"]["enum"]
+    assert set(schema["x-action-params"]["list_visits"]["params"]) == {
+        "person_id", "since", "until", "limit", "offset",
+    }
+
+
+def test_recognition_records_visits_not_one_row_per_frame(plugin):
+    node, _ = _run_one_frame(plugin, _FakeFrame.one(300))
+    # One frame at a time: LatestFrame overwrites, so pushing several at once
+    # publishes fewer results than frames — deliberately, that is its job.
+    for expected in range(2, 5):
+        node._image_cb(_FakeCompressedImage(_FakeFrame.one(300)))
+        assert _wait_until(
+            lambda: len(node.publishers[0].messages) >= expected, timeout=5.0)
+
+    visits = plugin.dispatch("face_recognition", {"action": "list_visits"})
+    assert visits["ok"] is True
+    assert visits["total"] == 1, "one visit for one continuous presence"
+    entry = visits["visits"][0]
+    assert entry["open"] is True
+    assert entry["sightings"] >= 4
+    assert entry["topic"] == "/cam/rgb"
+
+
+def test_list_visits_rejects_an_unparseable_time(plugin):
+    plugin._require_engine()
+    result = plugin.dispatch("face_recognition", {
+        "action": "list_visits", "since": "next thursday"})
+    assert result["ok"] is False
+    assert result["reason"] == face_plugin.REASON_BAD_INPUT
+
+
+def test_stopping_an_instance_closes_the_open_visit(plugin):
+    """Otherwise a visit in progress is lost when the card is stopped."""
+    node, _ = _run_one_frame(plugin, _FakeFrame.one(310))
+    engine = plugin._require_engine()
+    assert engine.db.stats()["open_visits"] == 1
+
+    plugin.dispatch("face_recognition", {"action": "stop"})
+    assert engine.db.stats()["open_visits"] == 0
+    closed = engine.db.list_visits()
+    assert closed["total"] == 1
+    assert not closed["visits"][0].get("open")
+
+
+def test_payload_reports_name_and_profile_but_no_timestamps(plugin):
+    engine = plugin._require_engine()
+    engine.db.add("小王", [_unit(320)], profile={"gender": "male"})
+    _node, payloads = _run_one_frame(plugin, _FakeFrame.one(320))
+    face = payloads[0]["faces"][0]
+    assert face["name"] == "小王"
+    assert face["profile"] == {"gender": "male"}
+    # "when was this person around" is a list_visits question.
+    assert "registered_at" not in face and "last_seen_at" not in face
+
+
+# ── recognize_by_photo / recognize_by_stream (read-only) ─────────────────────
+
+def test_recognize_actions_are_on_the_card():
+    schema = face_plugin.TOOLS[0]["inputSchema"]
+    actions = set(schema["properties"]["action"]["enum"])
+    assert {"recognize_by_photo", "recognize_by_stream"} <= actions
+    assert actions == set(schema["x-action-params"])
+    params = schema["x-action-params"]
+    assert set(params["recognize_by_photo"]["params"]) == {"image_path", "image_b64"}
+    assert set(params["recognize_by_stream"]["params"]) == {"window_s"}
+    # register/recognize are symmetric by suffix.
+    assert {"register_by_photo", "register_by_stream", "register_by_corpus"} <= actions
+
+
+def test_recognize_by_photo_identifies_a_registered_person(plugin, tmp_path):
+    engine = plugin._require_engine()
+    engine.db.add("小王", [_unit(400)], profile={"gender": "male"})
+    path = _write_photo(tmp_path, "who.jpg", _FakeFrame.one(400))
+
+    result = plugin.dispatch("face_recognition", {
+        "action": "recognize_by_photo", "image_path": path})
+    assert result["ok"] is True and result["count"] == 1
+    face = result["faces"][0]
+    assert face["person_id"] == "p-1"
+    assert face["name"] == "小王"
+    assert face["profile"] == {"gender": "male"}
+    assert face["score"] > 0.9
+
+
+def test_recognize_is_read_only(plugin, tmp_path):
+    """A query must not enrol the stranger it failed to recognise, nor log a
+    visit — otherwise asking "who is this" quietly changes the answer."""
+    engine = plugin._require_engine()
+    before = engine.db.stats()
+    path = _write_photo(tmp_path, "stranger.jpg", _FakeFrame.one(401))
+
+    result = plugin.dispatch("face_recognition", {
+        "action": "recognize_by_photo", "image_path": path})
+    assert result["ok"] is True
+    face = result["faces"][0]
+    assert face["person_id"] is None
+    assert face["known"] is False
+    # The near-miss score is reported so match_threshold can be tuned.
+    assert "best_score" in face
+
+    after = engine.db.stats()
+    assert after["persons"] == before["persons"] == 0
+    assert after["open_visits"] == 0
+    assert engine.db.list_visits()["total"] == 0
+
+
+def test_recognize_reports_every_face_without_the_ambiguity_gate(plugin, tmp_path):
+    """subject_dominance exists for enrolment, which must pick one person; a
+    query can just report everyone."""
+    engine = plugin._require_engine()
+    engine.db.add("A", [_unit(410)])
+    engine.db.add("B", [_unit(411)])
+    path = _write_photo(tmp_path, "two.jpg",
+                        _FakeFrame.build((410, 120, 500.0), (411, 118, 500.0)))
+
+    result = plugin.dispatch("face_recognition", {
+        "action": "recognize_by_photo", "image_path": path})
+    assert result["ok"] is True
+    assert result["count"] == 2
+    assert {f["name"] for f in result["faces"]} == {"A", "B"}
+
+    # The same photo is refused for registration, for the opposite reason.
+    refused = plugin.dispatch("face_recognition", {
+        "action": "register_by_photo", "image_path": path, "name": "C"})
+    assert refused["reason"] == face_plugin.REASON_AMBIGUOUS
+
+
+def test_recognize_by_photo_flags_a_low_quality_face(plugin, tmp_path):
+    path = _write_photo(tmp_path, "far.jpg", _FakeFrame.one(420, size=30, blur=4.0))
+    result = plugin.dispatch("face_recognition", {
+        "action": "recognize_by_photo", "image_path": path})
+    face = result["faces"][0]
+    assert face["quality"] == "low"
+    assert face["reason"] == face_plugin.REASON_LOW_QUALITY
+
+
+def test_recognize_by_photo_on_an_empty_frame(plugin, tmp_path):
+    path = _write_photo(tmp_path, "wall.jpg", b"")
+    result = plugin.dispatch("face_recognition", {
+        "action": "recognize_by_photo", "image_path": path})
+    assert result["ok"] is True and result["count"] == 0 and result["faces"] == []
+
+
+def test_recognize_by_photo_rejects_bad_input(plugin, tmp_path):
+    path = _write_photo(tmp_path, "corrupt.jpg", b"corrupt")
+    result = plugin.dispatch("face_recognition", {
+        "action": "recognize_by_photo", "image_path": path})
+    assert result["ok"] is False
+    assert result["reason"] == face_plugin.REASON_BAD_INPUT
+
+
+def test_recognize_by_stream_answers_who_is_there_now(plugin):
+    engine = plugin._require_engine()
+    engine.db.add("小李", [_unit(430)])
+    node, _ = _run_one_frame(plugin, _FakeFrame.one(430))
+    node._image_cb(_FakeCompressedImage(_FakeFrame.one(430)))
+
+    result = plugin.dispatch("face_recognition", {
+        "action": "recognize_by_stream"})
+    assert result["ok"] is True
+    assert result["count"] == 1
+    assert result["faces"][0]["name"] == "小李"
+    assert result["window_s"] == pytest.approx(1.0)
+    assert result["frames_examined"] >= 1
+
+
+def test_recognize_by_stream_reports_each_person_once(plugin):
+    """Several frames of the same two people must not become four entries."""
+    engine = plugin._require_engine()
+    engine.db.add("A", [_unit(440)])
+    engine.db.add("B", [_unit(441)])
+    spec = _FakeFrame.build((440, 120, 500.0), (441, 118, 500.0))
+    node, _ = _run_one_frame(plugin, spec)
+    for _ in range(3):
+        node._image_cb(_FakeCompressedImage(spec))
+
+    result = plugin.dispatch("face_recognition", {"action": "recognize_by_stream"})
+    assert result["count"] == 2
+    assert {f["name"] for f in result["faces"]} == {"A", "B"}
+
+
+def test_recognize_by_stream_without_a_running_instance(plugin):
+    plugin._require_engine()
+    result = plugin.dispatch("face_recognition", {"action": "recognize_by_stream"})
+    assert result["ok"] is False
+    assert result["reason"] == face_plugin.REASON_NO_FRAMES
+
+
+def test_recognize_by_stream_needs_an_instance_id_when_several_run(plugin):
+    for index in (1, 2):
+        plugin.dispatch("face_recognition", {
+            "action": "start", "input_topic": f"/cam{index}",
+            "instance_id": f"i{index}"})
+    assert _wait_until(lambda: len(plugin._nodes) == 2, timeout=5.0)
+    result = plugin.dispatch("face_recognition", {"action": "recognize_by_stream"})
+    assert result["reason"] == face_plugin.REASON_BAD_INPUT
+    assert "instance_id" in result["detail"]

--- a/perception/tests/test_face_plugin.py
+++ b/perception/tests/test_face_plugin.py
@@ -160,7 +160,7 @@ def _base_cfg(tmp_path, **overrides) -> dict:
         "max_faces": 8,
         "enroll_window_s": 3.0,
         "enroll_max_analyzed": 8,
-        "min_interval_ms": 0,
+        "detect_fps": 0,
         "unknown_capacity": 500,
         "max_batch": 200,
     }
@@ -355,7 +355,7 @@ def test_start_stop_churn_leaves_no_orphan_node(monkeypatch, tmp_path):
                 "action": "start", "input_topic": "/cam/rgb"})
             plugin.dispatch("face_recognition", {"action": "stop"})
             plugin.dispatch("face_recognition", {
-                "action": "config", "min_interval_ms": 10})
+                "action": "config", "detect_fps": 100})
         plugin.dispatch("face_recognition", {"action": "stop"})
         time.sleep(0.4)
 
@@ -882,10 +882,62 @@ def test_instance_config_rejects_shared_settings(plugin):
     assert _wait_until(lambda: plugin._nodes, timeout=5.0)
 
     ok = plugin.dispatch("face_recognition", {
-        "action": "config", "instance_id": "/cam", "min_interval_ms": 500})
+        "action": "config", "instance_id": "/cam", "detect_fps": 2})
     assert ok["status"] == "configured"
-    assert plugin._nodes["/cam"]._min_interval == pytest.approx(0.5)
+    assert plugin._nodes["/cam"]._detect_interval == pytest.approx(0.5)
 
     with pytest.raises(ValueError):
         plugin.dispatch("face_recognition", {
             "action": "config", "instance_id": "/cam", "match_threshold": 0.4})
+
+
+# ── detect_fps (检测频率) ──────────────────────────────────────────────────────
+
+def test_detect_fps_maps_to_an_interval_and_accepts_decimals():
+    assert face_plugin.detect_interval({}) == pytest.approx(1.0)        # default
+    assert face_plugin.detect_interval({"detect_fps": 2}) == pytest.approx(0.5)
+    assert face_plugin.detect_interval({"detect_fps": 0.5}) == pytest.approx(2.0)
+    assert face_plugin.detect_interval({"detect_fps": 0.2}) == pytest.approx(5.0)
+    assert face_plugin.detect_interval({"detect_fps": 10}) == pytest.approx(0.1)
+
+
+def test_detect_fps_zero_means_every_frame():
+    assert face_plugin.detect_interval({"detect_fps": 0}) == 0.0
+    assert face_plugin.detect_interval({"detect_fps": -3}) == 0.0
+
+
+def test_legacy_min_interval_ms_still_honoured():
+    """A canvas saved by the pre-detect_fps build must keep working."""
+    assert face_plugin.detect_interval({"min_interval_ms": 500}) == pytest.approx(0.5)
+    # detect_fps wins when both are present.
+    assert face_plugin.detect_interval(
+        {"detect_fps": 4, "min_interval_ms": 500}) == pytest.approx(0.25)
+
+
+def test_default_config_detects_once_per_second(monkeypatch, tmp_path):
+    """The shipped default, end to end through the node."""
+    probe = _EngineProbe(tmp_path)
+    monkeypatch.setattr(face_plugin, "_build_engine", probe)
+    cfg = _base_cfg(tmp_path)
+    cfg.pop("detect_fps")                     # fall back to the default
+    plugin = face_plugin.FaceRecognitionPlugin(cfg, _FakeExecutor())
+    try:
+        plugin.dispatch("face_recognition", {"action": "start", "input_topic": "/cam"})
+        assert _wait_until(lambda: plugin._nodes.get("/cam"), timeout=5.0)
+        assert plugin._nodes["/cam"]._detect_interval == pytest.approx(1.0)
+    finally:
+        plugin.dispatch("face_recognition", {"action": "stop"})
+
+
+def test_detect_fps_is_declared_on_the_card_as_a_decimal_number():
+    schema = face_plugin.TOOLS[0]["configSchema"]["properties"]["detect_fps"]
+    assert schema["type"] == "number"          # not integer — decimals required
+    assert schema["default"] == 1.0
+    assert schema["minimum"] == 0
+    assert schema.get("scope") == "instance"
+
+
+def test_device_is_declared_on_the_card_with_auto_default():
+    schema = face_plugin.TOOLS[0]["configSchema"]["properties"]["device"]
+    assert schema["default"] == "auto"
+    assert set(schema["enum"]) == {"auto", "cpu", "gpu"}

--- a/perception/tests/test_face_plugin.py
+++ b/perception/tests/test_face_plugin.py
@@ -1,0 +1,891 @@
+"""
+tests/test_face_plugin.py — Face plugin lifecycle, failure reasons, enrolment.
+
+ROS stubs come from vision_stubs (installed by conftest before collection). The
+analyzer is faked: the real one needs two ONNX models and onnxruntime, neither
+of which a host-side suite should require. The *decode* is validated separately
+against the real models — see perception/README.md § Face Recognition.
+
+Run: python -m pytest perception/tests -q
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+import time
+import zipfile
+
+import numpy as np
+import pytest
+
+from vision_stubs import (  # noqa: F401
+    _FakeCompressedImage,
+    _FakeExecutor,
+    _FakeNode,
+    _FakeString,
+    _wait_until,
+)
+
+import plugins.face as face_plugin  # noqa: E402
+import plugins.face_db as face_db_module  # noqa: E402
+from plugins.face_db import EMBEDDING_DIM, FaceDB  # noqa: E402
+from plugins.face_runtime import DetectedFace  # noqa: E402
+
+
+# ── fakes ─────────────────────────────────────────────────────────────────────
+
+def _unit(seed: int) -> np.ndarray:
+    rng = np.random.default_rng(seed)
+    raw = rng.standard_normal(EMBEDDING_DIM).astype(np.float32)
+    return raw / np.linalg.norm(raw)
+
+
+class _FakeFrame:
+    """A JPEG stand-in: the bytes encode which faces the fake analyzer reports.
+
+    `b"<identity>:<size>:<blur>|<identity>:<size>:<blur>"` — one segment per
+    face. This keeps the tests about the plugin's decisions rather than about
+    image encoding.
+    """
+
+    @staticmethod
+    def build(*faces: tuple[int, int, float]) -> bytes:
+        return "|".join(
+            f"{identity}:{size}:{blur}" for identity, size, blur in faces
+        ).encode()
+
+    @staticmethod
+    def one(identity: int, size: int = 120, blur: float = 500.0) -> bytes:
+        return _FakeFrame.build((identity, size, blur))
+
+
+class _FakeAnalyzer:
+    """Detects whatever the frame bytes say, and embeds by identity number."""
+
+    def __init__(self, delay: float = 0.0, frame_shape=(480, 640)):
+        self.delay = delay
+        self.closed = False
+        self.frame_shape = frame_shape
+        self.seen: list[bytes] = []
+        self.embed_calls = 0
+
+    # -- the surface plugins/face.py uses --
+    def decode_jpeg(self, data: bytes):
+        self.seen.append(data)
+        if data == b"corrupt":
+            return None
+        image = np.zeros((*self.frame_shape, 3), dtype=np.uint8)
+        image[0, 0, 0] = 1                      # keep .size truthy
+        self._spec = data.decode()
+        return image
+
+    def detect(self, image, max_faces: int = 0):
+        if self.delay:
+            time.sleep(self.delay)
+        if not self._spec:
+            return []
+        faces = []
+        height, width = self.frame_shape
+        segments = self._spec.split("|")
+        # Lay the boxes out left to right; the first one is centred, so it wins
+        # the centre-weighted dominance comparison when sizes are equal.
+        for index, segment in enumerate(segments):
+            identity, size, blur = segment.split(":")
+            side = int(size)
+            centre_x = width / 2 if index == 0 else (index * width) / (len(segments) + 1)
+            x1 = max(0.0, centre_x - side / 2)
+            y1 = max(0.0, height / 2 - side / 2)
+            face = DetectedFace(
+                bbox=(x1, y1, x1 + side, y1 + side),
+                det_score=0.9,
+                kps=np.zeros((5, 2), dtype=np.float32),
+                blur=float(blur),
+            )
+            face.identity = int(identity)
+            faces.append(face)
+        faces.sort(key=lambda f: f.area, reverse=True)
+        return faces[:max_faces] if max_faces else faces
+
+    def prepare(self, image, face):
+        face.aligned = np.zeros((112, 112, 3), dtype=np.uint8)
+        return face
+
+    def embed(self, aligned):
+        raise AssertionError("subclasses carry the identity; use _SpecAnalyzer")
+
+    def close(self):
+        self.closed = True
+
+
+class _SpecAnalyzer(_FakeAnalyzer):
+    """The analyzer the tests use: identity travels in the aligned crop.
+
+    `prepare` stamps the face's identity into pixel [0,0,0] and `embed` reads it
+    back, which is how a frame spec like `b"7:120:500"` ends up as a stable
+    512-d vector for person 7 without any model.
+    """
+
+    def prepare(self, image, face):
+        aligned = np.zeros((112, 112, 3), dtype=np.uint8)
+        aligned[0, 0, 0] = face.identity
+        face.aligned = aligned
+        return face
+
+    def embed(self, aligned):
+        self.embed_calls += 1
+        return _unit(int(aligned[0, 0, 0]))
+
+
+@pytest.fixture(autouse=True)
+def _tmp_models(monkeypatch, tmp_path):
+    """Keep the DB in tmp and never touch /models or the network."""
+    monkeypatch.setattr(
+        face_db_module, "require_models_subpath", lambda path, root="/models": str(path)
+    )
+    monkeypatch.setattr(
+        face_plugin, "_image_roots", lambda cfg: (str(tmp_path),)
+    )
+
+
+def _base_cfg(tmp_path, **overrides) -> dict:
+    cfg = {
+        "db_dir": os.path.join(str(tmp_path), "db"),
+        "match_threshold": 0.35,
+        "min_face_px": 64,
+        "blur_min": 60.0,
+        "det_thresh": 0.5,
+        "subject_dominance": 1.6,
+        "max_faces": 8,
+        "enroll_window_s": 3.0,
+        "enroll_max_analyzed": 8,
+        "min_interval_ms": 0,
+        "unknown_capacity": 500,
+        "max_batch": 200,
+    }
+    cfg.update(overrides)
+    return cfg
+
+
+class _EngineProbe:
+    """Counts engine builds; optional delay stands in for the model load."""
+
+    def __init__(self, tmp_path, delay: float = 0.0, analyzer_cls=_SpecAnalyzer):
+        self.tmp_path = tmp_path
+        self.delay = delay
+        self.analyzer_cls = analyzer_cls
+        self.calls = 0
+        self.built: list = []
+        self.lock = threading.Lock()
+
+    def __call__(self, cfg):
+        with self.lock:
+            self.calls += 1
+        if self.delay:
+            time.sleep(self.delay)
+        engine = face_plugin._FaceEngine(
+            self.analyzer_cls(), FaceDB(db_dir=cfg["db_dir"],
+                                       unknown_capacity=int(cfg.get("unknown_capacity", 500)))
+        )
+        self.built.append(engine)
+        return engine
+
+
+@pytest.fixture
+def plugin(monkeypatch, tmp_path):
+    probe = _EngineProbe(tmp_path)
+    monkeypatch.setattr(face_plugin, "_build_engine", probe)
+    executor = _FakeExecutor()
+    instance = face_plugin.FaceRecognitionPlugin(_base_cfg(tmp_path), executor)
+    instance._probe = probe
+    instance._executor_ref = executor
+    yield instance
+    instance.dispatch("face_recognition", {"action": "stop"})
+
+
+# ── tool definition ───────────────────────────────────────────────────────────
+
+def test_tool_shape_matches_the_card_contract():
+    tool = face_plugin.TOOLS[0]
+    assert tool["name"] == "face_recognition"
+    assert tool["type"] == "processor"
+    assert tool["multiInstance"] is True
+    assert tool["topic_in"][0]["format"] == "image/jpeg"
+    assert tool["topic_out"][0]["format"] == "data/json"
+
+    schema = tool["inputSchema"]
+    actions = set(schema["properties"]["action"]["enum"])
+    # Every action must be described in x-action-params, or agent-core splits
+    # the tool for the LLM with a parameter list that silently omits it.
+    assert actions == set(schema["x-action-params"])
+    declared = set(schema["properties"])
+    for action, spec in schema["x-action-params"].items():
+        missing = set(spec["params"]) - declared
+        assert not missing, f"{action} references undeclared params: {missing}"
+        assert spec["description"]
+
+    # unknown_capacity must be editable on the card, per the requirement.
+    assert "unknown_capacity" in tool["configSchema"]["properties"]
+    assert tool["configSchema"]["properties"]["unknown_capacity"]["default"] == 500
+
+
+# ── subject selection / failure reasons ───────────────────────────────────────
+
+def _faces(*specs):
+    analyzer = _SpecAnalyzer()
+    analyzer.decode_jpeg(_FakeFrame.build(*specs))
+    faces = analyzer.detect(None)
+    for face in faces:
+        analyzer.prepare(None, face)
+    return faces, (480, 640)
+
+
+def test_no_face_reason():
+    gates = face_plugin._gates(_base_cfg(""))
+    subject, failure = face_plugin.select_subject([], (480, 640), gates)
+    assert subject is None
+    assert failure["reason"] == face_plugin.REASON_NO_FACE
+    assert failure["faces"] == 0
+
+
+def test_low_quality_reason_names_every_failed_gate():
+    gates = face_plugin._gates(_base_cfg(""))
+    faces, shape = _faces((1, 40, 10.0))          # too small AND too blurry
+    subject, failure = face_plugin.select_subject(faces, shape, gates)
+    assert subject is None
+    assert failure["reason"] == face_plugin.REASON_LOW_QUALITY
+    assert "40 px" in failure["detail"] and "need" not in failure["detail"]
+    assert "move closer" in failure["detail"]
+    assert "hold still" in failure["detail"]
+    assert failure["candidates"][0]["min_side_px"] == 40
+
+
+def test_ambiguous_subject_lists_candidates():
+    gates = face_plugin._gates(_base_cfg(""))
+    faces, shape = _faces((1, 120, 500.0), (2, 118, 500.0))
+    subject, failure = face_plugin.select_subject(faces, shape, gates)
+    assert subject is None
+    assert failure["reason"] == face_plugin.REASON_AMBIGUOUS
+    assert failure["faces"] == 2
+    assert len(failure["candidates"]) == 2
+    assert "1.6" in failure["detail"] or "1.60" in failure["detail"]
+
+
+def test_a_dominant_face_wins_despite_a_bystander():
+    gates = face_plugin._gates(_base_cfg(""))
+    faces, shape = _faces((1, 200, 500.0), (2, 70, 500.0))
+    subject, failure = face_plugin.select_subject(faces, shape, gates)
+    assert failure is None
+    assert subject.identity == 1
+
+
+def test_a_blurred_bystander_does_not_make_it_ambiguous():
+    """Only faces that pass the quality gate can compete for the subject."""
+    gates = face_plugin._gates(_base_cfg(""))
+    faces, shape = _faces((1, 120, 500.0), (2, 120, 5.0))
+    subject, failure = face_plugin.select_subject(faces, shape, gates)
+    assert failure is None
+    assert subject.identity == 1
+
+
+def test_worst_reason_prefers_ambiguity_over_blur_over_absence():
+    failures = [
+        {"reason": face_plugin.REASON_NO_FACE, "detail": "a"},
+        {"reason": face_plugin.REASON_LOW_QUALITY, "detail": "b"},
+        {"reason": face_plugin.REASON_AMBIGUOUS, "detail": "c"},
+    ]
+    picked = face_plugin._worst_reason(failures)
+    assert picked["reason"] == face_plugin.REASON_AMBIGUOUS
+    assert picked["frames_examined"] == 3
+    assert picked["frame_reasons"] == {
+        face_plugin.REASON_AMBIGUOUS: 1,
+        face_plugin.REASON_LOW_QUALITY: 1,
+        face_plugin.REASON_NO_FACE: 1,
+    }
+    assert face_plugin._worst_reason([])["reason"] == face_plugin.REASON_NO_FACE
+
+
+# ── lifecycle ─────────────────────────────────────────────────────────────────
+
+def test_first_start_reports_loading_then_runs(plugin):
+    result = plugin.dispatch("face_recognition", {
+        "action": "start", "input_topic": "/cam/rgb"})
+    assert result["state"] == "loading"
+    assert result["output"] == "/cam/rgb/face"
+
+    assert _wait_until(lambda: plugin.dispatch(
+        "face_recognition", {"action": "info"})["state"] == "running")
+    info = plugin.dispatch("face_recognition", {"action": "info"})
+    assert info["topic_out"][0]["topic"] == "/cam/rgb/face"
+    assert info["database"]["persons"] == 0
+
+
+def test_concurrent_starts_build_one_engine(monkeypatch, tmp_path):
+    probe = _EngineProbe(tmp_path, delay=0.25)
+    monkeypatch.setattr(face_plugin, "_build_engine", probe)
+    plugin = face_plugin.FaceRecognitionPlugin(_base_cfg(tmp_path), _FakeExecutor())
+    try:
+        threads = [
+            threading.Thread(target=plugin.dispatch, args=(
+                "face_recognition",
+                {"action": "start", "input_topic": f"/cam{index}", "instance_id": f"i{index}"},
+            ))
+            for index in range(6)
+        ]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+        assert _wait_until(lambda: len(plugin._nodes) == 6, timeout=6.0)
+        assert probe.calls == 1          # one download, one load, N instances
+    finally:
+        plugin.dispatch("face_recognition", {"action": "stop"})
+
+
+def test_start_stop_churn_leaves_no_orphan_node(monkeypatch, tmp_path):
+    """The failure mode README § Plugin Concurrency documents."""
+    probe = _EngineProbe(tmp_path, delay=0.05)
+    monkeypatch.setattr(face_plugin, "_build_engine", probe)
+    _FakeNode.instances.clear()
+    plugin = face_plugin.FaceRecognitionPlugin(_base_cfg(tmp_path), _FakeExecutor())
+    try:
+        for _ in range(5):
+            plugin.dispatch("face_recognition", {
+                "action": "start", "input_topic": "/cam/rgb"})
+            plugin.dispatch("face_recognition", {"action": "stop"})
+            plugin.dispatch("face_recognition", {
+                "action": "config", "min_interval_ms": 10})
+        plugin.dispatch("face_recognition", {"action": "stop"})
+        time.sleep(0.4)
+
+        live = [
+            node for node in _FakeNode.instances
+            if getattr(node, "state", "idle") == "running" and not node.destroyed
+        ]
+        assert not live, f"{len(live)} orphaned node(s) still running"
+        assert not any(
+            node.worker_alive for node in _FakeNode.instances
+            if hasattr(node, "worker_alive")
+        )
+    finally:
+        plugin.dispatch("face_recognition", {"action": "stop"})
+
+
+def test_stop_is_idempotent_and_reports_idle(plugin):
+    assert plugin.dispatch("face_recognition", {"action": "stop"})["state"] == "idle"
+    assert plugin.dispatch("face_recognition", {"action": "stop"})["state"] == "idle"
+
+
+def test_start_requires_an_input_topic(plugin):
+    with pytest.raises(ValueError):
+        plugin.dispatch("face_recognition", {"action": "start"})
+
+
+def test_unknown_action_returns_none(plugin):
+    assert plugin.dispatch("face_recognition", {"action": "teleport"}) is None
+
+
+def test_engine_load_failure_surfaces_in_info(monkeypatch, tmp_path):
+    def explode(cfg):
+        raise RuntimeError("onnxruntime is not installed")
+    monkeypatch.setattr(face_plugin, "_build_engine", explode)
+    plugin = face_plugin.FaceRecognitionPlugin(_base_cfg(tmp_path), _FakeExecutor())
+    plugin.dispatch("face_recognition", {"action": "start", "input_topic": "/cam"})
+    assert _wait_until(lambda: plugin.dispatch(
+        "face_recognition", {"action": "info"})["state"] == "error")
+    info = plugin.dispatch("face_recognition", {"action": "info"})
+    assert "onnxruntime" in info["error"]
+    assert "onnxruntime" in info["desc"]
+
+
+# ── recognition stream ────────────────────────────────────────────────────────
+
+def _run_one_frame(plugin, frame: bytes, topic: str = "/cam/rgb"):
+    plugin.dispatch("face_recognition", {"action": "start", "input_topic": topic})
+    assert _wait_until(lambda: plugin._nodes.get(topic) is not None, timeout=5.0)
+    node = plugin._nodes[topic]
+    assert _wait_until(lambda: node.state == "running", timeout=5.0)
+    node._image_cb(_FakeCompressedImage(frame))
+    publisher = node.publishers[0]
+    assert _wait_until(lambda: publisher.messages, timeout=5.0)
+    return node, [json.loads(item) for item in publisher.messages]
+
+
+def test_unknown_face_gets_a_stable_id_across_frames(plugin):
+    node, payloads = _run_one_frame(plugin, _FakeFrame.one(7))
+    first = payloads[0]["faces"][0]
+    assert first["person_id"] == "unknown-1"
+    assert first["known"] is False
+    assert first["quality"] == "ok"
+
+    node._image_cb(_FakeCompressedImage(_FakeFrame.one(7)))
+    assert _wait_until(lambda: len(node.publishers[0].messages) >= 2, timeout=5.0)
+    second = json.loads(node.publishers[0].messages[-1])["faces"][0]
+    assert second["person_id"] == "unknown-1"      # same person, same id
+    assert second["score"] > 0.9
+
+
+def test_a_registered_person_is_reported_with_their_profile(plugin):
+    engine = plugin._require_engine()
+    engine.db.add("运营部小王", [_unit(3)], meta={"team": "ops"})
+
+    _node, payloads = _run_one_frame(plugin, _FakeFrame.one(3))
+    face = payloads[0]["faces"][0]
+    assert face["person_id"] == "p-1"
+    assert face["profile"] == "运营部小王"
+    assert face["known"] is True
+
+
+def test_a_low_quality_face_is_reported_but_not_enrolled(plugin):
+    """It must not burn an unknown-N slot on a face it cannot match again."""
+    _node, payloads = _run_one_frame(plugin, _FakeFrame.one(9, size=30, blur=4.0))
+    face = payloads[0]["faces"][0]
+    assert face["person_id"] is None
+    assert face["known"] is False
+    assert face["quality"] == "low"
+    assert face["reason"] == face_plugin.REASON_LOW_QUALITY
+    assert plugin._require_engine().db.stats()["persons"] == 0
+
+
+def test_a_corrupt_frame_publishes_an_error_not_a_crash(plugin):
+    _node, payloads = _run_one_frame(plugin, b"corrupt")
+    assert payloads[0]["error"] == "undecodable frame"
+    assert payloads[0]["count"] == 0
+
+
+def test_several_people_in_one_frame_are_all_reported(plugin):
+    _node, payloads = _run_one_frame(
+        plugin, _FakeFrame.build((1, 120, 500.0), (2, 118, 500.0))
+    )
+    payload = payloads[0]
+    assert payload["count"] == 2
+    ids = {face["person_id"] for face in payload["faces"]}
+    assert ids == {"unknown-1", "unknown-2"}      # ambiguity only blocks enrolment
+
+
+# ── register_user_photo ───────────────────────────────────────────────────────
+
+def _write_photo(tmp_path, name: str, frame: bytes) -> str:
+    path = tmp_path / name
+    path.write_bytes(frame)
+    return str(path)
+
+
+def test_register_from_a_photo_path(plugin, tmp_path):
+    path = _write_photo(tmp_path, "alice.jpg", _FakeFrame.one(11))
+    result = plugin.dispatch("face_recognition", {
+        "action": "register_user_photo", "image_path": path,
+        "profile": "Alice", "meta": {"team": "ops"},
+    })
+    assert result["ok"] is True
+    assert result["person_id"] == "p-1"
+    assert result["profile"] == "Alice"
+    assert result["meta"] == {"team": "ops"}
+
+    engine = plugin._require_engine()
+    assert engine.db.match(_unit(11), 0.35)[0] == "p-1"
+
+
+def test_register_from_base64(plugin):
+    import base64
+    encoded = base64.b64encode(_FakeFrame.one(12)).decode()
+    result = plugin.dispatch("face_recognition", {
+        "action": "register_user_photo", "image_b64": encoded, "profile": "Bob"})
+    assert result["ok"] is True and result["person_id"] == "p-1"
+
+
+def test_register_reports_each_failure_reason(plugin, tmp_path):
+    cases = {
+        "no_face": (b"", face_plugin.REASON_NO_FACE),
+        "blurry": (_FakeFrame.one(1, size=30, blur=3.0), face_plugin.REASON_LOW_QUALITY),
+        "crowd": (_FakeFrame.build((1, 120, 500.0), (2, 119, 500.0)),
+                  face_plugin.REASON_AMBIGUOUS),
+        "corrupt": (b"corrupt", face_plugin.REASON_BAD_INPUT),
+    }
+    for name, (frame, expected) in cases.items():
+        path = _write_photo(tmp_path, f"{name}.jpg", frame)
+        result = plugin.dispatch("face_recognition", {
+            "action": "register_user_photo", "image_path": path, "profile": name})
+        assert result["ok"] is False, name
+        assert result["reason"] == expected, name
+        assert result["detail"], name
+    assert plugin._require_engine().db.stats()["persons"] == 0
+
+
+def test_register_rejects_missing_and_out_of_root_paths(plugin, tmp_path):
+    missing = plugin.dispatch("face_recognition", {
+        "action": "register_user_photo", "image_path": str(tmp_path / "nope.jpg")})
+    assert missing["reason"] == face_plugin.REASON_BAD_INPUT
+
+    escaped = plugin.dispatch("face_recognition", {
+        "action": "register_user_photo", "image_path": "/etc/hostname"})
+    assert escaped["reason"] == face_plugin.REASON_BAD_INPUT
+    assert "must be under" in escaped["detail"]
+
+    nothing = plugin.dispatch("face_recognition", {
+        "action": "register_user_photo", "profile": "x"})
+    assert nothing["reason"] == face_plugin.REASON_BAD_INPUT
+
+
+def test_registering_a_known_face_merges_instead_of_duplicating(plugin, tmp_path):
+    path = _write_photo(tmp_path, "a.jpg", _FakeFrame.one(20))
+    first = plugin.dispatch("face_recognition", {
+        "action": "register_user_photo", "image_path": path, "profile": "Alice"})
+    second = plugin.dispatch("face_recognition", {
+        "action": "register_user_photo", "image_path": path, "profile": "Alice"})
+
+    assert second["person_id"] == first["person_id"]
+    assert second["merged"] is True
+    assert second["score_to_existing"] > 0.9
+    assert plugin._require_engine().db.stats()["persons"] == 1
+
+
+def test_registering_a_tracked_stranger_promotes_their_unknown_id(plugin, tmp_path):
+    """The id already on the activity stream must survive being named."""
+    _node, payloads = _run_one_frame(plugin, _FakeFrame.one(21))
+    unknown_id = payloads[0]["faces"][0]["person_id"]
+    assert unknown_id == "unknown-1"
+
+    path = _write_photo(tmp_path, "b.jpg", _FakeFrame.one(21))
+    result = plugin.dispatch("face_recognition", {
+        "action": "register_user_photo", "image_path": path, "profile": "Dave"})
+
+    assert result["person_id"] == unknown_id
+    assert result["promoted"] is True
+    record = plugin._require_engine().db.get_person(unknown_id)
+    assert record["named"] is True and record["profile"] == "Dave"
+
+
+# ── register_current_stream ───────────────────────────────────────────────────
+
+def test_register_from_the_stream_uses_the_whole_window(plugin):
+    node, _payloads = _run_one_frame(plugin, _FakeFrame.one(30))
+    for _ in range(4):
+        node._image_cb(_FakeCompressedImage(_FakeFrame.one(30)))
+
+    result = plugin.dispatch("face_recognition", {
+        "action": "register_current_stream", "profile": "Erin"})
+    assert result["ok"] is True
+    assert result["frames_examined"] >= 2
+    assert result["frames_used"] >= 2
+    assert result["window_s"] == pytest.approx(3.0)
+
+
+def test_register_from_the_stream_without_an_instance(plugin):
+    result = plugin.dispatch("face_recognition", {
+        "action": "register_current_stream", "profile": "Nobody"})
+    assert result["ok"] is False
+    assert result["reason"] == face_plugin.REASON_NO_FRAMES
+
+
+def test_register_from_the_stream_reports_a_crowd(plugin):
+    node, _ = _run_one_frame(
+        plugin, _FakeFrame.build((1, 120, 500.0), (2, 119, 500.0)))
+    for _ in range(3):
+        node._image_cb(_FakeCompressedImage(
+            _FakeFrame.build((1, 120, 500.0), (2, 119, 500.0))))
+
+    result = plugin.dispatch("face_recognition", {
+        "action": "register_current_stream", "profile": "Someone"})
+    assert result["ok"] is False
+    assert result["reason"] == face_plugin.REASON_AMBIGUOUS
+    assert result["frame_reasons"][face_plugin.REASON_AMBIGUOUS] >= 1
+
+
+def test_register_from_the_stream_refuses_an_unstable_subject(plugin):
+    """Two people taking turns must not be enrolled as one identity."""
+    node, _ = _run_one_frame(plugin, _FakeFrame.one(40))
+    for identity in (41, 42, 43, 44):
+        node._image_cb(_FakeCompressedImage(_FakeFrame.one(identity)))
+
+    result = plugin.dispatch("face_recognition", {
+        "action": "register_current_stream", "profile": "Whoever"})
+    assert result["ok"] is False
+    assert result["reason"] == face_plugin.REASON_AMBIGUOUS
+    assert "stable subject" in result["detail"]
+
+
+def test_register_stream_window_is_clamped_to_the_config(plugin):
+    node, _ = _run_one_frame(plugin, _FakeFrame.one(45))
+    node._image_cb(_FakeCompressedImage(_FakeFrame.one(45)))
+    result = plugin.dispatch("face_recognition", {
+        "action": "register_current_stream", "profile": "Frank", "window_s": 999})
+    assert result["window_s"] == pytest.approx(3.0)
+
+
+def test_register_stream_needs_an_instance_id_when_several_run(plugin):
+    for index in (1, 2):
+        plugin.dispatch("face_recognition", {
+            "action": "start", "input_topic": f"/cam{index}",
+            "instance_id": f"i{index}"})
+    assert _wait_until(lambda: len(plugin._nodes) == 2, timeout=5.0)
+    result = plugin.dispatch("face_recognition", {
+        "action": "register_current_stream", "profile": "x"})
+    assert result["reason"] == face_plugin.REASON_BAD_INPUT
+    assert "instance_id" in result["detail"]
+
+
+def test_the_window_drops_frames_older_than_enroll_window_s(monkeypatch, tmp_path):
+    probe = _EngineProbe(tmp_path)
+    monkeypatch.setattr(face_plugin, "_build_engine", probe)
+    plugin = face_plugin.FaceRecognitionPlugin(
+        _base_cfg(tmp_path, enroll_window_s=0.2), _FakeExecutor())
+    try:
+        node, _ = _run_one_frame(plugin, _FakeFrame.one(50))
+        assert len(node.recent_frames()) >= 1
+        time.sleep(0.35)
+        node._image_cb(_FakeCompressedImage(_FakeFrame.one(50)))
+        recent = node.recent_frames()
+        assert len(recent) == 1, "stale frames were not evicted from the window"
+    finally:
+        plugin.dispatch("face_recognition", {"action": "stop"})
+
+
+# ── register_user_photos (batch) ──────────────────────────────────────────────
+
+def _make_package(tmp_path, entries, manifest=None) -> str:
+    directory = tmp_path / "pack"
+    directory.mkdir(exist_ok=True)
+    for name, frame in entries.items():
+        (directory / name).write_bytes(frame)
+    if manifest is not None:
+        (directory / "manifest.json").write_text(
+            json.dumps(manifest, ensure_ascii=False))
+    return str(directory)
+
+
+def test_batch_reports_one_result_per_photo(plugin, tmp_path):
+    package = _make_package(
+        tmp_path,
+        {
+            "alice.jpg": _FakeFrame.one(60),
+            "bob.jpg": _FakeFrame.one(61, size=30, blur=3.0),
+            "team.jpg": _FakeFrame.build((62, 120, 500.0), (63, 119, 500.0)),
+            "empty.jpg": b"",
+        },
+        manifest={
+            "alice.jpg": "Alice from ops",
+            "bob.jpg": "Bob",
+            "team.jpg": "The team",
+            "empty.jpg": "Nobody",
+        },
+    )
+    result = plugin.dispatch("face_recognition", {
+        "action": "register_user_photos", "package": package})
+
+    assert result["ok"] is True
+    assert result["total"] == 4
+    assert result["registered"] == 1
+    assert result["failed"] == 3
+
+    by_file = {item["file"]: item for item in result["results"]}
+    assert by_file["alice.jpg"]["ok"] is True
+    assert by_file["alice.jpg"]["profile"] == "Alice from ops"
+    assert by_file["bob.jpg"]["reason"] == face_plugin.REASON_LOW_QUALITY
+    assert by_file["team.jpg"]["reason"] == face_plugin.REASON_AMBIGUOUS
+    assert by_file["team.jpg"]["candidates"]
+    assert by_file["empty.jpg"]["reason"] == face_plugin.REASON_NO_FACE
+    # Every failure explains itself — that is the requirement.
+    for item in result["results"]:
+        assert item.get("ok") or item["detail"]
+
+
+def test_batch_manifest_list_form_and_person_grouping(plugin, tmp_path):
+    package = _make_package(
+        tmp_path,
+        {"a1.jpg": _FakeFrame.one(70), "a2.jpg": _FakeFrame.one(71)},
+        manifest=[
+            {"file": "a1.jpg", "profile": "Grace", "person": "grace",
+             "meta": {"badge": "G1"}},
+            {"file": "a2.jpg", "profile": "Grace", "person": "grace"},
+        ],
+    )
+    result = plugin.dispatch("face_recognition", {
+        "action": "register_user_photos", "package": package})
+    assert result["registered"] == 2
+    ids = {item["person_id"] for item in result["results"]}
+    assert len(ids) == 1, "photos sharing a person key must become one identity"
+
+    engine = plugin._require_engine()
+    person = engine.db.get_person(ids.pop())
+    assert person["samples"] == 2
+    assert person["meta"] == {"badge": "G1"}
+
+
+def test_batch_falls_back_to_sidecars_then_the_filename(plugin, tmp_path):
+    directory = tmp_path / "pack2"
+    directory.mkdir()
+    (directory / "heidi.jpg").write_bytes(_FakeFrame.one(80))
+    (directory / "heidi.json").write_text(json.dumps(
+        {"profile": "Heidi from QA", "meta": {"floor": 2}}))
+    (directory / "ivan.jpg").write_bytes(_FakeFrame.one(81))
+    (directory / "ivan.txt").write_text("Ivan the intern\n")
+    (directory / "judy.jpg").write_bytes(_FakeFrame.one(82))
+
+    result = plugin.dispatch("face_recognition", {
+        "action": "register_user_photos", "package": str(directory)})
+    profiles = {item["file"]: item["profile"] for item in result["results"]}
+    assert profiles["heidi.jpg"] == "Heidi from QA"
+    assert profiles["ivan.jpg"] == "Ivan the intern"
+    assert profiles["judy.jpg"] == "judy"          # filename stem
+
+
+def test_batch_accepts_a_zip_and_refuses_traversal(plugin, tmp_path):
+    archive = tmp_path / "people.zip"
+    with zipfile.ZipFile(archive, "w") as handle:
+        handle.writestr("kate.jpg", _FakeFrame.one(90))
+        handle.writestr("../escape.jpg", _FakeFrame.one(91))
+        handle.writestr("/abs.jpg", _FakeFrame.one(92))
+        handle.writestr("manifest.json", json.dumps({"kate.jpg": "Kate"}))
+
+    result = plugin.dispatch("face_recognition", {
+        "action": "register_user_photos", "package": str(archive)})
+    assert result["registered"] == 1
+    assert [item["file"] for item in result["results"]] == ["kate.jpg"]
+    assert not (tmp_path / "escape.jpg").exists()
+
+
+def test_batch_rejects_an_empty_or_oversized_package(plugin, tmp_path, monkeypatch):
+    empty = tmp_path / "empty-pack"
+    empty.mkdir()
+    result = plugin.dispatch("face_recognition", {
+        "action": "register_user_photos", "package": str(empty)})
+    assert result["reason"] == face_plugin.REASON_BAD_INPUT
+    assert "no images" in result["detail"]
+
+    plugin._plugin_cfg["max_batch"] = 1
+    package = _make_package(
+        tmp_path, {"a.jpg": _FakeFrame.one(1), "b.jpg": _FakeFrame.one(2)})
+    result = plugin.dispatch("face_recognition", {
+        "action": "register_user_photos", "package": package})
+    assert result["reason"] == face_plugin.REASON_BAD_INPUT
+    assert "max_batch" in result["detail"]
+
+
+def test_batch_requires_a_package(plugin):
+    result = plugin.dispatch("face_recognition", {"action": "register_user_photos"})
+    assert result["reason"] == face_plugin.REASON_BAD_INPUT
+
+
+# ── roster CRUD ───────────────────────────────────────────────────────────────
+
+def test_roster_crud_through_dispatch(plugin, tmp_path):
+    path = _write_photo(tmp_path, "l.jpg", _FakeFrame.one(100))
+    created = plugin.dispatch("face_recognition", {
+        "action": "register_user_photo", "image_path": path,
+        "profile": "Leo", "meta": {"team": "ops", "floor": 3}})
+    person_id = created["person_id"]
+
+    listed = plugin.dispatch("face_recognition", {"action": "list_persons"})
+    assert listed["ok"] is True and listed["total"] == 1
+
+    filtered = plugin.dispatch("face_recognition", {
+        "action": "list_persons", "query": "ops"})
+    assert filtered["total"] == 1
+
+    updated = plugin.dispatch("face_recognition", {
+        "action": "update_person", "person_id": person_id,
+        "profile": "Leo (facilities)", "meta": {"floor": 4},
+        "meta_delete": ["team"]})
+    assert updated["person"]["profile"] == "Leo (facilities)"
+    assert updated["person"]["meta"] == {"floor": 4}
+
+    fetched = plugin.dispatch("face_recognition", {
+        "action": "get_person", "person_id": person_id})
+    assert fetched["person"]["meta"] == {"floor": 4}
+
+    forgotten = plugin.dispatch("face_recognition", {
+        "action": "forget", "person_id": person_id})
+    assert forgotten["ok"] is True and forgotten["forgotten"] == 1
+    assert plugin.dispatch("face_recognition", {"action": "list_persons"})["total"] == 0
+
+
+def test_roster_actions_report_missing_people(plugin):
+    for action in ("get_person", "update_person", "forget"):
+        result = plugin.dispatch("face_recognition", {
+            "action": action, "person_id": "p-404", "profile": "x"})
+        assert result["ok"] is False
+        assert result["reason"] == face_plugin.REASON_BAD_INPUT
+
+    for action in ("get_person", "update_person"):
+        with pytest.raises(ValueError):
+            plugin.dispatch("face_recognition", {"action": action})
+
+
+def test_forget_all_unknowns(plugin):
+    engine = plugin._require_engine()
+    engine.db.add("Mona", [_unit(110)])
+    engine.db.enroll_unknown(_unit(111))
+    engine.db.enroll_unknown(_unit(112))
+
+    result = plugin.dispatch("face_recognition", {
+        "action": "forget", "named": "unknown"})
+    assert result["forgotten"] == 2
+    stats = plugin._require_engine().db.stats()
+    assert (stats["named"], stats["unknown"]) == (1, 0)
+
+
+def test_update_person_names_an_unknown_keeping_its_id(plugin):
+    engine = plugin._require_engine()
+    unknown_id = engine.db.enroll_unknown(_unit(120))["id"]
+    result = plugin.dispatch("face_recognition", {
+        "action": "update_person", "person_id": unknown_id, "profile": "Nina"})
+    assert result["person"]["id"] == unknown_id
+    assert result["person"]["named"] is True
+
+
+# ── config ────────────────────────────────────────────────────────────────────
+
+def test_capacity_change_from_the_card_evicts_without_a_reload(plugin):
+    engine = plugin._require_engine()
+    engine.db.add("Owen", [_unit(130)])
+    for seed in range(5):
+        engine.db.touch(engine.db.enroll_unknown(_unit(200 + seed))["id"],
+                        when=1_000.0 + seed)
+    builds = plugin._probe.calls
+
+    result = plugin.dispatch("face_recognition", {
+        "action": "config", "unknown_capacity": 2})
+    assert result["unknown_evicted"] == 3
+    assert result["unknown_capacity"] == 2
+    assert plugin._probe.calls == builds, "capacity change must not rebuild the engine"
+
+    stats = plugin._require_engine().db.stats()
+    assert (stats["named"], stats["unknown"]) == (1, 2)
+
+
+def test_threshold_change_does_not_rebuild_but_takes_effect(plugin):
+    plugin._require_engine()
+    builds = plugin._probe.calls
+    plugin.dispatch("face_recognition", {
+        "action": "config", "match_threshold": 0.9})
+    assert plugin._probe.calls == builds
+    assert plugin._plugin_cfg["match_threshold"] == 0.9
+
+
+def test_model_affecting_change_rebuilds_and_retires_nodes(plugin, tmp_path):
+    plugin.dispatch("face_recognition", {"action": "start", "input_topic": "/cam"})
+    assert _wait_until(lambda: plugin._nodes, timeout=5.0)
+    builds = plugin._probe.calls
+
+    plugin.dispatch("face_recognition", {"action": "config", "device": "gpu"})
+    assert plugin._nodes == {}
+    assert plugin._engine is None
+
+    plugin.dispatch("face_recognition", {"action": "start", "input_topic": "/cam"})
+    assert _wait_until(lambda: plugin._probe.calls > builds, timeout=5.0)
+
+
+def test_instance_config_rejects_shared_settings(plugin):
+    plugin.dispatch("face_recognition", {"action": "start", "input_topic": "/cam"})
+    assert _wait_until(lambda: plugin._nodes, timeout=5.0)
+
+    ok = plugin.dispatch("face_recognition", {
+        "action": "config", "instance_id": "/cam", "min_interval_ms": 500})
+    assert ok["status"] == "configured"
+    assert plugin._nodes["/cam"]._min_interval == pytest.approx(0.5)
+
+    with pytest.raises(ValueError):
+        plugin.dispatch("face_recognition", {
+            "action": "config", "instance_id": "/cam", "match_threshold": 0.4})

--- a/perception/tests/test_face_plugin.py
+++ b/perception/tests/test_face_plugin.py
@@ -941,3 +941,47 @@ def test_device_is_declared_on_the_card_with_auto_default():
     schema = face_plugin.TOOLS[0]["configSchema"]["properties"]["device"]
     assert schema["default"] == "auto"
     assert set(schema["enum"]) == {"auto", "cpu", "gpu"}
+
+
+# ── card surface invariants ──────────────────────────────────────────────────
+
+def test_no_image_url_input():
+    """A URL fetch would give an unauthenticated LAN caller a request-forging
+    primitive inside the robot's network, for no benefit over path/base64."""
+    schema = face_plugin.TOOLS[0]["inputSchema"]
+    assert "image_url" not in schema["properties"]
+    for spec in schema["x-action-params"].values():
+        assert "image_url" not in spec["params"]
+
+
+def test_register_actions_take_no_person_id():
+    """Which identity a photo belongs to is decided by matching, not by the
+    caller — otherwise there are two ways to say it and they can disagree."""
+    params = face_plugin.TOOLS[0]["inputSchema"]["x-action-params"]
+    assert "person_id" not in params["register_user_photo"]["params"]
+    assert "person_id" not in params["register_current_stream"]["params"]
+    # It remains an input where it identifies an existing record.
+    for action in ("get_person", "update_person", "forget"):
+        assert "person_id" in params[action]["params"]
+
+
+def test_register_ignores_a_person_id_argument(plugin, tmp_path):
+    """Passing it anyway must not bypass matching."""
+    engine = plugin._require_engine()
+    engine.db.add("Someone else", [_unit(200)])
+    path = _write_photo(tmp_path, "x.jpg", _FakeFrame.one(201))
+
+    result = plugin.dispatch("face_recognition", {
+        "action": "register_user_photo", "image_path": path,
+        "profile": "New person", "person_id": "p-1"})
+    assert result["ok"] is True
+    assert result["person_id"] == "p-2", "person_id must not force the identity"
+    assert engine.db.get_person("p-1")["profile"] == "Someone else"
+
+
+def test_published_payload_carries_no_topic_field(plugin):
+    """A subscriber already knows the topic it read from, and OCR's payload
+    does not carry one either."""
+    _node, payloads = _run_one_frame(plugin, _FakeFrame.one(210))
+    assert "topic" not in payloads[0]
+    assert set(payloads[0]) == {"ts", "count", "faces", "latency_ms"}

--- a/perception/tests/test_face_plugin.py
+++ b/perception/tests/test_face_plugin.py
@@ -505,20 +505,22 @@ def test_base64_input_is_refused_with_a_pointer_to_what_works(plugin):
         "action": "register_by_photo", "image_b64": encoded, "name": "Bob"})
     assert result["ok"] is False
     assert result["reason"] == face_plugin.REASON_BAD_INPUT
-    assert "image_path" in result["detail"]
+    assert "file/upload" in result["detail"]
     assert "register_by_url" in result["detail"]
     assert plugin._require_engine().db.stats()["persons"] == 0
 
 
-def test_image_path_is_a_file_picker_field_pointing_at_the_shared_mount():
-    """`format: file` is what makes the canvas render a picker and upload via
-    agent-core's /api/file/upload — the same mechanism remote_image uses. The
-    upload has to land somewhere perception can read, hence uploadDir."""
+def test_image_path_is_a_file_picker_routed_through_the_upload_proxy():
+    """`format: file` makes the canvas render a picker; `uploadTo: mcp` sends it
+    to /api/mcp/<id>/file/upload, which streams the bytes to *this* service and
+    returns a path this container can open. Without uploadTo the upload would
+    land in agent-core, which perception cannot see — the original bug."""
     spec = face_plugin.TOOLS[0]["inputSchema"]["properties"]["image_path"]
     assert spec["format"] == "file"
     assert spec["accept"] == "image/*"
-    assert spec["uploadDir"] == "/uploads"
-    assert "/uploads" in face_plugin.DEFAULT_IMAGE_ROOTS[0]
+    assert spec["uploadTo"] == "mcp"
+    # No shared mount is involved, so the roots stay as they were.
+    assert "/uploads" not in face_plugin.DEFAULT_IMAGE_ROOTS
 
 
 def test_no_base64_anywhere_on_the_card():
@@ -528,14 +530,15 @@ def test_no_base64_anywhere_on_the_card():
         assert "image_b64" not in spec["params"], action
 
 
-def test_a_path_outside_the_roots_names_the_shared_mount(plugin):
+def test_a_path_outside_the_roots_says_how_to_hand_the_file_over(plugin):
     """The first real failure was image_path=/work/daiwen.jpg — a real file in
-    agent-core, invisible here. The error has to say where to put it instead."""
+    agent-core, invisible here. Told only "cannot read", the LLM retried with
+    another invisible path, so the error has to name the mechanism that works."""
     result = plugin.dispatch("face_recognition", {
-        "action": "register_by_photo", "image_path": "/work/daiwen.jpg"})
+        "action": "register_by_photo", "image_path": "/etc/hostname"})
     assert result["ok"] is False
     assert result["reason"] == face_plugin.REASON_BAD_INPUT
-    assert "/uploads" in result["detail"]
+    assert "file/upload" in result["detail"]
     assert "register_by_url" in result["detail"]
 
 

--- a/perception/tests/test_face_plugin.py
+++ b/perception/tests/test_face_plugin.py
@@ -72,6 +72,9 @@ class _FakeAnalyzer:
         self.embed_calls = 0
 
     # -- the surface plugins/face.py uses --
+    def decode_image(self, data: bytes, max_side: int = 0, max_pixels: int = 0):
+        return self.decode_jpeg(data)
+
     def decode_jpeg(self, data: bytes):
         self.seen.append(data)
         if data == b"corrupt":
@@ -1060,10 +1063,12 @@ def test_recognize_actions_are_on_the_card():
     assert {"recognize_by_photo", "recognize_by_stream"} <= actions
     assert actions == set(schema["x-action-params"])
     params = schema["x-action-params"]
-    assert set(params["recognize_by_photo"]["params"]) == {"image_path", "image_b64"}
+    assert set(params["recognize_by_photo"]["params"]) == {
+        "image_path", "image_b64", "url"}
     assert set(params["recognize_by_stream"]["params"]) == {"window_s"}
     # register/recognize are symmetric by suffix.
-    assert {"register_by_photo", "register_by_stream", "register_by_corpus"} <= actions
+    assert {"register_by_photo", "register_by_url",
+            "register_by_stream", "register_by_corpus"} <= actions
 
 
 def test_recognize_by_photo_identifies_a_registered_person(plugin, tmp_path):
@@ -1194,3 +1199,185 @@ def test_recognize_by_stream_needs_an_instance_id_when_several_run(plugin):
     result = plugin.dispatch("face_recognition", {"action": "recognize_by_stream"})
     assert result["reason"] == face_plugin.REASON_BAD_INPUT
     assert "instance_id" in result["detail"]
+
+
+# ── batch forget through dispatch ────────────────────────────────────────────
+
+def test_forget_accepts_a_list_of_ids(plugin):
+    engine = plugin._require_engine()
+    ids = [engine.db.add(f"p{s}", [_unit(500 + s)])["id"] for s in range(4)]
+
+    result = plugin.dispatch("face_recognition", {
+        "action": "forget", "person_ids": ids[:3]})
+    assert result["ok"] is True
+    assert result["forgotten"] == 3
+    assert result["person_ids"] == ids[:3]
+    assert "missing" not in result
+    assert engine.db.stats()["persons"] == 1
+
+
+def test_forget_accepts_a_comma_separated_string(plugin):
+    """An LLM (or a text field) sends "p-1, p-2" rather than a JSON array."""
+    engine = plugin._require_engine()
+    engine.db.add("A", [_unit(510)])
+    engine.db.add("B", [_unit(511)])
+
+    result = plugin.dispatch("face_recognition", {
+        "action": "forget", "person_ids": "p-1, p-2"})
+    assert result["forgotten"] == 2
+    assert engine.db.stats()["persons"] == 0
+
+
+def test_forget_reports_partial_success(plugin):
+    engine = plugin._require_engine()
+    engine.db.add("A", [_unit(520)])
+
+    result = plugin.dispatch("face_recognition", {
+        "action": "forget", "person_ids": ["p-1", "p-404"]})
+    assert result["ok"] is True, 'something was deleted, so the call succeeded'
+    assert result["forgotten"] == 1
+    assert result["missing"] == ["p-404"]
+    assert "p-404" in result["detail"]
+
+
+def test_forget_with_only_unknown_ids_is_an_error(plugin):
+    plugin._require_engine()
+    result = plugin.dispatch("face_recognition", {
+        "action": "forget", "person_ids": ["p-404", "p-405"]})
+    assert result["ok"] is False
+    assert result["reason"] == face_plugin.REASON_BAD_INPUT
+    assert result["missing"] == ["p-404", "p-405"]
+
+
+def test_forget_still_takes_a_single_id_and_the_unknown_scope(plugin):
+    engine = plugin._require_engine()
+    engine.db.add("A", [_unit(530)])
+    engine.db.enroll_unknown(_unit(531))
+    engine.db.enroll_unknown(_unit(532))
+
+    single = plugin.dispatch("face_recognition", {
+        "action": "forget", "person_id": "p-1"})
+    assert single["forgotten"] == 1
+
+    scoped = plugin.dispatch("face_recognition", {
+        "action": "forget", "named": "unknown"})
+    assert scoped["forgotten"] == 2 and scoped["scope"] == "unknown"
+
+
+def test_forget_requires_something_to_delete(plugin):
+    plugin._require_engine()
+    with pytest.raises(ValueError):
+        plugin.dispatch("face_recognition", {"action": "forget"})
+
+
+def test_person_ids_is_declared_with_an_example_for_the_llm():
+    """The accepted shapes have to be readable off the schema alone."""
+    schema = face_plugin.TOOLS[0]["inputSchema"]
+    spec = schema["properties"]["person_ids"]
+    assert spec["type"] == "array"
+    assert 'p-1' in spec["description"]          # a concrete example
+    assert 'missing' in spec["description"]      # and the return shape
+    assert "person_ids" in schema["x-action-params"]["forget"]["params"]
+
+
+# ── register_by_url ──────────────────────────────────────────────────────────
+
+def test_register_by_url_fetches_and_registers(plugin, monkeypatch):
+    fetched = {}
+
+    def fake_fetch(url, max_bytes):
+        fetched['url'] = url
+        return _FakeFrame.one(600)
+
+    monkeypatch.setattr(face_plugin, '_fetch_url', fake_fetch)
+    result = plugin.dispatch("face_recognition", {
+        "action": "register_by_url",
+        "url": "https://example.com/alice.jpg", "name": "Alice"})
+
+    assert result["ok"] is True
+    assert result["name"] == "Alice"
+    assert fetched['url'] == "https://example.com/alice.jpg"
+    assert result["source"] == "https://example.com/alice.jpg"
+
+
+def test_register_by_url_surfaces_a_fetch_failure(plugin, monkeypatch):
+    def fake_fetch(url, max_bytes):
+        raise face_plugin._BadInput(f"cannot fetch {url!r}: timed out", url)
+
+    monkeypatch.setattr(face_plugin, '_fetch_url', fake_fetch)
+    result = plugin.dispatch("face_recognition", {
+        "action": "register_by_url", "url": "https://example.com/x.jpg"})
+    assert result["ok"] is False
+    assert result["reason"] == face_plugin.REASON_BAD_INPUT
+    assert "timed out" in result["detail"]
+
+
+def test_recognize_by_photo_also_accepts_a_url(plugin, monkeypatch):
+    engine = plugin._require_engine()
+    engine.db.add("Bob", [_unit(610)])
+    monkeypatch.setattr(face_plugin, '_fetch_url',
+                        lambda url, max_bytes: _FakeFrame.one(610))
+
+    result = plugin.dispatch("face_recognition", {
+        "action": "recognize_by_photo", "url": "https://example.com/b.jpg"})
+    assert result["ok"] is True
+    assert result["faces"][0]["name"] == "Bob"
+
+
+def test_register_by_url_is_on_the_card_as_its_own_action():
+    """A URL fetch is a named capability, not a parameter smuggled into the
+    photo path — so it is visible on the card."""
+    schema = face_plugin.TOOLS[0]["inputSchema"]
+    assert "register_by_url" in schema["properties"]["action"]["enum"]
+    assert set(schema["x-action-params"]["register_by_url"]["params"]) == {
+        "url", "name", "profile"}
+
+
+# ── size / format handling is local, not a rejection ─────────────────────────
+
+def test_decode_options_come_from_config():
+    cfg = {"max_image_side": 1024, "max_image_pixels": 1_000_000}
+    assert face_plugin._decode_options(cfg) == {
+        "max_side": 1024, "max_pixels": 1_000_000}
+    defaults = face_plugin._decode_options({})
+    assert defaults["max_side"] == 2048 and defaults["max_pixels"] == 60_000_000
+
+
+def test_every_input_path_decodes_through_the_same_options(plugin, tmp_path):
+    """Resize/convert must apply to register and recognize alike, by photo,
+    url, corpus and stream — so they all have to reach decode_image with the
+    configured options rather than each path doing its own thing."""
+    engine = plugin._require_engine()
+    seen = []
+    original = engine.analyzer.decode_image
+
+    def spy(data, max_side=0, max_pixels=0):
+        seen.append((max_side, max_pixels))
+        return original(data, max_side, max_pixels)
+
+    engine.analyzer.decode_image = spy
+    plugin._plugin_cfg["max_image_side"] = 1234
+    plugin._plugin_cfg["max_image_pixels"] = 5_000_000
+
+    path = _write_photo(tmp_path, "a.jpg", _FakeFrame.one(700))
+    plugin.dispatch("face_recognition", {
+        "action": "register_by_photo", "image_path": path, "name": "A"})
+    plugin.dispatch("face_recognition", {
+        "action": "recognize_by_photo", "image_path": path})
+    package = _make_package(tmp_path, {"b.jpg": _FakeFrame.one(701)})
+    plugin.dispatch("face_recognition", {
+        "action": "register_by_corpus", "package": package})
+
+    assert len(seen) >= 3
+    assert all(opts == (1234, 5_000_000) for opts in seen), seen
+
+
+def test_the_byte_cap_is_a_transfer_guard_not_a_photo_limit():
+    """16 MB used to reject real phone photos; oversized images are now
+    downscaled locally instead."""
+    assert face_plugin.DEFAULT_MAX_IMAGE_BYTES == 64 * 1024 * 1024
+
+
+def test_corpus_finds_the_formats_both_decoders_read():
+    for suffix in (".jpg", ".png", ".webp", ".tif", ".tiff", ".gif", ".bmp"):
+        assert suffix in face_plugin._IMAGE_SUFFIXES

--- a/perception/tests/test_face_plugin.py
+++ b/perception/tests/test_face_plugin.py
@@ -495,12 +495,48 @@ def test_register_from_a_photo_path(plugin, tmp_path):
     assert engine.db.match(_unit(11), 0.35)[0] == "p-1"
 
 
-def test_register_from_base64(plugin):
+def test_base64_input_is_refused_with_a_pointer_to_what_works(plugin):
+    """Removed because an LLM failed on it twice in production: a 43 800-char
+    string does not survive being carried through a model's context, and what
+    arrived was truncated. Refusing loudly beats decoding garbage."""
     import base64
     encoded = base64.b64encode(_FakeFrame.one(12)).decode()
     result = plugin.dispatch("face_recognition", {
         "action": "register_by_photo", "image_b64": encoded, "name": "Bob"})
-    assert result["ok"] is True and result["person_id"] == "p-1"
+    assert result["ok"] is False
+    assert result["reason"] == face_plugin.REASON_BAD_INPUT
+    assert "image_path" in result["detail"]
+    assert "register_by_url" in result["detail"]
+    assert plugin._require_engine().db.stats()["persons"] == 0
+
+
+def test_image_path_is_a_file_picker_field_pointing_at_the_shared_mount():
+    """`format: file` is what makes the canvas render a picker and upload via
+    agent-core's /api/file/upload — the same mechanism remote_image uses. The
+    upload has to land somewhere perception can read, hence uploadDir."""
+    spec = face_plugin.TOOLS[0]["inputSchema"]["properties"]["image_path"]
+    assert spec["format"] == "file"
+    assert spec["accept"] == "image/*"
+    assert spec["uploadDir"] == "/uploads"
+    assert "/uploads" in face_plugin.DEFAULT_IMAGE_ROOTS[0]
+
+
+def test_no_base64_anywhere_on_the_card():
+    schema = face_plugin.TOOLS[0]["inputSchema"]
+    assert "image_b64" not in schema["properties"]
+    for action, spec in schema["x-action-params"].items():
+        assert "image_b64" not in spec["params"], action
+
+
+def test_a_path_outside_the_roots_names_the_shared_mount(plugin):
+    """The first real failure was image_path=/work/daiwen.jpg — a real file in
+    agent-core, invisible here. The error has to say where to put it instead."""
+    result = plugin.dispatch("face_recognition", {
+        "action": "register_by_photo", "image_path": "/work/daiwen.jpg"})
+    assert result["ok"] is False
+    assert result["reason"] == face_plugin.REASON_BAD_INPUT
+    assert "/uploads" in result["detail"]
+    assert "register_by_url" in result["detail"]
 
 
 def test_register_reports_each_failure_reason(plugin, tmp_path):
@@ -1063,8 +1099,7 @@ def test_recognize_actions_are_on_the_card():
     assert {"recognize_by_photo", "recognize_by_stream"} <= actions
     assert actions == set(schema["x-action-params"])
     params = schema["x-action-params"]
-    assert set(params["recognize_by_photo"]["params"]) == {
-        "image_path", "image_b64", "url"}
+    assert set(params["recognize_by_photo"]["params"]) == {"image_path", "url"}
     assert set(params["recognize_by_stream"]["params"]) == {"window_s"}
     # register/recognize are symmetric by suffix.
     assert {"register_by_photo", "register_by_url",

--- a/perception/tests/test_file_intake.py
+++ b/perception/tests/test_file_intake.py
@@ -1,0 +1,278 @@
+"""
+tests/test_file_intake.py — HTTP file intake (utils/file_intake.py).
+
+This is how a photo reaches the perception container at all. agent-core serves
+the browser but shares no filesystem with perception, so a path minted there is
+meaningless here — the first face-enrolment attempt failed with an `image_path`
+that really existed, in agent-core. agent-core now proxies the upload to
+`POST /file/upload` on this service, which writes the bytes where it can see
+them and returns its own absolute path.
+
+Stdlib only, so the drivers (bare ThreadingHTTPServer, no FastAPI) can reuse it.
+
+Run: python -m pytest perception/tests/test_file_intake.py -q
+"""
+
+from __future__ import annotations
+
+import glob
+import os
+
+import pytest
+
+from vision_stubs import PERCEPTION_ROOT  # noqa: F401  (puts perception on sys.path)
+
+from utils.file_intake import (  # noqa: E402
+    IntakeError,
+    access_token,
+    check_token,
+    handle_upload,
+    parse_multipart,
+    prune_old,
+    safe_filename,
+    safe_subdir,
+    store_stream,
+)
+
+BOUNDARY = "----boundary9d8f"
+JPEG = b"\xff\xd8\xff\xe0" + b"payload-bytes" * 500 + b"\xff\xd9"
+
+
+def _multipart(filename: str = "alice.jpg", payload: bytes = JPEG,
+               extra: dict | None = None) -> tuple[dict, bytes]:
+    parts = []
+    for key, value in (extra or {}).items():
+        parts.append(
+            f"--{BOUNDARY}\r\nContent-Disposition: form-data; name=\"{key}\"\r\n\r\n"
+            f"{value}\r\n".encode()
+        )
+    parts.append(
+        f"--{BOUNDARY}\r\n"
+        f'Content-Disposition: form-data; name="file"; filename="{filename}"\r\n'
+        f"Content-Type: image/jpeg\r\n\r\n".encode()
+        + payload + f"\r\n--{BOUNDARY}--\r\n".encode()
+    )
+    return ({"Content-Type": f"multipart/form-data; boundary={BOUNDARY}"},
+            b"".join(parts))
+
+
+# ── filename safety ───────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("raw, expect_not", [
+    ("../../etc/passwd", ".."),
+    ("../../../root/.ssh/authorized_keys", ".."),
+    ("/etc/shadow", "/"),
+    ("C:\\windows\\system32\\x.jpg", "\\"),
+    ("a/b/c.jpg", "/"),
+])
+def test_traversal_cannot_survive_the_filename(raw, expect_not):
+    """A client-supplied filename is joined onto a path, so it has to collapse
+    to a single component."""
+    cleaned = safe_filename(raw)
+    assert expect_not not in cleaned
+    assert os.path.basename(cleaned) == cleaned
+
+
+def test_chinese_filenames_are_kept():
+    """The people using this name their files in Chinese; mangling those to
+    underscores would make the upload directory unreadable."""
+    assert safe_filename("戴文渊.jpg") == "戴文渊.jpg"
+    assert safe_filename("陈雨强-正面.png") == "陈雨强-正面.png"
+
+
+def test_leading_dots_and_empty_names_get_a_fallback():
+    assert not safe_filename("...hidden").startswith(".")
+    assert safe_filename("") == "upload.bin"
+    assert safe_filename("..") == "upload.bin"
+    assert safe_filename("/") == "upload.bin"
+
+
+def test_absurdly_long_names_are_bounded_but_keep_the_extension():
+    """Many filesystems cap a component at 255 bytes, and a CJK name is 3 bytes
+    per character."""
+    cleaned = safe_filename("超长" * 200 + ".jpg")
+    assert len(cleaned.encode("utf-8")) <= 255
+    assert cleaned.endswith(".jpg")
+
+
+def test_macos_and_linux_uploads_of_one_name_agree():
+    """NFD vs NFC would otherwise produce two files that look identical."""
+    assert safe_filename("é.jpg") == safe_filename("e\u0301.jpg")
+
+
+def test_subdir_is_one_component_or_refused():
+    """Refused, not sanitised: turning "../escape" into ".._escape" made the
+    write succeed somewhere the caller did not ask for, silently."""
+    assert safe_subdir("") == ""
+    assert safe_subdir("faces") == "faces"
+    for bad in ("../escape", "..", ".", "a/b", "a\\b", "../../etc"):
+        with pytest.raises(IntakeError):
+            safe_subdir(bad)
+
+
+# ── auth ──────────────────────────────────────────────────────────────────────
+
+def test_token_check_is_a_noop_when_none_is_configured():
+    """Matches agent-core's own behaviour: no ACCESS_TOKEN means auth disabled,
+    so a dev deployment works untouched. Verified on Tianyi that the perception
+    container is not given one."""
+    check_token(None, None)
+    check_token(None, "")
+    check_token("anything", "")
+
+
+def test_a_configured_token_is_enforced():
+    check_token("secret", "secret")
+    for bad in (None, "", "wrong", "secre", "secrets"):
+        with pytest.raises(IntakeError) as caught:
+            check_token(bad, "secret")
+        assert caught.value.status == 401
+
+
+def test_access_token_prefers_the_environment(monkeypatch, tmp_path):
+    monkeypatch.setenv("ACCESS_TOKEN", "from-env")
+    assert access_token() == "from-env"
+
+
+def test_access_token_is_empty_when_there_is_no_source(monkeypatch):
+    monkeypatch.delenv("ACCESS_TOKEN", raising=False)
+    monkeypatch.setattr("utils.file_intake._ENV_CANDIDATES", ("/nonexistent/.env",))
+    assert access_token() == ""
+
+
+# ── storing ───────────────────────────────────────────────────────────────────
+
+def test_a_stored_file_is_byte_identical_and_reports_its_own_path(tmp_path):
+    headers, body = _multipart()
+    status, result = handle_upload(headers, body, str(tmp_path))
+
+    assert status == 200 and result["ok"]
+    assert os.path.isabs(result["path"])
+    assert result["path"].startswith(str(tmp_path))
+    assert result["bytes"] == len(JPEG)
+    with open(result["path"], "rb") as handle:
+        assert handle.read() == JPEG, "the bytes must survive the round trip"
+
+
+def test_files_land_in_a_date_directory(tmp_path):
+    import time
+    headers, body = _multipart()
+    _status, result = handle_upload(headers, body, str(tmp_path))
+    assert time.strftime("%Y-%m-%d") in result["path"]
+
+
+def test_a_subdir_is_honoured(tmp_path):
+    headers, body = _multipart(extra={"subdir": "faces"})
+    _status, result = handle_upload(headers, body, str(tmp_path))
+    assert os.sep + "faces" + os.sep in result["path"]
+
+
+def test_no_partial_file_is_left_under_the_final_name(tmp_path):
+    """A reader listing the directory must never see half a file."""
+    headers, body = _multipart()
+    status, result = handle_upload(headers, body, str(tmp_path), max_bytes=64)
+    assert status == 413 and not result["ok"]
+    assert glob.glob(os.path.join(str(tmp_path), "*", "*")) == []
+    assert glob.glob(os.path.join(str(tmp_path), "*", ".*.part")) == []
+
+
+def test_the_size_cap_is_enforced_while_writing_not_after(tmp_path):
+    """So an oversized body is never fully committed to disk or memory."""
+    big = b"x" * 5_000_000
+    headers, body = _multipart(payload=big)
+    status, result = handle_upload(headers, body, str(tmp_path), max_bytes=1_000_000)
+    assert status == 413
+    assert "limit" in result["error"]
+
+
+def test_an_empty_file_is_refused(tmp_path):
+    headers, body = _multipart(payload=b"")
+    status, result = handle_upload(headers, body, str(tmp_path))
+    assert status == 400 and "empty" in result["error"]
+
+
+def test_a_traversing_filename_stays_inside_the_base_dir(tmp_path):
+    headers, body = _multipart(filename="../../escaped.jpg")
+    _status, result = handle_upload(headers, body, str(tmp_path))
+    assert result["ok"]
+    assert os.path.realpath(result["path"]).startswith(os.path.realpath(str(tmp_path)))
+    assert not os.path.exists(tmp_path.parent / "escaped.jpg")
+
+
+def test_store_stream_directly(tmp_path):
+    import io
+    result = store_stream(io.BytesIO(b"abc"), "x.bin", str(tmp_path))
+    assert result["bytes"] == 3
+
+
+# ── request parsing ───────────────────────────────────────────────────────────
+
+def test_a_non_multipart_body_is_refused(tmp_path):
+    status, result = handle_upload(
+        {"Content-Type": "application/json"}, b'{"file": "x"}', str(tmp_path))
+    assert status == 400
+    assert "multipart" in result["error"]
+
+
+def test_a_multipart_body_without_a_file_part_is_refused(tmp_path):
+    body = (f"--{BOUNDARY}\r\nContent-Disposition: form-data; name=\"name\"\r\n\r\n"
+            f"Alice\r\n--{BOUNDARY}--\r\n").encode()
+    status, result = handle_upload(
+        {"Content-Type": f"multipart/form-data; boundary={BOUNDARY}"},
+        body, str(tmp_path))
+    assert status == 400
+    assert "file" in result["error"]
+
+
+def test_binary_containing_the_boundary_marker_survives(tmp_path):
+    """Hand-rolled boundary splitting mangles exactly this; cgi.FieldStorage
+    handles it, which is why the parser is not hand-written."""
+    tricky = b"\xff\xd8" + BOUNDARY.encode() + b"\r\n--not-the-end\r\n" + b"\xff\xd9"
+    headers, body = _multipart(payload=tricky)
+    _status, result = handle_upload(headers, body, str(tmp_path))
+    assert result["ok"]
+    with open(result["path"], "rb") as handle:
+        assert handle.read() == tricky
+
+
+def test_extra_form_fields_are_exposed_not_dropped():
+    headers, body = _multipart(extra={"subdir": "faces", "note": "hello"})
+    filename, _stream, fields = parse_multipart(headers, body)
+    assert filename == "alice.jpg"
+    assert fields["subdir"] == "faces"
+    assert fields["note"] == "hello"
+
+
+# ── retention ─────────────────────────────────────────────────────────────────
+
+def test_old_date_directories_are_pruned(tmp_path):
+    """Uploads are a transfer buffer, not storage: enrolment keeps the embedding
+    and never the photo, so this directory would grow forever on eMMC."""
+    for day in ("2020-01-01", "2020-06-15"):
+        (tmp_path / day).mkdir()
+        (tmp_path / day / "old.jpg").write_bytes(b"x")
+    import time
+    today = time.strftime("%Y-%m-%d")
+    (tmp_path / today).mkdir(exist_ok=True)
+    (tmp_path / today / "new.jpg").write_bytes(b"x")
+
+    assert prune_old(str(tmp_path), retention_days=7) == 2
+    assert (tmp_path / today / "new.jpg").exists()
+    assert not (tmp_path / "2020-01-01").exists()
+
+
+def test_prune_leaves_directories_it_does_not_recognise(tmp_path):
+    (tmp_path / "not-a-date").mkdir()
+    (tmp_path / "not-a-date" / "keep.jpg").write_bytes(b"x")
+    assert prune_old(str(tmp_path), retention_days=1) == 0
+    assert (tmp_path / "not-a-date" / "keep.jpg").exists()
+
+
+def test_prune_is_disabled_by_a_zero_retention(tmp_path):
+    (tmp_path / "2020-01-01").mkdir()
+    assert prune_old(str(tmp_path), retention_days=0) == 0
+    assert (tmp_path / "2020-01-01").exists()
+
+
+def test_prune_on_a_missing_directory_is_harmless(tmp_path):
+    assert prune_old(str(tmp_path / "nope")) == 0

--- a/perception/tests/test_onnx_provider.py
+++ b/perception/tests/test_onnx_provider.py
@@ -202,3 +202,78 @@ def test_pick_weights_falls_back_to_last_candidate(tmp_path):
 
 def test_pick_weights_with_no_candidates(tmp_path):
     assert onnx_provider.pick_weights(str(tmp_path)) == ""
+
+
+# ── standalone onnxruntime ───────────────────────────────────────────────────
+# A separate build from the one inside the sherpa-onnx wheel, so it needs its
+# own probe and its own tests — cuda_available() must not influence these.
+
+def _install_fake_ort(monkeypatch, providers):
+    """Install a fake `onnxruntime`, or remove it when providers is None."""
+    onnx_provider.onnxruntime_providers.cache_clear()
+    if providers is None:
+        monkeypatch.setitem(sys.modules, "onnxruntime", None)
+        return
+    module = types.ModuleType("onnxruntime")
+    module.get_available_providers = lambda: list(providers)
+    monkeypatch.setitem(sys.modules, "onnxruntime", module)
+
+
+def test_ort_providers_empty_when_not_installed(monkeypatch):
+    _install_fake_ort(monkeypatch, None)
+    assert onnx_provider.onnxruntime_providers() == ()
+
+
+def test_ort_missing_package_raises_rather_than_degrading(monkeypatch):
+    """There is nothing to degrade to; the plugin turns this into error state."""
+    _install_fake_ort(monkeypatch, None)
+    with pytest.raises(ImportError, match="onnxruntime is not installed"):
+        onnx_provider.ort_providers_for_device("cpu")
+
+
+def test_ort_cpu_device(monkeypatch):
+    _install_fake_ort(monkeypatch, ["CUDAExecutionProvider", "CPUExecutionProvider"])
+    assert onnx_provider.ort_providers_for_device("cpu") == ["CPUExecutionProvider"]
+
+
+def test_ort_gpu_uses_cuda_with_a_cpu_fallback(monkeypatch):
+    _install_fake_ort(monkeypatch, ["CUDAExecutionProvider", "CPUExecutionProvider"])
+    assert onnx_provider.ort_providers_for_device("gpu") == [
+        "CUDAExecutionProvider", "CPUExecutionProvider",
+    ]
+
+
+def test_ort_gpu_degrades_to_cpu_on_the_cpu_only_wheel(monkeypatch, caplog):
+    """The shipped image carries the CPU wheel; device: gpu must still work."""
+    _install_fake_ort(monkeypatch, ["CPUExecutionProvider"])
+    with caplog.at_level("WARNING"):
+        assert onnx_provider.ort_providers_for_device("gpu") == ["CPUExecutionProvider"]
+    assert any("no CUDA provider" in record.getMessage() for record in caplog.records)
+
+
+def test_ort_gpu_accepts_tensorrt_when_cuda_is_absent(monkeypatch):
+    _install_fake_ort(monkeypatch,
+                      ["TensorrtExecutionProvider", "CPUExecutionProvider"])
+    assert onnx_provider.ort_providers_for_device("gpu") == [
+        "TensorrtExecutionProvider", "CPUExecutionProvider",
+    ]
+
+
+def test_ort_probe_survives_a_broken_install(monkeypatch):
+    onnx_provider.onnxruntime_providers.cache_clear()
+    module = types.ModuleType("onnxruntime")
+
+    def explode():
+        raise RuntimeError("libonnxruntime.so: undefined symbol")
+
+    module.get_available_providers = explode
+    monkeypatch.setitem(sys.modules, "onnxruntime", module)
+    assert onnx_provider.onnxruntime_providers() == ()
+
+
+def test_ort_probe_is_independent_of_the_sherpa_wheel(monkeypatch, tmp_path):
+    """cuda_available() describes sherpa's runtime, not this one."""
+    _install_fake_sherpa(monkeypatch, tmp_path, with_cuda=True)
+    _install_fake_ort(monkeypatch, ["CPUExecutionProvider"])
+    assert onnx_provider.cuda_available() is True
+    assert onnx_provider.ort_providers_for_device("gpu") == ["CPUExecutionProvider"]

--- a/perception/tests/test_onnx_provider.py
+++ b/perception/tests/test_onnx_provider.py
@@ -248,7 +248,104 @@ def test_ort_gpu_degrades_to_cpu_on_the_cpu_only_wheel(monkeypatch, caplog):
     _install_fake_ort(monkeypatch, ["CPUExecutionProvider"])
     with caplog.at_level("WARNING"):
         assert onnx_provider.ort_providers_for_device("gpu") == ["CPUExecutionProvider"]
-    assert any("no CUDA provider" in record.getMessage() for record in caplog.records)
+    assert any("no GPU provider" in record.getMessage() for record in caplog.records)
+
+
+# ── device: auto ─────────────────────────────────────────────────────────────
+
+def test_auto_prefers_the_gpu_when_there_is_one(monkeypatch):
+    _install_fake_ort(monkeypatch, ["CUDAExecutionProvider", "CPUExecutionProvider"])
+    assert onnx_provider.ort_providers_for_device("auto") == [
+        "CUDAExecutionProvider", "CPUExecutionProvider",
+    ]
+
+
+def test_auto_falls_back_to_cpu_silently(monkeypatch, caplog):
+    """cpu is the expected outcome on a CPU-wheel image, not a misconfiguration,
+    so auto must not cry wolf on every robot."""
+    _install_fake_ort(monkeypatch, ["CPUExecutionProvider"])
+    with caplog.at_level("WARNING"):
+        assert onnx_provider.ort_providers_for_device("auto") == ["CPUExecutionProvider"]
+    assert not caplog.records
+
+
+def test_auto_is_the_default_for_an_empty_device(monkeypatch):
+    _install_fake_ort(monkeypatch, ["CUDAExecutionProvider", "CPUExecutionProvider"])
+    for value in ("", None, "  "):
+        assert onnx_provider.ort_providers_for_device(value)[0] == "CUDAExecutionProvider"
+
+
+def test_auto_takes_tensorrt_when_cuda_is_absent(monkeypatch):
+    _install_fake_ort(monkeypatch,
+                      ["TensorrtExecutionProvider", "CPUExecutionProvider"])
+    assert onnx_provider.ort_providers_for_device("auto")[0] == "TensorrtExecutionProvider"
+
+
+def test_explicit_cpu_never_takes_the_gpu(monkeypatch):
+    _install_fake_ort(monkeypatch, ["CUDAExecutionProvider", "CPUExecutionProvider"])
+    assert onnx_provider.ort_providers_for_device("cpu") == ["CPUExecutionProvider"]
+
+
+def test_unknown_ort_device_warns_and_uses_cpu(monkeypatch, caplog):
+    _install_fake_ort(monkeypatch, ["CUDAExecutionProvider", "CPUExecutionProvider"])
+    with caplog.at_level("WARNING"):
+        assert onnx_provider.ort_providers_for_device("tpu") == ["CPUExecutionProvider"]
+    assert any("unknown device" in r.getMessage() for r in caplog.records)
+
+
+# ── parked cores (the onnxruntime 1.19.x abort) ──────────────────────────────
+
+def test_cpu_topology_parses_sysfs_ranges(monkeypatch, tmp_path):
+    (tmp_path / "present").write_text("0-11\n")
+    (tmp_path / "online").write_text("0-7\n")
+    real_open = open
+
+    def fake_open(path, *args, **kwargs):
+        name = str(path)
+        if name.startswith("/sys/devices/system/cpu/"):
+            return real_open(tmp_path / name.rsplit("/", 1)[-1], *args, **kwargs)
+        return real_open(path, *args, **kwargs)
+
+    monkeypatch.setattr("builtins.open", fake_open)
+    assert onnx_provider.cpu_topology() == (12, 8)
+
+
+def test_cpu_topology_parses_comma_lists(monkeypatch, tmp_path):
+    (tmp_path / "present").write_text("0-3,8-11\n")
+    (tmp_path / "online").write_text("0-3,8\n")
+    real_open = open
+
+    def fake_open(path, *args, **kwargs):
+        name = str(path)
+        if name.startswith("/sys/devices/system/cpu/"):
+            return real_open(tmp_path / name.rsplit("/", 1)[-1], *args, **kwargs)
+        return real_open(path, *args, **kwargs)
+
+    monkeypatch.setattr("builtins.open", fake_open)
+    assert onnx_provider.cpu_topology() == (8, 5)
+
+
+def test_cpu_topology_is_zero_when_sysfs_is_absent(monkeypatch):
+    def fake_open(path, *args, **kwargs):
+        raise OSError("no sysfs")
+    monkeypatch.setattr("builtins.open", fake_open)
+    assert onnx_provider.cpu_topology() == (0, 0)
+
+
+def test_warn_on_parked_cores_only_fires_when_they_differ(monkeypatch, caplog):
+    """Tianyi in MODE_30W: present 0-11, online 0-7 — the precondition for the
+    1.19.x abort, which leaves no Python traceback to diagnose."""
+    monkeypatch.setattr(onnx_provider, "cpu_topology", lambda: (12, 8))
+    with caplog.at_level("WARNING"):
+        onnx_provider.warn_on_parked_cores("face")
+    assert any("12 CPUs present but only 8 online" in r.getMessage()
+               for r in caplog.records)
+
+    caplog.clear()
+    monkeypatch.setattr(onnx_provider, "cpu_topology", lambda: (6, 6))
+    with caplog.at_level("WARNING"):
+        onnx_provider.warn_on_parked_cores("face")
+    assert not caplog.records
 
 
 def test_ort_gpu_accepts_tensorrt_when_cuda_is_absent(monkeypatch):

--- a/perception/tests/vision_stubs.py
+++ b/perception/tests/vision_stubs.py
@@ -121,6 +121,16 @@ def _install_fake_ros():
     rclpy = types.ModuleType("rclpy")
     node_mod = types.ModuleType("rclpy.node")
     node_mod.Node = _FakeNode
+    # main.py does `import rclpy.executors`, which needs rclpy to be a package
+    # with that submodule attached — a bare ModuleType is not, and the import
+    # fails with "'rclpy' is not a package".
+    executors_mod = types.ModuleType("rclpy.executors")
+    executors_mod.MultiThreadedExecutor = _FakeExecutor
+    executors_mod.SingleThreadedExecutor = _FakeExecutor
+    rclpy.executors = executors_mod
+    rclpy.node = node_mod
+    rclpy.init = lambda *args, **kwargs: None
+    rclpy.shutdown = lambda *args, **kwargs: None
     qos_mod = types.ModuleType("rclpy.qos")
 
     class QoSProfile:
@@ -145,6 +155,7 @@ def _install_fake_ros():
     audio_msgs_msg.AudioChunk = _FakeAudioChunk
     for name, module in {
         "rclpy": rclpy, "rclpy.node": node_mod, "rclpy.qos": qos_mod,
+        "rclpy.executors": executors_mod,
         "sensor_msgs": sensor_msgs, "sensor_msgs.msg": sensor_msgs_msg,
         "std_msgs": std_msgs, "std_msgs.msg": std_msgs_msg,
         "audio_msgs": audio_msgs, "audio_msgs.msg": audio_msgs_msg,

--- a/perception/utils/cv2_compat.py
+++ b/perception/utils/cv2_compat.py
@@ -1,0 +1,67 @@
+"""
+utils/cv2_compat.py — Import cv2 on Jetson, where the system build is broken.
+
+The L4T images ship OpenCV as an apt package whose Python wrapper hits a
+circular import in `cv2/mat_wrapper` under some interpreter/numpy
+combinations: `import cv2` raises, or succeeds with the module half-built so
+that `cv2.IMREAD_COLOR` is missing. Loading the extension `.so` directly
+sidesteps the wrapper package entirely.
+
+`plugins/vop.py` (`_ensure_model`, around line 273) carries this workaround
+inline and is the origin of this code; it is left as-is deliberately — it is
+working in production and the copy here exists so new plugins do not each
+reinvent it.
+
+`imshow` and friends are stubbed for the same reason vop stubs them: the
+container is headless, and some OpenCV code paths call them unconditionally.
+"""
+
+from __future__ import annotations
+
+import glob
+import importlib.util
+import logging
+import sys
+
+log = logging.getLogger(__name__)
+
+
+def load_cv2():
+    """Return a usable `cv2` module, or raise ImportError."""
+    module = None
+    try:
+        import cv2 as module  # noqa: PLC0415
+        _ = module.IMREAD_COLOR      # half-built module raises AttributeError
+    except (ImportError, AttributeError):
+        module = _load_from_extension()
+
+    for name in ("imshow", "waitKey", "destroyAllWindows"):
+        if not hasattr(module, name):
+            setattr(module, name, _headless_stub(name))
+    return module
+
+
+def _load_from_extension():
+    candidates = sorted(
+        glob.glob("/usr/lib/python*/dist-packages/cv2/python-*/cv2.cpython-*.so")
+    )
+    if not candidates:
+        import cv2  # noqa: PLC0415 - let the original error surface
+        return cv2
+    path = candidates[0]
+    log.warning("[cv2_compat] system cv2 package is broken; loading %s directly",
+                path)
+    spec = importlib.util.spec_from_file_location("cv2", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    sys.modules["cv2"] = module
+    return module
+
+
+def _headless_stub(name: str):
+    if name == "waitKey":
+        return lambda *args, **kwargs: 0
+    return lambda *args, **kwargs: None
+
+
+__all__ = ["load_cv2"]

--- a/perception/utils/file_intake.py
+++ b/perception/utils/file_intake.py
@@ -1,0 +1,356 @@
+"""
+utils/file_intake.py — Receive a file over HTTP into a service's own container.
+
+## Why this exists
+
+agent-core serves the browser and holds the canvas; the tools that need a file
+(a photo to enrol a face, an audio clip to play) run in *other* containers. They
+share no filesystem: agent-core mounts `/opt/phanthy-motus`, perception mounts
+`/opt/embodied/models`, and each container's `/tmp` and `/work` are its own. So a
+path produced on one side means nothing on the other — which is exactly how the
+first face-enrolment attempt failed, with an `image_path` that really existed,
+in agent-core.
+
+The alternatives were worse:
+
+* **base64 through the tool call.** Tried, and it failed in production: a 43 800
+  character string does not survive being carried through an LLM's context, and
+  what arrived was truncated.
+* **A shared host mount.** Works, but needs every participating container
+  recreated (Docker fixes mounts at creation), one host directory per pairing,
+  and leaves the path ambiguous — `/uploads` in one container, something else in
+  another.
+
+Instead agent-core *proxies* the upload to the service that will read the file,
+resolving the target's address from the MCP registry (every service reports
+`url` when it registers, so the port is already known — including drivers, whose
+ports differ). The service writes the file into a directory it can actually see
+and returns **its own** absolute path, which the caller uses verbatim. One
+viewpoint, no mounts, no recreation.
+
+## The contract
+
+    POST /file/upload
+      multipart/form-data: file=<the file>, subdir=<optional>
+      header: X-Access-Token: <ACCESS_TOKEN>   (when the service has one)
+    → 200 {"ok": true, "path": "/models/uploads/2026-09-08/alice.jpg", "bytes": N}
+    → 4xx {"ok": false, "error": "..."}
+
+`path` is absolute *inside the receiving container*. That is the whole point.
+
+This module is deliberately dependency-free (stdlib only) so the drivers — which
+run a bare `ThreadingHTTPServer`, not FastAPI — can use the same implementation.
+"""
+
+from __future__ import annotations
+
+import cgi
+import hmac
+import io
+import json
+import logging
+import os
+import re
+import shutil
+import time
+import unicodedata
+
+log = logging.getLogger(__name__)
+
+DEFAULT_MAX_BYTES = 64 * 1024 * 1024
+DEFAULT_RETENTION_DAYS = 7
+# Date-stamped subdirectories, so retention is a directory listing rather than a
+# stat() per file, and a human reading the disk can see when something arrived.
+_DATE_FORMAT = "%Y-%m-%d"
+
+_SAFE_NAME = re.compile(r"[^A-Za-z0-9._\u4e00-\u9fff-]+")
+
+
+class IntakeError(Exception):
+    """Rejected upload. `status` is the HTTP code to answer with."""
+
+    def __init__(self, message: str, status: int = 400):
+        super().__init__(message)
+        self.message = message
+        self.status = status
+
+
+def safe_filename(name: str, fallback: str = "upload.bin") -> str:
+    """Reduce a client-supplied filename to something safe to join onto a path.
+
+    Takes the basename (so `../../etc/passwd` and `C:\\x\\y.jpg` both collapse),
+    strips anything outside a conservative allowlist, and keeps CJK because the
+    people using this name their files in Chinese. NFC-normalises first so a
+    macOS upload (NFD) and a Linux one produce the same name rather than two
+    files that look identical.
+    """
+    name = unicodedata.normalize("NFC", str(name or ""))
+    name = os.path.basename(name.replace("\\", "/")).strip()
+    name = _SAFE_NAME.sub("_", name).lstrip(".")
+    if not name or name in (".", ".."):
+        return fallback
+    # Bound the length: some filesystems cap a component at 255 bytes, and a CJK
+    # name is 3 bytes a character.
+    stem, extension = os.path.splitext(name)
+    while len((stem + extension).encode("utf-8")) > 200 and stem:
+        stem = stem[:-1]
+    return (stem + extension) or fallback
+
+
+def safe_subdir(subdir: str) -> str:
+    """Validate an optional caller-chosen subdirectory: one plain component.
+
+    Refuses anything containing a separator or a `..` rather than sanitising it.
+    Sanitising turned `../escape` into `.._escape`, which is a *valid* name — so
+    the write succeeded, just not where the caller asked, and nothing said so.
+    For a path a caller chose, "no" is a better answer than "somewhere else".
+    """
+    if not subdir:
+        return ""
+    raw = str(subdir).strip()
+    if "/" in raw or "\\" in raw or raw in (".", "..") or raw.startswith(".."):
+        raise IntakeError(f"subdir must be a single plain name: {subdir!r}")
+    cleaned = safe_filename(raw, fallback="")
+    if not cleaned or cleaned != raw:
+        raise IntakeError(f"invalid subdir: {subdir!r}")
+    return cleaned
+
+
+# ACCESS_TOKEN, when this service is given one. Read from the environment and
+# from the shared .env if that happens to be mounted — but **absent is the
+# normal case**, verified on Tianyi: the perception container has ROS_DOMAIN_ID
+# and the DDS profile, no ACCESS_TOKEN, and it mounts `dds-local.xml` as a single
+# file rather than the directory holding `.env`.
+#
+# So this endpoint is gated by *reachability*, not by a secret: it binds the same
+# host-network port the MCP server already serves `tools/call` on, and anything
+# that can reach it can already drive the plugin. The token check is here so that
+# a deployment which does distribute one gets enforcement for free, and so the
+# check is not something to remember to add later.
+_ENV_CANDIDATES = ("/opt/phanthy-motus/.env", "/work/.env")
+
+
+def access_token() -> str:
+    """ACCESS_TOKEN for this service, or "" when it has none.
+
+    Empty disables the check, which mirrors agent-core's own behaviour
+    (`auth.init()` prints "authentication disabled" and lets everything
+    through). A dev deployment therefore works untouched, and one that sets the
+    variable on the perception container enforces it on both ends automatically.
+    """
+    from os import environ
+    direct = environ.get("ACCESS_TOKEN", "").strip()
+    if direct:
+        return direct
+    for candidate in _ENV_CANDIDATES:
+        try:
+            with open(candidate, encoding="utf-8") as handle:
+                for line in handle:
+                    line = line.strip()
+                    if line.startswith("ACCESS_TOKEN=") and not line.startswith("#"):
+                        return line.split("=", 1)[1].strip()
+        except OSError:
+            continue
+    return ""
+
+
+def check_token(provided: str | None, expected: str | None) -> None:
+    """Compare an access token in constant time.
+
+    A write-anything endpoint on a host-network container is worth gating even
+    though `tools/call` next to it is not: MCP calls are bounded by the tool
+    schema, an upload is bounded only by the disk. When the service has no token
+    configured this is a no-op, so a development deployment still works.
+    """
+    if not expected:
+        return
+    if not provided or not hmac.compare_digest(str(provided), str(expected)):
+        raise IntakeError("invalid or missing access token", status=401)
+
+
+def store_stream(
+    stream,
+    filename: str,
+    base_dir: str,
+    max_bytes: int = DEFAULT_MAX_BYTES,
+    subdir: str = "",
+) -> dict:
+    """Write `stream` under `base_dir/<date>[/subdir]/<filename>`.
+
+    Streams in chunks and enforces `max_bytes` *while* writing, so an oversized
+    body is refused without ever being held in memory or fully committed to
+    disk. Writes to a temporary name and renames, so a reader that lists the
+    directory never sees a partial file under its final name — the same rule
+    `utils/model_downloader.py` follows for model downloads.
+    """
+    name = safe_filename(filename)
+    day = time.strftime(_DATE_FORMAT)
+    directory = os.path.join(base_dir, day, safe_subdir(subdir)) if subdir else \
+        os.path.join(base_dir, day)
+    os.makedirs(directory, exist_ok=True)
+
+    final = os.path.join(directory, name)
+    partial = os.path.join(directory, f".{name}.part")
+    written = 0
+    try:
+        with open(partial, "wb") as handle:
+            while True:
+                chunk = stream.read(1024 * 1024)
+                if not chunk:
+                    break
+                written += len(chunk)
+                if max_bytes and written > max_bytes:
+                    raise IntakeError(
+                        f"file exceeds the {max_bytes} byte limit",
+                        status=413,
+                    )
+                handle.write(chunk)
+            handle.flush()
+            os.fsync(handle.fileno())
+        if written == 0:
+            raise IntakeError("uploaded file is empty")
+        os.replace(partial, final)
+    except IntakeError:
+        _unlink_quietly(partial)
+        raise
+    except OSError as error:
+        _unlink_quietly(partial)
+        # Disk-full is the failure an operator can actually act on, and the raw
+        # errno message does not say which filesystem ran out.
+        raise IntakeError(f"cannot write to {directory}: {error}", status=507)
+
+    log.info("[file_intake] stored %s (%d bytes)", final, written)
+    return {"ok": True, "path": final, "bytes": written, "name": name}
+
+
+def parse_multipart(headers, body: bytes) -> tuple[str, io.BytesIO, dict]:
+    """Pull `(filename, stream, fields)` out of a multipart/form-data body.
+
+    `cgi.FieldStorage` rather than a hand-rolled boundary split: the drivers and
+    perception have no web framework, and getting multipart parsing subtly wrong
+    is a classic way to mangle binary payloads (a boundary appearing inside JPEG
+    data, CRLF translation, a missing final `--`). A test in
+    `tests/test_file_intake.py` pins the boundary-inside-payload case.
+
+    The returned stream is a fresh `BytesIO`, **not** FieldStorage's own file
+    object: for a body over ~1000 bytes FieldStorage spills to a
+    `TemporaryFile`, and it closes that file when the FieldStorage is collected —
+    which happens the moment this function returns. Handing the caller that
+    object gave "ValueError: read of closed file" for every upload big enough to
+    matter, and none small enough to notice.
+    """
+    content_type = headers.get("Content-Type", "")
+    if "multipart/form-data" not in content_type.lower():
+        raise IntakeError(
+            "expected multipart/form-data with a `file` part; "
+            f"got {content_type!r}"
+        )
+    environ = {"REQUEST_METHOD": "POST", "CONTENT_TYPE": content_type,
+               "CONTENT_LENGTH": str(len(body))}
+    form = cgi.FieldStorage(fp=io.BytesIO(body), environ=environ,
+                            headers={"content-type": content_type},
+                            keep_blank_values=True)
+    if "file" not in form:
+        raise IntakeError("no `file` part in the request")
+    item = form["file"]
+    if isinstance(item, list):
+        item = item[0]
+    if not getattr(item, "filename", ""):
+        raise IntakeError("the `file` part has no filename")
+    fields = {
+        key: form.getfirst(key, "")
+        for key in form.keys() if key != "file"
+    }
+    data = item.file.read()
+    return item.filename, io.BytesIO(data), fields
+
+
+def prune_old(base_dir: str, retention_days: int = DEFAULT_RETENTION_DAYS) -> int:
+    """Delete date directories older than `retention_days`. Returns how many.
+
+    Uploads are a transfer buffer, not storage: a face enrolled from a photo
+    keeps its *embedding*, never the photo. Without this the directory grows
+    forever on a 57 GB eMMC. Date-named directories mean this is a name
+    comparison, so it cannot accidentally delete a file that is merely being
+    read slowly.
+    """
+    if retention_days <= 0 or not os.path.isdir(base_dir):
+        return 0
+    cutoff = time.time() - retention_days * 86400
+    removed = 0
+    for entry in sorted(os.listdir(base_dir)):
+        path = os.path.join(base_dir, entry)
+        if not os.path.isdir(path):
+            continue
+        try:
+            stamp = time.mktime(time.strptime(entry, _DATE_FORMAT))
+        except ValueError:
+            continue          # not one of ours; leave it alone
+        if stamp < cutoff:
+            try:
+                shutil.rmtree(path)
+                removed += 1
+            except OSError as error:
+                log.warning("[file_intake] could not remove %s: %s", path, error)
+    if removed:
+        log.info("[file_intake] pruned %d upload director(ies) older than %d days",
+                 removed, retention_days)
+    return removed
+
+
+def handle_upload(
+    headers,
+    body: bytes,
+    base_dir: str,
+    token: str | None = None,
+    provided_token: str | None = None,
+    max_bytes: int = DEFAULT_MAX_BYTES,
+    retention_days: int = DEFAULT_RETENTION_DAYS,
+) -> tuple[int, dict]:
+    """Whole endpoint: auth, parse, store, prune. Returns `(status, payload)`.
+
+    Never raises for a client mistake — the caller can send the payload back as
+    JSON directly. This keeps the per-service glue to about five lines, which is
+    what makes it realistic to add the same endpoint to every driver.
+    """
+    try:
+        check_token(provided_token, token)
+        filename, stream, fields = parse_multipart(headers, body)
+        result = store_stream(
+            stream, filename, base_dir,
+            max_bytes=max_bytes, subdir=fields.get("subdir", ""),
+        )
+    except IntakeError as error:
+        return error.status, {"ok": False, "error": error.message}
+    except Exception as error:  # noqa: BLE001 - never 500 with a bare traceback
+        log.exception("[file_intake] unexpected failure")
+        return 500, {"ok": False, "error": str(error)}
+    # After the reply is composed, so a slow prune cannot delay the upload's
+    # acknowledgement; failures here are logged, not surfaced.
+    try:
+        prune_old(base_dir, retention_days)
+    except Exception:  # noqa: BLE001
+        log.warning("[file_intake] prune failed", exc_info=True)
+    return 200, result
+
+
+def _unlink_quietly(path: str) -> None:
+    try:
+        os.unlink(path)
+    except OSError:
+        pass
+
+
+__all__ = [
+    "DEFAULT_MAX_BYTES",
+    "access_token",
+    "DEFAULT_RETENTION_DAYS",
+    "IntakeError",
+    "check_token",
+    "handle_upload",
+    "parse_multipart",
+    "prune_old",
+    "safe_filename",
+    "safe_subdir",
+    "store_stream",
+]

--- a/perception/utils/model_downloader.py
+++ b/perception/utils/model_downloader.py
@@ -605,6 +605,45 @@ def ensure_ocr_model(model_dir: str, family: str | None = None) -> dict[str, str
     )
 
 
+# ── Face recognition (InsightFace buffalo_sc: SCRFD detector + ArcFace) ──
+# Plain ONNX, run by the standalone onnxruntime, so — unlike the OCR bundle —
+# there is nothing JetPack-specific about these files and no family selection:
+# one bundle serves both Jetson lines and any x86 dev host.
+#
+# Re-hosted on COS rather than fetched from the upstream GitHub release. The
+# release URL redirects to a signed, expiring `release-assets.githubusercontent`
+# URL, which cannot be pinned, and the robots have no reliable route to GitHub
+# anyway (see CLAUDE.md § "When a page or API won't load").
+FACE_MODEL_BASE = os.environ.get(
+    "FACE_MODEL_BASE_URL", f"{COS_BASE}/face/buffalo_sc"
+)
+# Pinned against the files re-hosted from the insightface v0.7 `buffalo_sc.zip`
+# release; the COS copies were re-downloaded and re-hashed after upload, so
+# these are the bytes a robot will actually receive.
+FACE_MODEL_FILES = {
+    # SCRFD-500M-BNKPS — detection + the 5 landmarks ArcFace alignment needs.
+    # 9 outputs: score/bbox/kps for strides 8, 16, 32 (verified against the
+    # decoder in plugins/face_runtime.py).
+    "det_500m.onnx": {
+        "size": 2524817,
+        "sha256": "5e4447f50245bbd7966bd6c0fa52938c61474a04ec7def48753668a9d8b4ea3a",
+    },
+    # ArcFace MobileFaceNet trained on Glint360K — 112x112 in, 512-d out.
+    "w600k_mbf.onnx": {
+        "size": 13616099,
+        "sha256": "9cc6e4a75f0e2bf0b1aed94578f144d15175f357bdc05e815e5c4a02b319eb4f",
+    },
+}
+
+
+def ensure_face_model(model_dir: str) -> dict[str, str]:
+    """Ensure the face detection + recognition ONNX pair is present."""
+    model_dir = require_models_subpath(model_dir)
+    return ensure_verified_bundle(
+        "face", model_dir, FACE_MODEL_BASE, FACE_MODEL_FILES
+    )
+
+
 def ensure_verified_archive(name: str, model_dir: str, url: str, entry: dict) -> None:
     """Ensure a size/SHA256-pinned archive has been unpacked into model_dir.
 

--- a/perception/utils/onnx_provider.py
+++ b/perception/utils/onnx_provider.py
@@ -193,3 +193,65 @@ def pick_weights(model_dir: str, *candidates: str) -> str:
         if os.path.exists(path):
             return path
     return os.path.join(model_dir, candidates[-1]) if candidates else ""
+
+
+# ── standalone onnxruntime ────────────────────────────────────────────────────
+# Everything above concerns the ONNX Runtime *bundled inside the sherpa-onnx
+# wheel*, which is the only one ASR and sherpa TTS can see. The face plugin uses
+# the standalone `onnxruntime` package, a completely separate build with its own
+# provider list — `cuda_available()` says nothing about it, and using that here
+# would report gpu support the face sessions do not have (or miss support they
+# do). Hence a second, independent probe.
+
+@lru_cache(maxsize=1)
+def onnxruntime_providers() -> tuple[str, ...]:
+    """Execution providers the installed `onnxruntime` package offers.
+
+    Empty when the package is absent, so a caller can distinguish "no GPU" from
+    "no onnxruntime at all". Unlike `cuda_available()` this is a real query
+    rather than a file probe: `get_available_providers()` is a cheap C call that
+    does not create a session or touch the driver.
+    """
+    try:
+        import onnxruntime as ort
+    except ImportError:
+        return ()
+    try:
+        return tuple(ort.get_available_providers())
+    except Exception:  # noqa: BLE001 - a broken install must not crash startup
+        log.warning("[onnx_provider] onnxruntime is installed but would not "
+                    "report its providers", exc_info=True)
+        return ()
+
+
+def ort_providers_for_device(device: str) -> list[str]:
+    """Provider list for `InferenceSession(..., providers=...)`.
+
+    A *wrong device* degrades: `device: gpu` baked into a config.yaml on an
+    image carrying the CPU-only wheel still returns a working CPU provider
+    list, with the reason in the log — same policy as `provider_for_device`.
+
+    A *missing package* raises, because there is nothing to degrade to. The
+    plugin's background loader turns that into its `error` state and surfaces
+    the message in the dashboard, which is where someone is watching.
+
+    CPU is always appended as the fallback provider. ORT falls back per node
+    anyway, and naming it explicitly is what makes an unsupported op degrade
+    instead of failing session creation.
+    """
+    device = normalize_device(device)
+    available = onnxruntime_providers()
+    if not available:
+        raise ImportError(
+            "onnxruntime is not installed; the face recognition plugin needs it "
+            "(see the onnxruntime layer in perception/Dockerfile.jetson)"
+        )
+    if device == "gpu":
+        if "CUDAExecutionProvider" in available:
+            return ["CUDAExecutionProvider", "CPUExecutionProvider"]
+        if "TensorrtExecutionProvider" in available:
+            return ["TensorrtExecutionProvider", "CPUExecutionProvider"]
+        log.warning("[onnx_provider] device=gpu but the installed onnxruntime "
+                    "has no CUDA provider (available: %s) — falling back to cpu",
+                    ", ".join(available))
+    return ["CPUExecutionProvider"]

--- a/perception/utils/onnx_provider.py
+++ b/perception/utils/onnx_provider.py
@@ -227,9 +227,15 @@ def onnxruntime_providers() -> tuple[str, ...]:
 def ort_providers_for_device(device: str) -> list[str]:
     """Provider list for `InferenceSession(..., providers=...)`.
 
-    A *wrong device* degrades: `device: gpu` baked into a config.yaml on an
-    image carrying the CPU-only wheel still returns a working CPU provider
-    list, with the reason in the log — same policy as `provider_for_device`.
+    `auto` (the default for the face plugin) means **use the GPU when there is
+    one**: CUDA if the installed wheel offers it, else TensorRT, else CPU. It
+    never warns, because resolving to cpu is the expected outcome on a
+    CPU-wheel image rather than a misconfiguration.
+
+    An explicit `gpu` that cannot be honoured *does* warn but still degrades —
+    same policy as `provider_for_device`: a `device: gpu` baked into a
+    config.yaml on an image carrying the CPU-only wheel should still boot a
+    working recogniser, with the reason in the log.
 
     A *missing package* raises, because there is nothing to degrade to. The
     plugin's background loader turns that into its `error` state and surfaces
@@ -239,19 +245,80 @@ def ort_providers_for_device(device: str) -> list[str]:
     anyway, and naming it explicitly is what makes an unsupported op degrade
     instead of failing session creation.
     """
-    device = normalize_device(device)
+    # Strip before defaulting: a config field left blank (or whitespace, which
+    # is what a cleared form control sends) means "unset", i.e. auto — not an
+    # unknown device to warn about. Same treatment normalize_device gives "".
+    requested = (device or "").strip().lower() or "auto"
     available = onnxruntime_providers()
     if not available:
         raise ImportError(
             "onnxruntime is not installed; the face recognition plugin needs it "
             "(see the onnxruntime layer in perception/Dockerfile.jetson)"
         )
-    if device == "gpu":
-        if "CUDAExecutionProvider" in available:
-            return ["CUDAExecutionProvider", "CPUExecutionProvider"]
-        if "TensorrtExecutionProvider" in available:
-            return ["TensorrtExecutionProvider", "CPUExecutionProvider"]
-        log.warning("[onnx_provider] device=gpu but the installed onnxruntime "
-                    "has no CUDA provider (available: %s) — falling back to cpu",
-                    ", ".join(available))
+
+    if requested in ("auto", "gpu", "cuda", "nvidia"):
+        for provider in ("CUDAExecutionProvider", "TensorrtExecutionProvider"):
+            if provider in available:
+                return [provider, "CPUExecutionProvider"]
+        if requested != "auto":
+            log.warning("[onnx_provider] device=%r but the installed onnxruntime "
+                        "has no GPU provider (available: %s) — falling back to cpu",
+                        device, ", ".join(available))
+    elif requested != "cpu":
+        log.warning("[onnx_provider] unknown device %r, using cpu", device)
     return ["CPUExecutionProvider"]
+
+
+def cpu_topology() -> tuple[int, int]:
+    """(present, online) CPU counts from sysfs; (0, 0) when unreadable.
+
+    Used only to warn. ONNX Runtime 1.19.x reads the *present* list, pins
+    threads to every core in it, and indexes a vector sized by the *online*
+    count — so on a Jetson where a power mode has parked some cores
+    (Tianyi in MODE_30W: present 0-11, online 0-7) `pthread_setaffinity_np`
+    returns EINVAL and the process abort()s inside `InferenceSession()`, taking
+    all of perception with it. The pinned versions do not do this, but a future
+    bump could reintroduce it, and the abort leaves no Python traceback anyone
+    can act on — so say the precondition out loud at load time.
+    """
+    def _count(path: str) -> int:
+        try:
+            with open(path) as handle:
+                spec = handle.read().strip()
+        except OSError:
+            return 0
+        total = 0
+        for chunk in spec.split(","):
+            if not chunk:
+                continue
+            if "-" in chunk:
+                low, _, high = chunk.partition("-")
+                total += int(high) - int(low) + 1
+            else:
+                total += 1
+        return total
+
+    return (_count("/sys/devices/system/cpu/present"),
+            _count("/sys/devices/system/cpu/online"))
+
+
+def warn_on_parked_cores(label: str = "onnx_provider") -> None:
+    """Log a warning when some CPUs are present but offline. See cpu_topology."""
+    present, online = cpu_topology()
+    if present and online and present != online:
+        log.warning(
+            "[%s] %d CPUs present but only %d online — this is the condition "
+            "under which onnxruntime 1.19.x abort()s during session creation "
+            "(pthread_setaffinity_np EINVAL on a parked core). Installed "
+            "onnxruntime is %s.",
+            label, present, online,
+            _installed_ort_version() or "not installed",
+        )
+
+
+def _installed_ort_version() -> str:
+    try:
+        import onnxruntime
+        return str(onnxruntime.__version__)
+    except Exception:  # noqa: BLE001
+        return ""


### PR DESCRIPTION
## Problem

When an MCP device (like perception) registers dynamically via ping endpoint, the `mcp_client.registry` was missing `input_schemas`. This caused:
- File upload interception to fail (no `format: file` detection)
- LLM could not auto-upload local files when calling tools like `register_by_photo`
- Card file uploads worked, but LLM file handling didn't

## Root Cause

`mcp_client._connect_one()` was only called at startup via `init_all()` for statically configured MCPs. Dynamically registered devices (via `/api/mcp/{id}/ping`) never populated schemas in the registry.

## Solution

In `_do_ping()`, check if `input_schemas` exists in registry after a device pings. If missing, call `_connect_one()` to:
1. Fetch tool schemas from the device
2. Populate `input_schemas` for file interception
3. Enable validation and file upload

## Result

✅ LLM can now auto-upload local files just like card uploads
✅ File interception works for all tools with `format: file`
✅ No behavior change for statically configured MCPs

## Testing

Tested with perception face_recognition:
- LLM downloads image → calls register_by_photo → file auto-uploads to perception
- Registration succeeds with uploaded file path
