### PR TITLE
feat(perception): indoor metric obstacle distance / 室内米制障碍物测距

### DIFF
--- a/perception/config.yaml
+++ b/perception/config.yaml
@@ -82,3 +82,18 @@ plugins:
       det_thresh: 0.1
       det_box_thresh: 0.1
     min_interval_ms: 0
+
+  obstacle:
+    enabled: true
+    provider: local
+    model_dir: /models/obstacle/dav2-small-metric
+    decision_threshold_m: 2.0
+    fallback_distance_m: 3.0
+    soft_timeout_s: 2.5
+    indoor:
+      roi: [0, 300, 213, 426]
+      roi_reference_size: [480, 640]
+      depth_percentile: 1.0
+      min_output_distance_m: 0.3
+      max_output_distance_m: 10.0
+      min_valid_pixels: 64

--- a/perception/main.py
+++ b/perception/main.py
@@ -131,6 +131,11 @@ class PerceptionBundle:
             self._plugins.append(OCRPlugin(plugins_cfg["ocr"], executor))
             log.info("OCRPlugin loaded")
 
+        if plugins_cfg.get("obstacle", {}).get("enabled", False):
+            from plugins.obstacle import ObstacleDistancePlugin
+            self._plugins.append(ObstacleDistancePlugin(plugins_cfg["obstacle"], executor))
+            log.info("ObstacleDistancePlugin loaded")
+
     def get_all_tools(self) -> list:
         tools = []
         for p in self._plugins:

--- a/perception/plugins/obstacle.py
+++ b/perception/plugins/obstacle.py
@@ -339,6 +339,17 @@ class ObstacleDistancePlugin:
         merged.update(self._instance_configs.get(node_key, {}))
         return merged
 
+    def _cached_adapter_locked(self, node_key: str) -> LocalDistanceAdapter | None:
+        """Read a current adapter without building. Caller holds _state_lock."""
+        if self._adapter_state != "ready":
+            return None
+        if not self._instance_configs.get(node_key):
+            return self._adapter
+        cached = self._instance_adapters.get(node_key)
+        if cached is not None and cached[0] == self._effective_cfg_locked(node_key):
+            return cached[1]
+        return None
+
     def _dispose(self, node_key: str, node: "_ObstacleNode") -> None:
         """Stop worker and fully destroy the node. Never called under lock."""
         try:
@@ -487,7 +498,11 @@ class ObstacleDistancePlugin:
                     generation == self._load_generation
                     and self._pending_starts.get(node_key) == input_topic
                 )
-                still_wanted = entry_valid and node_key not in self._nodes
+                still_wanted = (
+                    entry_valid
+                    and node_key not in self._nodes
+                    and self._cached_adapter_locked(node_key) is node_adapter
+                )
                 if still_wanted:
                     try:
                         self._executor.add_node(node)
@@ -499,7 +514,7 @@ class ObstacleDistancePlugin:
                         self._nodes[node_key] = node
                         del self._pending_starts[node_key]
                         registered = True
-                elif entry_valid:
+                elif entry_valid and node_key in self._nodes:
                     # A concurrent start already owns a live node for this
                     # key; drop the entry so the loop can progress.
                     del self._pending_starts[node_key]
@@ -645,21 +660,14 @@ class ObstacleDistancePlugin:
         start_node = None
         with self._state_lock:
             existing = self._nodes.get(node_key)
-            instance_cfg = self._instance_configs.get(node_key)
-            cached = self._instance_adapters.get(node_key)
-            adapter_available = self._adapter_state == "ready" and (
-                not instance_cfg
-                or (cached is not None and cached[0] == self._effective_cfg_locked(node_key))
-            )
-            if existing is not None:
+            node_adapter = self._cached_adapter_locked(node_key)
+            if existing is not None and node_adapter is not None:
                 start_node = existing        # idempotent re-start
-                shared = self._adapter
-            elif adapter_available:
+            elif node_adapter is not None:
                 # Claim the key before leaving the lock: a concurrent stop
                 # must always find the instance in _pending_starts or
                 # _nodes, never in an invisible in-between state.
                 self._pending_starts[node_key] = input_topic
-                shared = self._adapter
                 generation = self._load_generation
             else:
                 # Cold start, error retry, or an instance whose per-instance
@@ -673,7 +681,6 @@ class ObstacleDistancePlugin:
                     "output": f"{input_topic}/obstacle",
                 }
 
-        node_adapter = self._adapter_for_key(node_key, shared)
         if start_node is not None:
             return start_node.start(node_adapter)
 
@@ -686,7 +693,10 @@ class ObstacleDistancePlugin:
         with self._state_lock:
             claimed = self._pending_starts.get(node_key) == input_topic
             current = self._nodes.get(node_key)
-            fresh = generation == self._load_generation
+            fresh = (
+                generation == self._load_generation
+                and self._cached_adapter_locked(node_key) is node_adapter
+            )
             registered = False
             if claimed and current is None and fresh:
                 try:
@@ -701,8 +711,8 @@ class ObstacleDistancePlugin:
                     registered = True
             elif claimed and not fresh:
                 # A config change invalidated the adapter mid-start; keep the
-                # claim so the loader brings this instance up on the new one.
-                pass
+                # claim and let the existing loader build the replacement.
+                self._spawn_loader_locked()
             elif claimed:
                 del self._pending_starts[node_key]
         if not registered:

--- a/perception/plugins/obstacle.py
+++ b/perception/plugins/obstacle.py
@@ -1,0 +1,819 @@
+#!/usr/bin/env python3
+"""
+plugins/obstacle.py — ObstacleDistancePlugin: obstacle distance estimation.
+
+Subscribes to image/jpeg topics, estimates obstacle distance from camera,
+publishes distance results to ROS2 topic.
+Supports multi-instance (one instance per input topic).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import threading
+from copy import deepcopy
+
+from rclpy.node import Node
+from rclpy.qos import QoSProfile, ReliabilityPolicy, HistoryPolicy, DurabilityPolicy
+from sensor_msgs.msg import CompressedImage
+from std_msgs.msg import String
+
+from utils.latest_frame import LatestFrame
+from utils.log_sampling import SampledLogGate, escape_log_text
+from utils.qos import CAMERA_QOS
+from utils.ros_lifecycle import dispose_node
+
+log = logging.getLogger(__name__)
+
+
+_PUB_QOS = QoSProfile(
+    reliability=ReliabilityPolicy.RELIABLE,
+    history=HistoryPolicy.KEEP_LAST,
+    depth=10,
+    durability=DurabilityPolicy.VOLATILE,
+)
+
+TOOLS = [
+    {
+        "name": "obstacle",
+        "type": "processor",
+        "multiInstance": True,
+        "description": "Obstacle Distance Estimation — estimate distance to obstacles from camera feed",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": ["start", "stop", "info", "config"],
+                    "description": "Action to perform"
+                },
+                "input_topic": {
+                    "type": "string",
+                    "description": "ROS2 image topic to subscribe (e.g. /hostname/camera/rgb, required for action=start)"
+                },
+            },
+            "required": ["action"]
+        },
+        # Deliberately minimal: only what an operator meaningfully decides.
+        # provider (single valid value), model_dir and ROI/percentile settings
+        # stay config.yaml-only — the
+        # dispatch below still honors them, they are just not advertised to
+        # the config UI.
+        "configSchema": {
+            "type": "object",
+            "properties": {
+                "decision_threshold_m": {"type": "number", "exclusiveMinimum": 0, "default": 2.0, "description": "近障判定距离(米)：估算距离小于该值时 near_obstacle=true", "scope": "shared"},
+            },
+        },
+        "topic_in":  [{"format": "image/jpeg", "desc": "camera image input"}],
+        "topic_out": [{"format": "data/json",  "desc": "obstacle distance estimation result"}],
+    }
+]
+
+
+# ── Distance Estimation Pipeline ──────────────────────────────────────────────
+
+
+class LocalDistanceAdapter:
+    """Indoor metric depth inference on the shared TensorRT runtime."""
+
+    def __init__(self, cfg: dict):
+        from .obstacle_distance_core.estimator import ObstacleDistanceEstimator
+        from .obstacle_distance_core.metric_tensorrt_backend import MetricDepthBackend
+        from utils.model_downloader import ensure_obstacle_models
+
+        self._cfg = deepcopy(cfg or {})
+        engine_paths = ensure_obstacle_models(
+            self._cfg.get("model_dir", "/models/obstacle/dav2-small-metric")
+        )
+        self._cfg.setdefault("indoor_depth_engine", engine_paths["indoor-metric.engine"])
+        backend = MetricDepthBackend(
+            self._cfg["indoor_depth_engine"], self._cfg.get("indoor", {})
+        )
+        self._backends = (backend,)
+        self._estimator = ObstacleDistanceEstimator(backend, self._cfg)
+
+    def close(self) -> None:
+        """Release the TensorRT engines held by the backends."""
+        backends = getattr(self, "_backends", ())
+        self._backends = ()
+        for backend in backends:
+            close = getattr(backend, "close", None)
+            if callable(close):
+                try:
+                    close()
+                except Exception:
+                    log.debug("[obstacle] backend close failed", exc_info=True)
+
+    def estimate(self, image_bytes: bytes) -> dict:
+        """估算最近障碍物距离。"""
+        result = self._estimator.estimate(image_bytes)
+        return {
+            "pred_distance": result.distance_m,
+            "distance_m": result.distance_m,
+            "near_obstacle": result.near_obstacle,
+            "scene": result.scene,
+            "status": result.status,
+            "error_code": result.error_code,
+            "fallback": result.fallback,
+            "approximate_geometry": result.approximate_geometry,
+            "latency_ms": result.latency_ms,
+        }
+
+
+def _build_distance_adapter(cfg: dict) -> LocalDistanceAdapter:
+    if cfg.get("provider", "local") != "local":
+        raise ValueError("obstacle provider must be local")
+    return LocalDistanceAdapter(cfg)
+
+
+# ── ROS2 Node (one per instance/topic) ────────────────────────────────────────
+
+class _ObstacleNode(Node):
+    """Per-topic obstacle distance estimation node."""
+
+    def __init__(self, input_topic: str, node_suffix: str):
+        super().__init__(f"obstacle_{node_suffix}")
+        self._input_topic = input_topic
+        self._output_topic = f"{input_topic}/obstacle"
+        self._pub = self.create_publisher(String, self._output_topic, _PUB_QOS)
+        self._sub: object | None = None
+        # Latest frame wins: the camera callback overwrites, the worker pops.
+        # A FIFO here would make the estimator report stale frames whenever
+        # inference falls behind the camera.
+        self._frames: LatestFrame = LatestFrame()
+        self._frames.close()
+        self._stop_event = threading.Event()
+        self._worker: threading.Thread | None = None
+        self._lifecycle_lock = threading.Lock()
+        self._detect_count = 0
+        self._logged_first_frame = False
+        self._log_gate = SampledLogGate(every=100)
+        self.state = "idle"
+
+    def start(self, adapter: LocalDistanceAdapter) -> dict:
+        with self._lifecycle_lock:
+            if self.state == "running":
+                return {"state": "running", "input": self._input_topic, "output": self._output_topic}
+            if self._worker is not None and self._worker.is_alive():
+                raise RuntimeError("previous obstacle worker is still stopping")
+            if self._sub is None:
+                self._sub = self.create_subscription(
+                    CompressedImage, self._input_topic, self._image_cb, CAMERA_QOS
+                )
+            # Use a distinct event and frame slot for every worker generation.
+            # If an old inference ever outlives stop()'s join timeout, a later
+            # start must not clear that worker's stop signal and revive it.
+            stop_event = threading.Event()
+            frames: LatestFrame = LatestFrame()
+            self._stop_event = stop_event
+            self._frames = frames
+            self._worker = threading.Thread(
+                target=self._inference_worker,
+                args=(stop_event, frames, adapter),
+                daemon=True,
+                name=f"obstacle_worker_{self._input_topic}",
+            )
+            self._worker.start()
+            self.state = "running"
+        log.info(f"[obstacle] started: {self._input_topic} -> {self._output_topic}")
+        return {"state": "running", "input": self._input_topic, "output": self._output_topic}
+
+    def stop(self) -> dict:
+        # stop() only pauses the inference worker; the node itself stays
+        # registered until the plugin retires it (see ObstacleDistancePlugin.
+        # _dispose_node), so a later start on the same topic reuses it.
+        with self._lifecycle_lock:
+            self.state = "idle"
+            self._stop_event.set()
+            self._frames.close()  # drops the pending frame and wakes the worker
+            worker = self._worker
+            if worker and worker.is_alive():
+                worker.join(timeout=3.0)
+            if worker is None or not worker.is_alive():
+                self._worker = None
+            else:
+                log.warning(
+                    "[obstacle] worker still stopping after timeout: %s",
+                    self._input_topic,
+                )
+        log.info(f"[obstacle] stopped: {self._input_topic}")
+        return {"state": "idle", "input": self._input_topic}
+
+    def _image_cb(self, msg: CompressedImage):
+        if self.state != "running":
+            return
+        try:
+            image_bytes = bytes(msg.data)
+        except Exception:
+            log.warning(
+                "[obstacle] received image frame with invalid data on %s",
+                self._input_topic,
+            )
+            return
+        if not self._logged_first_frame:
+            # First frame only: msg.format is externally supplied — escape and
+            # cap it, and never put it in a per-frame log.
+            self._logged_first_frame = True
+            log.info(
+                "[obstacle] first image frame on %s: size=%d bytes, format=%.32r",
+                self._input_topic, len(image_bytes), str(msg.format),
+            )
+        # Latest frame wins (no backpressure, no history).
+        self._frames.push(image_bytes)
+
+    def _inference_worker(
+        self,
+        stop_event: threading.Event,
+        frames: LatestFrame,
+        adapter: LocalDistanceAdapter,
+    ):
+        while not stop_event.is_set():
+            jpeg_bytes = frames.pop(timeout=1.0)
+            if jpeg_bytes is None:
+                continue
+            if stop_event.is_set():
+                break
+            try:
+                result = adapter.estimate(jpeg_bytes)
+                # Hot path: log state transitions unthrottled, sample steady
+                # state (first + every 100th) so camera-rate output cannot
+                # flood the container logs.
+                outcome = "fallback" if result.get("fallback") else "ok"
+                should_log, transition, occurrence = self._log_gate.check(outcome)
+                if should_log:
+                    emit = log.info if transition else log.debug
+                    emit(
+                        "[obstacle] %s scene=%s error_code=%s latency_ms=%.1f "
+                        "distance_m=%s (frame %d)",
+                        outcome,
+                        result.get("scene"),
+                        result.get("error_code"),
+                        float(result.get("latency_ms", 0.0)),
+                        result.get("pred_distance"),
+                        occurrence,
+                    )
+                if not stop_event.is_set():
+                    self._publish_result(result)
+            except Exception as e:
+                outcome = f"error:{type(e).__name__}"
+                should_log, transition, occurrence = self._log_gate.check(outcome)
+                if transition:
+                    # Full traceback only when the error class first appears.
+                    log.error("[obstacle] inference error: %s",
+                              escape_log_text(e), exc_info=True)
+                elif should_log:
+                    log.error("[obstacle] inference error (occurrence %d): %s",
+                              occurrence, escape_log_text(e))
+
+    def _publish_result(self, result: dict):
+        self._detect_count += 1
+        msg = String()
+        # Publish the whole structured result the adapter produced. A bare
+        # distance cannot be told apart from the estimator's fallback (
+        # fallback_distance_m, 3.0 by default), and consumers also need the
+        # near_obstacle/scene/status/error_code/latency fields this plugin
+        # advertises as data/json. pred_distance is still present, so existing
+        # subscribers keep working.
+        msg.data = json.dumps(result, ensure_ascii=False)
+        self._pub.publish(msg)
+
+
+# ── Plugin class ──────────────────────────────────────────────────────────────
+
+class ObstacleDistancePlugin:
+    """Obstacle-distance MCP plugin with the same non-blocking
+    start/stop/load state machine as the OCR plugin:
+
+        idle --start--> loading --ok--> ready/running
+                          |               ^
+                          +----fail--> error (next start retries)
+
+    * first start records the instance as pending, spawns one background
+      loader and immediately returns {"state": "loading"};
+    * concurrent starts only add pending instances — the engines are
+      downloaded and initialised once (single-flight);
+    * info is a pure query and never blocks on the loader;
+    * stop during loading cancels the pending instance; stop of a live
+      instance disposes its node (executor.remove_node + destroy_node);
+    * config bumps a load generation so a stale loader can never install
+      an adapter built from an outdated configuration.
+
+    One shared adapter serves every instance without per-instance
+    configuration; instances that do carry per-instance configuration get
+    their own cached adapter, built by the same background loader (the
+    verified-bundle download is deduplicated by the downloader's file lock,
+    so extra instances never re-download).
+    """
+
+    PREFIX = "obstacle"
+
+    def __init__(self, plugin_cfg: dict, executor):
+        self._executor = executor
+        self._plugin_cfg = deepcopy(plugin_cfg or {})
+        self._provider = self._plugin_cfg.get("provider", "local")
+
+        # Guarded by _state_lock, held for bookkeeping only — never while
+        # building engines or joining workers.
+        self._state_lock = threading.Lock()
+        self._nodes: dict[str, _ObstacleNode] = {}
+        self._instance_configs: dict[str, dict] = {}
+        self._instance_adapters: dict[str, tuple[dict, LocalDistanceAdapter]] = {}
+        self._pending_starts: dict[str, str] = {}   # node_key -> input_topic
+        self._adapter: LocalDistanceAdapter | None = None
+        self._adapter_state = "idle"                # idle|loading|ready|error
+        self._load_error: str | None = None
+        self._load_generation = 0
+        self._loader_thread: threading.Thread | None = None
+
+        log.info("[obstacle] plugin registered: provider=%s", self._provider)
+
+    def get_tools(self) -> list:
+        return TOOLS
+
+    # ── helpers ───────────────────────────────────────────────────────────
+
+    def _effective_cfg_locked(self, node_key: str) -> dict:
+        merged = deepcopy(self._plugin_cfg)
+        merged.update(self._instance_configs.get(node_key, {}))
+        return merged
+
+    def _dispose(self, node_key: str, node: "_ObstacleNode") -> None:
+        """Stop worker and fully destroy the node. Never called under lock."""
+        try:
+            node.stop()
+        finally:
+            dispose_node(self._executor, node, label=f"obstacle/{node_key}")
+        log.info(f"[obstacle] node disposed: {node_key}")
+
+    @staticmethod
+    def _close_adapter(adapter) -> None:
+        if adapter is None:
+            return
+        close = getattr(adapter, "close", None)
+        if callable(close):
+            try:
+                close()
+            except Exception:
+                log.debug("[obstacle] adapter close failed", exc_info=True)
+
+    # ── background loader (single-flight) ────────────────────────────────
+
+    def _spawn_loader_locked(self) -> None:
+        """Ensure the one background loader/bring-up thread is running.
+
+        Caller holds the lock. Single-flight: never two loaders. The loader
+        clears self._loader_thread under the same lock right before exiting,
+        so a pending entry added here is always observed by a live loader.
+        """
+        thread = self._loader_thread
+        if thread is not None and thread.is_alive():
+            return
+        if self._adapter is None or self._adapter_state == "error":
+            self._adapter_state = "loading"
+            self._load_error = None
+        generation = self._load_generation
+        cfg = deepcopy(self._plugin_cfg)
+        thread = threading.Thread(
+            target=self._loader, args=(generation, cfg),
+            name="obstacle-adapter-loader", daemon=True,
+        )
+        self._loader_thread = thread
+        thread.start()
+
+    def _finish_loader_locked(self, generation: int) -> None:
+        """Loader exit handshake. Caller holds the lock.
+
+        Clears the thread handle; if a config change replaced the generation
+        while this loader ran and instances are still pending, respawn a
+        loader for the new configuration so no pending start is stranded.
+        """
+        self._loader_thread = None
+        if generation != self._load_generation and self._pending_starts:
+            self._spawn_loader_locked()
+
+    def _adapter_for_key(self, node_key: str, shared: LocalDistanceAdapter):
+        """Return the adapter serving node_key, building the per-instance one
+        on demand. Runs in the loader thread — never under the lock.
+
+        The build happens outside the lock, so a per-instance config can
+        change mid-build. The result is committed only if the effective
+        config is still the one it was built for; otherwise it is closed and
+        the build retried, so a node never starts on a stale adapter and a
+        replaced cache entry never leaks its engine.
+        """
+        while True:
+            with self._state_lock:
+                if not self._instance_configs.get(node_key):
+                    return shared
+                effective = self._effective_cfg_locked(node_key)
+                cached = self._instance_adapters.get(node_key)
+                if cached is not None and cached[0] == effective:
+                    return cached[1]
+            adapter = _build_distance_adapter(effective)
+            stale = None
+            with self._state_lock:
+                still_wanted = (
+                    bool(self._instance_configs.get(node_key))
+                    and self._effective_cfg_locked(node_key) == effective
+                )
+                if still_wanted:
+                    previous = self._instance_adapters.get(node_key)
+                    if previous is not None and previous[1] is not adapter:
+                        stale = previous[1]
+                    self._instance_adapters[node_key] = (effective, adapter)
+            if still_wanted:
+                if stale is not None:
+                    self._close_adapter(stale)
+                return adapter
+            # Config changed (or the per-instance config was removed) while
+            # building: discard this result and re-evaluate.
+            self._close_adapter(adapter)
+
+    def _loader(self, generation: int, cfg: dict) -> None:
+        with self._state_lock:
+            adapter = self._adapter if generation == self._load_generation else None
+        if adapter is None:
+            try:
+                adapter = _build_distance_adapter(cfg)
+            except Exception as error:  # noqa: BLE001 - surfaced via info
+                log.exception("[obstacle] adapter load failed")
+                with self._state_lock:
+                    if generation == self._load_generation:
+                        self._adapter_state = "error"
+                        self._load_error = str(error)
+                    self._finish_loader_locked(generation)
+                return
+
+            with self._state_lock:
+                if generation != self._load_generation:
+                    stale = adapter
+                else:
+                    self._adapter = adapter
+                    self._adapter_state = "ready"
+                    stale = None
+            if stale is not None:
+                self._close_adapter(stale)
+                with self._state_lock:
+                    self._finish_loader_locked(generation)
+                return
+
+        # Bring up every instance that is still pending.
+        while True:
+            with self._state_lock:
+                if generation != self._load_generation or not self._pending_starts:
+                    self._finish_loader_locked(generation)
+                    return
+                node_key, input_topic = next(iter(self._pending_starts.items()))
+            # README lifecycle rule: register under the lock *before*
+            # starting, so a concurrent stop (or a failure at any later
+            # point) can always locate the node — a started-but-unregistered
+            # worker would be unreachable and leak.
+            try:
+                node_adapter = self._adapter_for_key(node_key, adapter)
+                suffix = node_key.replace("/", "_").replace("-", "_").lstrip("_")
+                node = _ObstacleNode(input_topic, suffix)
+            except Exception as error:  # noqa: BLE001 - keep serving others
+                log.error("[obstacle] failed to build instance %r on %r: %s",
+                          node_key, input_topic, escape_log_text(error))
+                with self._state_lock:
+                    if self._pending_starts.get(node_key) == input_topic:
+                        del self._pending_starts[node_key]
+                continue
+            registered = False
+            with self._state_lock:
+                entry_valid = (
+                    generation == self._load_generation
+                    and self._pending_starts.get(node_key) == input_topic
+                )
+                still_wanted = entry_valid and node_key not in self._nodes
+                if still_wanted:
+                    try:
+                        self._executor.add_node(node)
+                    except Exception as error:  # noqa: BLE001
+                        log.error("[obstacle] failed to register instance %r: %s",
+                                  node_key, escape_log_text(error))
+                        del self._pending_starts[node_key]
+                    else:
+                        self._nodes[node_key] = node
+                        del self._pending_starts[node_key]
+                        registered = True
+                elif entry_valid:
+                    # A concurrent start already owns a live node for this
+                    # key; drop the entry so the loop can progress.
+                    del self._pending_starts[node_key]
+            if not registered:
+                try:
+                    node.destroy_node()   # never started, never registered
+                except Exception:  # noqa: BLE001
+                    pass
+                continue
+            try:
+                node.start(node_adapter)
+            except Exception as error:  # noqa: BLE001
+                log.error("[obstacle] failed to start instance %r: %s",
+                          node_key, escape_log_text(error))
+                with self._state_lock:
+                    if self._nodes.get(node_key) is node:
+                        del self._nodes[node_key]
+                self._dispose(node_key, node)
+                continue
+            with self._state_lock:
+                still_ours = self._nodes.get(node_key) is node
+            if not still_ours:
+                # A concurrent stop retired the node while start() ran; its
+                # dispose handled teardown — stop the worker start spawned.
+                node.stop()
+
+    # ── per-instance status (lock held) ───────────────────────────────────
+
+    def _instance_state_locked(self, node_key: str) -> str:
+        node = self._nodes.get(node_key)
+        if node is not None:
+            return node.state
+        if node_key in self._pending_starts:
+            return "error" if self._adapter_state == "error" else "loading"
+        return "idle"
+
+    # ── MCP dispatch ──────────────────────────────────────────────────────
+
+    def dispatch(self, name: str, args: dict) -> dict | None:
+        action = args.get("action", name)
+        instance_id = args.get("instance_id", "")
+
+        if action == "info":
+            return self._do_info(instance_id, args)
+        if action == "start":
+            return self._do_start(instance_id, args)
+        if action == "stop":
+            return self._do_stop(instance_id)
+        if action == "config":
+            return self._do_config(instance_id, args)
+        return None
+
+    _DESC = "Obstacle distance estimation from camera feed"
+
+    def _desc_for(self, state: str, load_error: str | None) -> str:
+        """Dashboard-facing description, mirroring the ASR plugin (#113): the
+        static blurb normally, a reason while loading or after a failure."""
+        if state == "loading":
+            return "Loading obstacle models and TensorRT engines..."
+        if state == "error" and load_error:
+            return f"Model load failed: {load_error}"
+        return self._DESC
+
+    def _do_info(self, instance_id: str, args: dict) -> dict:
+        input_topic = args.get("input_topic", "")
+        if not input_topic:
+            topics_list = args.get("input_topics") or []
+            if topics_list:
+                input_topic = topics_list[0]
+
+        with self._state_lock:
+            instances: dict[str, dict] = {}
+            for key, node in self._nodes.items():
+                instances[key] = {
+                    "input": node._input_topic,
+                    "output": node._output_topic,
+                    "detect_count": node._detect_count,
+                    "state": node.state,
+                }
+            for key, topic in self._pending_starts.items():
+                if key in instances:
+                    continue
+                state = self._instance_state_locked(key)
+                entry = {
+                    "input": topic,
+                    "output": f"{topic}/obstacle",
+                    "detect_count": 0,
+                    "state": state,
+                }
+                if state == "error" and self._load_error:
+                    entry["error"] = self._load_error
+                instances[key] = entry
+
+            if instance_id and instance_id in instances:
+                input_topic = instances[instance_id]["input"]
+            elif not input_topic and instances:
+                input_topic = next(iter(instances.values()))["input"]
+
+            states = {entry["state"] for entry in instances.values()}
+            if "loading" in states or self._adapter_state == "loading":
+                state = "loading"
+            elif "running" in states:
+                state = "running"
+            elif "error" in states or self._adapter_state == "error":
+                state = "error"
+            else:
+                state = "idle"
+            load_error = self._load_error
+
+        topics_in = [{"topic": input_topic, "format": "image/jpeg"}] if input_topic else []
+        topics_out = [{"topic": f"{input_topic}/obstacle", "format": "data/json"}] if input_topic else []
+        result = {
+            "name": "ObstacleDistance", "manufacture": "Embodied", "model": "obstacle",
+            "state": state,
+            "instances": instances,
+            "topic_in": topics_in,
+            "topic_out": topics_out,
+            "desc": self._desc_for(state, load_error),
+        }
+        if state == "error" and load_error:
+            result["error"] = load_error
+        return result
+
+    def _do_start(self, instance_id: str, args: dict) -> dict:
+        input_topic = args.get("input_topic")
+        if not input_topic:
+            topics_list = args.get("input_topics") or []
+            if topics_list:
+                input_topic = topics_list[0]
+        if not input_topic:
+            raise ValueError("input_topic is required")
+        node_key = instance_id or input_topic
+
+        retired = None
+        with self._state_lock:
+            previous = self._nodes.get(node_key)
+            if previous is not None and previous._input_topic != input_topic:
+                # Topics are fixed at node construction; rebind the key.
+                retired = self._nodes.pop(node_key)
+        if retired is not None:
+            self._dispose(node_key, retired)
+
+        start_node = None
+        with self._state_lock:
+            existing = self._nodes.get(node_key)
+            instance_cfg = self._instance_configs.get(node_key)
+            cached = self._instance_adapters.get(node_key)
+            adapter_available = self._adapter_state == "ready" and (
+                not instance_cfg
+                or (cached is not None and cached[0] == self._effective_cfg_locked(node_key))
+            )
+            if existing is not None:
+                start_node = existing        # idempotent re-start
+                shared = self._adapter
+            elif adapter_available:
+                # Claim the key before leaving the lock: a concurrent stop
+                # must always find the instance in _pending_starts or
+                # _nodes, never in an invisible in-between state.
+                self._pending_starts[node_key] = input_topic
+                shared = self._adapter
+                generation = self._load_generation
+            else:
+                # Cold start, error retry, or an instance whose per-instance
+                # adapter is not built yet — all go through the background
+                # loader so start never blocks on engine initialisation.
+                self._pending_starts[node_key] = input_topic
+                self._spawn_loader_locked()
+                return {
+                    "state": "loading",
+                    "input": input_topic,
+                    "output": f"{input_topic}/obstacle",
+                }
+
+        node_adapter = self._adapter_for_key(node_key, shared)
+        if start_node is not None:
+            return start_node.start(node_adapter)
+
+        suffix_source = node_key if retired is None else f"{node_key}_{input_topic}"
+        suffix = suffix_source.replace("/", "_").replace("-", "_").lstrip("_")
+        node = _ObstacleNode(input_topic, suffix)
+        # README lifecycle rule: register before start, so a concurrent stop
+        # (or an add_node/start failure) can always locate the node instead of
+        # leaking a started worker that nothing tracks.
+        with self._state_lock:
+            claimed = self._pending_starts.get(node_key) == input_topic
+            current = self._nodes.get(node_key)
+            fresh = generation == self._load_generation
+            registered = False
+            if claimed and current is None and fresh:
+                try:
+                    self._executor.add_node(node)
+                except Exception as error:  # noqa: BLE001
+                    log.error("[obstacle] failed to register instance %r: %s",
+                              node_key, escape_log_text(error))
+                    del self._pending_starts[node_key]
+                else:
+                    self._nodes[node_key] = node
+                    del self._pending_starts[node_key]
+                    registered = True
+            elif claimed and not fresh:
+                # A config change invalidated the adapter mid-start; keep the
+                # claim so the loader brings this instance up on the new one.
+                pass
+            elif claimed:
+                del self._pending_starts[node_key]
+        if not registered:
+            try:
+                node.destroy_node()   # never started, never registered
+            except Exception:  # noqa: BLE001
+                pass
+            if current is not None:
+                return current.start(node_adapter)
+            if claimed and not fresh:
+                return {"state": "loading", "input": input_topic,
+                        "output": f"{input_topic}/obstacle"}
+            return {"state": "idle", "input": input_topic,
+                    "output": f"{input_topic}/obstacle"}
+        try:
+            result = node.start(node_adapter)
+        except Exception:
+            with self._state_lock:
+                if self._nodes.get(node_key) is node:
+                    del self._nodes[node_key]
+            self._dispose(node_key, node)
+            raise
+        with self._state_lock:
+            still_ours = self._nodes.get(node_key) is node
+        if not still_ours:
+            # A concurrent stop retired the node while start() ran; its
+            # dispose handled teardown — stop the worker this start spawned.
+            node.stop()
+            return {"state": "idle", "input": input_topic,
+                    "output": f"{input_topic}/obstacle"}
+        return result
+
+    def _do_stop(self, instance_id: str) -> dict:
+        to_dispose: list[tuple[str, _ObstacleNode]] = []
+        with self._state_lock:
+            if instance_id:
+                self._pending_starts.pop(instance_id, None)
+                node = self._nodes.pop(instance_id, None)
+                if node is not None:
+                    to_dispose.append((instance_id, node))
+                stopped = [instance_id]
+            else:
+                self._pending_starts.clear()
+                stopped = list(self._nodes)
+                to_dispose.extend(self._nodes.items())
+                self._nodes = {}
+        for node_key, node in to_dispose:
+            self._dispose(node_key, node)
+        if instance_id:
+            return {"state": "idle"}
+        return {"state": "idle", "stopped_instances": stopped}
+
+    def _do_config(self, instance_id: str, args: dict) -> dict:
+        cfg = {
+            k: v for k, v in args.items()
+            if k not in ('action', 'instance_id') and v is not None and v != ''
+        }
+
+        if instance_id:
+            retired = None
+            stale_adapter = None
+            with self._state_lock:
+                previous_cfg = self._instance_configs.get(instance_id, {})
+                merged_cfg = deepcopy(previous_cfg)
+                merged_cfg.update(cfg)
+                self._instance_configs[instance_id] = merged_cfg
+                retired = self._nodes.pop(instance_id, None)
+                if merged_cfg != previous_cfg:
+                    dropped = self._instance_adapters.pop(instance_id, None)
+                    if dropped is not None:
+                        stale_adapter = dropped[1]
+            if retired is not None:
+                # The instance goes back to idle; the next start rebuilds it
+                # with the merged per-instance configuration.
+                self._dispose(instance_id, retired)
+            self._close_adapter(stale_adapter)
+            return {
+                "status": "configured",
+                "instance_id": instance_id,
+                "config": merged_cfg,
+            }
+
+        with self._state_lock:
+            merged_cfg = deepcopy(self._plugin_cfg)
+            merged_cfg.update(cfg)
+            if merged_cfg == self._plugin_cfg:
+                log.debug("[obstacle] configuration unchanged")
+                return {"status": "configured", "config": cfg}
+
+            self._plugin_cfg = merged_cfg
+            self._provider = merged_cfg.get("provider", "local")
+            # Invalidate any in-flight load and every cached adapter; nodes
+            # built on the old adapters are retired. Pending starts stay
+            # pending and are served by a fresh loader for the new config.
+            self._load_generation += 1
+            stale_adapters = [self._adapter]
+            stale_adapters.extend(
+                adapter for _cfg, adapter in self._instance_adapters.values()
+            )
+            self._adapter = None
+            self._instance_adapters = {}
+            disposed = list(self._nodes.items())
+            self._nodes = {}
+            if self._pending_starts:
+                self._spawn_loader_locked()
+            else:
+                self._adapter_state = "idle"
+                self._load_error = None
+        for node_key, node in disposed:
+            self._dispose(node_key, node)
+        for adapter in stale_adapters:
+            self._close_adapter(adapter)
+        log.info("[obstacle] configuration updated")
+        return {"status": "configured", "config": cfg}

--- a/perception/plugins/obstacle.py
+++ b/perception/plugins/obstacle.py
@@ -146,7 +146,8 @@ class _ObstacleNode(Node):
         self._frames.close()
         self._stop_event = threading.Event()
         self._worker: threading.Thread | None = None
-        self._lifecycle_lock = threading.Lock()
+        self._lifecycle_lock = threading.RLock()
+        self._retired = False
         self._detect_count = 0
         self._logged_first_frame = False
         self._log_gate = SampledLogGate(every=100)
@@ -154,6 +155,8 @@ class _ObstacleNode(Node):
 
     def start(self, adapter: LocalDistanceAdapter) -> dict:
         with self._lifecycle_lock:
+            if self._retired:
+                return {"state": "idle", "input": self._input_topic, "output": self._output_topic}
             if self.state == "running":
                 return {"state": "running", "input": self._input_topic, "output": self._output_topic}
             if self._worker is not None and self._worker.is_alive():
@@ -181,9 +184,7 @@ class _ObstacleNode(Node):
         return {"state": "running", "input": self._input_topic, "output": self._output_topic}
 
     def stop(self) -> dict:
-        # stop() only pauses the inference worker; the node itself stays
-        # registered until the plugin retires it (see ObstacleDistancePlugin.
-        # _dispose_node), so a later start on the same topic reuses it.
+        # A plain stop pauses the worker; permanent teardown uses retire().
         with self._lifecycle_lock:
             self.state = "idle"
             self._stop_event.set()
@@ -200,6 +201,14 @@ class _ObstacleNode(Node):
                 )
         log.info(f"[obstacle] stopped: {self._input_topic}")
         return {"state": "idle", "input": self._input_topic}
+
+    def retire(self) -> dict:
+        """Permanently stop this node before destroying its ROS handles."""
+        with self._lifecycle_lock:
+            # Match OCR: a delayed start must see retirement before touching
+            # subscriptions or creating another worker on this node.
+            self._retired = True
+            return self.stop()
 
     def _image_cb(self, msg: CompressedImage):
         if self.state != "running":
@@ -353,7 +362,7 @@ class ObstacleDistancePlugin:
     def _dispose(self, node_key: str, node: "_ObstacleNode") -> None:
         """Stop worker and fully destroy the node. Never called under lock."""
         try:
-            node.stop()
+            node.retire()
         finally:
             dispose_node(self._executor, node, label=f"obstacle/{node_key}")
         log.info(f"[obstacle] node disposed: {node_key}")

--- a/perception/plugins/obstacle_distance_core/__init__.py
+++ b/perception/plugins/obstacle_distance_core/__init__.py
@@ -1,0 +1,1 @@
+"""Indoor obstacle distance estimation."""

--- a/perception/plugins/obstacle_distance_core/contracts.py
+++ b/perception/plugins/obstacle_distance_core/contracts.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from enum import Enum
+from typing import Protocol
+
+
+class ErrorCode(str, Enum):
+    INVALID_IMAGE = "invalid_image"
+    MODEL_ERROR = "model_error"
+    TIMEOUT = "timeout"
+    INVALID_DEPTH = "invalid_depth"
+    NO_VALID_DEPTH = "no_valid_depth"
+
+
+class ObstacleDistanceError(Exception):
+    def __init__(self, code: ErrorCode, message: str) -> None:
+        self.code = code
+        self.message = message
+        super().__init__(message)
+
+
+class IndoorDistanceBackend(Protocol):
+    def predict_indoor_distance(
+        self,
+        image_bytes: bytes,
+        deadline_monotonic: float,
+    ) -> float:
+        ...

--- a/perception/plugins/obstacle_distance_core/estimator.py
+++ b/perception/plugins/obstacle_distance_core/estimator.py
@@ -1,0 +1,262 @@
+from __future__ import annotations
+
+import math
+import time
+from copy import deepcopy
+from dataclasses import dataclass
+from numbers import Real
+from typing import Callable, Mapping
+
+from .contracts import ErrorCode, IndoorDistanceBackend, ObstacleDistanceError
+
+
+@dataclass(frozen=True)
+class DistanceResult:
+    distance_m: float
+    near_obstacle: bool
+    decision_threshold_m: float
+    scene: str
+    status: str
+    error_code: str | None
+    fallback: bool
+    approximate_geometry: bool
+    latency_ms: float
+    timestamp: float
+
+
+def _finite_number(
+    value: object,
+    *,
+    name: str,
+    positive: bool = False,
+    nonnegative: bool = False,
+) -> float:
+    if isinstance(value, bool) or not isinstance(value, Real):
+        raise ValueError(f"{name} must be a finite number")
+    try:
+        converted = float(value)
+    except (TypeError, ValueError, OverflowError):
+        raise ValueError(f"{name} must be a finite number") from None
+    if not math.isfinite(converted):
+        raise ValueError(f"{name} must be a finite number")
+    if positive and converted <= 0:
+        raise ValueError(f"{name} must be positive")
+    if nonnegative and converted < 0:
+        raise ValueError(f"{name} must be nonnegative")
+    return converted
+
+
+def _time_value(value: object) -> float:
+    if isinstance(value, bool) or not isinstance(value, Real):
+        raise ObstacleDistanceError(
+            ErrorCode.MODEL_ERROR,
+            "time source returned an invalid value",
+        )
+    try:
+        converted = float(value)
+    except (TypeError, ValueError, OverflowError):
+        raise ObstacleDistanceError(
+            ErrorCode.MODEL_ERROR,
+            "time source returned an invalid value",
+        ) from None
+    if not math.isfinite(converted):
+        raise ObstacleDistanceError(
+            ErrorCode.MODEL_ERROR,
+            "time source returned an invalid value",
+        )
+    return converted
+
+
+class ObstacleDistanceEstimator:
+    def __init__(
+        self,
+        depth_backend: IndoorDistanceBackend,
+        config: Mapping[str, object],
+        *,
+        monotonic: Callable[[], float] = time.monotonic,
+        wall_time: Callable[[], float] = time.time,
+    ) -> None:
+        if not isinstance(config, Mapping):
+            raise ValueError("estimator config must be a mapping")
+        self._config = deepcopy(dict(config))
+        self._monotonic = monotonic
+        self._wall_time = wall_time
+        self._decision_threshold_m = _finite_number(
+            self._config.get("decision_threshold_m", 2.0),
+            name="decision_threshold_m",
+            positive=True,
+        )
+        self._fallback_distance_m = _finite_number(
+            self._config.get("fallback_distance_m", 3.0),
+            name="fallback_distance_m",
+            nonnegative=True,
+        )
+        self._soft_timeout_s = _finite_number(
+            self._config.get("soft_timeout_s", 2.5),
+            name="soft_timeout_s",
+            positive=True,
+        )
+
+        if not callable(getattr(depth_backend, "predict_indoor_distance", None)):
+            raise ValueError("estimator requires an indoor distance backend")
+        self._depth_backend = depth_backend
+
+    def _latency_ms(
+        self,
+        started_monotonic: float | None,
+        *,
+        finished_monotonic: float | None,
+        suppress_clock_errors: bool,
+    ) -> float:
+        if started_monotonic is None:
+            return 0.0
+        if finished_monotonic is None:
+            try:
+                finished_monotonic = _time_value(self._monotonic())
+            except Exception:
+                if suppress_clock_errors:
+                    return 0.0
+                raise ObstacleDistanceError(
+                    ErrorCode.MODEL_ERROR,
+                    "time source failed",
+                ) from None
+        elapsed = (finished_monotonic - started_monotonic) * 1000.0
+        if elapsed < 0:
+            return 0.0
+        return elapsed
+
+    def _result(
+        self,
+        *,
+        distance_m: float,
+        scene: str,
+        status: str,
+        error_code: str | None,
+        fallback: bool,
+        approximate_geometry: bool,
+        started_monotonic: float | None,
+        timestamp: float,
+        finished_monotonic: float | None = None,
+    ) -> DistanceResult:
+        return DistanceResult(
+            distance_m=distance_m,
+            near_obstacle=distance_m < self._decision_threshold_m,
+            decision_threshold_m=self._decision_threshold_m,
+            scene=scene,
+            status=status,
+            error_code=error_code,
+            fallback=fallback,
+            approximate_geometry=approximate_geometry,
+            latency_ms=self._latency_ms(
+                started_monotonic,
+                finished_monotonic=finished_monotonic,
+                suppress_clock_errors=fallback,
+            ),
+            timestamp=timestamp,
+        )
+
+    def _fallback(
+        self,
+        *,
+        code: ErrorCode,
+        scene: str,
+        started_monotonic: float | None,
+        timestamp: float,
+    ) -> DistanceResult:
+        safe_code = code if isinstance(code, ErrorCode) else ErrorCode.MODEL_ERROR
+        try:
+            safe_timestamp = _time_value(timestamp)
+        except Exception:
+            safe_timestamp = 0.0
+        return self._result(
+            distance_m=self._fallback_distance_m,
+            scene=scene,
+            status="error",
+            error_code=safe_code.value,
+            fallback=True,
+            approximate_geometry=False,
+            started_monotonic=started_monotonic,
+            timestamp=safe_timestamp,
+        )
+
+    def _check_deadline(self, deadline_monotonic: float) -> float:
+        observed_monotonic = _time_value(self._monotonic())
+        if observed_monotonic >= deadline_monotonic:
+            raise ObstacleDistanceError(
+                ErrorCode.TIMEOUT,
+                "obstacle distance inference timed out",
+            )
+        return observed_monotonic
+
+    @staticmethod
+    def _validated_distance(value: object) -> float:
+        if isinstance(value, bool) or not isinstance(value, Real):
+            raise ObstacleDistanceError(
+                ErrorCode.MODEL_ERROR,
+                "estimated distance is invalid",
+            )
+        try:
+            distance = float(value)
+        except (TypeError, ValueError, OverflowError):
+            raise ObstacleDistanceError(
+                ErrorCode.MODEL_ERROR,
+                "estimated distance is invalid",
+            ) from None
+        if not math.isfinite(distance) or distance < 0:
+            raise ObstacleDistanceError(
+                ErrorCode.MODEL_ERROR,
+                "estimated distance is invalid",
+            )
+        return distance
+
+    def estimate(
+        self,
+        image_bytes: bytes,
+        timestamp: float | None = None,
+    ) -> DistanceResult:
+        started_monotonic = None
+        result_timestamp = 0.0
+        scene = "indoor"
+        try:
+            if not isinstance(image_bytes, bytes) or not image_bytes:
+                raise ObstacleDistanceError(
+                    ErrorCode.INVALID_IMAGE,
+                    "image bytes must be nonempty",
+                )
+            started_monotonic = _time_value(self._monotonic())
+            result_timestamp = _time_value(
+                timestamp if timestamp is not None else self._wall_time()
+            )
+            deadline_monotonic = started_monotonic + self._soft_timeout_s
+
+            self._check_deadline(deadline_monotonic)
+            distance = self._depth_backend.predict_indoor_distance(
+                image_bytes, deadline_monotonic
+            )
+            distance = self._validated_distance(distance)
+            finished_monotonic = self._check_deadline(deadline_monotonic)
+            return self._result(
+                distance_m=distance,
+                scene=scene,
+                status="ok",
+                error_code=None,
+                fallback=False,
+                approximate_geometry=False,
+                started_monotonic=started_monotonic,
+                timestamp=result_timestamp,
+                finished_monotonic=finished_monotonic,
+            )
+        except ObstacleDistanceError as error:
+            return self._fallback(
+                code=error.code,
+                scene=scene,
+                started_monotonic=started_monotonic,
+                timestamp=result_timestamp,
+            )
+        except Exception:
+            return self._fallback(
+                code=ErrorCode.MODEL_ERROR,
+                scene=scene,
+                started_monotonic=started_monotonic,
+                timestamp=result_timestamp,
+            )

--- a/perception/plugins/obstacle_distance_core/metric_tensorrt_backend.py
+++ b/perception/plugins/obstacle_distance_core/metric_tensorrt_backend.py
@@ -1,0 +1,150 @@
+"""DAv2-Small metric depth on the shared Jetson TensorRT runtime."""
+
+from __future__ import annotations
+
+import logging
+import math
+import threading
+import time
+from numbers import Real
+from typing import Mapping
+
+import numpy as np
+
+from utils.tensorrt_runtime import TensorRTEngine
+
+from .contracts import ErrorCode, ObstacleDistanceError
+
+log = logging.getLogger(__name__)
+
+_INPUT_HEIGHT = 384
+_INPUT_WIDTH = 512
+
+
+def _finite_number(value: object, name: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, Real):
+        raise ValueError(f"{name} must be a finite number")
+    value = float(value)
+    if not math.isfinite(value):
+        raise ValueError(f"{name} must be a finite number")
+    return value
+
+
+def _check_deadline(deadline: float) -> None:
+    if deadline > 0 and time.monotonic() >= deadline:
+        raise ObstacleDistanceError(ErrorCode.TIMEOUT, "model inference timed out")
+
+
+def _prepare_image(image: np.ndarray) -> np.ndarray:
+    import cv2
+
+    resized = cv2.resize(image, (_INPUT_WIDTH, _INPUT_HEIGHT), interpolation=cv2.INTER_LINEAR)
+    rgb = resized[:, :, ::-1]
+    chw = np.transpose(rgb, (2, 0, 1))
+    # Channel normalization and patch padding are already part of the engine.
+    return np.ascontiguousarray(chw, dtype=np.float32)[None] / 255.0
+
+
+def _resize_align_corners(image: np.ndarray, height: int, width: int) -> np.ndarray:
+    import cv2
+
+    if image.shape == (height, width):
+        return image.astype(np.float32, copy=False)
+    source_height, source_width = image.shape
+    x = np.linspace(0, source_width - 1, width, dtype=np.float32)
+    y = np.linspace(0, source_height - 1, height, dtype=np.float32)
+    map_x, map_y = np.meshgrid(x, y)
+    return cv2.remap(
+        image.astype(np.float32, copy=False), map_x, map_y,
+        interpolation=cv2.INTER_LINEAR, borderMode=cv2.BORDER_REPLICATE,
+    )
+
+
+class MetricDepthBackend:
+    """Return the ROI percentile directly in metres, without score calibration."""
+
+    def __init__(self, engine_path: str, config: Mapping[str, object]):
+        self._engine_path = engine_path
+        self._engine: TensorRTEngine | None = None
+        self._engine_init_lock = threading.Lock()
+        if not isinstance(config, Mapping):
+            raise ValueError("indoor configuration must be a mapping")
+        self._roi = config.get("roi", (0, 300, 213, 426))
+        reference = config.get("roi_reference_size", (480, 640))
+        if (
+            not isinstance(reference, (list, tuple)) or len(reference) != 2
+            or any(type(v) is not int or v <= 0 for v in reference)
+        ):
+            raise ValueError("ROI reference size must contain two positive integers")
+        self._reference_height, self._reference_width = reference
+        if (
+            not isinstance(self._roi, (list, tuple)) or len(self._roi) != 4
+            or any(type(v) is not int for v in self._roi)
+        ):
+            raise ValueError("ROI must contain four integer coordinates")
+        r0, r1, c0, c1 = self._roi
+        if not (0 <= r0 < r1 <= reference[0] and 0 <= c0 < c1 <= reference[1]):
+            raise ValueError("ROI is outside the reference image")
+        self._percentile = _finite_number(config.get("depth_percentile", 1.0), "depth percentile")
+        if not 0 <= self._percentile <= 100:
+            raise ValueError("depth percentile must be between 0 and 100")
+        self._minimum = _finite_number(config.get("min_output_distance_m", 0.3), "minimum distance")
+        self._maximum = _finite_number(config.get("max_output_distance_m", 10.0), "maximum distance")
+        if not 0 <= self._minimum < self._maximum:
+            raise ValueError("indoor depth output range is invalid")
+        self._min_valid_pixels = config.get("min_valid_pixels", 64)
+        if type(self._min_valid_pixels) is not int or self._min_valid_pixels <= 0:
+            raise ValueError("minimum valid pixels must be a positive integer")
+
+    def _get_engine(self) -> TensorRTEngine:
+        if self._engine is None:
+            with self._engine_init_lock:
+                if self._engine is None:
+                    started = time.monotonic()
+                    engine = TensorRTEngine(self._engine_path)
+                    try:
+                        if not engine.is_static or engine.input_shape != (1, 3, _INPUT_HEIGHT, _INPUT_WIDTH):
+                            raise ObstacleDistanceError(ErrorCode.MODEL_ERROR, "indoor engine input shape is incompatible")
+                        if len(engine.output_names) != 1:
+                            raise ObstacleDistanceError(ErrorCode.MODEL_ERROR, "indoor engine must have one output")
+                    except Exception:
+                        engine.close()
+                        raise
+                    self._engine = engine
+                    log.info("[obstacle] indoor depth engine loaded in %.1fms", 1000 * (time.monotonic() - started))
+        return self._engine
+
+    def close(self) -> None:
+        with self._engine_init_lock:
+            engine, self._engine = self._engine, None
+        if engine is not None:
+            engine.close()
+
+    def predict_indoor_distance(self, image_bytes: bytes, deadline_monotonic: float) -> float:
+        import cv2
+
+        _check_deadline(deadline_monotonic)
+        try:
+            image = cv2.imdecode(np.frombuffer(image_bytes, dtype=np.uint8), cv2.IMREAD_COLOR)
+        except Exception:
+            image = None
+        if image is None or image.size == 0:
+            raise ObstacleDistanceError(ErrorCode.INVALID_IMAGE, "image bytes could not be decoded")
+        height, width = image.shape[:2]
+        outputs = self._get_engine().infer(_prepare_image(image))
+        if len(outputs) != 1:
+            raise ObstacleDistanceError(ErrorCode.MODEL_ERROR, "indoor engine must have one output")
+        depth = np.asarray(outputs[0]).squeeze()
+        if depth.shape != (_INPUT_HEIGHT, _INPUT_WIDTH):
+            raise ObstacleDistanceError(ErrorCode.INVALID_DEPTH, "indoor engine output shape is incompatible")
+        depth = _resize_align_corners(depth, height, width)
+        r0, r1, c0, c1 = self._roi
+        r0, r1 = (round(height * r / self._reference_height) for r in (r0, r1))
+        c0, c1 = (round(width * c / self._reference_width) for c in (c0, c1))
+        values = depth[r0:r1, c0:c1]
+        values = values[np.isfinite(values) & (values > 0)]
+        if values.size < self._min_valid_pixels:
+            raise ObstacleDistanceError(ErrorCode.NO_VALID_DEPTH, "indoor ROI does not contain enough valid depth")
+        distance = float(np.clip(np.percentile(values, self._percentile), self._minimum, self._maximum))
+        _check_deadline(deadline_monotonic)
+        return distance

--- a/perception/tests/test_obstacle_backend.py
+++ b/perception/tests/test_obstacle_backend.py
@@ -1,0 +1,114 @@
+"""Image-to-distance processing with a fake engine, not model artifacts."""
+
+import time
+
+import cv2
+import numpy as np
+import pytest
+
+from plugins.obstacle_distance_core import metric_tensorrt_backend as backend_module
+from plugins.obstacle_distance_core.contracts import ErrorCode, ObstacleDistanceError
+
+
+class _Engine:
+    input_shape = (1, 3, 384, 512)
+    is_static = True
+    output_names = ["depth_m"]
+
+    def __init__(self):
+        self.depth = np.full((1, 1, 384, 512), 1.5, dtype=np.float32)
+        self.closed = False
+        self.input = None
+
+    def infer(self, tensor):
+        self.input = tensor
+        return [self.depth]
+
+    def close(self):
+        self.closed = True
+
+
+@pytest.fixture
+def engine(monkeypatch):
+    engine = _Engine()
+    monkeypatch.setattr(backend_module, "TensorRTEngine", lambda path: engine)
+    return engine
+
+
+def _jpeg(height=480, width=640):
+    image = np.full((height, width, 3), [30, 60, 90], dtype=np.uint8)
+    ok, encoded = cv2.imencode(".jpg", image)
+    assert ok
+    return encoded.tobytes()
+
+
+def _predict(config=None, image=None):
+    backend = backend_module.MetricDepthBackend("unused.engine", config or {})
+    try:
+        return backend.predict_indoor_distance(
+            _jpeg() if image is None else image, time.monotonic() + 10,
+        )
+    finally:
+        backend.close()
+
+
+def test_jpeg_to_rgb_float_nchw(engine):
+    jpeg = _jpeg()
+    assert _predict(image=jpeg) == 1.5
+    decoded = cv2.imdecode(np.frombuffer(jpeg, np.uint8), cv2.IMREAD_COLOR)
+    assert engine.input.shape == (1, 3, 384, 512)
+    assert engine.input.dtype == np.float32 and engine.input.flags.c_contiguous
+    np.testing.assert_allclose(engine.input[0, :, 0, 0], decoded[0, 0, ::-1] / 255.0)
+
+
+def test_bad_jpeg_does_not_load_engine(monkeypatch):
+    def unexpected(path):
+        pytest.fail("invalid image loaded an engine")
+    monkeypatch.setattr(backend_module, "TensorRTEngine", unexpected)
+    with pytest.raises(ObstacleDistanceError) as error:
+        _predict(image=b"not a jpeg")
+    assert error.value.code is ErrorCode.INVALID_IMAGE
+
+
+@pytest.mark.parametrize("attribute,value", [
+    ("input_shape", (1, 3, 640, 640)), ("is_static", False), ("output_names", ["a", "b"]),
+])
+def test_incompatible_engine_is_closed(engine, attribute, value):
+    setattr(engine, attribute, value)
+    with pytest.raises(ObstacleDistanceError) as error:
+        _predict()
+    assert error.value.code is ErrorCode.MODEL_ERROR and engine.closed
+
+
+def test_wrong_output_shape_is_rejected(engine):
+    engine.depth = np.ones((1, 1, 384, 511), dtype=np.float32)
+    with pytest.raises(ObstacleDistanceError) as error:
+        _predict()
+    assert error.value.code is ErrorCode.INVALID_DEPTH
+
+
+@pytest.mark.parametrize("height,width,percentile", [(480, 640, 1), (720, 1280, 50)])
+def test_scaled_roi_and_percentile_on_depth_plane(engine, height, width, percentile):
+    y, x = np.mgrid[:384, :512]
+    engine.depth = (1 + x / 512 + 2 * y / 384).astype(np.float32)[None, None]
+    y, x = np.mgrid[:height, :width]
+    expected = 1 + (x * 511 / (width - 1)) / 512 + 2 * (y * 383 / (height - 1)) / 384
+    roi = expected[:round(height * 300 / 480), round(width * 213 / 640):round(width * 426 / 640)]
+    # OpenCV remap uses a quantized interpolation table.
+    assert _predict({"depth_percentile": percentile}, _jpeg(height, width)) == pytest.approx(
+        np.percentile(roi, percentile), abs=3e-4,
+    )
+
+
+@pytest.mark.parametrize("value,expected", [(0.1, 0.3), (1.5, 1.5), (20.0, 10.0)])
+def test_metric_output_clamps_without_score_conversion(engine, value, expected):
+    engine.depth.fill(value)
+    assert _predict() == pytest.approx(expected)
+
+
+@pytest.mark.parametrize("value", [float("nan"), float("inf"), 0.0, -1.0])
+def test_invalid_depth_pixels_are_not_clear_space(engine, value):
+    engine.depth.fill(value)
+    with pytest.raises(ObstacleDistanceError) as error:
+        _predict()
+    assert error.value.code is ErrorCode.NO_VALID_DEPTH

--- a/perception/tests/test_obstacle_estimator.py
+++ b/perception/tests/test_obstacle_estimator.py
@@ -1,0 +1,52 @@
+"""Metric-distance validation and structured failure outputs."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from plugins.obstacle_distance_core.contracts import ErrorCode, ObstacleDistanceError
+from plugins.obstacle_distance_core.estimator import ObstacleDistanceEstimator
+
+
+def _estimator(value=1.5, **config):
+    backend = SimpleNamespace(predict_indoor_distance=lambda data, deadline: value)
+    return ObstacleDistanceEstimator(backend, config)
+
+
+@pytest.mark.parametrize("distance,near", [(1.5, True), (2.0, False), (2.5, False)])
+def test_metric_distance_and_strict_threshold(distance, near):
+    result = _estimator(distance, decision_threshold_m=2.0).estimate(b"image")
+    assert result.distance_m == distance and result.near_obstacle is near
+    assert result.scene == "indoor" and result.status == "ok"
+    assert not result.fallback and result.error_code is None
+
+
+@pytest.mark.parametrize("value", [float("nan"), float("inf"), -1, True])
+def test_invalid_distance_is_reported_as_failure(value):
+    result = _estimator(value).estimate(b"image")
+    assert result.fallback and result.error_code == "model_error"
+    assert result.status == "error" and result.distance_m == 3.0
+
+
+@pytest.mark.parametrize("image", [b"", None, "not bytes"])
+def test_invalid_image_is_rejected_before_backend(image):
+    def predict(data, deadline):
+        pytest.fail("invalid image reached model")
+    estimator = ObstacleDistanceEstimator(SimpleNamespace(predict_indoor_distance=predict), {})
+    result = estimator.estimate(image)
+    assert result.fallback and result.error_code == "invalid_image"
+
+
+@pytest.mark.parametrize("code", [ErrorCode.TIMEOUT, ErrorCode.NO_VALID_DEPTH])
+def test_backend_failure_reason_is_preserved(code):
+    def predict(data, deadline):
+        raise ObstacleDistanceError(code, "inference failed")
+    estimator = ObstacleDistanceEstimator(SimpleNamespace(predict_indoor_distance=predict), {})
+    result = estimator.estimate(b"image")
+    assert result.fallback and result.error_code == code.value
+
+
+@pytest.mark.parametrize("config", [{"decision_threshold_m": 0}, {"soft_timeout_s": -1}, {"fallback_distance_m": float("nan")}])
+def test_invalid_configuration_is_rejected(config):
+    with pytest.raises(ValueError):
+        _estimator(**config)

--- a/perception/tests/test_obstacle_plugin.py
+++ b/perception/tests/test_obstacle_plugin.py
@@ -236,3 +236,105 @@ def test_loader_failure_retries_and_stop_disposes_node(plugin, monkeypatch):
     plugin.dispatch("obstacle", {"action": "stop"})
     assert node.destroyed and not plugin._executor.nodes
     assert len(attempts) == 2
+
+
+@pytest.mark.parametrize("teardown", ["stop", "config", "rebind"])
+def test_late_start_cannot_revive_disposed_existing_node(plugin, monkeypatch, teardown):
+    _start(plugin)
+    _running(plugin)
+    node = plugin._nodes["a"]
+    original_start = node.start
+    entered, resume = threading.Event(), threading.Event()
+    outcome = {}
+
+    def delayed_start(adapter):
+        entered.set()
+        assert resume.wait(5)
+        return original_start(adapter)
+
+    monkeypatch.setattr(node, "start", delayed_start)
+    caller = threading.Thread(target=lambda: outcome.update(_start(plugin)))
+    caller.start()
+    try:
+        assert entered.wait(3)
+        if teardown == "config":
+            _config(plugin, "a", 1.5)
+        elif teardown == "rebind":
+            plugin.dispatch("obstacle", {
+                "action": "start", "instance_id": "a", "input_topic": "/cam/new",
+            })
+        else:
+            plugin.dispatch("obstacle", {"action": "stop", "instance_id": "a"})
+        assert node.destroyed
+        resume.set()
+        caller.join(timeout=3)
+        assert not caller.is_alive()
+        assert outcome["state"] == "idle"
+        assert node.state == "idle" and node._worker is None
+        if teardown != "rebind":
+            _start(plugin)
+        _running(plugin)
+        assert plugin._nodes["a"] is not node
+    finally:
+        resume.set()
+        caller.join(timeout=3)
+        node.stop()  # also cleans up a revived worker when testing old code
+
+
+@pytest.mark.parametrize("warm_adapter", [False, True])
+def test_stop_between_node_registration_and_first_start(plugin, monkeypatch, warm_adapter):
+    if warm_adapter:
+        _start(plugin)
+        _running(plugin)
+    entered, resume = threading.Event(), threading.Event()
+    original_start = obstacle_module._ObstacleNode.start
+    invalid_handle_calls = []
+    outcome = {}
+
+    def delayed_start(node, adapter):
+        entered.set()
+        assert resume.wait(5)
+        return original_start(node, adapter)
+
+    monkeypatch.setattr(obstacle_module._ObstacleNode, "start", delayed_start)
+    caller = threading.Thread(target=lambda: outcome.update(_start(plugin, "b")))
+    caller.start()
+    node = None
+    try:
+        assert entered.wait(3)
+        node = plugin._nodes["b"]
+        subscribe = node.create_subscription
+
+        def guarded_subscribe(*args, **kwargs):
+            if node.destroyed:
+                invalid_handle_calls.append(True)
+                raise RuntimeError("node handle is destroyed")
+            return subscribe(*args, **kwargs)
+
+        monkeypatch.setattr(node, "create_subscription", guarded_subscribe)
+        plugin.dispatch("obstacle", {"action": "stop", "instance_id": "b"})
+        assert node.destroyed
+        resume.set()
+        caller.join(timeout=3)
+        assert _wait_until(lambda: plugin._loader_thread is None)
+        assert not caller.is_alive() and not invalid_handle_calls
+        assert node.state == "idle" and node._worker is None
+        assert not node.subscriptions and "b" not in plugin._nodes
+        assert outcome["state"] == ("idle" if warm_adapter else "loading")
+    finally:
+        resume.set()
+        caller.join(timeout=3)
+        if node is not None:
+            node.stop()
+
+
+def test_plain_stop_can_restart_but_disposal_is_permanent(plugin):
+    _start(plugin)
+    _running(plugin)
+    node = plugin._nodes["a"]
+    adapter = plugin._adapter
+    node.stop()
+    assert node.start(adapter)["state"] == "running"
+    plugin.dispatch("obstacle", {"action": "stop"})
+    assert node.start(adapter)["state"] == "idle"
+    assert node.destroyed and node._worker is None

--- a/perception/tests/test_obstacle_plugin.py
+++ b/perception/tests/test_obstacle_plugin.py
@@ -1,0 +1,238 @@
+"""Obstacle loader and configured-start regressions, without models or a GPU."""
+
+import threading
+
+import pytest
+
+from vision_stubs import _FakeExecutor, _wait_until
+from plugins import obstacle as obstacle_module
+
+
+class _Adapter:
+    def __init__(self, cfg):
+        self.cfg = dict(cfg)
+        self.closed = False
+
+    def close(self):
+        self.closed = True
+
+
+@pytest.fixture
+def plugin(monkeypatch):
+    monkeypatch.setattr(obstacle_module, "_build_distance_adapter", _Adapter)
+    plugin = obstacle_module.ObstacleDistancePlugin({}, _FakeExecutor())
+    yield plugin
+    plugin.dispatch("obstacle", {"action": "stop"})
+    loader = plugin._loader_thread
+    if loader is not None:
+        loader.join(timeout=3)
+
+
+def _start(plugin, key="a"):
+    return plugin.dispatch("obstacle", {
+        "action": "start", "instance_id": key, "input_topic": f"/cam/{key}",
+    })
+
+
+def _config(plugin, key, threshold):
+    return plugin.dispatch("obstacle", {
+        "action": "config", "instance_id": key,
+        "decision_threshold_m": threshold,
+    })
+
+
+def _running(plugin, key="a"):
+    def ready():
+        with plugin._state_lock:
+            node = plugin._nodes.get(key)
+            return node is not None and node.state == "running"
+    assert _wait_until(ready)
+
+
+class _PauseAfterCacheCheck:
+    """Schedule config/stop after start releases its cache-read lock."""
+
+    def __init__(self, lock):
+        self.lock = lock
+        self.reached = threading.Event()
+        self.resume = threading.Event()
+        self.exits = 0
+
+    def __enter__(self):
+        self.lock.acquire()
+
+    def __exit__(self, *exc):
+        self.lock.release()
+        if threading.current_thread().name == "mcp-start-test":
+            self.exits += 1
+            if self.exits == 2:
+                self.reached.set()
+                assert self.resume.wait(5)
+
+
+def test_registration_info_and_config_do_not_build(plugin, monkeypatch):
+    def unexpected(cfg):
+        pytest.fail("model work before start")
+    monkeypatch.setattr(obstacle_module, "_build_distance_adapter", unexpected)
+    assert plugin.get_tools()
+    assert plugin.dispatch("obstacle", {"action": "info"})["state"] == "idle"
+    _config(plugin, "a", 1.5)
+    assert plugin._loader_thread is None
+
+
+def test_configured_start_uses_background_loader(plugin, monkeypatch):
+    _start(plugin)
+    _running(plugin)
+    entered, release = threading.Event(), threading.Event()
+    threads = []
+
+    def build(cfg):
+        threads.append(threading.current_thread().name)
+        entered.set()
+        assert release.wait(5)
+        return _Adapter(cfg)
+
+    monkeypatch.setattr(obstacle_module, "_build_distance_adapter", build)
+    _config(plugin, "b", 1.5)
+    try:
+        assert _start(plugin, "b")["state"] == "loading"
+        assert entered.wait(3)
+        assert threads == ["obstacle-adapter-loader"]
+        assert plugin.dispatch("obstacle", {"action": "info"})["instances"]["b"]["state"] == "loading"
+    finally:
+        release.set()
+    _running(plugin, "b")
+
+
+@pytest.mark.parametrize("action", ["config", "stop"])
+def test_cache_invalidated_during_start_never_builds_on_mcp(plugin, monkeypatch, action):
+    _start(plugin)
+    _running(plugin)
+    _config(plugin, "b", 1.5)
+    _start(plugin, "b")
+    _running(plugin, "b")
+    plugin.dispatch("obstacle", {"action": "stop", "instance_id": "b"})
+    old_adapter = plugin._instance_adapters["b"][1]
+    paused = _PauseAfterCacheCheck(plugin._state_lock)
+    monkeypatch.setattr(plugin, "_state_lock", paused)
+    release_build, built, returned = threading.Event(), threading.Event(), threading.Event()
+    threads, outcome = [], {}
+
+    def build(cfg):
+        threads.append(threading.current_thread().name)
+        built.set()
+        assert release_build.wait(5)
+        return _Adapter(cfg)
+
+    def start():
+        try:
+            outcome.update(_start(plugin, "b"))
+        finally:
+            returned.set()
+
+    monkeypatch.setattr(obstacle_module, "_build_distance_adapter", build)
+    caller = threading.Thread(target=start, name="mcp-start-test")
+    caller.start()
+    try:
+        assert paused.reached.wait(3)
+        if action == "config":
+            _config(plugin, "b", 2.0)
+        else:
+            plugin.dispatch("obstacle", {"action": "stop", "instance_id": "b"})
+        paused.resume.set()
+        assert returned.wait(1), "MCP start waited for adapter construction"
+        assert outcome["state"] == ("loading" if action == "config" else "idle")
+        if action == "config":
+            assert built.wait(3)
+            assert threads == ["obstacle-adapter-loader"]
+            assert old_adapter.closed
+        else:
+            assert threads == [] and "b" not in plugin._nodes
+    finally:
+        paused.resume.set()
+        release_build.set()
+        caller.join(timeout=3)
+    if action == "config":
+        _running(plugin, "b")
+        assert plugin._instance_adapters["b"][1].cfg["decision_threshold_m"] == 2.0
+
+
+def test_config_changed_before_loader_registers_node(plugin, monkeypatch):
+    _start(plugin)
+    _running(plugin)
+    entered, release = threading.Event(), threading.Event()
+    original = obstacle_module._ObstacleNode
+    created = []
+
+    def create(topic, suffix):
+        node = original(topic, suffix)
+        created.append(node)
+        if len(created) == 1:
+            entered.set()
+            assert release.wait(5)
+        return node
+
+    monkeypatch.setattr(obstacle_module, "_ObstacleNode", create)
+    _config(plugin, "b", 1.5)
+    try:
+        assert _start(plugin, "b")["state"] == "loading"
+        assert entered.wait(3)
+        _config(plugin, "b", 2.0)
+    finally:
+        release.set()
+    _running(plugin, "b")
+    assert created[0].destroyed and len(created) == 2
+    assert plugin._instance_adapters["b"][1].cfg["decision_threshold_m"] == 2.0
+
+
+@pytest.mark.parametrize("action", ["config", "stop"])
+def test_config_or_stop_during_loading(plugin, monkeypatch, action):
+    entered, release = threading.Event(), threading.Event()
+    adapters = []
+
+    def build(cfg):
+        adapter = _Adapter(cfg)
+        adapters.append(adapter)
+        if len(adapters) == 1:
+            entered.set()
+            assert release.wait(5)
+        return adapter
+
+    monkeypatch.setattr(obstacle_module, "_build_distance_adapter", build)
+    try:
+        assert _start(plugin)["state"] == "loading"
+        assert entered.wait(3)
+        if action == "config":
+            _config(plugin, "", 1.5)
+        else:
+            plugin.dispatch("obstacle", {"action": "stop"})
+    finally:
+        release.set()
+    assert _wait_until(lambda: plugin._loader_thread is None)
+    if action == "config":
+        _running(plugin)
+        assert len(adapters) == 2 and adapters[0].closed
+        assert plugin._adapter.cfg["decision_threshold_m"] == 1.5
+    else:
+        assert not plugin._nodes and not plugin._pending_starts
+
+
+def test_loader_failure_retries_and_stop_disposes_node(plugin, monkeypatch):
+    attempts = []
+
+    def build(cfg):
+        attempts.append(cfg)
+        if len(attempts) == 1:
+            raise RuntimeError("model unavailable")
+        return _Adapter(cfg)
+
+    monkeypatch.setattr(obstacle_module, "_build_distance_adapter", build)
+    assert _start(plugin)["state"] == "loading"
+    assert _wait_until(lambda: plugin._adapter_state == "error")
+    assert "model unavailable" in plugin.dispatch("obstacle", {"action": "info"})["error"]
+    _start(plugin)
+    _running(plugin)
+    node = plugin._nodes["a"]
+    plugin.dispatch("obstacle", {"action": "stop"})
+    assert node.destroyed and not plugin._executor.nodes
+    assert len(attempts) == 2

--- a/perception/utils/model_downloader.py
+++ b/perception/utils/model_downloader.py
@@ -594,6 +594,35 @@ OCR_MODEL_BUNDLES = {
 }
 
 
+# ── Indoor obstacle distance (DAv2-Small TensorRT engines) ─────────────
+OBSTACLE_MODEL_REVISION = "c01f28781812143550249725f1ce1ed4eac165a7"
+OBSTACLE_MODEL_BASE = os.environ.get(
+    "OBSTACLE_MODEL_BASE_URL",
+    "https://www.modelscope.cn/models/Flame4pd/"
+    f"obstacle-indoor-dav2-small-trt/resolve/{OBSTACLE_MODEL_REVISION}",
+)
+OBSTACLE_MODEL_BUNDLES = {
+    "jp61": {
+        "base_url": f"{OBSTACLE_MODEL_BASE}/jp61",
+        "files": {
+            "indoor-metric.engine": {
+                "size": 53636420,
+                "sha256": "2c9b5c2041c618cdaa2de13ac38396e729e3dcb21d9037a350c57f0973b40054",
+            },
+        },
+    },
+    "jp511": {
+        "base_url": f"{OBSTACLE_MODEL_BASE}/jp511",
+        "files": {
+            "indoor-metric.engine": {
+                "size": 51526115,
+                "sha256": "7b0a0b47befca4e2df4480dfcf81a5854917e92e3efcb7148e0a3e3aa1bab4ed",
+            },
+        },
+    },
+}
+
+
 def ensure_ocr_model(model_dir: str, family: str | None = None) -> dict[str, str]:
     """Ensure the OCR TensorRT bundle matching the runtime TensorRT is present."""
     model_dir = require_models_subpath(model_dir)
@@ -742,3 +771,22 @@ def ensure_vits2_model(model_dir: str, family: str | None = None) -> str:
         entry,
     )
     return os.path.join(model_dir, "engines", key)
+
+
+def ensure_obstacle_models(
+    model_dir: str, bundle: str | None = None
+) -> dict[str, str]:
+    """Ensure the obstacle TensorRT engines matching the runtime TensorRT.
+
+    ``bundle`` (or the OBSTACLE_MODEL_BUNDLE environment variable) is an
+    explicit test override such as "jp61"/"jp511"; production deployments
+    leave it unset and follow the importable TensorRT version.
+    """
+    family = bundle or os.environ.get("OBSTACLE_MODEL_BUNDLE") or None
+    model_dir = require_models_subpath(model_dir)
+    key = select_bundle_family(OBSTACLE_MODEL_BUNDLES, family)
+    entry = OBSTACLE_MODEL_BUNDLES[key]
+    log.info(f"[model_downloader] obstacle: using {key} bundle")
+    return ensure_verified_bundle(
+        f"obstacle/{key}", model_dir, entry["base_url"], entry["files"]
+    )


### PR DESCRIPTION
> 更新 / Update: `9243237` 按 main OCR 的方式补永久节点退役，修复迟到 start 复活已销毁节点，并增加后端测试。模型和 ModelScope 地址不变。前一 head `a9da2c2` 双 JP 构建已通过；当前 head 单独请求重新构建与 review。

## 中文

替代 #101，范围收敛为**室内障碍物米制距离估计**。基于 main `53b093d` 重建，当前 head 为 `9243237`。

- 室内模型改为 DAv2-Small FP16，直接输出米制深度；在配置 ROI 内取深度百分位，不再使用 ZipDepth 逆深度分数、线性标定或分类边界强制修正。
- 不包含车辆分支、YOLO 深度/分割、分辨率或内容场景路由；场景选择配置移除，输出 `scene` 固定为 `indoor`。
- **沿用 #101 的生命周期**：非阻塞 start、后台单飞加载、info 查询、config 换代、stop 销毁节点及执行器注册。节点销毁对齐 main OCR 的 `RLock + _retired + retire()`，让迟到 start 在触碰 ROS 句柄前返回 idle；普通暂停后仍可重启。插件保留原状态机，并在 review 后修复启动缓存失效的交接：MCP 只读缓存，构建仅在已有 loader 线程执行，注册节点前复查 adapter。没有新增预热、节点常驻、多实例分发或场景引擎装卸策略。
- 保留旧 PR 的工具注册默认值和可配置距离阈值（默认 2m），不改其他插件配置。输出 topic 与包含状态/错误/兜底标志的 JSON 契约保持不变。
- 复用 main 的 TensorRT/CUDA runtime 与模型懒下载工具。每个 JetPack 只下载一份室内引擎；构造、info、config 不联网、不初始化推理引擎。
- **无 Dockerfile、部署、端口、共享 runtime 或既有测试改动**。不上传实验脚本、测试数据、评测结果或模型二进制到 Git。

### 模型分发

本轮按请求暂用公开 ModelScope，不包含 COS 迁移或其他基础设施变化：
[Flame4pd/obstacle-indoor-dav2-small-trt](https://www.modelscope.cn/models/Flame4pd/obstacle-indoor-dav2-small-trt)，固定 revision `c01f28781812143550249725f1ce1ed4eac165a7`。

| 制品 | 运行环境 | 字节 |
| --- | --- | ---: |
| `jp61/indoor-metric.engine` | TensorRT 10.4 / Orin | 53,636,420 |
| `jp511/indoor-metric.engine` | TensorRT 8.5.2.2 / Orin | 51,526,115 |

两份文件均已匿名完整回下载，大小与 SHA256 均通过；模型卡声明权重已微调并保留 Apache-2.0 许可证。

### 验证边界

- 按 review 要求新增 44 项仓库内产品回归测试；加上本地 43 项室内推理/生命周期检查与 55 项上游共享 runtime/OCR 测试，共 142 项通过。关键缓存交接和迟到 start 回归能检测修复前问题；6 项节点退役回归重复 10 轮全部通过。新增后端测试实际运行 JPEG 解码和 ROI/百分位处理，仅替换 engine。
- Python 3.8 语法检查和完整 diff 检查通过；输入预处理与 ROI 深度提取与所选模型运行实现一致。
- 这两份固定引擎有既往 JP5/JP6 原生推理验证；**当前重建 PR 尚未在 Jetson 做端到端验证**。历史引擎验证不等于本 PR 容器验证。
- 请求 bot review 与 JetPack 5.1.1 / 6.1 构建。当前 PR 未作平台提交。

## English

Supersedes #101 with an **indoor-only metric obstacle-distance plugin**, replayed on main `53b093d`, with focused cache-handoff and node-retirement review fixes in head `9243237`.

- Use fine-tuned DAv2-Small FP16 metric-depth engines and an ROI depth percentile. Remove inverse-depth score calibration and threshold snapping.
- Omit vehicle depth/segmentation and scene routing. Preserve the structured result topic/schema, with `scene: indoor`.
- Preserve #101's non-blocking loader state machine; align permanent node teardown with main OCR's locked retired flag so late starts cannot revive destroyed nodes. Plain pause/restart remains supported. The cache-handoff fix makes the MCP start path cache-only, delegates cache misses to the existing loader, and checks adapter freshness before node registration. No startup warmup, retained-node policy, process dispatcher or scene-unloading changes are introduced.
- Reuse main's TensorRT runtime and lazy verified downloader. Preserve existing plugin defaults and the operator-configurable 2m threshold; sibling plugins remain untouched.
- No Dockerfile, deployment, port, shared-runtime or existing-test changes. No model binaries, datasets or experiment tools are committed.

The two public ModelScope engines are pinned to the revision above and were fully downloaded anonymously with matching size/SHA256. ModelScope is intentionally retained for this revision; a COS migration is outside this PR's requested scope.

Validation: 44 new in-repository product regression cases, 43 local indoor/lifecycle checks and 55 upstream shared-runtime/OCR checks passed (142 total), plus Python 3.8 syntax and diff checks. Targeted regressions detect the pre-fix cache-handoff and late-start failures. All six retirement cases also passed ten repeated runs. Backend tests exercise real JPEG decoding and ROI/percentile processing with only the engine replaced by a fake. The exact engine artifacts have prior native JP5/JP6 inference evidence, but **this rebased PR has not yet undergone Jetson end-to-end validation**. Requesting bot review and both JetPack build targets; no evaluation-platform submission is included.
