### PR TITLE
perception: add a Thai TTS engine (mms-th), and rename engines <model>-<languages>

### DIFF
--- a/perception/Dockerfile.jetson
+++ b/perception/Dockerfile.jetson
@@ -419,6 +419,41 @@ print('[build] VITS2 frontend ok on numpy ' + numpy.__version__)"; \
 # bundles on jp6.1. Verified on Orin5 (py3.8, glibc 2.31) and Tianyi (py3.10).
 RUN pip3 install --no-cache-dir --no-deps -i ${PYPI_MIRROR} onnxruntime==1.18.1
 
+# ── Thai TTS frontend deps ────────────────────────────────────────
+# Three pure-Python wheels, no compiled extensions and no build-time model fetch,
+# so this needs none of the python3-dev / numpy-pin machinery the VITS2 frontend
+# step above does.
+#
+# Placed last among the dependency layers, and with its ARG declared here rather
+# than beside the others at the top of the file. Both are for build cache: an
+# `ARG` instruction changes the cache key of every layer that follows it, so
+# declaring ENABLE_THAI_TTS up top would rebuild the entire ~16 GB image — CUDA,
+# torch, sherpa-onnx, OCR and all — for three small wheels. Down here the only
+# layers invalidated are the source COPYs below, which any code change
+# invalidates anyway.
+#
+# The import check is not ceremony: the frontend degrades quietly by design — a
+# missing pythainlp only warns and skips normalisation — so a failed install
+# would ship an image whose Thai voice drops every digit and mispronounces every
+# word containing ำ, with nothing to say so until someone listened. Build time is
+# the only place that failure is cheap. The ThapSap and Kham lookups matter for
+# the same reason: wunsen and khanaa are imported for one class each, and the
+# frontend catches ImportError around both.
+ARG ENABLE_THAI_TTS=1
+COPY perception/plugins/requirements.thai.txt /tmp/thai-requirements.txt
+RUN if [ "${ENABLE_THAI_TTS}" = "1" ]; then \
+      pip3 install --no-cache-dir -i "${PYPI_MIRROR}" -r /tmp/thai-requirements.txt && \
+      python3 -c "import pythainlp; \
+from pythainlp.util import bahttext, num_to_thaiword, expand_maiyamok, normalize, remove_zw; \
+from pythainlp.tokenize import word_tokenize; \
+from wunsen import ThapSap; \
+from khanaa import Kham; \
+assert num_to_thaiword(305), 'num_to_thaiword returned nothing'; \
+assert Kham(onset='ก', vowel='อา').form, 'khanaa produced no syllable'; \
+assert word_tokenize('สวัสดีครับ', engine='newmm'), 'newmm returned no tokens'; \
+print('[build] Thai TTS frontend ok on pythainlp ' + pythainlp.__version__)"; \
+    fi && rm -f /tmp/thai-requirements.txt
+
 # ── Application code ───────────────────────────────────────────────
 WORKDIR /work
 COPY perception/main.py    /work/main.py

--- a/perception/README.md
+++ b/perception/README.md
@@ -78,27 +78,30 @@ The VAD parameters can be adjusted per ASR canvas card via the instance config (
 ## TTS Engines
 
 `tts_engine` (configSchema on the `tts` tool, and `plugins.tts.engine` in
-`config.yaml`) selects the voice. **Engines are named after the model, not the
-runtime**: two of the three run on sherpa-onnx, so a name like `sherpa_onnx`
-identified neither of them and left no room for the second.
+`config.yaml`) selects the voice. Engines are named **`<model>-<languages>`** —
+the same shape `asr_model` uses (`x-asr-zh-en`, `paraformer-zh-en`, `zipformer-en`),
+because the dashboard renders the raw enum string, so these two dropdowns sit side
+by side in front of the same operator. Language codes, not country codes: `zh`, not
+`cn`. Naming an engine after its *runtime* was the previous mistake — `matcha-zh-en`
+and `mms-th` both run on sherpa-onnx, so `sherpa_onnx` identified neither.
 
 | `tts_engine` | model | languages | runtime | model dir |
 |---|---|---|---|---|
-| `vits2` (default) | VITS2 ZH/EN 16 kHz | 中 / 英, code-switching | TensorRT | `/models/vits2` |
-| `matcha` | matcha-icefall-zh-en + vocos | 中 / 英 | ONNX Runtime | `/models/sherpa-onnx/tts` |
-| `mms_thai` | MMS-TTS-THAI-MALE-NARRATOR | ไทย only | ONNX Runtime | `/models/mms-thai` |
+| `vits2-zh-en` (default) | VITS2 16 kHz | 中 / 英, code-switching | TensorRT | `/models/vits2` |
+| `matcha-zh-en` | matcha-icefall-zh-en + vocos | 中 / 英 | ONNX Runtime | `/models/sherpa-onnx/tts` |
+| `mms-th` | MMS-TTS-THAI-MALE-NARRATOR | ไทย only | ONNX Runtime | `/models/mms-th` |
 
-The previous names `vits2_trt` and `sherpa_onnx` are still accepted and resolve to
-`vits2` and `matcha` (`ENGINE_ALIASES` in `plugins/tts.py`). They are not
-decoration: both are already persisted in ConfigDB rows and in `config.yaml` on
-every deployed robot, and `_select_engine` raises on an unknown engine — so
-dropping them would put every existing TTS card into `state: error` on the next
-restart.
+`vits2_trt` and `sherpa_onnx` still resolve, via `ENGINE_ALIASES` in
+`plugins/tts.py`, and underscores fold to hyphens first so `vits2_zh_en` works too.
+The aliases are not decoration: both old names are already persisted in ConfigDB
+rows and in `config.yaml` on every deployed robot, and `_select_engine` raises on an
+unknown engine — so dropping them would put every existing TTS card into
+`state: error` on the next restart.
 
 Only one engine is resident at a time. Switching disposes the outgoing one's nodes
 first, because two live publishers on one audio topic play both voices at once.
 
-### `mms_thai`, and why it cannot be handed raw text
+### `mms-th`, and why it cannot be handed raw text
 
 The Thai voice is an ONNX export of
 [VIZINTZOR/MMS-TTS-THAI-MALE-NARRATOR](https://huggingface.co/VIZINTZOR/MMS-TTS-THAI-MALE-NARRATOR),
@@ -211,7 +214,7 @@ cards vanished. Budget for it before enabling.
 
 TTS is simpler: Matcha and the Thai MMS model are fp32 only, so both devices load
 the same files and `device` only picks the provider (Matcha measured ~4.3x). The
-`vits2` engine ignores `device` entirely — it is a TensorRT engine and never
+`vits2-zh-en` engine ignores `device` entirely — it is a TensorRT engine and never
 touches ONNX Runtime.
 
 `device: gpu` also needs a CUDA sherpa-onnx wheel. Both Jetson images install one —
@@ -439,7 +442,7 @@ fp16 weights, and the registry test rejects it.
   `_vad_segment_sync`). silero infers one 512-sample window at a time — too little
   work to amortise a kernel launch plus two copies per 32 ms of audio — and in
   `_vad_worker` it would hold a second CUDA context in a child process.
-- **`vits2` TTS**, as above: TensorRT, not ONNX Runtime.
+- **`vits2-zh-en` TTS**, as above: TensorRT, not ONNX Runtime.
 
 ### GPU bundle distribution
 

--- a/perception/README.md
+++ b/perception/README.md
@@ -75,6 +75,107 @@ The VAD parameters can be adjusted per ASR canvas card via the instance config (
 
 ---
 
+## TTS Engines
+
+`tts_engine` (configSchema on the `tts` tool, and `plugins.tts.engine` in
+`config.yaml`) selects the voice. **Engines are named after the model, not the
+runtime**: two of the three run on sherpa-onnx, so a name like `sherpa_onnx`
+identified neither of them and left no room for the second.
+
+| `tts_engine` | model | languages | runtime | model dir |
+|---|---|---|---|---|
+| `vits2` (default) | VITS2 ZH/EN 16 kHz | 中 / 英, code-switching | TensorRT | `/models/vits2` |
+| `matcha` | matcha-icefall-zh-en + vocos | 中 / 英 | ONNX Runtime | `/models/sherpa-onnx/tts` |
+| `mms_thai` | MMS-TTS-THAI-MALE-NARRATOR | ไทย only | ONNX Runtime | `/models/mms-thai` |
+
+The previous names `vits2_trt` and `sherpa_onnx` are still accepted and resolve to
+`vits2` and `matcha` (`ENGINE_ALIASES` in `plugins/tts.py`). They are not
+decoration: both are already persisted in ConfigDB rows and in `config.yaml` on
+every deployed robot, and `_select_engine` raises on an unknown engine — so
+dropping them would put every existing TTS card into `state: error` on the next
+restart.
+
+Only one engine is resident at a time. Switching disposes the outgoing one's nodes
+first, because two live publishers on one audio topic play both voices at once.
+
+### `mms_thai`, and why it cannot be handed raw text
+
+The Thai voice is an ONNX export of
+[VIZINTZOR/MMS-TTS-THAI-MALE-NARRATOR](https://huggingface.co/VIZINTZOR/MMS-TTS-THAI-MALE-NARRATOR),
+a fine-tune of Meta's MMS VITS — 36 M parameters, **natively 16 kHz** (which is why
+this voice and not the more popular `FEMALEV2`, which is 22.05 kHz and would need a
+resampler), end-to-end so there is no vocoder, and character-level so there is no
+lexicon and no espeak-ng data. Produced by `tools/export_mms_thai_onnx.py`.
+
+**Licence: CC-BY-NC-4.0, inherited from `facebook/mms-tts`. Non-commercial.**
+Re-evaluate before shipping it in a product. Every small Thai model with usable
+quality has the same constraint — the MMS family and Piper's `th_TH-tsync2` are all
+CC-BY-NC — and the only permissively-licensed alternative found was
+`VachaSpeech-0.6B` (Apache-2.0), a 0.6 B autoregressive model that is not viable on
+CPU and marginal on an Orin GPU.
+
+The tokenizer is character-level over exactly **71 characters** and skips
+everything else. sherpa-onnx records the loss as a C++ stderr line that never
+reaches the Python logger or the dashboard; the audio simply comes back short. So
+`plugins/thai_frontend.py` is **not optional**, and three of the omissions are not
+guessable:
+
+- **`ำ` (U+0E33 SARA AM) is not in the table**, but `ํ` (U+0E4D) and `า` (U+0E32)
+  are. MMS was trained on text spelling the vowel as that pair, so every `ำ` is
+  rewritten — otherwise น้ำ, ทำ, คำ, สำหรับ and a large part of the language lose
+  their vowel. Measured: "น้ำ ทำ คำ สำหรับ น้ำหนัก" logs five skipped U+0E33 and
+  synthesizes 1.34 s; rewritten it is 1.51 s and those five vowels are audible.
+- **`ๆ`** (maiyamok) is absent, so `ต่างๆ` is expanded to the repeated word.
+- **Of the Arabic digits only `0 1 2 4` are present** — `3` and `5`-`9` are not, and
+  neither are the Thai digits `๐`-`๙`. No numeral can be passed through; every
+  number becomes words.
+
+Mixed text is transliterated into Thai script rather than routed to another engine,
+so the deployment keeps one voice: numbers via `pythainlp`, Chinese via
+`pypinyin` → `wunsen`, Latin via a hand lexicon then a `khanaa`-based rule
+fallback. **`wunsen` does not handle English** — it covers Japanese, Korean,
+Mandarin and Vietnamese only — so the Latin path is the rule table in
+`thai_frontend.py`, and a name it gets wrong belongs in `_LATIN_LEXICON`, not in
+the rules. The consequence to be clear about: English inside a Thai sentence is
+spoken with a Thai accent by the Thai voice, not natively. Native pronunciation
+would need both engines resident at once, which the facade forbids.
+
+`tests/test_thai_frontend.py` guards one property above all — every character the
+frontend emits is one the model can pronounce. That is the assertion that catches a
+silent drop.
+
+### Adding a Thai voice, or replacing this one
+
+```bash
+pip3 install torch transformers onnx onnxruntime soundfile   # not in the image
+python3 tools/export_mms_thai_onnx.py --repo <hf-repo> --out /tmp/thai-tts
+```
+
+The script refuses a checkpoint that is not 16 kHz or not single-speaker, and its
+self-check fails if the ONNX output is silent, disagrees with torch on duration, or
+ignores `length_scale` (which would make the card's `speed` field decoration).
+
+Two metadata keys decide whether the result loads at all, and getting either wrong
+is worse than an ordinary error:
+
+- **`frontend` must be exactly `characters`.** sherpa-onnx's
+  `OfflineTtsVitsImpl::InitFrontend` dispatches on that string; anything else
+  reaches the lexicon branch, which logs "Not a model using characters as modeling
+  unit" and calls `SHERPA_ONNX_EXIT(-1)` — a **process exit**, so `main.py`'s
+  try/except around the TTS plugin cannot turn it into a card in `state: error`,
+  and ASR, VOP and OCR go down with it. `_validate_thai_manifest` checks the
+  release's `manifest.json` before constructing `OfflineTts` so this fails as an
+  exception instead.
+- **`comment` must not contain `piper`, `coqui` or `Inflect`.** Those select
+  different, shorter ONNX input layouts in `OfflineTtsVitsModel::Run`.
+
+Then tar `model.onnx`, `tokens.txt`, `manifest.json` and `LICENSE`, upload to
+`public/` with credentials from `resource-center/deploy/values.env`
+(`prisma/articles/upload-figs.js` cannot — it only accepts image extensions and
+forces its own key shape), **re-download from COS and hash that copy**, and paste
+the verified `size`/`sha256` into `THAI_TTS_ARCHIVE`. Hashing the local file you
+uploaded defeats the point of the pin, which is to catch a bad transfer.
+
 ## sherpa-onnx Device Selection
 
 `device: cpu | gpu` (under `plugins.asr` and `plugins.tts` in `config.yaml`, and on
@@ -108,9 +209,10 @@ on gpu ASR was enough to exhaust memory: perception was restarted in a loop, Age
 Core could not reach port 15720, and the dashboard rolled the project back and the
 cards vanished. Budget for it before enabling.
 
-TTS is simpler: Matcha is fp32 only, so both devices load the same files and
-`device` only picks the provider (gpu measured ~4.3x). The `vits2_trt` engine
-ignores `device` entirely — it is a TensorRT engine and never touches ONNX Runtime.
+TTS is simpler: Matcha and the Thai MMS model are fp32 only, so both devices load
+the same files and `device` only picks the provider (Matcha measured ~4.3x). The
+`vits2` engine ignores `device` entirely — it is a TensorRT engine and never
+touches ONNX Runtime.
 
 `device: gpu` also needs a CUDA sherpa-onnx wheel. Both Jetson images install one —
 jp5.11 and jp6.1 each have their own build, because the wheel is tied to a
@@ -337,7 +439,7 @@ fp16 weights, and the registry test rejects it.
   `_vad_segment_sync`). silero infers one 512-sample window at a time — too little
   work to amortise a kernel launch plus two copies per 32 ms of audio — and in
   `_vad_worker` it would hold a second CUDA context in a child process.
-- **`vits2_trt` TTS**, as above: TensorRT, not ONNX Runtime.
+- **`vits2` TTS**, as above: TensorRT, not ONNX Runtime.
 
 ### GPU bundle distribution
 

--- a/perception/config.yaml
+++ b/perception/config.yaml
@@ -50,14 +50,14 @@ plugins:
 
   tts:
     enabled: true
-    engine: vits2
+    engine: vits2-zh-en
     backend: trt
     model_dir: /models/vits2
     speaker_id: 0
     speed: 1.0
     warmup: true
     max_chunk_tokens: 256
-    # matcha / mms_thai only — vits2 runs on TensorRT and ignores this.
+    # matcha-zh-en / mms-th only — vits2-zh-en runs on TensorRT and ignores this.
     # Matcha is fp32, so both devices load the same weights and only the provider
     # changes; gpu measured ~4.3x faster at num_threads=2.
     device: cpu

--- a/perception/config.yaml
+++ b/perception/config.yaml
@@ -50,14 +50,14 @@ plugins:
 
   tts:
     enabled: true
-    engine: vits2_trt
+    engine: vits2
     backend: trt
     model_dir: /models/vits2
     speaker_id: 0
     speed: 1.0
     warmup: true
     max_chunk_tokens: 256
-    # sherpa_onnx engine only — vits2_trt runs on TensorRT and ignores this.
+    # matcha / mms_thai only — vits2 runs on TensorRT and ignores this.
     # Matcha is fp32, so both devices load the same weights and only the provider
     # changes; gpu measured ~4.3x faster at num_threads=2.
     device: cpu

--- a/perception/plugins/requirements.thai.txt
+++ b/perception/plugins/requirements.thai.txt
@@ -1,0 +1,29 @@
+# Thai TTS text-frontend runtime (plugins/thai_frontend.py).
+#
+# All three are pure-Python wheels with no compiled extensions and no model
+# downloads at import — pythainlp's newmm dictionary ships inside its wheel, so
+# the container never reaches the network for it. Nothing here needs numpy, so
+# unlike the VITS2 frontend set there is no C-ABI pin to preserve.
+#
+# **pythainlp is pinned per Python version, and it has to be.** 5.3.x declares
+# `requires_python >=3.9`, and the two JetPack lines are not the same
+# interpreter: jp61 is cp310, jp511 is cp38. Left unpinned, pip resolves 5.3.7 on
+# one line and 5.2.0 on the other — the same divergence documented for kaldifst
+# in vits2_tts_trt/requirements.jetson.txt. Pinning both explicitly makes the
+# split visible instead of emergent. 5.2.0 was checked to export every function
+# the frontend calls (bahttext, num_to_thaiword, expand_maiyamok, normalize,
+# remove_zw, word_tokenize), so the older line is not a degraded one.
+pythainlp==5.2.0; python_version < "3.9"
+pythainlp==5.3.7; python_version >= "3.9"
+# Same version the VITS2 frontend set pins, restated so installing this one
+# second cannot move it.
+importlib_resources==5.12.0; python_version < "3.9"
+# Thai transliteration of foreign words. wunsen composes Chinese pinyin into Thai
+# script; khanaa spells a Thai syllable from onset/vowel/coda and is what the
+# Latin fallback uses. Both MIT, both ~20 KB.
+#
+# wunsen does NOT handle English — it covers Japanese, Korean, Mandarin and
+# Vietnamese only. The Latin path is khanaa plus the rule table in
+# plugins/thai_frontend.py, not wunsen.
+wunsen==0.0.3
+khanaa==0.1.1

--- a/perception/plugins/thai_frontend.py
+++ b/perception/plugins/thai_frontend.py
@@ -1,0 +1,544 @@
+#!/usr/bin/env python3
+"""
+plugins/thai_frontend.py — text normalisation for the MMS Thai VITS model.
+
+The model's tokenizer is character-level over exactly **71 characters** and it
+drops everything outside that set. sherpa-onnx records the loss as a C++ stderr
+line ("Skip unknown character. Unicode codepoint: \\U+0e33") that never reaches
+the Python logger or the dashboard, and HF's tokenizer just maps the character to
+`<unk>`; either way the *audio* simply comes back short, which is the same
+failure the ZH/EN frontend documents at
+``plugins/vits2_tts_trt/frontend/cleaner.py`` ("the digit was dropped instead of
+pronounced"). That is why this module exists rather than passing text straight to
+sherpa-onnx.
+
+Three of the omissions are not obvious and each one silently mangles ordinary
+Thai:
+
+* ``ำ`` (U+0E33 SARA AM) **is not in the vocabulary**, but ``ํ`` (U+0E4D) and
+  ``า`` (U+0E32) both are. MMS was trained on text that spelled the vowel as
+  that pair, so every ``ำ`` has to be rewritten — otherwise น้ำ, ทำ, คำ, สำหรับ
+  and a large fraction of the language lose their vowel. Measured: the sentence
+  "น้ำ ทำ คำ สำหรับ น้ำหนัก" logs five skipped U+0E33 and synthesizes 1.34 s;
+  rewritten it is 1.51 s, and those five vowels are audible.
+* ``ๆ`` (maiyamok, the repeat marker) is absent, so ``ต่างๆ`` must be expanded to
+  the repeated word before it reaches the model.
+* Thai digits ``๐-๙`` are absent, and of the Arabic digits only ``0 1 2 4``
+  survive — ``3 5 6 7 8 9`` are not in the set. So no numeral can be passed
+  through; every number has to become words.
+
+Everything the model cannot say is dropped **with a warning naming the
+characters**, mirroring the "cannot voice" log the VITS2 frontend emits. Silence
+about dropped text is the specific bug this module is written to prevent.
+
+Latin and Chinese runs are transliterated into Thai script rather than routed to
+another engine: the deployment speaks with one voice, and Thai-accented English
+is what a Thai speaker actually produces for a foreign brand or model name.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Iterable, Iterator, Optional
+
+log = logging.getLogger(__name__)
+
+# The MMS Thai tokenizer's alphabet. Verified byte-identical (same 71 entries,
+# same ids) between facebook/mms-tts-tha and the VIZINTZOR fine-tunes, so it is
+# safe as a default — but ThaiFrontend still prefers the tokens.txt shipped with
+# the loaded model, so a future voice with a different table cannot drift.
+MMS_THAI_VOCAB = frozenset(
+    "านร่เ้องกวะัมทพยลจีคตดหขิแสบปไูใ็ื์ชุึํโผถญซธศณษฟภฉฝฐฤฏฮฆ๋ฎ'0๊ฑ142-ฬฒฌ "
+)
+
+# Obsolete or decorative characters with a spoken equivalent that *is* in the
+# table. ๅ and ฯ have none worth guessing at, so they fall through to the final
+# sweep and are reported as dropped.
+_CHAR_FALLBACKS = {
+    "ฃ": "ข",      # obsolete kho khuat
+    "ฅ": "ค",      # obsolete kho khon
+    "ฦ": "ล",      # obsolete lu
+    "ฺ": "",  # phinthu — a silencing mark, nothing to say
+    "๎": "",  # yamakkan
+    "​": "",  # zero-width space, common in copy-pasted Thai
+}
+
+# Multi-character expansions applied before maiyamok, because ฯลฯ expands *into*
+# a ๆ that then has to be expanded in turn.
+_PHRASE_EXPANSIONS = {
+    "ฯลฯ": "และอื่นๆ",
+    "๏": "",
+    "๚": "",
+    "๛": "",
+    "%": "เปอร์เซ็นต์",
+    "°": "องศา",
+    "+": "บวก",
+    "=": "เท่ากับ",
+    "&": "และ",
+    "@": "แอท",
+}
+
+_THAI_DIGITS = str.maketrans("๐๑๒๓๔๕๖๗๘๙", "0123456789")
+
+# Punctuation becomes a space rather than nothing. Space is in the vocabulary
+# and is Thai's own phrase separator, so this buys the pause the punctuation
+# implied; dropping it instead runs two clauses together.
+_PUNCT_TO_SPACE = re.compile(r"[,.!?;:()\[\]{}<>\"“”„‘’«»/\\|~*#…、。，！？\n\r\t]+")
+
+_THAI_RUN = re.compile(r"[฀-๿]+")
+_CJK_RUN = re.compile(r"[一-鿿㐀-䶿]+")
+_LATIN_RUN = re.compile(r"[A-Za-z][A-Za-z'\-]*")
+# Digit groups, optionally with thousands separators and a decimal part.
+_NUMBER = re.compile(r"\d+(?:,\d{3})*(?:\.\d+)?")
+# Currency, both orders. Thai reads an amount of money with its own units
+# (…บาท…สตางค์), so "฿120.50" is not "120.50" followed by the word for baht —
+# replacing ฿ with บาท on its own produced "บาทหนึ่งร้อยยี่สิบ", the words in the
+# wrong order.
+_CURRENCY = re.compile(
+    r"฿\s*(\d+(?:,\d{3})*(?:\.\d+)?)"
+    r"|(\d+(?:,\d{3})*(?:\.\d+)?)\s*(?:฿|บาท)"
+)
+
+# Above this many digits a group is an identifier (phone, serial, order number)
+# rather than a quantity, and is read digit by digit. Below it, cardinal reading
+# is what a Thai speaker uses for counts, prices and years alike — 2026 reads as
+# สองพันยี่สิบหก, which is correct for the year. A leading zero also forces
+# digit-by-digit: 07 is never "seven".
+_CARDINAL_MAX_DIGITS = 4
+
+_THAI_DIGIT_WORDS = {
+    "0": "ศูนย์", "1": "หนึ่ง", "2": "สอง", "3": "สาม", "4": "สี่",
+    "5": "ห้า", "6": "หก", "7": "เจ็ด", "8": "แปด", "9": "เก้า",
+}
+
+# Thai names of the Latin letters, for acronyms. A Thai speaker says "เอ ไอ" for
+# AI, never a transliterated syllable, so short all-caps tokens take this path.
+_LATIN_LETTER_NAMES = {
+    "a": "เอ", "b": "บี", "c": "ซี", "d": "ดี", "e": "อี", "f": "เอฟ",
+    "g": "จี", "h": "เอช", "i": "ไอ", "j": "เจ", "k": "เค", "l": "แอล",
+    "m": "เอ็ม", "n": "เอ็น", "o": "โอ", "p": "พี", "q": "คิว", "r": "อาร์",
+    "s": "เอส", "t": "ที", "u": "ยู", "v": "วี", "w": "ดับเบิลยู",
+    "x": "เอ็กซ์", "y": "วาย", "z": "แซด",
+}
+
+# Words the deployment actually says, where the rule-based fallback below is
+# either wrong or merely worse than the form Thai speakers already use. This is
+# the list to extend when a name comes out wrong — not the rule table.
+_LATIN_LEXICON = {
+    "robot": "โรบอต",
+    "ok": "โอเค",
+    "okay": "โอเค",
+    "hello": "เฮลโล",
+    "hi": "ไฮ",
+    "wifi": "ไวไฟ",
+    "internet": "อินเทอร์เน็ต",
+    "computer": "คอมพิวเตอร์",
+    "battery": "แบตเตอรี่",
+    "start": "สตาร์ท",
+    "stop": "สตอป",
+    "menu": "เมนู",
+    "email": "อีเมล",
+    "online": "ออนไลน์",
+    "offline": "ออฟไลน์",
+    "server": "เซิร์ฟเวอร์",
+    "sensor": "เซ็นเซอร์",
+    "motor": "มอเตอร์",
+    "camera": "กล้อง",
+    "meter": "เมตร",
+    "metre": "เมตร",
+    "kilometer": "กิโลเมตร",
+    "kilogram": "กิโลกรัม",
+    "gram": "กรัม",
+    "second": "วินาที",
+    "minute": "นาที",
+    "hour": "ชั่วโมง",
+    "bangkok": "กรุงเทพ",
+    "thailand": "ประเทศไทย",
+    "china": "ประเทศจีน",
+    "welcome": "เวลคัม",
+    "thank": "แธงค์",
+    "you": "ยู",
+    "please": "พลีซ",
+    "yes": "เยส",
+    "no": "โน",
+    "error": "เออเรอร์",
+    "test": "เทสต์",
+    "demo": "เดโม",
+}
+
+# ── Latin → Thai rule fallback ────────────────────────────────────────────────
+#
+# A reduced form of the Royal Institute's English transliteration guidance,
+# enough for names and product codes. Digraphs are matched before single letters,
+# so ordering inside each table matters and they are consulted longest-first.
+
+_ONSET_DIGRAPHS = {
+    "sch": "ช", "chr": "คร", "shr": "ชร", "thr": "ธร", "phr": "ฟร",
+    "str": "สตร", "spr": "สปร", "scr": "สคร", "spl": "สปล",
+    "ch": "ช", "sh": "ช", "th": "ธ", "ph": "ฟ", "wh": "ว", "kn": "น",
+    "gh": "ก", "gn": "น", "ps": "ซ", "qu": "คว", "wr": "ร", "rh": "ร",
+    "bl": "บล", "br": "บร", "cl": "คล", "cr": "คร", "dr": "ดร", "fl": "ฟล",
+    "fr": "ฟร", "gl": "กล", "gr": "กร", "pl": "พล", "pr": "พร", "sc": "สค",
+    "sk": "สค", "sl": "สล", "sm": "สม", "sn": "สน", "sp": "สป", "st": "สต",
+    "sw": "สว", "tr": "ทร", "tw": "ทว",
+}
+
+_ONSET_SINGLE = {
+    "b": "บ", "c": "ค", "d": "ด", "f": "ฟ", "g": "ก", "h": "ฮ", "j": "จ",
+    "k": "ค", "l": "ล", "m": "ม", "n": "น", "p": "พ", "q": "ค", "r": "ร",
+    "s": "ส", "t": "ท", "v": "ว", "w": "ว", "x": "ซ", "y": "ย", "z": "ซ",
+}
+
+# khanaa spells a vowel from its abstract form, with อ standing for the onset
+# slot. Long/short choice follows the usual English reading of the grapheme.
+_VOWELS = {
+    "eau": "โอ", "eig": "เอ", "igh": "ไอ",
+    "ai": "เอ", "ay": "เอ", "ea": "อี", "ee": "อี", "ei": "เอ", "eu": "อู",
+    "ew": "อู", "ey": "อี", "ie": "อี", "oa": "โอ", "oe": "โอ", "oi": "ออย",
+    "oo": "อู", "ou": "อาว", "ow": "โอ", "oy": "ออย", "ue": "อู", "ui": "อู",
+    "au": "ออ", "aw": "ออ", "oa r": "ออ",
+    "a": "อา", "e": "เอ", "i": "อิ", "o": "โอ", "u": "อู", "y": "อิ",
+}
+
+# Thai permits only these finals. Anything else is folded onto the nearest one,
+# which is what the Royal Institute rules do too.
+_CODAS = {
+    "ng": "ง", "nk": "ง", "ck": "ก", "gh": "ก", "ph": "ฟ", "sh": "ช",
+    "ch": "ช", "th": "ด", "tch": "ช",
+    "b": "บ", "p": "บ", "f": "ฟ", "v": "ฟ", "d": "ด", "t": "ด", "s": "ส",
+    "z": "ส", "c": "ก", "k": "ก", "g": "ก", "q": "ก", "x": "ก",
+    "m": "ม", "n": "น", "l": "ล", "r": "ร", "y": "ย", "w": "ว", "j": "จ",
+    "h": "",
+}
+
+_LATIN_VOWEL_CHARS = set("aeiouy")
+
+
+def _longest_match(table: dict, text: str, start: int) -> tuple[Optional[str], int]:
+    """Return (mapped, consumed) for the longest key of `table` at text[start:]."""
+    for length in range(min(3, len(text) - start), 0, -1):
+        key = text[start:start + length]
+        if key in table:
+            return table[key], length
+    return None, 0
+
+
+def _split_latin_syllables(word: str) -> list[tuple[str, str, str]]:
+    """Split a lowercase Latin word into (onset, vowel, coda) grapheme groups.
+
+    Deliberately naive — consonant runs, then vowel runs, then the consonants
+    that a following vowel does not claim as its onset. Good enough for names
+    and model codes, which is all the fallback is for; anything that matters is
+    better added to _LATIN_LEXICON than modelled here.
+    """
+    groups: list[tuple[str, str, str]] = []
+    index = 0
+    length = len(word)
+    while index < length:
+        onset_start = index
+        while index < length and word[index] not in _LATIN_VOWEL_CHARS:
+            index += 1
+        onset = word[onset_start:index]
+
+        vowel_start = index
+        while index < length and word[index] in _LATIN_VOWEL_CHARS:
+            index += 1
+        vowel = word[vowel_start:index]
+
+        coda_start = index
+        while index < length and word[index] not in _LATIN_VOWEL_CHARS:
+            index += 1
+        consonants = word[coda_start:index]
+        # A single consonant between two vowels opens the next syllable rather
+        # than closing this one: "moto" is โม-โท, not มด-โท.
+        if index < length and len(consonants) == 1:
+            coda, carry = "", consonants
+        elif index < length and len(consonants) > 1:
+            coda, carry = consonants[:-1], consonants[-1:]
+        else:
+            coda, carry = consonants, ""
+
+        if not vowel and not coda and onset:
+            # All-consonant tail, e.g. the "ng" of a word we already consumed.
+            groups.append((onset, "", ""))
+        elif vowel or onset or coda:
+            groups.append((onset, vowel, coda))
+
+        if carry:
+            word = carry + word[index:]
+            length = len(word)
+            index = 0
+    return groups
+
+
+def _map_group(table: dict, graphemes: str) -> str:
+    """Map a grapheme run through `table`, longest match first, dropping misses."""
+    out: list[str] = []
+    index = 0
+    while index < len(graphemes):
+        mapped, consumed = _longest_match(table, graphemes, index)
+        if mapped is None:
+            index += 1
+            continue
+        out.append(mapped)
+        index += consumed
+    return "".join(out)
+
+
+def _transliterate_latin_word(word: str) -> str:
+    """Latin word → Thai script, via the lexicon then the rule fallback."""
+    lowered = word.lower().strip("'-")
+    if not lowered:
+        return ""
+    if lowered in _LATIN_LEXICON:
+        return _LATIN_LEXICON[lowered]
+    # Acronyms and short codes: Thai speakers spell these out.
+    if word.isupper() and len(lowered) <= 4:
+        return " ".join(_LATIN_LETTER_NAMES.get(ch, "") for ch in lowered).strip()
+
+    try:
+        from khanaa import Kham
+    except ImportError:
+        log.warning("[thai] khanaa is not installed; spelling %r letter by letter", word)
+        return " ".join(_LATIN_LETTER_NAMES.get(ch, "") for ch in lowered).strip()
+
+    syllables: list[str] = []
+    for onset_gr, vowel_gr, coda_gr in _split_latin_syllables(lowered):
+        onset = _map_group(_ONSET_DIGRAPHS, onset_gr) or _map_group(_ONSET_SINGLE, onset_gr)
+        vowel, _ = _longest_match(_VOWELS, vowel_gr, 0)
+        coda = _map_group(_CODAS, coda_gr)
+        if not vowel:
+            # Consonant-only group: give it the inherent short vowel so it is
+            # pronounceable at all rather than dropped.
+            vowel = "อะ" if onset else ""
+        if not onset and not vowel:
+            continue
+        if not onset:
+            onset = "อ"      # ตัวเต็ม placeholder onset for a vowel-initial syllable
+        try:
+            syllables.append(Kham(onset=onset, vowel=vowel, coda=coda).form)
+        except Exception:
+            # khanaa refuses impossible combinations (e.g. a coda the vowel
+            # already carries). Keep the syllable audible rather than losing it.
+            log.debug("[thai] khanaa refused onset=%r vowel=%r coda=%r from %r",
+                      onset, vowel, coda, word)
+            try:
+                syllables.append(Kham(onset=onset, vowel=vowel).form)
+            except Exception:
+                continue
+    return "".join(syllables)
+
+
+def _transliterate_cjk(run: str) -> str:
+    """Chinese → Thai script, via pinyin and the Royal Institute's zh rules.
+
+    pypinyin is already an image dependency (the VITS2 ZH frontend uses it) and
+    wunsen transliterates *from* numeric-tone pinyin, so the two compose. Both
+    are optional here: without them the run falls through to the final sweep and
+    is reported as dropped rather than silently vanishing.
+    """
+    try:
+        from pypinyin import Style, lazy_pinyin
+        from wunsen import ThapSap
+    except ImportError:
+        log.warning("[thai] pypinyin/wunsen unavailable; cannot say Chinese %r", run)
+        return ""
+    try:
+        pinyin = lazy_pinyin(run, style=Style.TONE3, neutral_tone_with_five=False)
+        return ThapSap("zh", system="RI49").thap(" ".join(pinyin))
+    except Exception as error:
+        log.warning("[thai] Chinese transliteration failed for %r: %s", run, error)
+        return ""
+
+
+def _number_to_thai(literal: str) -> str:
+    """Read a digit group as Thai words."""
+    from pythainlp.util import num_to_thaiword
+
+    cleaned = literal.replace(",", "")
+    integer, _, fraction = cleaned.partition(".")
+
+    digit_by_digit = (
+        len(integer) > _CARDINAL_MAX_DIGITS
+        or (len(integer) > 1 and integer.startswith("0"))
+    )
+    if digit_by_digit:
+        head = "".join(_THAI_DIGIT_WORDS.get(ch, "") for ch in integer)
+    else:
+        try:
+            head = num_to_thaiword(int(integer))
+        except Exception:
+            head = "".join(_THAI_DIGIT_WORDS.get(ch, "") for ch in integer)
+
+    if not fraction:
+        return head
+    # num_to_thaiword_float only exists on pythainlp's dev branch, so the
+    # fractional part is spelled out digit by digit after จุด — which is also
+    # how Thai reads decimals aloud.
+    tail = "".join(_THAI_DIGIT_WORDS.get(ch, "") for ch in fraction)
+    return f"{head}จุด{tail}"
+
+
+class ThaiFrontend:
+    """Turn arbitrary text into something the MMS Thai tokenizer can say.
+
+    `vocab` should be the character set of the loaded model's tokens.txt. It
+    defaults to MMS_THAI_VOCAB so the class is unit-testable without a model,
+    but the adapter passes the real set: the final sweep is only a guarantee if
+    it is checked against the model actually running.
+    """
+
+    def __init__(self, vocab: Optional[Iterable[str]] = None,
+                 phrase_spacing: bool = False):
+        self._vocab = frozenset(vocab) if vocab else MMS_THAI_VOCAB
+        # Inserting a space at every word boundary is *not* obviously right: MMS
+        # was trained on Thai that only spaces phrase boundaries, so per-word
+        # spacing may hurt prosody rather than help it. Off until measured on
+        # device.
+        self._phrase_spacing = phrase_spacing
+        if "ำ" in self._vocab:
+            # A future voice whose table does have sara am needs no rewrite, and
+            # rewriting anyway would be wrong.
+            log.info("[thai] model vocabulary includes ำ; skipping the sara-am rewrite")
+
+    # ── normalisation ────────────────────────────────────────────────────
+
+    def normalize(self, text: str) -> str:
+        """Return text containing only characters the model can pronounce."""
+        if not text:
+            return ""
+
+        stage = self._pre_clean(text)
+        stage = self._expand_maiyamok(stage)
+        # Numbers first: the punctuation sweep below turns "." and "," into
+        # spaces, which cuts "1,250.50" into three unrelated numbers read as
+        # "one / two hundred fifty / fifty".
+        stage = _CURRENCY.sub(self._currency_to_thai, stage)
+        stage = _NUMBER.sub(lambda m: _number_to_thai(m.group(0)), stage)
+        stage = _PUNCT_TO_SPACE.sub(" ", stage)
+        stage = self._transliterate_foreign(stage)
+        stage = self._rewrite_sara_am(stage)
+        if self._phrase_spacing:
+            stage = self._space_words(stage)
+        stage = self._drop_unspeakable(stage)
+        return re.sub(r"\s{2,}", " ", stage).strip()
+
+    @staticmethod
+    def _currency_to_thai(match: "re.Match[str]") -> str:
+        """Read a money amount with Thai's own units via bahttext."""
+        literal = (match.group(1) or match.group(2) or "").replace(",", "")
+        if not literal:
+            return match.group(0)
+        try:
+            from pythainlp.util import bahttext
+
+            return bahttext(float(literal))
+        except Exception as error:
+            log.warning("[thai] bahttext failed for %r: %s", literal, error)
+            return f"{_number_to_thai(literal)}บาท"
+
+    def _pre_clean(self, text: str) -> str:
+        for source, target in _PHRASE_EXPANSIONS.items():
+            if source in text:
+                text = text.replace(source, target)
+        text = text.translate(_THAI_DIGITS)
+        for source, target in _CHAR_FALLBACKS.items():
+            if source in text:
+                text = text.replace(source, target)
+        try:
+            from pythainlp.util import normalize as thai_normalize
+            from pythainlp.util import remove_zw
+            # normalize() fixes reordered vowel/tone sequences and duplicated
+            # marks — both produce a valid-looking string the model mispronounces.
+            text = thai_normalize(remove_zw(text))
+        except ImportError:
+            log.warning("[thai] pythainlp unavailable; skipping Thai normalisation")
+        return text
+
+    @staticmethod
+    def _expand_maiyamok(text: str) -> str:
+        if "ๆ" not in text:
+            return text
+        try:
+            from pythainlp.util import expand_maiyamok
+        except ImportError:
+            log.warning("[thai] pythainlp unavailable; ๆ will be dropped")
+            return text
+        try:
+            return "".join(expand_maiyamok(text))
+        except Exception as error:
+            log.warning("[thai] ๆ expansion failed: %s", error)
+            return text
+
+    def _transliterate_foreign(self, text: str) -> str:
+        text = _CJK_RUN.sub(lambda m: _transliterate_cjk(m.group(0)), text)
+        return _LATIN_RUN.sub(lambda m: _transliterate_latin_word(m.group(0)), text)
+
+    def _rewrite_sara_am(self, text: str) -> str:
+        """ำ → ํ + า, the spelling MMS's character table actually has."""
+        if "ำ" in self._vocab:
+            return text
+        return text.replace("ำ", "ํา")
+
+    @staticmethod
+    def _space_words(text: str) -> str:
+        try:
+            from pythainlp.tokenize import word_tokenize
+        except ImportError:
+            return text
+        return " ".join(word_tokenize(text, engine="newmm", keep_whitespace=False))
+
+    def _drop_unspeakable(self, text: str) -> str:
+        kept: list[str] = []
+        dropped: list[str] = []
+        for char in text:
+            if char in self._vocab:
+                kept.append(char)
+            elif char.isspace():
+                kept.append(" ")
+            else:
+                dropped.append(char)
+        if dropped:
+            # Named, not counted: the ZH/EN frontend learned the hard way that a
+            # silent drop reads downstream as a model bug. See
+            # tests/test_vits2_frontend.py::test_unvoiceable_characters_do_not_
+            # silence_the_rest.
+            log.warning("[thai] no pronunciation for %s; not in the audio",
+                        ", ".join(sorted(set(dropped))))
+        return "".join(kept)
+
+    # ── chunking ─────────────────────────────────────────────────────────
+
+    def iter_chunks(self, text: str, max_chars: int = 180) -> Iterator[str]:
+        """Split normalised text into synthesis chunks.
+
+        Splits on Thai's own phrase separator — the space — rather than calling
+        pythainlp's sent_tokenize, whose default `crfcut` engine needs
+        python-crfsuite. That is a compiled wheel and one more thing to build
+        for arm64, for a job a whitespace split already does: Thai marks clause
+        boundaries with spaces and has no sentence-final period.
+        """
+        text = text.strip()
+        if not text:
+            return
+        if len(text) <= max_chars:
+            yield text
+            return
+
+        chunk: list[str] = []
+        size = 0
+        for piece in text.split(" "):
+            if not piece:
+                continue
+            if size and size + 1 + len(piece) > max_chars:
+                yield " ".join(chunk)
+                chunk, size = [piece], len(piece)
+            else:
+                chunk.append(piece)
+                size += (1 if size else 0) + len(piece)
+        # A single phrase longer than the budget has no space to split on; hand
+        # it over whole rather than cutting mid-syllable, which would change the
+        # pronunciation.
+        if chunk:
+            yield " ".join(chunk)

--- a/perception/plugins/tts.py
+++ b/perception/plugins/tts.py
@@ -1,8 +1,11 @@
 #!/usr/bin/env python3
 """
-plugins/tts.py — TTSPlugin: sherpa-onnx VITS TTS.
+plugins/tts.py — the TTS tool contract and its ONNX Runtime engines.
 
-On-device text-to-speech using sherpa-onnx MeloTTS (Chinese + English).
+Engines are named after the model, not the runtime: `vits2` (ZH/EN, TensorRT,
+implemented in plugins/vits2_tts_trt), `matcha` (ZH/EN, Matcha-icefall) and
+`mms_thai` (Thai, MMS VITS). The last two both run on sherpa-onnx, which is why
+naming either of them after the framework did not work.
 """
 
 from __future__ import annotations
@@ -173,20 +176,31 @@ TOOLS = [
                 # builds the config form from configSchema, so an engine that
                 # exists solely as a baked YAML key cannot be seen or switched
                 # without rebuilding the image. Mirrors asr_model in asr.py.
-                "tts_engine": {"type": "string", "enum": ["vits2_trt", "sherpa_onnx"],
-                               "description": "TTS engine (vits2_trt = VITS2 TensorRT on Jetson, "
-                                              "sherpa_onnx = sherpa-onnx Matcha)",
-                               "default": "vits2_trt", "scope": "shared"},
-                # sherpa_onnx only — vits2_trt is a TensorRT engine and never
-                # touches ONNX Runtime, so this field does nothing for it. Matcha's
-                # weights are fp32, so both devices load the same files and only
-                # the provider changes; measured 4.3x faster on gpu.
+                "tts_engine": {"type": "string", "enum": ["vits2", "matcha", "mms_thai"],
+                               "description": "TTS engine, named by model "
+                                              "(vits2 = VITS2 ZH/EN on TensorRT, "
+                                              "matcha = Matcha-icefall ZH/EN, "
+                                              "mms_thai = MMS Thai, Thai only)",
+                               "default": "vits2", "scope": "shared"},
+                # matcha and mms_thai only — vits2 is a TensorRT engine and never
+                # touches ONNX Runtime, so this field does nothing for it.
+                # Matcha's weights are fp32, so both devices load the same files and
+                # only the provider changes; measured 4.3x faster on gpu.
                 "device":      {"type": "string", "enum": ["cpu", "gpu"],
-                                "description": "Inference device for the sherpa_onnx engine "
+                                "description": "Inference device for the ONNX Runtime engines "
                                                "(gpu needs the CUDA sherpa-onnx wheel; ~4.3x faster)",
                                 "default": "cpu", "scope": "shared",
-                                "x-show-when": {"tts_engine": "sherpa_onnx"}},
-                "speaker_id": {"type": "integer", "description": "Speaker ID (VITS2 supports 0 only)", "default": 0, "scope": "shared"},
+                                "x-show-when": {"tts_engine": ["matcha", "mms_thai"]}},
+                # Thai has no spaces between words, and MMS was trained on text
+                # that spaced only phrase boundaries. Segmenting every word may
+                # help prosody or hurt it — off until it has been A/B'd on device.
+                "thai_phrase_spacing": {
+                    "type": "boolean",
+                    "description": "Insert word boundaries before synthesis (Thai only; "
+                                   "experimental — may change prosody either way)",
+                    "default": False, "scope": "shared",
+                    "x-show-when": {"tts_engine": "mms_thai"}},
+                "speaker_id": {"type": "integer", "description": "Speaker ID (vits2 and mms_thai support 0 only)", "default": 0, "scope": "shared"},
                 "speed":      {"type": "number", "description": "Speech speed (1.0 = normal)", "default": 1.0, "scope": "shared"},
             },
             "required": []
@@ -208,7 +222,7 @@ class TTSAdapter(ABC):
         yield self.synthesize(text)
 
 
-class SherpaOnnxTTSAdapter(TTSAdapter):
+class MatchaTTSAdapter(TTSAdapter):
     """On-device TTS using sherpa-onnx Matcha (flow-matching, fast non-autoregressive)."""
 
     def __init__(self, model_dir: str, speaker_id: int = 0, speed: float = 1.0,
@@ -275,16 +289,193 @@ class SherpaOnnxTTSAdapter(TTSAdapter):
             yield pcm[i:i + CHUNK_BYTES]
 
 
+class MmsThaiTTSAdapter(TTSAdapter):
+    """On-device Thai TTS using sherpa-onnx VITS (MMS Thai, character-level).
+
+    A separate adapter rather than a flag on the Matcha one: the two share no
+    model file. Matcha is an acoustic model plus a vocos vocoder and reads ZH rule
+    FSTs; MMS VITS is end-to-end, has no vocoder, and has no rule FSTs at all
+    because sherpa-onnx ships none for Thai. Everything Thai-specific therefore
+    happens in Python, in plugins/thai_frontend.py, before the text gets here.
+
+    The frontend is not optional. The tokenizer is character-level over 71
+    characters and silently drops the rest, so unnormalised text loses its digits,
+    its Latin words, and — because ``ำ`` is not in the table — the vowel of a
+    large fraction of ordinary Thai words.
+    """
+
+    def __init__(self, model_dir: str, speaker_id: int = 0, speed: float = 1.0,
+                 device: str = "cpu", phrase_spacing: bool = False):
+        import os
+        from utils.model_downloader import ensure_thai_tts_model
+        from utils.onnx_provider import provider_for_device
+
+        if speaker_id != 0:
+            # MMS Thai is single-speaker. Accepting a stray id would silently
+            # synthesize speaker 0 anyway and make the card look configurable.
+            raise ValueError(
+                f"the Thai VITS model has one speaker; speaker_id must be 0, got {speaker_id}"
+            )
+
+        model_dir = ensure_thai_tts_model(model_dir)
+        model_path = os.path.join(model_dir, "model.onnx")
+        tokens_path = os.path.join(model_dir, "tokens.txt")
+        for path in (model_path, tokens_path):
+            if not os.path.exists(path):
+                raise FileNotFoundError(f"Thai TTS model is incomplete: {path} is missing")
+        _validate_thai_manifest(model_dir)
+
+        import sherpa_onnx
+
+        provider = provider_for_device(device, (model_path,))
+        tts_config = sherpa_onnx.OfflineTtsConfig(
+            model=sherpa_onnx.OfflineTtsModelConfig(
+                vits=sherpa_onnx.OfflineTtsVitsModelConfig(
+                    model=model_path,
+                    tokens=tokens_path,
+                    # Character-level: no lexicon, and no espeak-ng data dir.
+                    # Passing either makes sherpa-onnx take a phoneme path this
+                    # model was not trained for.
+                    lexicon="",
+                    data_dir="",
+                    length_scale=1.0 / speed if speed else 1.0,
+                ),
+                num_threads=2,
+                provider=provider,
+            ),
+            # No rule_fsts: sherpa-onnx has no Thai number/date FSTs. That work is
+            # thai_frontend.normalize()'s, and it has to happen anyway because the
+            # digits 3 and 5-9 are not in the token table at all.
+            rule_fsts="",
+        )
+        self._tts = sherpa_onnx.OfflineTts(tts_config)
+
+        model_rate = int(getattr(self._tts, "sample_rate", 0) or 0)
+        if model_rate and model_rate != SAMPLE_RATE:
+            # The ROS topic is audio/pcm-16k and the pacing constants are derived
+            # from that rate, so a 22.05 kHz voice would not merely need resampling
+            # — it would play back at the wrong pitch *and* drift against the
+            # 100 ms frame clock. Refuse instead. (FEMALEV2 is 22.05 kHz; MALE-
+            # NARRATOR is 16 kHz, which is why that one is the packaged voice.)
+            raise RuntimeError(
+                f"Thai TTS model is {model_rate} Hz but the audio pipeline is "
+                f"{SAMPLE_RATE} Hz; a resampler would have to be added first"
+            )
+
+        from plugins.thai_frontend import ThaiFrontend
+
+        self._frontend = ThaiFrontend(
+            vocab=_read_token_chars(tokens_path),
+            phrase_spacing=phrase_spacing,
+        )
+        self._sid = speaker_id
+        self._speed = speed
+        log.info(f"[tts] sherpa-onnx Thai VITS loaded: model_dir={model_dir}, "
+                 f"speed={speed}, device={device}, provider={provider}, "
+                 f"sample_rate={model_rate or SAMPLE_RATE}")
+
+    def synthesize(self, text: str) -> bytes:
+        return b''.join(self.synthesize_stream(text))
+
+    def synthesize_stream(self, text: str):
+        import struct
+
+        normalized = self._frontend.normalize(text)
+        if not normalized:
+            log.warning("[tts] nothing speakable left in %r after Thai normalisation", text)
+            return
+        for chunk in self._frontend.iter_chunks(normalized):
+            audio = self._tts.generate(chunk, sid=self._sid, speed=self._speed)
+            float_samples = audio.samples
+            pcm = struct.pack(f'<{len(float_samples)}h',
+                              *[int(max(-32768, min(32767, s * 32767))) for s in float_samples])
+            for i in range(0, len(pcm), CHUNK_BYTES):
+                yield pcm[i:i + CHUNK_BYTES]
+
+
+def _validate_thai_manifest(model_dir: str) -> None:
+    """Check the release's manifest before sherpa-onnx gets a chance to exit(-1).
+
+    sherpa-onnx picks its text frontend from the ONNX `frontend` metadata string,
+    and only the exact value "characters" selects the character-level path this
+    model needs. Any other value reaches a branch that logs "Not a model using
+    characters as modeling unit" and calls `SHERPA_ONNX_EXIT(-1)` — a **process
+    exit**, so main.py's try/except around the TTS plugin cannot turn it into a
+    card in `state: error`; it takes ASR, VOP and OCR down with it.
+
+    The manifest that tools/export_mms_thai_onnx.py writes alongside the model
+    records what it set, so a mismatched or hand-assembled release fails here as
+    an ordinary exception instead. Mirrors _validate_manifest in
+    plugins/vits2_tts_trt/runtime/backends/trt_numpy_tts_engine.py.
+    """
+    import os
+
+    manifest_path = os.path.join(model_dir, "manifest.json")
+    if not os.path.exists(manifest_path):
+        raise FileNotFoundError(
+            f"{manifest_path} is missing; this release was not produced by "
+            "tools/export_mms_thai_onnx.py and cannot be checked before load"
+        )
+    with open(manifest_path, encoding="utf-8") as handle:
+        manifest = json.load(handle)
+
+    frontend = manifest.get("frontend")
+    if frontend != "characters":
+        raise RuntimeError(
+            f"Thai TTS release declares frontend={frontend!r}; sherpa-onnx needs "
+            "'characters' and hard-exits the process on anything else"
+        )
+    rate = int(manifest.get("sample_rate") or 0)
+    if rate != SAMPLE_RATE:
+        raise RuntimeError(
+            f"Thai TTS release is {rate} Hz but the audio pipeline is "
+            f"{SAMPLE_RATE} Hz; a resampler would have to be added first"
+        )
+    speakers = int(manifest.get("n_speakers") or 1)
+    if speakers != 1:
+        raise RuntimeError(
+            f"Thai TTS release declares {speakers} speakers; the adapter only "
+            "supports a single-speaker model"
+        )
+
+
+def _read_token_chars(tokens_path: str) -> set:
+    """Read the model's own token table so the frontend checks against it.
+
+    The frontend has a hardcoded copy for unit tests, but the guarantee "the
+    output only contains characters this model can say" is only true if it is
+    checked against the model that is actually loaded.
+    """
+    chars = set()
+    with open(tokens_path, encoding="utf-8") as handle:
+        for line in handle:
+            line = line.rstrip("\n")
+            if not line:
+                continue
+            # "<token> <id>", and the token may itself be a space — so split off
+            # the id from the right rather than splitting the line.
+            token, _, _ = line.rpartition(" ")
+            if token:
+                chars.add(token)
+    return chars
 
 
 def _build_tts_adapter(cfg: dict) -> TTSAdapter:
     import os
     from utils.onnx_provider import normalize_device
-    model_dir = cfg.get('model_dir', '/models/sherpa-onnx/tts')
+    engine = str(cfg.get('engine', '')).lower()
+    default_dir = ('/models/mms-thai' if engine == 'mms_thai'
+                   else '/models/sherpa-onnx/tts')
+    model_dir = cfg.get('model_dir', default_dir)
     speaker_id = int(cfg.get('speaker_id', 0))
     speed = float(cfg.get('speed', 1.0))
     device = normalize_device(cfg.get('device'), cfg.get('hw_provider'))
-    return SherpaOnnxTTSAdapter(model_dir, speaker_id, speed, device)
+    if engine == 'mms_thai':
+        return MmsThaiTTSAdapter(
+            model_dir, speaker_id, speed, device,
+            phrase_spacing=bool(cfg.get('thai_phrase_spacing', False)),
+        )
+    return MatchaTTSAdapter(model_dir, speaker_id, speed, device)
 
 
 # ── ROS2 Node ─────────────────────────────────────────────────────────────────
@@ -915,13 +1106,31 @@ class SherpaOnnxTTSPlugin:
         return self._adapter.synthesize(text)
 
 
-DEFAULT_TTS_ENGINE = "vits2_trt"
-TTS_ENGINES = ("vits2_trt", "sherpa_onnx")
+DEFAULT_TTS_ENGINE = "vits2"
+# Named after the model, not the runtime that happens to execute it. Two of these
+# run on sherpa-onnx, so a name like "sherpa_onnx" said nothing about what you
+# would hear and left no room for the second one.
+TTS_ENGINES = ("vits2", "matcha", "mms_thai")
+# The old runtime-flavoured names, still accepted. They are not decoration: both
+# are already persisted in ConfigDB rows and in config.yaml on every deployed
+# robot, and _select_engine raises on an unknown engine — so dropping them would
+# turn every existing TTS card into "Unsupported TTS engine" on the next restart.
+ENGINE_ALIASES = {
+    "vits2_trt": "vits2",
+    "sherpa_onnx": "matcha",
+    "sherpa_thai": "mms_thai",   # only ever existed on this branch
+}
 # Where each engine keeps its own model files. Used for any engine other than
 # the one config.yaml was written for; see TTSPlugin._model_dir_for.
 ENGINE_MODEL_DIRS = {
-    "vits2_trt": "/models/vits2",
-    "sherpa_onnx": "/models/sherpa-onnx/tts",
+    "vits2": "/models/vits2",
+    # Kept at the old path: it is already populated on deployed robots and
+    # renaming it would force every one of them to re-download the Matcha pair.
+    "matcha": "/models/sherpa-onnx/tts",
+    # Its own directory, not a sibling file in the Matcha one: both engines call
+    # their weights by different names but share nothing, and pointing them at one
+    # directory is the mistake ENGINE_MODEL_DIRS exists to prevent.
+    "mms_thai": "/models/mms-thai",
 }
 # How long an `action=config` engine switch waits for the new engine before
 # answering `loading`. Sized so the bounded part of a build finishes inside it
@@ -997,6 +1206,10 @@ class TTSPlugin:
     @staticmethod
     def _select_engine(value) -> str:
         engine = str(value or DEFAULT_TTS_ENGINE).strip().lower()
+        # Resolve before validating, so a stored "sherpa_onnx" keeps working and
+        # everything downstream — _build, ENGINE_MODEL_DIRS, the `engine` field in
+        # info — sees only the current name.
+        engine = ENGINE_ALIASES.get(engine, engine)
         if engine not in TTS_ENGINES:
             raise ValueError(f"Unsupported TTS engine: {engine}")
         return engine
@@ -1010,7 +1223,7 @@ class TTSPlugin:
         cfg = dict(self._cfg)
         cfg["engine"] = engine
         cfg["model_dir"] = self._model_dir_for(engine)
-        impl = (self._build_vits2(cfg) if engine == "vits2_trt"
+        impl = (self._build_vits2(cfg) if engine == "vits2"
                 else SherpaOnnxTTSPlugin(cfg, self._executor))
         # An implementation may swallow its own model-load failure and come back
         # as an object that reports error through info (sherpa does exactly

--- a/perception/plugins/tts.py
+++ b/perception/plugins/tts.py
@@ -2,10 +2,10 @@
 """
 plugins/tts.py — the TTS tool contract and its ONNX Runtime engines.
 
-Engines are named after the model, not the runtime: `vits2` (ZH/EN, TensorRT,
-implemented in plugins/vits2_tts_trt), `matcha` (ZH/EN, Matcha-icefall) and
-`mms_thai` (Thai, MMS VITS). The last two both run on sherpa-onnx, which is why
-naming either of them after the framework did not work.
+Engines are named `<model>-<languages>`, the same shape `asr_model` uses:
+`vits2-zh-en` (TensorRT, implemented in plugins/vits2_tts_trt), `matcha-zh-en`
+(Matcha-icefall) and `mms-th` (MMS VITS). The last two both run on sherpa-onnx,
+which is why naming either of them after the framework did not work.
 """
 
 from __future__ import annotations
@@ -176,21 +176,22 @@ TOOLS = [
                 # builds the config form from configSchema, so an engine that
                 # exists solely as a baked YAML key cannot be seen or switched
                 # without rebuilding the image. Mirrors asr_model in asr.py.
-                "tts_engine": {"type": "string", "enum": ["vits2", "matcha", "mms_thai"],
-                               "description": "TTS engine, named by model "
-                                              "(vits2 = VITS2 ZH/EN on TensorRT, "
-                                              "matcha = Matcha-icefall ZH/EN, "
-                                              "mms_thai = MMS Thai, Thai only)",
-                               "default": "vits2", "scope": "shared"},
-                # matcha and mms_thai only — vits2 is a TensorRT engine and never
-                # touches ONNX Runtime, so this field does nothing for it.
+                "tts_engine": {"type": "string",
+                               "enum": ["vits2-zh-en", "matcha-zh-en", "mms-th"],
+                               "description": "TTS engine, named <model>-<languages> to match "
+                                              "asr_model (vits2-zh-en = VITS2 on TensorRT, "
+                                              "matcha-zh-en = Matcha-icefall, "
+                                              "mms-th = MMS Thai)",
+                               "default": "vits2-zh-en", "scope": "shared"},
+                # matcha-zh-en and mms-th only — vits2-zh-en is a TensorRT engine
+                # and never touches ONNX Runtime, so this field does nothing for it.
                 # Matcha's weights are fp32, so both devices load the same files and
                 # only the provider changes; measured 4.3x faster on gpu.
                 "device":      {"type": "string", "enum": ["cpu", "gpu"],
                                 "description": "Inference device for the ONNX Runtime engines "
                                                "(gpu needs the CUDA sherpa-onnx wheel; ~4.3x faster)",
                                 "default": "cpu", "scope": "shared",
-                                "x-show-when": {"tts_engine": ["matcha", "mms_thai"]}},
+                                "x-show-when": {"tts_engine": ["matcha-zh-en", "mms-th"]}},
                 # Thai has no spaces between words, and MMS was trained on text
                 # that spaced only phrase boundaries. Segmenting every word may
                 # help prosody or hurt it — off until it has been A/B'd on device.
@@ -199,8 +200,8 @@ TOOLS = [
                     "description": "Insert word boundaries before synthesis (Thai only; "
                                    "experimental — may change prosody either way)",
                     "default": False, "scope": "shared",
-                    "x-show-when": {"tts_engine": "mms_thai"}},
-                "speaker_id": {"type": "integer", "description": "Speaker ID (vits2 and mms_thai support 0 only)", "default": 0, "scope": "shared"},
+                    "x-show-when": {"tts_engine": "mms-th"}},
+                "speaker_id": {"type": "integer", "description": "Speaker ID (vits2-zh-en and mms-th support 0 only)", "default": 0, "scope": "shared"},
                 "speed":      {"type": "number", "description": "Speech speed (1.0 = normal)", "default": 1.0, "scope": "shared"},
             },
             "required": []
@@ -464,13 +465,13 @@ def _build_tts_adapter(cfg: dict) -> TTSAdapter:
     import os
     from utils.onnx_provider import normalize_device
     engine = str(cfg.get('engine', '')).lower()
-    default_dir = ('/models/mms-thai' if engine == 'mms_thai'
+    default_dir = ('/models/mms-th' if engine == 'mms-th'
                    else '/models/sherpa-onnx/tts')
     model_dir = cfg.get('model_dir', default_dir)
     speaker_id = int(cfg.get('speaker_id', 0))
     speed = float(cfg.get('speed', 1.0))
     device = normalize_device(cfg.get('device'), cfg.get('hw_provider'))
-    if engine == 'mms_thai':
+    if engine == 'mms-th':
         return MmsThaiTTSAdapter(
             model_dir, speaker_id, speed, device,
             phrase_spacing=bool(cfg.get('thai_phrase_spacing', False)),
@@ -1106,31 +1107,41 @@ class SherpaOnnxTTSPlugin:
         return self._adapter.synthesize(text)
 
 
-DEFAULT_TTS_ENGINE = "vits2"
-# Named after the model, not the runtime that happens to execute it. Two of these
-# run on sherpa-onnx, so a name like "sherpa_onnx" said nothing about what you
-# would hear and left no room for the second one.
-TTS_ENGINES = ("vits2", "matcha", "mms_thai")
-# The old runtime-flavoured names, still accepted. They are not decoration: both
-# are already persisted in ConfigDB rows and in config.yaml on every deployed
-# robot, and _select_engine raises on an unknown engine — so dropping them would
-# turn every existing TTS card into "Unsupported TTS engine" on the next restart.
+DEFAULT_TTS_ENGINE = "vits2-zh-en"
+# `<model>-<languages>`, the shape `asr_model` in plugins/asr.py already uses
+# (x-asr-zh-en, paraformer-zh-en, zipformer-en). Two reasons to match it rather
+# than invent a second convention: the dashboard renders the raw enum string, so
+# this is what an operator reads in the dropdown right next to the ASR one; and
+# naming an engine after its runtime said nothing about what you would hear —
+# `matcha` and `mms-th` both run on sherpa-onnx.
+#
+# Language codes, not country codes: `zh`, not `cn`.
+TTS_ENGINES = ("vits2-zh-en", "matcha-zh-en", "mms-th")
+# Older spellings, still accepted. `vits2_trt` and `sherpa_onnx` are not
+# decoration: both are already persisted in ConfigDB rows and in config.yaml on
+# every deployed robot, and _select_engine raises on an unknown engine — so
+# dropping them would turn every existing TTS card into "Unsupported TTS engine"
+# on the next restart. The bare `vits2`/`matcha`/`mms_thai` forms existed only on
+# this branch before the languages were added, and cost one line each to keep.
 ENGINE_ALIASES = {
-    "vits2_trt": "vits2",
-    "sherpa_onnx": "matcha",
-    "sherpa_thai": "mms_thai",   # only ever existed on this branch
+    "vits2-trt": "vits2-zh-en",
+    "vits2": "vits2-zh-en",
+    "sherpa-onnx": "matcha-zh-en",
+    "matcha": "matcha-zh-en",
+    "mms-thai": "mms-th",
+    "mms-tts-thai": "mms-th",
 }
 # Where each engine keeps its own model files. Used for any engine other than
 # the one config.yaml was written for; see TTSPlugin._model_dir_for.
 ENGINE_MODEL_DIRS = {
-    "vits2": "/models/vits2",
+    "vits2-zh-en": "/models/vits2",
     # Kept at the old path: it is already populated on deployed robots and
     # renaming it would force every one of them to re-download the Matcha pair.
-    "matcha": "/models/sherpa-onnx/tts",
+    "matcha-zh-en": "/models/sherpa-onnx/tts",
     # Its own directory, not a sibling file in the Matcha one: both engines call
     # their weights by different names but share nothing, and pointing them at one
     # directory is the mistake ENGINE_MODEL_DIRS exists to prevent.
-    "mms_thai": "/models/mms-thai",
+    "mms-th": "/models/mms-th",
 }
 # How long an `action=config` engine switch waits for the new engine before
 # answering `loading`. Sized so the bounded part of a build finishes inside it
@@ -1206,7 +1217,11 @@ class TTSPlugin:
     @staticmethod
     def _select_engine(value) -> str:
         engine = str(value or DEFAULT_TTS_ENGINE).strip().lower()
-        # Resolve before validating, so a stored "sherpa_onnx" keeps working and
+        # Underscores fold to hyphens before the alias lookup, so both the stored
+        # `vits2_trt` and a hand-typed `vits2_zh_en` land on the same key and the
+        # alias table only has to spell each old name once.
+        engine = engine.replace("_", "-")
+        # Resolve before validating, so a stored `sherpa_onnx` keeps working and
         # everything downstream — _build, ENGINE_MODEL_DIRS, the `engine` field in
         # info — sees only the current name.
         engine = ENGINE_ALIASES.get(engine, engine)
@@ -1223,7 +1238,7 @@ class TTSPlugin:
         cfg = dict(self._cfg)
         cfg["engine"] = engine
         cfg["model_dir"] = self._model_dir_for(engine)
-        impl = (self._build_vits2(cfg) if engine == "vits2"
+        impl = (self._build_vits2(cfg) if engine == "vits2-zh-en"
                 else SherpaOnnxTTSPlugin(cfg, self._executor))
         # An implementation may swallow its own model-load failure and come back
         # as an object that reports error through info (sherpa does exactly

--- a/perception/tests/test_thai_frontend.py
+++ b/perception/tests/test_thai_frontend.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+"""
+tests/test_thai_frontend.py — the Thai TTS text frontend.
+
+Pure Python: no model, no ROS, no sherpa-onnx. What it guards is one property,
+and the whole engine depends on it — **every character the frontend emits must be
+one the MMS Thai tokenizer can actually pronounce.** Anything else is skipped
+during synthesis with only a C++ stderr line to show for it, so the audio just
+comes back short. Same failure the ZH/EN frontend records in
+test_vits2_frontend.py::test_digits_are_not_stripped_by_the_chinese_path.
+
+The optional transliteration deps (pythainlp, wunsen/khanaa, pypinyin) are not
+installed on every dev host. Tests that need one skip; the vocabulary-containment
+tests do not, because that guarantee has to hold on any host.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from plugins.thai_frontend import MMS_THAI_VOCAB, ThaiFrontend
+
+
+def _have(module: str) -> bool:
+    try:
+        __import__(module)
+        return True
+    except ImportError:
+        return False
+
+
+needs_pythainlp = pytest.mark.skipif(
+    not _have("pythainlp"), reason="pythainlp is not installed on this host"
+)
+needs_khanaa = pytest.mark.skipif(
+    not _have("khanaa"), reason="khanaa is not installed on this host"
+)
+needs_pypinyin = pytest.mark.skipif(
+    not (_have("pypinyin") and _have("wunsen")),
+    reason="pypinyin/wunsen are not installed on this host",
+)
+
+
+@pytest.fixture
+def frontend():
+    return ThaiFrontend()
+
+
+def _assert_speakable(text: str) -> None:
+    """The single invariant: nothing outside the model's alphabet survives."""
+    stray = sorted({ch for ch in text if ch not in MMS_THAI_VOCAB})
+    assert not stray, f"{stray} cannot be pronounced by the model but reached it"
+
+
+# ── the vocabulary itself ────────────────────────────────────────────────────
+
+def test_the_alphabet_matches_what_the_model_ships():
+    # 71 tokens, the count the exported tokens.txt has. A silent change here
+    # would move the goalposts for every other test in this file.
+    assert len(MMS_THAI_VOCAB) == 71
+
+
+def test_sara_am_really_is_absent_which_is_why_it_is_rewritten():
+    """The premise of _rewrite_sara_am. If this ever fails, drop the rewrite."""
+    assert "ำ" not in MMS_THAI_VOCAB
+    # …and both halves of the replacement are present, or the rewrite would only
+    # trade one unpronounceable character for two.
+    assert "ํ" in MMS_THAI_VOCAB
+    assert "า" in MMS_THAI_VOCAB
+
+
+def test_most_arabic_digits_are_absent_which_is_why_numbers_are_spelled_out():
+    """Only 0 1 2 4 are in the table — 3 and 5-9 are not."""
+    assert {"0", "1", "2", "4"} <= set(MMS_THAI_VOCAB)
+    for digit in "356789":
+        assert digit not in MMS_THAI_VOCAB
+
+
+# ── the invariant, across the shapes real text takes ─────────────────────────
+
+@needs_pythainlp
+@pytest.mark.parametrize("text", [
+    "สวัสดีครับ ห้อง 305 พร้อมแล้ว",
+    "น้ำ ทำ คำ สำหรับ น้ำหนัก",
+    "ต่างๆ นานา และมากๆ",
+    "ราคา 1,250.50 บาท",
+    "เบอร์โทร 0812345678",
+    "ปี 2026 เดือน 12",
+    "ฯลฯ ๗๘๙ ฿100",
+    "ผลลัพธ์ ✅ เรียบร้อย",
+    "อุณหภูมิ 25° และ 80%",
+    "",
+    "   ",
+])
+def test_output_only_contains_characters_the_model_can_say(frontend, text):
+    _assert_speakable(frontend.normalize(text))
+
+
+@needs_pythainlp
+@needs_khanaa
+@pytest.mark.parametrize("text", [
+    "หุ่นยนต์ Bumi พร้อม",
+    "เชื่อมต่อ WiFi แล้ว",
+    "ระบบ AI, USB และ G1",
+    "Bangkok Sukhumvit station",
+])
+def test_latin_is_transliterated_not_passed_through(frontend, text):
+    out = frontend.normalize(text)
+    _assert_speakable(out)
+    assert not any(ch.isascii() and ch.isalpha() for ch in out), \
+        "a Latin letter reached the model, which would drop it"
+
+
+# ── the specific rewrites ────────────────────────────────────────────────────
+
+@needs_pythainlp
+def test_sara_am_is_rewritten_so_the_vowel_survives(frontend):
+    out = frontend.normalize("น้ำ")
+    assert "ำ" not in out
+    assert "ํา" in out, "the vowel was dropped instead of respelled"
+    _assert_speakable(out)
+
+
+def test_a_vocabulary_that_has_sara_am_is_left_alone():
+    """A future voice whose table contains ำ must not be rewritten."""
+    richer = ThaiFrontend(vocab=set(MMS_THAI_VOCAB) | {"ำ"})
+    assert richer._rewrite_sara_am("น้ำ") == "น้ำ"
+
+
+@needs_pythainlp
+def test_digits_become_words_rather_than_being_dropped(frontend):
+    out = frontend.normalize("ห้อง 305")
+    # 3 and 5 are not in the table at all, so surviving as digits means silence.
+    assert "3" not in out and "5" not in out
+    assert "สาม" in out, "the digit was dropped instead of pronounced"
+    _assert_speakable(out)
+
+
+@needs_pythainlp
+def test_a_decimal_is_not_cut_apart_by_the_punctuation_sweep(frontend):
+    """The sweep turns "." and "," into spaces, so numbers must be read first.
+
+    Running it the other way round read 1,250.50 as three unrelated numbers —
+    "one", "two hundred fifty", "fifty".
+    """
+    out = frontend.normalize("ระยะ 1,250.50 เมตร")
+    assert "จุด" in out, "the decimal point was lost"
+    assert "หนึ่งพัน" in out, "the thousands group was split off"
+    _assert_speakable(out)
+
+
+@needs_pythainlp
+def test_currency_reads_with_thai_units_in_the_right_order(frontend):
+    out = frontend.normalize("฿100")
+    # Replacing ฿ with บาท on its own put the unit *before* the amount.
+    assert out.index("ร้อย") < out.index("บาท")
+    _assert_speakable(out)
+
+
+@needs_pythainlp
+def test_a_long_digit_group_is_read_digit_by_digit(frontend):
+    """An 10-digit phone number is an identifier, not a quantity."""
+    out = frontend.normalize("0812345678")
+    assert "ศูนย์" in out and "แปด" in out
+    # Cardinal reading would have produced a "hundred million"-scale word.
+    assert "ล้าน" not in out
+    _assert_speakable(out)
+
+
+@needs_pythainlp
+def test_maiyamok_is_expanded_because_the_marker_is_not_in_the_table(frontend):
+    assert "ๆ" not in MMS_THAI_VOCAB
+    out = frontend.normalize("ต่างๆ")
+    assert "ๆ" not in out
+    assert out.count("ต่าง") == 2, "the repeat marker was dropped, not expanded"
+    _assert_speakable(out)
+
+
+@needs_pythainlp
+def test_thai_digits_are_read_too(frontend):
+    out = frontend.normalize("๗ ชิ้น")
+    assert "๗" not in out
+    assert "เจ็ด" in out
+    _assert_speakable(out)
+
+
+@needs_pypinyin
+@needs_pythainlp
+def test_chinese_is_transliterated_rather_than_dropped(frontend):
+    out = frontend.normalize("ยินดีต้อนรับ 你好 ครับ")
+    assert "你" not in out and "好" not in out
+    # The Thai around it must survive intact — the point of the vits2 frontend's
+    # test_unvoiceable_characters_do_not_silence_the_rest.
+    assert "ยินดีต้อนรับ" in out and "ครับ" in out
+    _assert_speakable(out)
+
+
+# ── the drop is announced ────────────────────────────────────────────────────
+
+@needs_pythainlp
+def test_unspeakable_characters_are_named_in_a_warning(frontend, caplog):
+    """A silent drop reads downstream as a model bug, so it must be logged."""
+    with caplog.at_level(logging.WARNING, logger="plugins.thai_frontend"):
+        out = frontend.normalize("ผลลัพธ์ ✅ เรียบร้อย")
+    assert any("✅" in record.getMessage() for record in caplog.records), \
+        "the dropped character was not named in any warning"
+    # …and the surrounding Thai still made it through.
+    assert "ผลลัพธ์" in out and "เรียบร้อย" in out
+    _assert_speakable(out)
+
+
+# ── chunking ─────────────────────────────────────────────────────────────────
+
+def test_short_text_is_one_chunk(frontend):
+    assert list(frontend.iter_chunks("สวัสดีครับ")) == ["สวัสดีครับ"]
+
+
+def test_empty_text_yields_nothing(frontend):
+    assert list(frontend.iter_chunks("   ")) == []
+
+
+def test_long_text_is_split_at_spaces_within_the_budget(frontend):
+    text = " ".join(["สวัสดีครับ"] * 40)
+    chunks = list(frontend.iter_chunks(text, max_chars=90))
+    assert len(chunks) > 1
+    assert all(len(chunk) <= 90 for chunk in chunks)
+    # Nothing may be lost or duplicated by the split.
+    assert " ".join(chunks) == text
+
+
+def test_a_phrase_longer_than_the_budget_is_not_cut_mid_word(frontend):
+    """Cutting inside a Thai syllable changes how it is pronounced."""
+    text = "ก" * 300
+    chunks = list(frontend.iter_chunks(text, max_chars=90))
+    assert chunks == [text], "a space-less phrase was split anyway"

--- a/perception/tests/test_tts_engine_switch.py
+++ b/perception/tests/test_tts_engine_switch.py
@@ -87,23 +87,23 @@ def _fake_engines(monkeypatch):
     # _build, and stubbing it out would skip exactly what these tests check.
     # sherpa-onnx really does fetch its model in __init__, hence the delay.
     #
-    # The fake takes its name from cfg["engine"] rather than a literal: matcha and
-    # mms_thai are two different models behind this one constructor, so a
-    # hardcoded name silently filed a Thai engine under "matcha".
+    # The fake takes its name from cfg["engine"] rather than a literal: matcha-zh-en
+    # and mms-th are two different models behind this one constructor, so a
+    # hardcoded name silently filed a Thai engine under "matcha-zh-en".
     monkeypatch.setattr(
         tts, "SherpaOnnxTTSPlugin",
-        lambda cfg, executor: _FakeEngine(cfg.get("engine", "matcha"), cfg, executor,
+        lambda cfg, executor: _FakeEngine(cfg.get("engine", "matcha-zh-en"), cfg, executor,
                                           engines.add, delay=0.3),
     )
     monkeypatch.setattr(
         tts.TTSPlugin, "_build_vits2",
-        lambda self, cfg: _FakeEngine("vits2", cfg, self._executor, engines.add),
+        lambda self, cfg: _FakeEngine("vits2-zh-en", cfg, self._executor, engines.add),
     )
     return engines
 
 
 def _plugin(**cfg):
-    return tts.TTSPlugin({"engine": "vits2", **cfg}, _FakeExecutor())
+    return tts.TTSPlugin({"engine": "vits2-zh-en", **cfg}, _FakeExecutor())
 
 
 def test_config_schema_exposes_the_engine_selector():
@@ -117,15 +117,15 @@ def test_config_schema_exposes_the_engine_selector():
 
 def test_default_engine_is_built_at_startup(_fake_engines):
     plugin = _plugin()
-    assert _fake_engines.order == ["vits2"]
-    assert plugin.dispatch("tts", {"action": "info"})["engine"] == "vits2"
+    assert _fake_engines.order == ["vits2-zh-en"]
+    assert plugin.dispatch("tts", {"action": "info"})["engine"] == "vits2-zh-en"
 
 
 def test_actions_are_forwarded_to_the_active_engine(_fake_engines):
     plugin = _plugin()
     result = plugin.dispatch("tts", {"action": "start", "input_topic": "/say"})
-    assert result["engine_seen"] == "vits2"
-    assert _fake_engines["vits2"].calls[-1]["input_topic"] == "/say"
+    assert result["engine_seen"] == "vits2-zh-en"
+    assert _fake_engines["vits2-zh-en"].calls[-1]["input_topic"] == "/say"
 
 
 def test_switch_stops_the_old_engine_and_waits_for_the_new_one(_fake_engines):
@@ -134,17 +134,17 @@ def test_switch_stops_the_old_engine_and_waits_for_the_new_one(_fake_engines):
     dashboard send a start the engine could not honour — see the deferred-start
     tests at the bottom for the case where waiting is not enough."""
     plugin = _plugin()
-    outgoing = _fake_engines["vits2"]
+    outgoing = _fake_engines["vits2-zh-en"]
 
-    result = plugin.dispatch("tts", {"action": "config", "tts_engine": "matcha"})
+    result = plugin.dispatch("tts", {"action": "config", "tts_engine": "matcha-zh-en"})
 
     assert result["status"] == "configured"
     assert "state" not in result, "a completed switch must not report loading"
-    assert result["engine"] == "matcha"
+    assert result["engine"] == "matcha-zh-en"
     # The outgoing engine is stopped before the new one can publish.
     assert outgoing.stopped is True
     # And the engine is live *now*, so the start that follows lands on it.
-    assert plugin.dispatch("tts", {"action": "info"})["engine"] == "matcha"
+    assert plugin.dispatch("tts", {"action": "info"})["engine"] == "matcha-zh-en"
     assert plugin.dispatch("tts", {"action": "start",
                                    "input_topic": "/say"})["state"] == "running"
 
@@ -153,7 +153,7 @@ def test_config_gives_up_waiting_and_reports_loading(monkeypatch, _fake_engines)
     """A build slower than the bound — a cold model download — still goes async."""
     monkeypatch.setattr(tts, "ENGINE_SWITCH_WAIT_S", 0.05)
     result = _plugin().dispatch("tts", {"action": "config",
-                                        "tts_engine": "matcha"})
+                                        "tts_engine": "matcha-zh-en"})
     assert result["status"] == "configured"
     assert result["state"] == "loading"
 
@@ -166,10 +166,10 @@ def test_config_reports_a_build_failure_instead_of_loading(monkeypatch):
     monkeypatch.setattr(tts, "SherpaOnnxTTSPlugin", _Boom)
     monkeypatch.setattr(
         tts.TTSPlugin, "_build_vits2",
-        lambda self, cfg: _FakeEngine("vits2", cfg, self._executor, lambda i: None),
+        lambda self, cfg: _FakeEngine("vits2-zh-en", cfg, self._executor, lambda i: None),
     )
-    plugin = tts.TTSPlugin({"engine": "vits2"}, _FakeExecutor())
-    result = plugin.dispatch("tts", {"action": "config", "tts_engine": "matcha"})
+    plugin = tts.TTSPlugin({"engine": "vits2-zh-en"}, _FakeExecutor())
+    result = plugin.dispatch("tts", {"action": "config", "tts_engine": "matcha-zh-en"})
     assert result["status"] == "error"
     assert "Protobuf parsing failed" in result["message"]
 
@@ -179,38 +179,38 @@ def test_info_reports_loading_while_the_new_engine_builds(monkeypatch, _fake_eng
     window in which the facade has no engine."""
     monkeypatch.setattr(tts, "ENGINE_SWITCH_WAIT_S", 0.05)
     plugin = _plugin()
-    plugin.dispatch("tts", {"action": "config", "tts_engine": "matcha"})
+    plugin.dispatch("tts", {"action": "config", "tts_engine": "matcha-zh-en"})
 
     info = plugin.dispatch("tts", {"action": "info"})
     assert info["state"] == "loading"
-    assert "matcha" in info["desc"]
+    assert "matcha-zh-en" in info["desc"]
     # Other actions answer loading too, rather than hanging or lying.
     assert plugin.dispatch("tts", {"action": "speak", "text": "hi"})["state"] == "loading"
 
 
 def test_switching_back_and_forth_keeps_one_engine_live(_fake_engines):
     plugin = _plugin()
-    plugin.dispatch("tts", {"action": "config", "tts_engine": "matcha"})
-    assert _wait_until(lambda: "matcha" in _fake_engines)
+    plugin.dispatch("tts", {"action": "config", "tts_engine": "matcha-zh-en"})
+    assert _wait_until(lambda: "matcha-zh-en" in _fake_engines)
     assert _wait_until(
         lambda: plugin.dispatch("tts", {"action": "info"})["state"] != "loading"
     )
-    sherpa = _fake_engines["matcha"]
+    sherpa = _fake_engines["matcha-zh-en"]
 
-    plugin.dispatch("tts", {"action": "config", "tts_engine": "vits2"})
+    plugin.dispatch("tts", {"action": "config", "tts_engine": "vits2-zh-en"})
     assert sherpa.stopped is True
     assert _wait_until(
         lambda: plugin.dispatch("tts", {"action": "info"})["state"] != "loading"
     )
-    assert plugin.dispatch("tts", {"action": "info"})["engine"] == "vits2"
-    assert _fake_engines.order == ["vits2", "matcha", "vits2"]
+    assert plugin.dispatch("tts", {"action": "info"})["engine"] == "vits2-zh-en"
+    assert _fake_engines.order == ["vits2-zh-en", "matcha-zh-en", "vits2-zh-en"]
 
 
 def test_reconfiguring_the_same_engine_does_not_rebuild(_fake_engines):
     plugin = _plugin()
-    result = plugin.dispatch("tts", {"action": "config", "tts_engine": "vits2",
+    result = plugin.dispatch("tts", {"action": "config", "tts_engine": "vits2-zh-en",
                                      "speed": 1.3})
-    assert _fake_engines.order == ["vits2"], "same engine was rebuilt"
+    assert _fake_engines.order == ["vits2-zh-en"], "same engine was rebuilt"
     # tts_engine is the facade's own field and must not be forwarded as if it
     # were an engine parameter; speed must be.
     applied = result["applied"]
@@ -220,17 +220,17 @@ def test_reconfiguring_the_same_engine_does_not_rebuild(_fake_engines):
 def test_shared_config_survives_an_engine_switch(_fake_engines):
     plugin = _plugin()
     plugin.dispatch("tts", {"action": "config", "speed": 0.7})
-    plugin.dispatch("tts", {"action": "config", "tts_engine": "matcha"})
-    assert _wait_until(lambda: "matcha" in _fake_engines)
-    assert _fake_engines["matcha"].cfg["speed"] == 0.7
+    plugin.dispatch("tts", {"action": "config", "tts_engine": "matcha-zh-en"})
+    assert _wait_until(lambda: "matcha-zh-en" in _fake_engines)
+    assert _fake_engines["matcha-zh-en"].cfg["speed"] == 0.7
 
 
 def test_unknown_engine_is_refused_without_touching_the_live_one(_fake_engines):
     plugin = _plugin()
     with pytest.raises(ValueError):
         plugin.dispatch("tts", {"action": "config", "tts_engine": "espeak"})
-    assert _fake_engines["vits2"].stopped is False
-    assert plugin.dispatch("tts", {"action": "info"})["engine"] == "vits2"
+    assert _fake_engines["vits2-zh-en"].stopped is False
+    assert plugin.dispatch("tts", {"action": "info"})["engine"] == "vits2-zh-en"
 
 
 def test_engine_build_failure_is_reported_not_raised(monkeypatch):
@@ -249,7 +249,7 @@ def test_engine_build_failure_is_reported_not_raised(monkeypatch):
 
 def test_concurrent_switches_leave_exactly_one_engine_live(_fake_engines):
     plugin = _plugin()
-    targets = ["matcha", "vits2", "matcha", "vits2"]
+    targets = ["matcha-zh-en", "vits2-zh-en", "matcha-zh-en", "vits2-zh-en"]
     threads = [
         threading.Thread(
             target=lambda e=e: plugin.dispatch(
@@ -287,39 +287,69 @@ def test_each_engine_gets_its_own_model_dir(_fake_engines):
     "I picked sherpa_onnx and it downloaded the VITS2 model" looked like.
     """
     plugin = tts.TTSPlugin(
-        {"engine": "vits2", "model_dir": "/models/vits2"}, _FakeExecutor()
+        {"engine": "vits2-zh-en", "model_dir": "/models/vits2"}, _FakeExecutor()
     )
-    assert _fake_engines["vits2"].cfg["model_dir"] == "/models/vits2"
+    assert _fake_engines["vits2-zh-en"].cfg["model_dir"] == "/models/vits2"
 
-    plugin.dispatch("tts", {"action": "config", "tts_engine": "matcha"})
-    assert _wait_until(lambda: "matcha" in _fake_engines)
-    assert (_fake_engines["matcha"].cfg["model_dir"]
-            == tts.ENGINE_MODEL_DIRS["matcha"])
+    plugin.dispatch("tts", {"action": "config", "tts_engine": "matcha-zh-en"})
+    assert _wait_until(lambda: "matcha-zh-en" in _fake_engines)
+    assert (_fake_engines["matcha-zh-en"].cfg["model_dir"]
+            == tts.ENGINE_MODEL_DIRS["matcha-zh-en"])
 
-    plugin.dispatch("tts", {"action": "config", "tts_engine": "mms_thai"})
-    assert _wait_until(lambda: "mms_thai" in _fake_engines)
+    plugin.dispatch("tts", {"action": "config", "tts_engine": "mms-th"})
+    assert _wait_until(lambda: "mms-th" in _fake_engines)
     # Its own directory, not a file alongside Matcha's: the two share no weights.
-    assert (_fake_engines["mms_thai"].cfg["model_dir"]
-            == tts.ENGINE_MODEL_DIRS["mms_thai"])
-    assert (tts.ENGINE_MODEL_DIRS["mms_thai"]
-            != tts.ENGINE_MODEL_DIRS["matcha"])
+    assert (_fake_engines["mms-th"].cfg["model_dir"]
+            == tts.ENGINE_MODEL_DIRS["mms-th"])
+    assert (tts.ENGINE_MODEL_DIRS["mms-th"]
+            != tts.ENGINE_MODEL_DIRS["matcha-zh-en"])
 
 
 # ── legacy engine names (upgrade regression) ─────────────────────────────────
 
 def test_engines_are_named_after_the_model_not_the_runtime():
-    """Two engines run on sherpa-onnx, so a runtime name identifies neither."""
-    assert set(tts.TTS_ENGINES) == {"vits2", "matcha", "mms_thai"}
-    assert tts.DEFAULT_TTS_ENGINE == "vits2"
+    """`<model>-<languages>`, the shape asr_model already uses.
+
+    Two engines run on sherpa-onnx, so a runtime name identifies neither. And the
+    dashboard renders the raw enum string, so this is what an operator reads in
+    the dropdown next to the ASR one — a second convention would be visible.
+    """
+    assert set(tts.TTS_ENGINES) == {"vits2-zh-en", "matcha-zh-en", "mms-th"}
+    assert tts.DEFAULT_TTS_ENGINE == "vits2-zh-en"
+    for engine in tts.TTS_ENGINES:
+        assert "_" not in engine, "asr_model uses hyphens; do not mix separators"
+        assert "cn" not in engine.split("-"), "zh is the language code; cn is a country"
+    # Every engine needs a model dir, or _model_dir_for raises a KeyError on the
+    # first switch to it.
+    assert set(tts.ENGINE_MODEL_DIRS) == set(tts.TTS_ENGINES)
+
+
+def test_the_asr_model_field_uses_the_same_shape():
+    """Guards the reason for the naming: the two dropdowns sit side by side."""
+    import plugins.asr as asr
+
+    asr_models = asr.TOOLS[0]["configSchema"]["properties"]["asr_model"]["enum"]
+    assert all("_" not in name for name in asr_models), \
+        "asr_model changed separator; tts_engine was matched to it deliberately"
 
 
 @pytest.mark.parametrize("stored, expected", [
-    ("vits2_trt", "vits2"),
-    ("sherpa_onnx", "matcha"),
-    ("VITS2_TRT", "vits2"),
-    (" sherpa_onnx ", "matcha"),
+    # What is actually persisted in ConfigDB and config.yaml on deployed robots.
+    ("vits2_trt", "vits2-zh-en"),
+    ("sherpa_onnx", "matcha-zh-en"),
+    # Case and stray whitespace, as a hand-edited YAML value arrives.
+    ("VITS2_TRT", "vits2-zh-en"),
+    (" sherpa_onnx ", "matcha-zh-en"),
+    # The bare forms this branch briefly used before the languages were added.
+    ("vits2", "vits2-zh-en"),
+    ("matcha", "matcha-zh-en"),
+    ("mms_thai", "mms-th"),
+    # Underscores fold to hyphens, so someone typing the new name the old way
+    # still lands on it rather than getting "Unsupported TTS engine".
+    ("vits2_zh_en", "vits2-zh-en"),
+    ("mms-th", "mms-th"),
 ])
-def test_the_old_runtime_flavoured_names_still_resolve(_fake_engines, stored, expected):
+def test_the_old_and_hand_typed_names_still_resolve(_fake_engines, stored, expected):
     """Every deployed robot has one of the old names in ConfigDB and config.yaml.
 
     _select_engine raises on an unknown engine and TTSPlugin.__init__ turns that
@@ -332,26 +362,33 @@ def test_the_old_runtime_flavoured_names_still_resolve(_fake_engines, stored, ex
     assert plugin.dispatch("tts", {"action": "info"})["engine"] == expected
 
 
+def test_every_alias_resolves_to_a_real_engine():
+    """A typo in ENGINE_ALIASES would only surface when someone upgraded."""
+    for alias, target in tts.ENGINE_ALIASES.items():
+        assert target in tts.TTS_ENGINES, f"{alias} points at nothing"
+        assert "_" not in alias, "aliases are looked up after _ folds to -"
+
+
 def test_a_legacy_name_arriving_by_config_also_resolves(_fake_engines):
-    plugin = tts.TTSPlugin({"engine": "vits2"}, _FakeExecutor())
+    plugin = tts.TTSPlugin({"engine": "vits2-zh-en"}, _FakeExecutor())
     plugin.dispatch("tts", {"action": "config", "tts_engine": "sherpa_onnx"})
-    assert _wait_until(lambda: "matcha" in _fake_engines)
-    assert plugin.dispatch("tts", {"action": "info"})["engine"] == "matcha"
+    assert _wait_until(lambda: "matcha-zh-en" in _fake_engines)
+    assert plugin.dispatch("tts", {"action": "info"})["engine"] == "matcha-zh-en"
 
 
 def test_configured_model_dir_follows_the_configured_engine(_fake_engines):
     """A sherpa-configured deployment keeps its own path, and VITS2 gets its own."""
     plugin = tts.TTSPlugin(
-        {"engine": "matcha", "model_dir": "/models/custom/sherpa"},
+        {"engine": "matcha-zh-en", "model_dir": "/models/custom/sherpa"},
         _FakeExecutor(),
     )
-    assert _wait_until(lambda: "matcha" in _fake_engines)
-    assert _fake_engines["matcha"].cfg["model_dir"] == "/models/custom/sherpa"
+    assert _wait_until(lambda: "matcha-zh-en" in _fake_engines)
+    assert _fake_engines["matcha-zh-en"].cfg["model_dir"] == "/models/custom/sherpa"
 
-    plugin.dispatch("tts", {"action": "config", "tts_engine": "vits2"})
-    assert _wait_until(lambda: "vits2" in _fake_engines)
-    assert (_fake_engines["vits2"].cfg["model_dir"]
-            == tts.ENGINE_MODEL_DIRS["vits2"])
+    plugin.dispatch("tts", {"action": "config", "tts_engine": "vits2-zh-en"})
+    assert _wait_until(lambda: "vits2-zh-en" in _fake_engines)
+    assert (_fake_engines["vits2-zh-en"].cfg["model_dir"]
+            == tts.ENGINE_MODEL_DIRS["vits2-zh-en"])
 
 
 def test_engine_that_reports_error_after_construction_is_not_installed(monkeypatch):
@@ -371,7 +408,7 @@ def test_engine_that_reports_error_after_construction_is_not_installed(monkeypat
 
     monkeypatch.setattr(tts, "SherpaOnnxTTSPlugin",
                         lambda cfg, executor: _BrokenEngine())
-    plugin = tts.TTSPlugin({"engine": "matcha"}, _FakeExecutor())
+    plugin = tts.TTSPlugin({"engine": "matcha-zh-en"}, _FakeExecutor())
 
     info = plugin.dispatch("tts", {"action": "info"})
     assert info["state"] == "error"
@@ -392,7 +429,7 @@ def test_engine_that_reports_error_after_construction_is_not_installed(monkeypat
 def test_start_during_a_switch_is_replayed_once_the_engine_is_up(monkeypatch, _fake_engines):
     monkeypatch.setattr(tts, "ENGINE_SWITCH_WAIT_S", 0.05)
     plugin = _plugin()
-    plugin.dispatch("tts", {"action": "config", "tts_engine": "matcha"})
+    plugin.dispatch("tts", {"action": "config", "tts_engine": "matcha-zh-en"})
 
     # The build is still in flight, so the call cannot start anything yet.
     result = plugin.dispatch("tts", {"action": "start",
@@ -400,8 +437,8 @@ def test_start_during_a_switch_is_replayed_once_the_engine_is_up(monkeypatch, _f
                                      "input_topic": "/say"})
     assert result["state"] == "loading"
 
-    _wait_until(lambda: "matcha" in _fake_engines)
-    incoming = _fake_engines["matcha"]
+    _wait_until(lambda: "matcha-zh-en" in _fake_engines)
+    incoming = _fake_engines["matcha-zh-en"]
     _wait_until(lambda: any(c.get("action") == "start" for c in incoming.calls))
 
     started = [c for c in incoming.calls if c.get("action") == "start"]
@@ -414,14 +451,14 @@ def test_a_stop_during_a_switch_cancels_the_deferred_start(monkeypatch, _fake_en
     """Otherwise the node reappears after the operator asked for it to stop."""
     monkeypatch.setattr(tts, "ENGINE_SWITCH_WAIT_S", 0.05)
     plugin = _plugin()
-    plugin.dispatch("tts", {"action": "config", "tts_engine": "matcha"})
+    plugin.dispatch("tts", {"action": "config", "tts_engine": "matcha-zh-en"})
     plugin.dispatch("tts", {"action": "start", "instance_id": "card-1",
                             "input_topic": "/say"})
     assert plugin.dispatch("tts", {"action": "stop",
                                    "instance_id": "card-1"})["state"] == "idle"
 
-    _wait_until(lambda: "matcha" in _fake_engines)
-    incoming = _fake_engines["matcha"]
+    _wait_until(lambda: "matcha-zh-en" in _fake_engines)
+    incoming = _fake_engines["matcha-zh-en"]
     time.sleep(0.4)   # past the fake build delay, so a replay would have landed
     assert not [c for c in incoming.calls if c.get("action") == "start"]
 
@@ -429,13 +466,13 @@ def test_a_stop_during_a_switch_cancels_the_deferred_start(monkeypatch, _fake_en
 def test_deferred_starts_are_per_instance(monkeypatch, _fake_engines):
     monkeypatch.setattr(tts, "ENGINE_SWITCH_WAIT_S", 0.05)
     plugin = _plugin()
-    plugin.dispatch("tts", {"action": "config", "tts_engine": "matcha"})
+    plugin.dispatch("tts", {"action": "config", "tts_engine": "matcha-zh-en"})
     for card, topic in (("card-1", "/say/a"), ("card-2", "/say/b")):
         plugin.dispatch("tts", {"action": "start", "instance_id": card,
                                 "input_topic": topic})
 
-    _wait_until(lambda: "matcha" in _fake_engines)
-    incoming = _fake_engines["matcha"]
+    _wait_until(lambda: "matcha-zh-en" in _fake_engines)
+    incoming = _fake_engines["matcha-zh-en"]
     _wait_until(lambda: len([c for c in incoming.calls
                              if c.get("action") == "start"]) == 2)
     topics = sorted(c["input_topic"] for c in incoming.calls
@@ -446,11 +483,11 @@ def test_deferred_starts_are_per_instance(monkeypatch, _fake_engines):
 def test_start_after_the_build_finishes_is_not_replayed_twice(_fake_engines):
     """A start that the live engine already handled must not also be queued."""
     plugin = _plugin()
-    plugin.dispatch("tts", {"action": "config", "tts_engine": "matcha"})
+    plugin.dispatch("tts", {"action": "config", "tts_engine": "matcha-zh-en"})
     _wait_until(lambda: plugin.dispatch("tts", {"action": "info"})["state"] != "loading")
 
     plugin.dispatch("tts", {"action": "start", "instance_id": "card-1",
                             "input_topic": "/say"})
     time.sleep(0.2)
-    incoming = _fake_engines["matcha"]
+    incoming = _fake_engines["matcha-zh-en"]
     assert len([c for c in incoming.calls if c.get("action") == "start"]) == 1

--- a/perception/tests/test_tts_engine_switch.py
+++ b/perception/tests/test_tts_engine_switch.py
@@ -85,21 +85,25 @@ def _fake_engines(monkeypatch):
     # Patch the two engine constructors, not TTSPlugin._build: the facade's own
     # per-engine model_dir selection and post-construction health check live in
     # _build, and stubbing it out would skip exactly what these tests check.
-    # sherpa-onnx really does fetch its Matcha model in __init__, hence the delay.
+    # sherpa-onnx really does fetch its model in __init__, hence the delay.
+    #
+    # The fake takes its name from cfg["engine"] rather than a literal: matcha and
+    # mms_thai are two different models behind this one constructor, so a
+    # hardcoded name silently filed a Thai engine under "matcha".
     monkeypatch.setattr(
         tts, "SherpaOnnxTTSPlugin",
-        lambda cfg, executor: _FakeEngine("sherpa_onnx", cfg, executor,
+        lambda cfg, executor: _FakeEngine(cfg.get("engine", "matcha"), cfg, executor,
                                           engines.add, delay=0.3),
     )
     monkeypatch.setattr(
         tts.TTSPlugin, "_build_vits2",
-        lambda self, cfg: _FakeEngine("vits2_trt", cfg, self._executor, engines.add),
+        lambda self, cfg: _FakeEngine("vits2", cfg, self._executor, engines.add),
     )
     return engines
 
 
 def _plugin(**cfg):
-    return tts.TTSPlugin({"engine": "vits2_trt", **cfg}, _FakeExecutor())
+    return tts.TTSPlugin({"engine": "vits2", **cfg}, _FakeExecutor())
 
 
 def test_config_schema_exposes_the_engine_selector():
@@ -113,15 +117,15 @@ def test_config_schema_exposes_the_engine_selector():
 
 def test_default_engine_is_built_at_startup(_fake_engines):
     plugin = _plugin()
-    assert _fake_engines.order == ["vits2_trt"]
-    assert plugin.dispatch("tts", {"action": "info"})["engine"] == "vits2_trt"
+    assert _fake_engines.order == ["vits2"]
+    assert plugin.dispatch("tts", {"action": "info"})["engine"] == "vits2"
 
 
 def test_actions_are_forwarded_to_the_active_engine(_fake_engines):
     plugin = _plugin()
     result = plugin.dispatch("tts", {"action": "start", "input_topic": "/say"})
-    assert result["engine_seen"] == "vits2_trt"
-    assert _fake_engines["vits2_trt"].calls[-1]["input_topic"] == "/say"
+    assert result["engine_seen"] == "vits2"
+    assert _fake_engines["vits2"].calls[-1]["input_topic"] == "/say"
 
 
 def test_switch_stops_the_old_engine_and_waits_for_the_new_one(_fake_engines):
@@ -130,17 +134,17 @@ def test_switch_stops_the_old_engine_and_waits_for_the_new_one(_fake_engines):
     dashboard send a start the engine could not honour — see the deferred-start
     tests at the bottom for the case where waiting is not enough."""
     plugin = _plugin()
-    outgoing = _fake_engines["vits2_trt"]
+    outgoing = _fake_engines["vits2"]
 
-    result = plugin.dispatch("tts", {"action": "config", "tts_engine": "sherpa_onnx"})
+    result = plugin.dispatch("tts", {"action": "config", "tts_engine": "matcha"})
 
     assert result["status"] == "configured"
     assert "state" not in result, "a completed switch must not report loading"
-    assert result["engine"] == "sherpa_onnx"
+    assert result["engine"] == "matcha"
     # The outgoing engine is stopped before the new one can publish.
     assert outgoing.stopped is True
     # And the engine is live *now*, so the start that follows lands on it.
-    assert plugin.dispatch("tts", {"action": "info"})["engine"] == "sherpa_onnx"
+    assert plugin.dispatch("tts", {"action": "info"})["engine"] == "matcha"
     assert plugin.dispatch("tts", {"action": "start",
                                    "input_topic": "/say"})["state"] == "running"
 
@@ -149,7 +153,7 @@ def test_config_gives_up_waiting_and_reports_loading(monkeypatch, _fake_engines)
     """A build slower than the bound — a cold model download — still goes async."""
     monkeypatch.setattr(tts, "ENGINE_SWITCH_WAIT_S", 0.05)
     result = _plugin().dispatch("tts", {"action": "config",
-                                        "tts_engine": "sherpa_onnx"})
+                                        "tts_engine": "matcha"})
     assert result["status"] == "configured"
     assert result["state"] == "loading"
 
@@ -162,10 +166,10 @@ def test_config_reports_a_build_failure_instead_of_loading(monkeypatch):
     monkeypatch.setattr(tts, "SherpaOnnxTTSPlugin", _Boom)
     monkeypatch.setattr(
         tts.TTSPlugin, "_build_vits2",
-        lambda self, cfg: _FakeEngine("vits2_trt", cfg, self._executor, lambda i: None),
+        lambda self, cfg: _FakeEngine("vits2", cfg, self._executor, lambda i: None),
     )
-    plugin = tts.TTSPlugin({"engine": "vits2_trt"}, _FakeExecutor())
-    result = plugin.dispatch("tts", {"action": "config", "tts_engine": "sherpa_onnx"})
+    plugin = tts.TTSPlugin({"engine": "vits2"}, _FakeExecutor())
+    result = plugin.dispatch("tts", {"action": "config", "tts_engine": "matcha"})
     assert result["status"] == "error"
     assert "Protobuf parsing failed" in result["message"]
 
@@ -175,38 +179,38 @@ def test_info_reports_loading_while_the_new_engine_builds(monkeypatch, _fake_eng
     window in which the facade has no engine."""
     monkeypatch.setattr(tts, "ENGINE_SWITCH_WAIT_S", 0.05)
     plugin = _plugin()
-    plugin.dispatch("tts", {"action": "config", "tts_engine": "sherpa_onnx"})
+    plugin.dispatch("tts", {"action": "config", "tts_engine": "matcha"})
 
     info = plugin.dispatch("tts", {"action": "info"})
     assert info["state"] == "loading"
-    assert "sherpa_onnx" in info["desc"]
+    assert "matcha" in info["desc"]
     # Other actions answer loading too, rather than hanging or lying.
     assert plugin.dispatch("tts", {"action": "speak", "text": "hi"})["state"] == "loading"
 
 
 def test_switching_back_and_forth_keeps_one_engine_live(_fake_engines):
     plugin = _plugin()
-    plugin.dispatch("tts", {"action": "config", "tts_engine": "sherpa_onnx"})
-    assert _wait_until(lambda: "sherpa_onnx" in _fake_engines)
+    plugin.dispatch("tts", {"action": "config", "tts_engine": "matcha"})
+    assert _wait_until(lambda: "matcha" in _fake_engines)
     assert _wait_until(
         lambda: plugin.dispatch("tts", {"action": "info"})["state"] != "loading"
     )
-    sherpa = _fake_engines["sherpa_onnx"]
+    sherpa = _fake_engines["matcha"]
 
-    plugin.dispatch("tts", {"action": "config", "tts_engine": "vits2_trt"})
+    plugin.dispatch("tts", {"action": "config", "tts_engine": "vits2"})
     assert sherpa.stopped is True
     assert _wait_until(
         lambda: plugin.dispatch("tts", {"action": "info"})["state"] != "loading"
     )
-    assert plugin.dispatch("tts", {"action": "info"})["engine"] == "vits2_trt"
-    assert _fake_engines.order == ["vits2_trt", "sherpa_onnx", "vits2_trt"]
+    assert plugin.dispatch("tts", {"action": "info"})["engine"] == "vits2"
+    assert _fake_engines.order == ["vits2", "matcha", "vits2"]
 
 
 def test_reconfiguring_the_same_engine_does_not_rebuild(_fake_engines):
     plugin = _plugin()
-    result = plugin.dispatch("tts", {"action": "config", "tts_engine": "vits2_trt",
+    result = plugin.dispatch("tts", {"action": "config", "tts_engine": "vits2",
                                      "speed": 1.3})
-    assert _fake_engines.order == ["vits2_trt"], "same engine was rebuilt"
+    assert _fake_engines.order == ["vits2"], "same engine was rebuilt"
     # tts_engine is the facade's own field and must not be forwarded as if it
     # were an engine parameter; speed must be.
     applied = result["applied"]
@@ -216,17 +220,17 @@ def test_reconfiguring_the_same_engine_does_not_rebuild(_fake_engines):
 def test_shared_config_survives_an_engine_switch(_fake_engines):
     plugin = _plugin()
     plugin.dispatch("tts", {"action": "config", "speed": 0.7})
-    plugin.dispatch("tts", {"action": "config", "tts_engine": "sherpa_onnx"})
-    assert _wait_until(lambda: "sherpa_onnx" in _fake_engines)
-    assert _fake_engines["sherpa_onnx"].cfg["speed"] == 0.7
+    plugin.dispatch("tts", {"action": "config", "tts_engine": "matcha"})
+    assert _wait_until(lambda: "matcha" in _fake_engines)
+    assert _fake_engines["matcha"].cfg["speed"] == 0.7
 
 
 def test_unknown_engine_is_refused_without_touching_the_live_one(_fake_engines):
     plugin = _plugin()
     with pytest.raises(ValueError):
         plugin.dispatch("tts", {"action": "config", "tts_engine": "espeak"})
-    assert _fake_engines["vits2_trt"].stopped is False
-    assert plugin.dispatch("tts", {"action": "info"})["engine"] == "vits2_trt"
+    assert _fake_engines["vits2"].stopped is False
+    assert plugin.dispatch("tts", {"action": "info"})["engine"] == "vits2"
 
 
 def test_engine_build_failure_is_reported_not_raised(monkeypatch):
@@ -245,7 +249,7 @@ def test_engine_build_failure_is_reported_not_raised(monkeypatch):
 
 def test_concurrent_switches_leave_exactly_one_engine_live(_fake_engines):
     plugin = _plugin()
-    targets = ["sherpa_onnx", "vits2_trt", "sherpa_onnx", "vits2_trt"]
+    targets = ["matcha", "vits2", "matcha", "vits2"]
     threads = [
         threading.Thread(
             target=lambda e=e: plugin.dispatch(
@@ -283,29 +287,71 @@ def test_each_engine_gets_its_own_model_dir(_fake_engines):
     "I picked sherpa_onnx and it downloaded the VITS2 model" looked like.
     """
     plugin = tts.TTSPlugin(
-        {"engine": "vits2_trt", "model_dir": "/models/vits2"}, _FakeExecutor()
+        {"engine": "vits2", "model_dir": "/models/vits2"}, _FakeExecutor()
     )
-    assert _fake_engines["vits2_trt"].cfg["model_dir"] == "/models/vits2"
+    assert _fake_engines["vits2"].cfg["model_dir"] == "/models/vits2"
 
+    plugin.dispatch("tts", {"action": "config", "tts_engine": "matcha"})
+    assert _wait_until(lambda: "matcha" in _fake_engines)
+    assert (_fake_engines["matcha"].cfg["model_dir"]
+            == tts.ENGINE_MODEL_DIRS["matcha"])
+
+    plugin.dispatch("tts", {"action": "config", "tts_engine": "mms_thai"})
+    assert _wait_until(lambda: "mms_thai" in _fake_engines)
+    # Its own directory, not a file alongside Matcha's: the two share no weights.
+    assert (_fake_engines["mms_thai"].cfg["model_dir"]
+            == tts.ENGINE_MODEL_DIRS["mms_thai"])
+    assert (tts.ENGINE_MODEL_DIRS["mms_thai"]
+            != tts.ENGINE_MODEL_DIRS["matcha"])
+
+
+# ── legacy engine names (upgrade regression) ─────────────────────────────────
+
+def test_engines_are_named_after_the_model_not_the_runtime():
+    """Two engines run on sherpa-onnx, so a runtime name identifies neither."""
+    assert set(tts.TTS_ENGINES) == {"vits2", "matcha", "mms_thai"}
+    assert tts.DEFAULT_TTS_ENGINE == "vits2"
+
+
+@pytest.mark.parametrize("stored, expected", [
+    ("vits2_trt", "vits2"),
+    ("sherpa_onnx", "matcha"),
+    ("VITS2_TRT", "vits2"),
+    (" sherpa_onnx ", "matcha"),
+])
+def test_the_old_runtime_flavoured_names_still_resolve(_fake_engines, stored, expected):
+    """Every deployed robot has one of the old names in ConfigDB and config.yaml.
+
+    _select_engine raises on an unknown engine and TTSPlugin.__init__ turns that
+    into a build error, so dropping the aliases would not degrade gracefully — it
+    would put every existing TTS card into `state: error` on the next restart.
+    """
+    plugin = tts.TTSPlugin({"engine": stored}, _FakeExecutor())
+    assert _wait_until(lambda: expected in _fake_engines)
+    # info reports the resolved name, so nothing downstream sees the legacy spelling.
+    assert plugin.dispatch("tts", {"action": "info"})["engine"] == expected
+
+
+def test_a_legacy_name_arriving_by_config_also_resolves(_fake_engines):
+    plugin = tts.TTSPlugin({"engine": "vits2"}, _FakeExecutor())
     plugin.dispatch("tts", {"action": "config", "tts_engine": "sherpa_onnx"})
-    assert _wait_until(lambda: "sherpa_onnx" in _fake_engines)
-    assert (_fake_engines["sherpa_onnx"].cfg["model_dir"]
-            == tts.ENGINE_MODEL_DIRS["sherpa_onnx"])
+    assert _wait_until(lambda: "matcha" in _fake_engines)
+    assert plugin.dispatch("tts", {"action": "info"})["engine"] == "matcha"
 
 
 def test_configured_model_dir_follows_the_configured_engine(_fake_engines):
     """A sherpa-configured deployment keeps its own path, and VITS2 gets its own."""
     plugin = tts.TTSPlugin(
-        {"engine": "sherpa_onnx", "model_dir": "/models/custom/sherpa"},
+        {"engine": "matcha", "model_dir": "/models/custom/sherpa"},
         _FakeExecutor(),
     )
-    assert _wait_until(lambda: "sherpa_onnx" in _fake_engines)
-    assert _fake_engines["sherpa_onnx"].cfg["model_dir"] == "/models/custom/sherpa"
+    assert _wait_until(lambda: "matcha" in _fake_engines)
+    assert _fake_engines["matcha"].cfg["model_dir"] == "/models/custom/sherpa"
 
-    plugin.dispatch("tts", {"action": "config", "tts_engine": "vits2_trt"})
-    assert _wait_until(lambda: "vits2_trt" in _fake_engines)
-    assert (_fake_engines["vits2_trt"].cfg["model_dir"]
-            == tts.ENGINE_MODEL_DIRS["vits2_trt"])
+    plugin.dispatch("tts", {"action": "config", "tts_engine": "vits2"})
+    assert _wait_until(lambda: "vits2" in _fake_engines)
+    assert (_fake_engines["vits2"].cfg["model_dir"]
+            == tts.ENGINE_MODEL_DIRS["vits2"])
 
 
 def test_engine_that_reports_error_after_construction_is_not_installed(monkeypatch):
@@ -325,7 +371,7 @@ def test_engine_that_reports_error_after_construction_is_not_installed(monkeypat
 
     monkeypatch.setattr(tts, "SherpaOnnxTTSPlugin",
                         lambda cfg, executor: _BrokenEngine())
-    plugin = tts.TTSPlugin({"engine": "sherpa_onnx"}, _FakeExecutor())
+    plugin = tts.TTSPlugin({"engine": "matcha"}, _FakeExecutor())
 
     info = plugin.dispatch("tts", {"action": "info"})
     assert info["state"] == "error"
@@ -346,7 +392,7 @@ def test_engine_that_reports_error_after_construction_is_not_installed(monkeypat
 def test_start_during_a_switch_is_replayed_once_the_engine_is_up(monkeypatch, _fake_engines):
     monkeypatch.setattr(tts, "ENGINE_SWITCH_WAIT_S", 0.05)
     plugin = _plugin()
-    plugin.dispatch("tts", {"action": "config", "tts_engine": "sherpa_onnx"})
+    plugin.dispatch("tts", {"action": "config", "tts_engine": "matcha"})
 
     # The build is still in flight, so the call cannot start anything yet.
     result = plugin.dispatch("tts", {"action": "start",
@@ -354,8 +400,8 @@ def test_start_during_a_switch_is_replayed_once_the_engine_is_up(monkeypatch, _f
                                      "input_topic": "/say"})
     assert result["state"] == "loading"
 
-    _wait_until(lambda: "sherpa_onnx" in _fake_engines)
-    incoming = _fake_engines["sherpa_onnx"]
+    _wait_until(lambda: "matcha" in _fake_engines)
+    incoming = _fake_engines["matcha"]
     _wait_until(lambda: any(c.get("action") == "start" for c in incoming.calls))
 
     started = [c for c in incoming.calls if c.get("action") == "start"]
@@ -368,14 +414,14 @@ def test_a_stop_during_a_switch_cancels_the_deferred_start(monkeypatch, _fake_en
     """Otherwise the node reappears after the operator asked for it to stop."""
     monkeypatch.setattr(tts, "ENGINE_SWITCH_WAIT_S", 0.05)
     plugin = _plugin()
-    plugin.dispatch("tts", {"action": "config", "tts_engine": "sherpa_onnx"})
+    plugin.dispatch("tts", {"action": "config", "tts_engine": "matcha"})
     plugin.dispatch("tts", {"action": "start", "instance_id": "card-1",
                             "input_topic": "/say"})
     assert plugin.dispatch("tts", {"action": "stop",
                                    "instance_id": "card-1"})["state"] == "idle"
 
-    _wait_until(lambda: "sherpa_onnx" in _fake_engines)
-    incoming = _fake_engines["sherpa_onnx"]
+    _wait_until(lambda: "matcha" in _fake_engines)
+    incoming = _fake_engines["matcha"]
     time.sleep(0.4)   # past the fake build delay, so a replay would have landed
     assert not [c for c in incoming.calls if c.get("action") == "start"]
 
@@ -383,13 +429,13 @@ def test_a_stop_during_a_switch_cancels_the_deferred_start(monkeypatch, _fake_en
 def test_deferred_starts_are_per_instance(monkeypatch, _fake_engines):
     monkeypatch.setattr(tts, "ENGINE_SWITCH_WAIT_S", 0.05)
     plugin = _plugin()
-    plugin.dispatch("tts", {"action": "config", "tts_engine": "sherpa_onnx"})
+    plugin.dispatch("tts", {"action": "config", "tts_engine": "matcha"})
     for card, topic in (("card-1", "/say/a"), ("card-2", "/say/b")):
         plugin.dispatch("tts", {"action": "start", "instance_id": card,
                                 "input_topic": topic})
 
-    _wait_until(lambda: "sherpa_onnx" in _fake_engines)
-    incoming = _fake_engines["sherpa_onnx"]
+    _wait_until(lambda: "matcha" in _fake_engines)
+    incoming = _fake_engines["matcha"]
     _wait_until(lambda: len([c for c in incoming.calls
                              if c.get("action") == "start"]) == 2)
     topics = sorted(c["input_topic"] for c in incoming.calls
@@ -400,11 +446,11 @@ def test_deferred_starts_are_per_instance(monkeypatch, _fake_engines):
 def test_start_after_the_build_finishes_is_not_replayed_twice(_fake_engines):
     """A start that the live engine already handled must not also be queued."""
     plugin = _plugin()
-    plugin.dispatch("tts", {"action": "config", "tts_engine": "sherpa_onnx"})
+    plugin.dispatch("tts", {"action": "config", "tts_engine": "matcha"})
     _wait_until(lambda: plugin.dispatch("tts", {"action": "info"})["state"] != "loading")
 
     plugin.dispatch("tts", {"action": "start", "instance_id": "card-1",
                             "input_topic": "/say"})
     time.sleep(0.2)
-    incoming = _fake_engines["sherpa_onnx"]
+    incoming = _fake_engines["matcha"]
     assert len([c for c in incoming.calls if c.get("action") == "start"]) == 1

--- a/perception/tests/test_vits2_tts_plugin.py
+++ b/perception/tests/test_vits2_tts_plugin.py
@@ -25,6 +25,9 @@ from vision_stubs import (  # noqa: F401
 
 import plugins.vits2_tts_trt.plugin as vits2  # noqa: E402
 from plugins.vits2_tts_trt.adapter import Vits2TensorRTAdapter  # noqa: E402
+# The engine list is owned by plugins/tts.py and imported by this package rather
+# than restated, so assert against the source of truth instead of a copy.
+import plugins.tts as tts  # noqa: E402
 
 
 class _FakeAdapter(Vits2TensorRTAdapter):
@@ -450,7 +453,7 @@ def test_tool_is_the_standard_tts_tool_with_an_engine_selector():
     config = tools[0]["configSchema"]["properties"]
     # The engine has to be visible in the device panel, or switching it means
     # rebuilding the image (see PR #112 review).
-    assert config["tts_engine"]["enum"] == ["vits2_trt", "sherpa_onnx"]
+    assert config["tts_engine"]["enum"] == list(tts.TTS_ENGINES)
     assert vits2.TTSPlugin.PREFIX == "tts"
 
 

--- a/perception/tools/export_mms_thai_onnx.py
+++ b/perception/tools/export_mms_thai_onnx.py
@@ -1,0 +1,371 @@
+#!/usr/bin/env python3
+"""
+tools/export_mms_thai_onnx.py — export an MMS Thai VITS checkpoint for sherpa-onnx.
+
+The Thai voice is a fine-tune of Meta's MMS VITS (VIZINTZOR/MMS-TTS-THAI-*), and
+those are published as HF `VitsModel` PyTorch weights. sherpa-onnx wants a single
+ONNX graph plus a `tokens.txt`, so the recipe has to live in the repo rather than
+only in whatever produced the tarball on COS — same reason as
+tools/convert_onnx_fp16.py.
+
+    python3 tools/export_mms_thai_onnx.py \
+        --repo VIZINTZOR/MMS-TTS-THAI-MALE-NARRATOR \
+        --out /tmp/thai-tts
+
+Requires packages that are NOT in the perception image; run it on a dev host:
+
+    pip3 install torch transformers onnx onnxruntime soundfile
+
+Four things are load-bearing:
+
+- **The input signature must be exactly what sherpa-onnx's generic VITS path
+  sends.** `OfflineTtsVitsModel::Run` dispatches on the ONNX `comment` metadata:
+  anything containing "piper", "coqui" or "Inflect" takes a different, shorter
+  argument list. `comment=mms` falls through to `RunVits`, which feeds
+  ``(x, x_length, noise_scale, length_scale, noise_scale_w)`` positionally and
+  appends `sid` only when the 6th input is literally named `sid` or `speaker`.
+  Names and order, not just shapes, decide whether the model loads.
+
+- **The scales have to be graph inputs, not baked constants.** HF's
+  `VitsModel.forward` reads `self.noise_scale` / `self.noise_scale_duration` and
+  derives `length_scale` from `speaking_rate`, so exporting it as-is freezes the
+  speed at whatever the config said and the plugin's `speed` field stops doing
+  anything. Hence the wrapper below reimplements the generation path with tensor
+  scales.
+
+- **`add_blank`, `sample_rate` and the token table are read from the checkpoint,
+  never hardcoded.** The Thai fine-tunes disagree with each other on sample rate
+  (MALE-NARRATOR is 16 kHz, FEMALEV2 is 22.05 kHz) and the plugin asserts 16 kHz
+  at load, so a hardcoded value would turn a wrong-voice mistake into wrong-pitch
+  audio.
+
+- **`tokens.txt` carries no `<unk>` line.** The tokenizer's vocab.json holds ids
+  0-70 and adds `<unk>` at 71, but sherpa-onnx simply skips characters it cannot
+  find, so the reference layout (willwade/mms-tts-multilingual-models-onnx,
+  `tha/tokens.txt`) lists only the 71 real tokens. The space token is written as
+  a literal space followed by the separator, i.e. the line is ``"  70"``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+
+DEFAULT_REPO = "VIZINTZOR/MMS-TTS-THAI-MALE-NARRATOR"
+
+# What the plugin expects. A voice that disagrees is a different integration.
+EXPECTED_SAMPLE_RATE = 16000
+
+
+def _tokens_txt(vocab: dict[str, int]) -> str:
+    """Render vocab.json as sherpa-onnx's `<token> <id>` table.
+
+    Sorted by id, not by token: sherpa-onnx trusts the id column, but a table
+    whose rows are out of order is impossible to diff against the reference.
+    """
+    lines = [f"{token} {index}" for token, index in sorted(vocab.items(), key=lambda kv: kv[1])]
+    return "\n".join(lines) + "\n"
+
+
+def build_wrapper(model):
+    """Wrap VitsModel so its scales become graph inputs.
+
+    The body follows `transformers.models.vits.VitsModel.forward`; the only
+    changes are that noise_scale / length_scale / noise_scale_w arrive as tensors
+    and the return value is the bare waveform.
+    """
+    import torch
+    from torch import nn
+
+    class ExportableVits(nn.Module):
+        def __init__(self, inner):
+            super().__init__()
+            self.inner = inner
+
+        def forward(self, x, x_length, noise_scale, length_scale, noise_scale_w):
+            inner = self.inner
+            mask_dtype = inner.text_encoder.embed_tokens.weight.dtype
+            attention_mask = (
+                torch.arange(x.shape[1], device=x.device).unsqueeze(0) < x_length.unsqueeze(1)
+            ).to(torch.int64)
+            input_padding_mask = attention_mask.unsqueeze(-1).to(mask_dtype)
+
+            encoded = inner.text_encoder(
+                input_ids=x,
+                padding_mask=input_padding_mask,
+                attention_mask=attention_mask,
+                return_dict=True,
+            )
+            hidden_states = encoded.last_hidden_state.transpose(1, 2)
+            input_padding_mask = input_padding_mask.transpose(1, 2)
+            prior_means = encoded.prior_means
+            prior_log_variances = encoded.prior_log_variances
+
+            if inner.config.use_stochastic_duration_prediction:
+                log_duration = inner.duration_predictor(
+                    hidden_states, input_padding_mask, None,
+                    reverse=True, noise_scale=noise_scale_w,
+                )
+            else:
+                log_duration = inner.duration_predictor(hidden_states, input_padding_mask, None)
+
+            duration = torch.ceil(torch.exp(log_duration) * input_padding_mask * length_scale)
+            predicted_lengths = torch.clamp_min(torch.sum(duration, [1, 2]), 1).long()
+
+            indices = torch.arange(
+                predicted_lengths.max(), dtype=predicted_lengths.dtype, device=predicted_lengths.device
+            )
+            output_padding_mask = (indices.unsqueeze(0) < predicted_lengths.unsqueeze(1))
+            output_padding_mask = output_padding_mask.unsqueeze(1).to(input_padding_mask.dtype)
+
+            attn_mask = torch.unsqueeze(input_padding_mask, 2) * torch.unsqueeze(output_padding_mask, -1)
+            batch_size, _, output_length, input_length = attn_mask.shape
+            cum_duration = torch.cumsum(duration, -1).view(batch_size * input_length, 1)
+            indices = torch.arange(output_length, dtype=duration.dtype, device=duration.device)
+            valid_indices = (indices.unsqueeze(0) < cum_duration).to(attn_mask.dtype)
+            valid_indices = valid_indices.view(batch_size, input_length, output_length)
+            padded_indices = valid_indices - nn.functional.pad(
+                valid_indices, [0, 0, 1, 0, 0, 0]
+            )[:, :-1]
+            attn = padded_indices.unsqueeze(1).transpose(2, 3) * attn_mask
+
+            prior_means = torch.matmul(attn.squeeze(1), prior_means).transpose(1, 2)
+            prior_log_variances = torch.matmul(attn.squeeze(1), prior_log_variances).transpose(1, 2)
+
+            prior_latents = (
+                prior_means
+                + torch.randn_like(prior_means) * torch.exp(prior_log_variances) * noise_scale
+            )
+            latents = inner.flow(prior_latents, output_padding_mask, None, reverse=True)
+            waveform = inner.decoder(latents * output_padding_mask, None).squeeze(1)
+            return waveform
+
+    wrapper = ExportableVits(model)
+    wrapper.eval()
+    return wrapper
+
+
+def add_metadata(path: str, meta: dict[str, str]) -> None:
+    """Write sherpa-onnx's metadata onto an existing ONNX file, in place."""
+    import onnx
+
+    model = onnx.load(path)
+    # Clear first: re-running the export otherwise appends duplicate keys, and
+    # ONNX Runtime returns the first match, so a corrected value would be ignored.
+    del model.metadata_props[:]
+    for key, value in meta.items():
+        entry = model.metadata_props.add()
+        entry.key = key
+        entry.value = str(value)
+    onnx.save(model, path)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--repo", default=DEFAULT_REPO, help="HF repo id of the MMS Thai voice")
+    parser.add_argument("--out", required=True, help="output directory")
+    parser.add_argument("--opset", type=int, default=15)
+    parser.add_argument("--allow-sample-rate", type=int, default=EXPECTED_SAMPLE_RATE,
+                        help="refuse a checkpoint whose sample rate differs; the plugin "
+                             "asserts 16 kHz because the ROS topic is audio/pcm-16k")
+    parser.add_argument("--check-text", default="สวัสดีครับ ระบบพร้อมแล้ว",
+                        help="Thai sentence used for the torch-vs-onnx comparison")
+    args = parser.parse_args()
+
+    import numpy as np
+    import onnxruntime
+    import torch
+    from transformers import VitsModel, VitsTokenizer
+
+    os.makedirs(args.out, exist_ok=True)
+
+    print(f"[export] loading {args.repo}")
+    tokenizer = VitsTokenizer.from_pretrained(args.repo)
+    model = VitsModel.from_pretrained(args.repo)
+    model.eval()
+
+    sample_rate = int(model.config.sampling_rate)
+    if sample_rate != args.allow_sample_rate:
+        print(f"[export] ERROR: {args.repo} is {sample_rate} Hz, expected "
+              f"{args.allow_sample_rate}. The perception TTS topic is audio/pcm-16k "
+              f"and the adapter asserts that rate; exporting this voice would need a "
+              f"resampler added first.", file=sys.stderr)
+        return 1
+    if int(model.config.num_speakers) > 1:
+        print(f"[export] ERROR: {args.repo} declares {model.config.num_speakers} "
+              f"speakers; the adapter only accepts speaker_id=0.", file=sys.stderr)
+        return 1
+
+    # tokens.txt straight from the tokenizer's own table, so it cannot drift.
+    vocab = tokenizer.get_vocab()
+    vocab = {token: index for token, index in vocab.items() if token != tokenizer.unk_token}
+    tokens_path = os.path.join(args.out, "tokens.txt")
+    with open(tokens_path, "w", encoding="utf-8") as handle:
+        handle.write(_tokens_txt(vocab))
+    print(f"[export] wrote {tokens_path} ({len(vocab)} tokens)")
+
+    if "ำ" in vocab:
+        print("[export] NOTE: this table contains ำ, so plugins/thai_frontend.py "
+              "will skip its sara-am rewrite. Verify that is right for this voice.")
+    else:
+        print("[export] table has no ำ (expected for MMS) — the frontend rewrites it to ํา")
+
+    wrapper = build_wrapper(model)
+
+    encoded = tokenizer(text=args.check_text, return_tensors="pt")
+    x = encoded["input_ids"]
+    x_length = torch.tensor([x.shape[1]], dtype=torch.int64)
+    noise_scale = torch.tensor([float(model.noise_scale)], dtype=torch.float32)
+    length_scale = torch.tensor([1.0], dtype=torch.float32)
+    noise_scale_w = torch.tensor([float(model.noise_scale_duration)], dtype=torch.float32)
+
+    onnx_path = os.path.join(args.out, "model.onnx")
+    print(f"[export] tracing to {onnx_path} (opset {args.opset})")
+    torch.onnx.export(
+        wrapper,
+        (x, x_length, noise_scale, length_scale, noise_scale_w),
+        onnx_path,
+        opset_version=args.opset,
+        do_constant_folding=True,
+        # The TorchScript tracer, not the dynamo exporter. torch>=2.9 defaults to
+        # dynamo, which refuses this graph: HF's attention path emits
+        # `aten._is_all_true` from an internal assertion and there is no ONNX
+        # decomposition for it ("No ONNX function found"). The tracer drops
+        # assertions, which is exactly what an inference-only export wants.
+        dynamo=False,
+        # Names and order are the contract with RunVits; see the module docstring.
+        input_names=["x", "x_length", "noise_scale", "length_scale", "noise_scale_w"],
+        output_names=["y"],
+        dynamic_axes={"x": {0: "N", 1: "L"}, "x_length": {0: "N"}, "y": {0: "N", 1: "T"}},
+    )
+
+    add_metadata(onnx_path, {
+        "model_type": "vits",
+        # Must not contain piper/coqui/Inflect — those select other input layouts.
+        "comment": "mms",
+        # THE key that decides whether the model loads at all. sherpa-onnx's
+        # OfflineTtsVitsImpl::InitFrontend dispatches on this exact string: only
+        # "characters" selects OfflineTtsCharacterFrontend. Anything else falls
+        # through to the lexicon branch, which refuses an empty --vits-lexicon with
+        # "Not a model using characters as modeling unit" and calls exit(-1) — so
+        # the failure is a hard process exit, not an exception the plugin can
+        # report. `comment=mms` alone is not enough; it only steers the *input
+        # layout*, not the text frontend.
+        "frontend": "characters",
+        "language": "Thai",
+        "voice": "tha",
+        "sample_rate": sample_rate,
+        "add_blank": int(bool(getattr(tokenizer, "add_blank", True))),
+        "n_speakers": 1,
+        "speaker_id": 0,
+        "has_espeak": 0,
+        "punctuation": "",
+        "url": f"https://huggingface.co/{args.repo}",
+        "license": "CC-BY-NC-4.0 (inherited from facebook/mms-tts)",
+    })
+    size_mb = os.path.getsize(onnx_path) / 1e6
+    print(f"[export] wrote {onnx_path} ({size_mb:.1f} MB)")
+
+    # A manifest beside the model, mirroring what the VITS2 release ships, so the
+    # adapter can validate before it constructs sherpa_onnx.OfflineTts. That check
+    # is not belt-and-braces: sherpa-onnx answers a wrong `frontend` value with
+    # SHERPA_ONNX_EXIT(-1), a process exit that takes ASR, VOP and OCR down with
+    # it and that main.py's try/except around the TTS plugin cannot catch.
+    manifest = {
+        "model": "model.onnx",
+        "tokens": "tokens.txt",
+        "repo": args.repo,
+        "sample_rate": sample_rate,
+        "frontend": "characters",
+        "comment": "mms",
+        "n_speakers": 1,
+        "license": "CC-BY-NC-4.0",
+        "exported_by": "tools/export_mms_thai_onnx.py",
+    }
+    manifest_path = os.path.join(args.out, "manifest.json")
+    with open(manifest_path, "w", encoding="utf-8") as handle:
+        json.dump(manifest, handle, ensure_ascii=False, indent=2)
+    print(f"[export] wrote {manifest_path}")
+
+    # ── self-check: torch vs onnxruntime on the same input ────────────────
+    #
+    # VITS samples latents from a normal distribution, so the two waveforms can
+    # never be identical. What must match is duration and loudness: a broken
+    # export usually produces the right shape and silence, or a wildly different
+    # length because a scale got frozen or transposed.
+    print("[export] self-check: torch vs onnxruntime")
+    with torch.no_grad():
+        torch_wave = wrapper(x, x_length, noise_scale, length_scale, noise_scale_w).numpy()[0]
+
+    session = onnxruntime.InferenceSession(onnx_path, providers=["CPUExecutionProvider"])
+    onnx_wave = session.run(None, {
+        "x": x.numpy(), "x_length": x_length.numpy(),
+        "noise_scale": noise_scale.numpy(),
+        "length_scale": length_scale.numpy(),
+        "noise_scale_w": noise_scale_w.numpy(),
+    })[0][0]
+
+    def rms(wave):
+        return float(np.sqrt(np.mean(np.square(wave.astype(np.float64)))) + 1e-12)
+
+    torch_seconds = len(torch_wave) / sample_rate
+    onnx_seconds = len(onnx_wave) / sample_rate
+    print(f"[export]   torch: {torch_seconds:.2f}s rms={rms(torch_wave):.4f}")
+    print(f"[export]   onnx : {onnx_seconds:.2f}s rms={rms(onnx_wave):.4f}")
+
+    problems = []
+    if rms(onnx_wave) < 1e-3:
+        problems.append("the ONNX output is effectively silent")
+    if not 0.8 <= (onnx_seconds / max(torch_seconds, 1e-6)) <= 1.25:
+        problems.append(f"durations disagree ({torch_seconds:.2f}s vs {onnx_seconds:.2f}s)")
+    ratio = rms(onnx_wave) / rms(torch_wave)
+    if not 0.5 <= ratio <= 2.0:
+        problems.append(f"loudness disagrees (ratio {ratio:.2f})")
+
+    # length_scale must actually change the duration, or `speed` on the card is
+    # decoration — this is the check that catches a frozen scale, which the
+    # comparison above cannot see.
+    slow = session.run(None, {
+        "x": x.numpy(), "x_length": x_length.numpy(),
+        "noise_scale": noise_scale.numpy(),
+        "length_scale": np.array([1.5], dtype=np.float32),
+        "noise_scale_w": noise_scale_w.numpy(),
+    })[0][0]
+    slow_ratio = len(slow) / max(len(onnx_wave), 1)
+    print(f"[export]   length_scale=1.5 → {slow_ratio:.2f}x duration")
+    if slow_ratio < 1.2:
+        problems.append(f"length_scale does not affect duration ({slow_ratio:.2f}x); "
+                        "the plugin's speed field would do nothing")
+
+    try:
+        import soundfile
+
+        wav_path = os.path.join(args.out, "sample.wav")
+        soundfile.write(wav_path, onnx_wave, sample_rate)
+        print(f"[export] wrote {wav_path} — listen to it before uploading")
+    except ImportError:
+        print("[export] soundfile not installed; skipped the sample wav")
+
+    with open(os.path.join(args.out, "LICENSE"), "w", encoding="utf-8") as handle:
+        handle.write(
+            f"Source: https://huggingface.co/{args.repo}\n"
+            "License: CC-BY-NC-4.0, inherited from facebook/mms-tts.\n"
+            "NON-COMMERCIAL. Re-evaluate before shipping this in a product.\n"
+        )
+
+    if problems:
+        print("[export] FAILED:", file=sys.stderr)
+        for problem in problems:
+            print(f"[export]   - {problem}", file=sys.stderr)
+        return 1
+
+    print("[export] OK. Next: tar it up, upload to COS, and pin size+sha256 in "
+          "utils/model_downloader.py THAI_TTS_ARCHIVE.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/perception/utils/model_downloader.py
+++ b/perception/utils/model_downloader.py
@@ -781,3 +781,41 @@ def ensure_vits2_model(model_dir: str, family: str | None = None) -> str:
         entry,
     )
     return os.path.join(model_dir, "engines", key)
+
+
+# The Thai TTS voice: an ONNX export of VIZINTZOR/MMS-TTS-THAI-MALE-NARRATOR,
+# produced by tools/export_mms_thai_onnx.py. One pinned tarball rather than a
+# per-file bundle because the payload is a model plus its token table plus the
+# licence note, and the archive checksum then covers all three.
+#
+# Licence: CC-BY-NC-4.0, inherited from facebook/mms-tts. NON-COMMERCIAL —
+# see the LICENSE file inside the archive.
+THAI_TTS_MODEL_BASE = os.environ.get("THAI_TTS_MODEL_BASE_URL", COS_BASE)
+THAI_TTS_ARCHIVE = {
+    "archive": "mms-tts-thai-male-narrator-16k.tar.gz",
+    # Verified by re-downloading the uploaded object and hashing that copy, not
+    # the local file that was uploaded — the point of the pin is to catch a bad
+    # transfer, and hashing the source cannot.
+    "size": 105246833,
+    "sha256": "85aba3adca3017e955993a3f1ca0fd9aed3216a24b8c64b210f02375b12a4eb4",
+}
+
+
+def ensure_thai_tts_model(model_dir: str) -> str:
+    """Ensure the Thai VITS model + tokens are installed; return the directory."""
+    model_dir = require_models_subpath(model_dir)
+    if not THAI_TTS_ARCHIVE.get("sha256") or not THAI_TTS_ARCHIVE.get("size"):
+        # Refuse rather than download unpinned: every other model here is
+        # size+SHA256 verified, and a Thai voice that skipped that would be the
+        # one unauthenticated blob in the image's supply chain.
+        raise RuntimeError(
+            "THAI_TTS_ARCHIVE has no pinned size/sha256 — publish the tarball to "
+            "COS and record them (see tools/export_mms_thai_onnx.py)"
+        )
+    ensure_verified_archive(
+        "thai-tts",
+        model_dir,
+        f"{THAI_TTS_MODEL_BASE.rstrip('/')}/{THAI_TTS_ARCHIVE['archive']}",
+        THAI_TTS_ARCHIVE,
+    )
+    return model_dir


### PR DESCRIPTION
## What

Adds a Thai voice to the TTS card — an ONNX export of [VIZINTZOR/MMS-TTS-THAI-MALE-NARRATOR](https://huggingface.co/VIZINTZOR/MMS-TTS-THAI-MALE-NARRATOR), 36M params, natively 16 kHz, on the sherpa-onnx runtime already in the image.

Engines are also renamed to **`<model>-<languages>`**, the shape `asr_model` has always used:

| before | after | model | languages |
|---|---|---|---|
| `vits2_trt` | `vits2-zh-en` | VITS2 (TensorRT) | 中 / 英 |
| `sherpa_onnx` | `matcha-zh-en` | matcha-icefall-zh-en | 中 / 英 |
| — | **`mms-th`** | MMS-TTS-THAI-MALE-NARRATOR | ไทย |

Two reasons to match `asr_model` (`x-asr-zh-en`, `paraformer-zh-en`, `zipformer-en`) rather than invent a second convention: the dashboard renders the **raw enum string** — `sidebar.js` only substitutes a label for microphone devices, not configSchema enums — so these are what an operator reads in two dropdowns side by side; and `zh` is the language code while `cn` is a country code, which nothing else in the repo uses.

`_select_engine` folds `_` → `-` before the alias lookup, so `vits2_trt`, `sherpa_onnx` and a hand-typed `vits2_zh_en` all resolve. The old names **must** keep working: they are persisted in ConfigDB rows and `config.yaml` on every deployed robot, and an unknown engine raises, which `TTSPlugin.__init__` turns into `state: error` on every existing TTS card.

## Why a Thai-only model

No small multilingual option exists. Checked each candidate's own language list: **MOSS-TTS-Nano** (20 langs), **Kokoro-82M**, **CosyVoice3-0.5B**, **Qwen3-TTS-0.6B** — none include Thai. **k2-fsa/OmniVoice** does, at 3.2 GB. **KhanomTan v1.0** is the only zh/en/th model and is 2022 Common Voice quality under CC-BY-NC-SA. So Thai is its own engine; 中/英 stay on `vits2-zh-en`.

`MALE-NARRATOR` rather than the more-downloaded `FEMALEV2` because it is **16 kHz**, matching `audio/pcm-16k` exactly — no resampler.

## ⚠️ Licence

**CC-BY-NC-4.0, inherited from `facebook/mms-tts`. Non-commercial.** Not specific to this checkpoint: the whole MMS family and Piper's `th_TH-tsync2` are CC-BY-NC, and the only permissive alternative found (`VachaSpeech-0.6B`, Apache-2.0) is a 0.6B autoregressive model — not viable on CPU, marginal on an Orin GPU. Recorded in the README, the archive's `LICENSE` and the manifest. **Needs a decision before this ships in a product.**

## The frontend is not optional

The tokenizer is character-level over exactly **71 characters** and skips the rest. sherpa-onnx records the loss only as a C++ stderr line that never reaches the Python logger or the dashboard — the audio just comes back short. Three omissions are not guessable:

- **`ำ` (U+0E33) is absent** while `ํ` and `า` are present, so every `ำ` is rewritten to that pair. Measured: `น้ำ ทำ คำ สำหรับ น้ำหนัก` logs five skipped U+0E33 and synthesizes 1.34 s; rewritten it is 1.51 s and the vowels are audible. Without this, น้ำ/ทำ/คำ/สำหรับ and much of the language lose their vowel.
- **`ๆ`** is absent → expanded to the repeated word.
- **Of the Arabic digits only `0 1 2 4` exist** — `3` and `5`–`9` do not, nor do `๐`–`๙`. Every number becomes words.

Mixed text is transliterated into Thai script rather than routed to a second engine, so the robot keeps one voice: numbers via `pythainlp`, Chinese via `pypinyin` → `wunsen`, Latin via a hand lexicon then a `khanaa` rule fallback.

**Correction worth flagging:** `wunsen` does *not* handle English (ja/ko/zh/vi only), so the Latin path is a local rule table, and a name it gets wrong belongs in `_LATIN_LEXICON`. Tradeoff to be explicit about: English inside a Thai sentence is spoken Thai-accented, not natively — native pronunciation needs both engines resident, which the facade forbids.

## Two guards for failures worse than an error

sherpa-onnx picks its text frontend from the ONNX `frontend` metadata string and answers anything but `characters` with `SHERPA_ONNX_EXIT(-1)` — a **process exit**, which `main.py`'s try/except cannot catch and which takes ASR, VOP and OCR down too. So the export writes a `manifest.json` and `_validate_thai_manifest` checks it *before* constructing `OfflineTts`. The adapter also refuses a non-16 kHz model rather than resampling silently.

## Build cache

The Dockerfile block and its `ARG` are at the **end** of the dependency layers deliberately: an `ARG` instruction changes the cache key of every following layer, so declaring `ENABLE_THAI_TTS` at the top would rebuild the whole ~16 GB image for three pure-Python wheels. As committed it is a pure insertion at line 422 — **33 of 45 instructions keep their cache**, including apt, the colcon build and the torch/OCR/sherpa-onnx installs.

`pythainlp` is pinned per Python version: 5.3.x requires `>=3.9` while **jp511 is cp38**, so unpinned it resolves differently per JetPack line. 5.2.0 was checked to export every function the frontend calls.

## Verified

- Export self-check: torch vs ONNX agree on duration and loudness; `length_scale` changes duration, so the card's `speed` field actually works
- **Loaded and synthesized through sherpa-onnx itself**, RTF ~0.31 on CPU at `num_threads=2`
- All nine alias forms resolve to the right engine; an unknown one is still refused
- Adapter emits correct 3200-byte frames; all three guards fire (speaker_id≠0, `frontend=lexicon`, 22.05 kHz)
- Tarball uploaded to COS, **re-downloaded, and the pinned size/sha256 are the downloaded copy's** — hashing the local file defeats the point of the pin
- `387 passed / 25 skipped`; `65 passed` with the Thai deps installed

## Not verified

**No Jetson run and no audio through a real speaker.** Neither Orin has one. Before merge this wants: `--jp-version 5.11` and `6.1` builds, an engine switch on device, and a listen on a robot with a speaker (Go2 / G1 / Bumi).

Also unmeasured: `thai_phrase_spacing` defaults off and needs an on-device A/B.

🤖 Generated with [Claude Code](https://claude.com/claude-code)