### PR TITLE
fix(core): 按实例关联同名卡片的启动状态

### DIFF
--- a/agent-core/src/api/config.py
+++ b/agent-core/src/api/config.py
@@ -271,7 +271,7 @@ async def _do_start_project():
                 # also releases the frontend's wait on this item.
                 print(f'[start-project] {tool_name} ({mcp_id}) load abandoned (idle)')
                 await push_event({'type': 'project_start_item', 'payload': {
-                    'tool': tool_name, 'mcp_id': mcp_id, 'status': 'cancelled',
+                    'tool': tool_name, 'mcp_id': mcp_id, 'instance_id': card_id, 'status': 'cancelled',
                     'message': '启动已取消',
                 }})
                 return
@@ -283,12 +283,12 @@ async def _do_start_project():
                 except Exception as error:
                     print(f'[start-project] {tool_name} topic re-register failed: {error}')
             await push_event({'type': 'project_start_item', 'payload': {
-                'tool': tool_name, 'mcp_id': mcp_id, 'status': status,
+                'tool': tool_name, 'mcp_id': mcp_id, 'instance_id': card_id, 'status': status,
                 'message': message if status == 'error' else '',
             }})
             return
         await push_event({'type': 'project_start_item', 'payload': {
-            'tool': tool_name, 'mcp_id': mcp_id, 'status': 'error',
+            'tool': tool_name, 'mcp_id': mcp_id, 'instance_id': card_id, 'status': 'error',
             'message': f'模型加载超过 {LOADING_TIMEOUT_S // 60} 分钟仍未就绪',
         }})
 
@@ -312,7 +312,7 @@ async def _do_start_project():
 
     # 广播启动开始
     await push_event({'type': 'project_start_begin', 'payload': {
-        'cards': [{'tool': c.get('toolName', ''), 'mcp_id': c.get('mcpId', '')} for c in all_ordered],
+        'cards': [{'tool': c.get('toolName', ''), 'mcp_id': c.get('mcpId', ''), 'instance_id': c.get('id', '')} for c in all_ordered],
     }})
 
     errors = []
@@ -328,7 +328,7 @@ async def _do_start_project():
             return
 
         await push_event({'type': 'project_start_item', 'payload': {
-            'tool': tool_name, 'mcp_id': mcp_id, 'status': 'starting',
+            'tool': tool_name, 'mcp_id': mcp_id, 'instance_id': card_id, 'status': 'starting',
         }})
 
         args = {'action': 'start', 'instance_id': card_id}
@@ -362,7 +362,7 @@ async def _do_start_project():
                 if tool_state == 'error':
                     print(f'[start-project] {tool_name} ({mcp_id}) self-check failed: {tool_message}')
                     await push_event({'type': 'project_start_item', 'payload': {
-                        'tool': tool_name, 'mcp_id': mcp_id, 'status': 'error', 'message': tool_message,
+                        'tool': tool_name, 'mcp_id': mcp_id, 'instance_id': card_id, 'status': 'error', 'message': tool_message,
                     }})
                     errors.append(tool_name)
                 elif tool_state == 'loading':
@@ -376,7 +376,7 @@ async def _do_start_project():
                     message = tool_message or '模型加载中，就绪后自动开始'
                     print(f'[start-project] {tool_name} ({mcp_id}) loading: {message}')
                     await push_event({'type': 'project_start_item', 'payload': {
-                        'tool': tool_name, 'mcp_id': mcp_id, 'status': 'loading',
+                        'tool': tool_name, 'mcp_id': mcp_id, 'instance_id': card_id, 'status': 'loading',
                         'message': message,
                     }})
                     _asyncio.create_task(
@@ -385,7 +385,7 @@ async def _do_start_project():
                 else:
                     print(f'[start-project] started {tool_name} ({mcp_id})')
                     await push_event({'type': 'project_start_item', 'payload': {
-                        'tool': tool_name, 'mcp_id': mcp_id, 'status': 'ready',
+                        'tool': tool_name, 'mcp_id': mcp_id, 'instance_id': card_id, 'status': 'ready',
                     }})
                 # Resolve topic_out for the downstream cards and register it on
                 # the bus. Non-fatal: a card that cannot answer info() still runs.
@@ -403,13 +403,13 @@ async def _do_start_project():
                           or f'启动失败 (code={result.get("code")})')[:200]
                 print(f'[start-project] {tool_name} error: {result}')
                 await push_event({'type': 'project_start_item', 'payload': {
-                    'tool': tool_name, 'mcp_id': mcp_id, 'status': 'error', 'message': msg,
+                    'tool': tool_name, 'mcp_id': mcp_id, 'instance_id': card_id, 'status': 'error', 'message': msg,
                 }})
                 errors.append(tool_name)
         except Exception as e:
             print(f'[start-project] failed {tool_name}: {e}')
             await push_event({'type': 'project_start_item', 'payload': {
-                'tool': tool_name, 'mcp_id': mcp_id, 'status': 'error', 'message': str(e)[:100],
+                'tool': tool_name, 'mcp_id': mcp_id, 'instance_id': card_id, 'status': 'error', 'message': str(e)[:100],
             }})
             errors.append(tool_name)
 
@@ -509,7 +509,7 @@ async def _do_start_project():
             tool_name = card.get('toolName', '')
             print(f'[start-project] {tool_name}: {message}')
             await push_event({'type': 'project_start_item', 'payload': {
-                'tool': tool_name, 'mcp_id': card.get('mcpId', ''),
+                'tool': tool_name, 'mcp_id': card.get('mcpId', ''), 'instance_id': card.get('id', ''),
                 'status': 'error', 'message': message,
             }})
             errors.append(tool_name)

--- a/agent-core/tests/test_start_project_resolution.py
+++ b/agent-core/tests/test_start_project_resolution.py
@@ -9,6 +9,7 @@ get it wrong and the fake cannot answer, exactly as on the robot.
 Run: cd agent-core && python3 -m pytest tests/test_start_project_resolution.py
 """
 import asyncio
+import json
 import os
 import pathlib
 import sys
@@ -239,3 +240,72 @@ def test_a_live_answer_beats_a_stale_persisted_one(driver):
     }
     assert _start(layout) is True
     assert driver.starts[CORE]['input_topic'] == '/ubuntu/mic/audio'
+
+
+@pytest.mark.parametrize('failure', [None, 'response', 'exception'])
+def test_same_name_camera_instances_have_independent_startup_events(driver, monkeypatch, failure):
+    ids = ['camera-rgb', 'camera-depth', 'camera-ir']
+    channels = dict(zip(ids, ['rgb', 'depth', 'infrared']))
+    started, registered = [], []
+
+    async def call(mcp_id, req):
+        cid = req.arguments['instance_id']
+        action = req.arguments['action']
+        if action == 'start':
+            started.append(cid)
+            if cid == ids[1]:
+                if failure == 'response':
+                    return {'code': 500, 'message': 'Camera failed'}
+                if failure == 'exception':
+                    raise RuntimeError('Camera disconnected')
+        channel = channels[cid]
+        payload = {'state': 'idle' if action == 'stop' else 'running',
+                   'topic_out': [{'topic': f'/robot/ext_camera/{cid}/{channel}',
+                                  'format': 'image/depth-zlib' if channel == 'depth' else 'image/jpeg'}]}
+        return {'code': 200, 'data': [{'type': 'text', 'text': json.dumps(payload)}]}
+
+    async def register(topic, fmt, mcp_id):
+        registered.append((topic, fmt))
+
+    monkeypatch.setattr(sys.modules['api.mcp_manage'], 'mcp_call_tool', call)
+    monkeypatch.setattr(sys.modules['api.inspection'], 'register_topic_internal', register)
+    assert _start({'cards': [_card(cid, 'ext_camera') for cid in ids], 'connections': []}) is (failure is None)
+    assert started == ids  # The real scheduler must call all three instances.
+    begin = next(e['payload'] for e in driver.events if e['type'] == 'project_start_begin')
+    assert [c.get('instance_id') for c in begin['cards']] == ids
+    progress = [e['payload'] for e in driver.events if e['type'] == 'project_start_item']
+    assert all(e.get('instance_id') in ids for e in progress)
+    for cid in ids:
+        states = [e['status'] for e in progress if e['instance_id'] == cid]
+        assert states == ['starting', 'error' if failure and cid == ids[1] else 'ready']
+    if failure is None:
+        assert registered == [(f'/robot/ext_camera/{cid}/{channels[cid]}',
+                               'image/depth-zlib' if channels[cid] == 'depth' else 'image/jpeg') for cid in ids]
+
+
+def test_late_loading_outcomes_keep_their_instance_identity(driver, monkeypatch):
+    ids = ['loading-a', 'loading-b', 'loading-c']
+    outcomes = dict(zip(ids, ['running', 'idle', 'error']))
+
+    async def call(mcp_id, req):
+        cid = req.arguments['instance_id']
+        state = 'loading' if req.arguments['action'] == 'start' else outcomes[cid]
+        return {'code': 200, 'data': {'state': state}}
+
+    async def no_delay(seconds):
+        pass
+
+    monkeypatch.setattr(sys.modules['api.mcp_manage'], 'mcp_call_tool', call)
+    monkeypatch.setattr(asyncio, 'sleep', no_delay)
+    config.main['canvas_layout'] = {'cards': [_card(cid, 'tts') for cid in ids], 'connections': []}
+
+    async def run():
+        assert await config_api._do_start_project() is True
+        pending = [t for t in asyncio.all_tasks() if t is not asyncio.current_task()]
+        await asyncio.gather(*pending)
+
+    asyncio.run(run())
+    events = [e['payload'] for e in driver.events if e['type'] == 'project_start_item']
+    assert all(e.get('instance_id') in ids for e in events)
+    for cid, terminal in zip(ids, ['ready', 'cancelled', 'error']):
+        assert [e['status'] for e in events if e['instance_id'] == cid] == ['starting', 'loading', terminal]

--- a/agent-core/web/js/canvas-startup.test.mjs
+++ b/agent-core/web/js/canvas-startup.test.mjs
@@ -1,0 +1,90 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { test } from 'node:test';
+import vm from 'node:vm';
+
+// Execute the real startup event handler, with only its browser/network edges
+// replaced. This catches duplicate-name rows and premature loading completion.
+const source = readFileSync(new URL('./canvas.js', import.meta.url), 'utf8');
+const start = source.indexOf('async function _startProject()');
+const end = source.indexOf('\nfunction _stopProject()', start);
+assert(start >= 0 && end > start);
+const startup = source.slice(start, end).replace(
+  "await import('./motus-stream.js')", 'eventBus');
+
+async function replay(cards, events) {
+  let handler;
+  const state = { rows: [], countdowns: 0, waiting: 0 };
+  const context = {
+    eventBus: {
+      onMotusEvent: (_, fn) => { handler = fn; },
+      offMotusEvent: () => {},
+    },
+    _saveLayout: async () => {}, _cards: [], _projectRunning: false,
+    _syncProjectBtn: () => {}, _logActivity: () => {},
+    document: { querySelectorAll: () => [] },
+    _showStartupModal: items => {
+      state.rows = Array.from(items, ({ card }) => ({ id: card.id, status: 'waiting' }));
+      return {
+        updateItem: (i, status) => { state.rows[i].status = status; },
+        startCountdown: () => { state.countdowns++; },
+        setWaiting: n => { state.waiting = n; },
+      };
+    },
+    fetch: async () => {
+      handler({ type: 'project_start_begin', payload: { cards } });
+      for (const event of events) handler(event);
+      return { ok: true };
+    },
+  };
+  await vm.runInNewContext(startup + '\n_startProject()', context);
+  return state;
+}
+
+const cameras = ['rgb-card', 'depth-card', 'ir-card'].map(instance_id => ({
+  tool: 'ext_camera', mcp_id: 'go2', instance_id,
+}));
+const item = (card, status) => ({ type: 'project_start_item', payload: { ...card, status } });
+const done = { type: 'project_start_done', payload: { has_error: false } };
+
+test('all same-name camera rows reach ready', async () => {
+  const result = await replay(cameras, [
+    ...cameras.flatMap(card => [item(card, 'starting'), item(card, 'ready')]), done,
+  ]);
+  assert.deepEqual(result.rows.map(r => r.status), ['ready', 'ready', 'ready']);
+  assert.deepEqual(result.rows.map(r => r.id), cameras.map(c => c.instance_id));
+  assert.equal(result.countdowns, 1);
+});
+
+test('one settled instance does not hide another instance still loading', async () => {
+  const result = await replay(cameras, [
+    item(cameras[0], 'ready'), item(cameras[1], 'loading'), item(cameras[2], 'loading'),
+    done, item(cameras[2], 'ready'),
+  ]);
+  assert.deepEqual(result.rows.map(r => r.status), ['ready', 'loading', 'ready']);
+  assert.equal(result.countdowns, 0);
+});
+
+test('errors and cancellation settle only their own rows', async () => {
+  const result = await replay(cameras, [
+    ...cameras.map(card => item(card, 'loading')), done,
+    item(cameras[2], 'cancelled'), item(cameras[0], 'ready'), item(cameras[1], 'error'),
+  ]);
+  assert.deepEqual(result.rows.map(r => r.status), ['ready', 'error', 'cancelled']);
+  assert.equal(result.countdowns, 1);
+});
+
+test('legacy single-card events without instance_id remain supported', async () => {
+  const legacy = { tool: 'mic', mcp_id: 'go2' };
+  const result = await replay([legacy], [item(legacy, 'ready'), done]);
+  assert.equal(result.rows[0].status, 'ready');
+  assert.equal(result.countdowns, 1);
+});
+
+test('an event for another instance cannot keep this modal waiting', async () => {
+  const result = await replay(cameras, [
+    ...cameras.map(card => item(card, 'ready')),
+    item({ ...cameras[0], instance_id: 'deleted-card' }, 'loading'), done,
+  ]);
+  assert.equal(result.countdowns, 1);
+});

--- a/agent-core/web/js/canvas.js
+++ b/agent-core/web/js/canvas.js
@@ -1565,7 +1565,10 @@ async function _startProject() {
 
   // Subscribe to startup progress events
   let modal = null;
-  let itemIndex = {};  // tool_name -> index in modal
+  let itemIndex = new Map();
+  // Tool names identify capabilities; instance IDs identify the actual cards.
+  // Empty instance IDs preserve old single-card event payloads.
+  const itemKey = item => JSON.stringify([item.mcp_id, item.tool, item.instance_id || '']);
   // Cards that accepted start but are still loading a model (perception TTS/OCR
   // fetch and warm one up). The backend settles them with a later ready/error
   // event, so the subscription has to outlive project_start_done — otherwise
@@ -1583,12 +1586,13 @@ async function _startProject() {
     const p = event.payload || {};
     if (event.type === 'project_start_begin') {
       const cards = p.cards || [];
-      const items = cards.map(c => ({ card: { toolName: c.tool, mcpId: c.mcp_id } }));
+      const items = cards.map(c => ({ card: { id: c.instance_id, toolName: c.tool, mcpId: c.mcp_id } }));
       modal = _showStartupModal(items);
-      cards.forEach((c, i) => { itemIndex[`${c.mcp_id}:${c.tool}`] = i; });
+      itemIndex = new Map(cards.map((c, i) => [itemKey(c), i]));
     } else if (event.type === 'project_start_item') {
-      const key = `${p.mcp_id}:${p.tool}`;
-      const idx = itemIndex[key];
+      const key = itemKey(p);
+      const idx = itemIndex.get(key);
+      if (idx === undefined) return;
       // Anything other than 'loading' is terminal for the wait: ready, error,
       // cancelled, or a status added later.
       if (p.status === 'loading') loading.add(key);
@@ -1758,6 +1762,7 @@ function _showStartupModal(items) {
   items.forEach(({ card }) => {
     const li = document.createElement('li');
     li.className = 'startup-modal-item';
+    li.title = card.id || '';
     li.innerHTML = `<span class="startup-dot"></span><span class="startup-name">${card.toolName}</span><span class="startup-status">等待启动</span>`;
     list.appendChild(li);
     dots.push(li.querySelector('.startup-dot'));


### PR DESCRIPTION
同一设备上放置三张同名 `ext_camera` 卡片，分别选择 RGB、depth 和 infrared 后，三个实例已经在后台启动，监控页也能收到三路画面，但启动弹窗显示“等待启动、等待启动、已就绪”。本 PR 修复 Core 的实例状态关联，使每张卡片分别显示自己的启动、加载、失败及取消结果。

## 原因：实例调用正确，状态事件丢失身份

后端 `_do_start_project()` 已对每张卡调用 `start(instance_id)`，但 `project_start_begin` 和 `project_start_item` 只发送 `mcp_id`、`tool`，没有发送 `instance_id`。前端以 `${mcp_id}:${tool}` 建立行索引，三张同名卡片使用相同的键；最后一张覆盖前两张，后续所有状态都写到最后一行。

这不是相机采集只能运行一个实例，也不是 Driver 未实现实例隔离。**旧 Core 可以启动三个实例；错误在于启动进度无法与具体卡片对应。** 同一设备上的其他同名多实例能力也会经过相同的错误路径。

问题也影响错误诊断：在回归用例中让第二张卡返回失败，旧界面先把错误写到第三行，随后又被第三张卡的成功覆盖。后端仍判定整次启动失败，但用户无法从行状态判断失败的是哪张卡。异步加载实例同样需要分别跟踪，不能靠事件顺序推测归属。

## 修改及必要性

- `agent-core/src/api/config.py`：开始列表和每条进度事件增加 `instance_id`，覆盖 starting、ready、error、loading，以及异步就绪、取消和超时分支。实例 ID 来自画布卡片，既有调度顺序、MCP 调用、状态判定和 topic 注册逻辑保持原有行为。
- `agent-core/web/js/canvas.js`：以 `[mcp_id, tool, instance_id]` 的 JSON 表示作为 Map 键，分别更新每张卡的状态及待加载集合；忽略未知实例事件。行 title 带卡片 ID，便于区分同名实例。
- 缺少实例 ID 的历史单卡事件仍按空 ID 处理。正确显示同名多实例需要前后端一起更新；仅部署其中一侧仍无法完成身份关联。

仅修改 Driver 不能修复这个协议缺口：即使在 Driver 的返回 JSON 和外层响应中添加实例 ID，旧 Core 仍会重新构造不含该字段的启动事件。将三种模态拆成不同工具名称会绕开冲突，却破坏“同一张可重复添加的卡片通过 channel 选择模态”的接口，也无法处理一般的同名实例。

## 对照验证

针对实际运行的 `release.260905.9005d5b` 源码及其最小补丁版本，捕获同一组三张相机的实际幂等 `start/info` MCP 返回，离线执行两个真实后端调度器，并把产生的事件交叉重放到两个真实前端启动处理函数。只替换网络、配置存储、事件传输和 DOM 边界，没有重新实现被测调度或匹配逻辑。

| 后端 | 前端 | 独立 start 调用 | 最终行状态 |
| --- | --- | --- | --- |
| 旧版 | 旧版 | 3 | 等待、等待、就绪 |
| 修复版 | 旧版 | 3 | 等待、等待、就绪 |
| 旧版 | 修复版 | 3 | 等待、等待、就绪 |
| 修复版 | 修复版 | 3 | 就绪、就绪、就绪 |

两个后端均注册了三个不同的图像 topic。额外检查了 Driver 追加身份字段以及第二实例失败的反例；只有成对的 Core 修复能够保持正确的行归属。从部署版本的后端 AST 中仅删除新增的事件 `instance_id` 后，新旧模块完全一致。

真机验证：Go2 + RealSense D435i、同一多实例 Driver。在原 Core 下已验证三路持续并发采集 30 秒、均约 15fps；应用相同的 Core 身份关联补丁后，使用者手动启动项目，确认三张卡片的启动显示恢复正常，三路监控继续约 15fps。离线返回捕获是已运行实例的幂等调用，不将其宣称为新增冷启动实测。

## PR 分支检查

- `python -m pytest -q tests/test_start_project_resolution.py tests/test_start_project_order.py tests/test_layout_stop_removed.py`：**33 passed**。
- `node --test web/js/canvas-startup.test.mjs`：**5 passed**。
- `git diff --check`：通过。
- 回归覆盖同名实例全部就绪、单实例返回错误/抛异常、异步加载结果归属、失败与取消、未知实例事件、历史单卡事件，以及原有启动依赖和实例移除停止行为。

## 范围与关联

本 PR 只包含启动状态关联及测试。独立核查发现的监控首次注册格式时序问题不包含在本 PR；它不是修复启动弹窗所必需的改动。没有更改相机采集、深度滤波、Driver、执行器控制、安全确认或部署配置。

相关场景：4paradigm/phanthymotus-driver#248 的统一 `ext_camera` 多实例支持。Core 修复用于准确反映实例生命周期，不应作为 Driver 三路采集能力成立的前提。
