### PR TITLE
perception: add kokoro-multi TTS engine (Kokoro-82M v1.0, 9 languages)

### DIFF
--- a/perception/Dockerfile.jetson
+++ b/perception/Dockerfile.jetson
@@ -483,6 +483,35 @@ print('[build] Thai deps import ok: pythainlp %s, khanaa %s, wunsen %s' % \
 (pythainlp.__version__, m.version('khanaa'), m.version('wunsen')))"; \
     fi && rm -f /tmp/thai-requirements.txt
 
+# ── Japanese TTS frontend dep ─────────────────────────────────────────────────
+# One pure-Python wheel with a bundled dictionary (~180 MB installed, and that is
+# the whole cost of Japanese support).
+#
+# Same ARG placement as ENABLE_THAI_TTS above and for the same build-cache reason:
+# an `ARG` up top would rebuild the entire ~16 GB image for one wheel.
+#
+# Janome and not the obvious alternatives, both of which were checked first:
+#   pykakasi       does the same job but is GPL-3.0.
+#   fugashi/cutlet declare requires_python >= 3.9, so they cannot run on jp5.11's
+#                  cp38 at all.
+# Janome is Apache-2.0, `py3-none-any`, and was verified to import and convert on
+# both cp38 (jp5.11) and cp310 (jp6.1) before being picked.
+#
+# The import check is not ceremony: it is the same trap requirements.thai.txt
+# documents — a pure-Python wheel installs happily on cp38 and then fails at
+# import. Verified by running it, not by reading `requires_python`.
+ARG ENABLE_JA_TTS=1
+COPY perception/plugins/requirements.ja.txt /tmp/ja-requirements.txt
+RUN if [ "${ENABLE_JA_TTS}" = "1" ]; then \
+      pip3 install --no-cache-dir -i "${PYPI_MIRROR}" -r /tmp/ja-requirements.txt && \
+      python3 -c "from janome.tokenizer import Tokenizer; \
+t = Tokenizer(); \
+out = ''.join((k.reading if k.reading and k.reading != '*' else k.surface) \
+              for k in t.tokenize('今日は2026年10月1日です')); \
+assert not any(0x4E00 <= ord(c) <= 0x9FFF for c in out), out; \
+print('[build] janome ok, no kanji left: %s' % out)"; \
+    fi && rm -f /tmp/ja-requirements.txt
+
 # ── Application code ───────────────────────────────────────────────
 WORKDIR /work
 COPY perception/main.py    /work/main.py

--- a/perception/Dockerfile.jetson
+++ b/perception/Dockerfile.jetson
@@ -454,14 +454,34 @@ RUN . /etc/jetpack.env && \
 # Neither half works alone — see the measurements on the wheel-selection step above.
 # Do not "simplify" this away and go back to the PyPI CPU wheel: that has no bridge
 # at all, and this copy then silently does nothing while the plugin logs
-# "device='gpu' ... falling back to cpu".
+# "device='gpu' ... falling back to cpu". Re-confirmed by running the same probe in
+# both images, with and without sherpa_onnx imported first — the import order makes
+# no difference, so this is not something symbol interposition can rescue:
+#
+#   release.260910.84b5450 (PyPI wheel + copy)  compiled-in ['Azure','CPU']  18.5 ms
+#   release.260910.10266c2 (COS wheel + copy)   compiled-in [...,'CUDA',...]  6.0 ms
+#
+# The price of the copy, and it is a real one: the standalone runtime (1.18.0) and
+# sherpa's (**1.18.1**, not 1.18.0 — check `sherpa_onnx/lib/`) now share a single
+# provider library, since the soname collides and the first dlopen wins. They
+# coexist fine for separate graphs — face keeps its 3x with a sherpa CUDA session
+# live — but a *second* CUDA session on the **Kokoro** graph fails in whichever
+# runtime did not load the provider, symmetrically:
+#
+#   sherpa's session first  -> the standalone one fails, naming /home/tian/Yxh/...
+#   the standalone first    -> sherpa's fails, naming /home/yifanl/...
+#   both: "Error mapping output names: Could not find OrtValue '/Squeeze_2_output_0'"
+#
+# That is why plugins/kokoro_direct.py is CPU-only by construction and takes no
+# device argument. Anything else that wants a standalone CUDA session on a graph
+# sherpa also loads has the same constraint.
 RUN . /etc/jetpack.env && \
     if [ "${JP_VERSION}" = "61" ]; then \
         SHERPA_LIB="/usr/local/lib/python3.10/dist-packages/sherpa_onnx/lib" && \
         ORT_CAPI="/usr/local/lib/python3.10/dist-packages/onnxruntime/capi" && \
         cp "${SHERPA_LIB}/libonnxruntime_providers_cuda.so" "${ORT_CAPI}/" && \
         cp "${SHERPA_LIB}/libonnxruntime_providers_shared.so" "${ORT_CAPI}/" && \
-        echo "[build] JP6.1: Enabled GPU using sherpa-onnx's onnxruntime 1.18.0 (cuDNN 9)"; \
+        echo "[build] JP6.1: GPU enabled via sherpa-onnx's cuDNN-9 CUDA provider"; \
     fi
 
 # ── Thai TTS frontend deps ────────────────────────────────────────

--- a/perception/Dockerfile.jetson
+++ b/perception/Dockerfile.jetson
@@ -419,24 +419,42 @@ print('[build] VITS2 frontend ok on numpy ' + numpy.__version__)"; \
 #
 # GPU variant: NVIDIA provides onnxruntime-gpu wheels for Jetson. Hosted on COS.
 # jp5.11 uses 1.15.1 (CUDA 11.4, Python 3.8, GLIBCXX_3.4.28 compatible).
-# jp6.1 reuses sherpa-onnx's bundled onnxruntime 1.18.0 (cuDNN 9 compatible) rather
-# than installing a separate wheel. The bundled version is already installed with
-# sherpa-onnx and links correctly against JP6.1's cuDNN 9.
-# The GPU wheel is ~39 MB vs ~5 MB for CPU-only, but provides CUDAExecutionProvider
-# and TensorrtExecutionProvider with ~3.6x performance improvement (JP5.11: 5ms vs 17ms,
-# JP6.1: 6ms vs 20ms per inference).
+#
+# jp6.1 needs **both halves**, and shipping either alone leaves the face plugin on
+# the CPU while claiming otherwise. Measured on Orin 6 with buffalo_sc/w600k_mbf:
+#
+#   onnxruntime==1.18.0 (PyPI, CPU build) + this layer's copy   18.53 ms   54 FPS
+#   the COS gpu wheel alone                                     19.10 ms   52 FPS
+#   the COS gpu wheel + this layer's copy                        5.89 ms  170 FPS
+#
+# They fail for opposite reasons. The PyPI wheel is a CPU build: its pybind layer
+# has no provider-bridge code, so `get_available_providers()` never lists CUDA no
+# matter what .so files sit beside it, and copying one in is a no-op. The COS wheel
+# does have the bridge, but was built against cuDNN 8 and JP6.1 ships 9, so loading
+# its provider fails with "libcudnn.so.8: cannot open shared object file".
+#
+# So: install the COS wheel for the bridge, then overwrite its cuDNN 8 provider with
+# sherpa-onnx's cuDNN 9 one in the step below. Both halves, or neither works.
+# History note, because this looked settled twice: the tree alternated between the
+# two single-halves (ae0e13a, ad4a091, cdd23fd) and merged on the CPU one.
 RUN . /etc/jetpack.env && \
     case "${JP_VERSION}" in \
         511) ORT_WHEEL="https://agi-phanthy-dev-1252788780.cos.ap-beijing.myqcloud.com/public/onnxruntime/jp511/onnxruntime_gpu-1.15.1-cp38-cp38-linux_aarch64.whl" ;; \
-        61)  ORT_WHEEL="onnxruntime==1.18.0" ;; \
+        61)  ORT_WHEEL="https://agi-phanthy-dev-1252788780.cos.ap-beijing.myqcloud.com/public/onnxruntime/jp61/onnxruntime_gpu-1.18.0-cp310-cp310-linux_aarch64.whl" ;; \
         *)   ORT_WHEEL="onnxruntime==1.18.1" ;; \
     esac && \
     pip3 install --no-cache-dir --no-deps -i ${PYPI_MIRROR} "${ORT_WHEEL}"
 
-# ── JP6.1: Enable GPU using sherpa-onnx's bundled onnxruntime ────────────────
-# sherpa-onnx 1.13.6+cuda bundles onnxruntime 1.18.0 compiled against cuDNN 9,
-# which is exactly what JP6.1 requires. We reuse its CUDA provider libraries
-# instead of compiling our own or waiting for an official wheel.
+# ── JP6.1: the second half of the GPU fix ────────────────────────────────────
+# The COS wheel installed above carries the provider bridge but was built against
+# cuDNN 8; JP6.1 ships 9, so its own provider fails to load with
+# "libcudnn.so.8: cannot open shared object file". sherpa-onnx 1.13.6+cuda bundles
+# the same provider built against cuDNN 9, so overwrite the wheel's copy with it.
+#
+# Neither half works alone — see the measurements on the wheel-selection step above.
+# Do not "simplify" this away and go back to the PyPI CPU wheel: that has no bridge
+# at all, and this copy then silently does nothing while the plugin logs
+# "device='gpu' ... falling back to cpu".
 RUN . /etc/jetpack.env && \
     if [ "${JP_VERSION}" = "61" ]; then \
         SHERPA_LIB="/usr/local/lib/python3.10/dist-packages/sherpa_onnx/lib" && \

--- a/perception/README.md
+++ b/perception/README.md
@@ -102,6 +102,63 @@ unknown engine — so dropping them would put every existing TTS card into
 Only one engine is resident at a time. Switching disposes the outgoing one's nodes
 first, because two live publishers on one audio topic play both voices at once.
 
+### Chinese number normalisation is applied by us, never by `rule_fsts`
+
+Affects both sherpa-onnx engines that can speak Chinese (`matcha-zh-en`,
+`kokoro-multi`). Both pass **`rule_fsts=""`** and call `plugins/zh_text_norm.py`
+instead. Do not "simplify" that back.
+
+sherpa-onnx applies every FST in `rule_fsts` to the **whole text before its frontend
+decides what is Chinese** (`offline-tts-kokoro-impl.h`: the `tn_list_` loop runs, and
+only then `ConvertTextToTokenIds`). The frontend routes on `[一-鿿]`. So handing it
+the ZH number/date/phone FSTs rewrites every digit into Chinese characters *first*,
+and the frontend then reads them in Chinese — regardless of `lang`, in every language:
+
+| input | with `rule_fsts` | fixed |
+|---|---|---|
+| `...opened in 2026.` | `...opened in 二千零二十六.` | unchanged, espeak reads it |
+| `We have 25 exhibits today.` | `We have 二十五 exhibits today.` | unchanged |
+| `Hola, tenemos 25 exposiciones hoy.` | `Hola, tenemos 二十五 exposiciones.` | unchanged |
+
+The FSTs are not the problem and must not be dropped — for Chinese they are
+load-bearing and good: `2026年` → `二零二六年`, `2026年1月15日` →
+`二零二六年一月十五日`, `第25个展品` → `第二十五个展品`, `延迟200毫秒` →
+`延迟二百毫秒`.
+
+So `zh_text_norm` runs them in Python, before sherpa sees the text, and only on the
+Chinese parts. **A digit run is Chinese when either neighbour is** — which gets both
+directions right in a way that gating on `tts_language` could not:
+
+```
+"延迟 200 毫秒"        -> Chinese on both sides   -> 二百
+"共25 items"           -> Chinese only before     -> 二十五
+"In 2026 我们开业"     -> Chinese only after      -> 二零二六
+"we have 25 exhibits"  -> Chinese on neither      -> left to espeak
+```
+
+Two details are load-bearing and pinned by `tests/test_zh_text_norm.py`, which needs
+no model and no `kaldifst`:
+
+- **Whole segments go to the FST, never the bare digits.** `date-zh.fst` has to see
+  the `年` to produce `二零二六年` instead of the quantity form `二千零二十六`.
+- **The CJK range is the same one sherpa routes on** (`一-鿿`). If the two
+  disagreed, text could be normalised here and then routed to espeak anyway.
+
+`matcha-zh-en` has no language field at all, which is the other reason the decision is
+made per number rather than per engine setting.
+
+`kaldifst` reaches the image through `plugins/vits2_tts_trt/requirements.jetson.txt`,
+installed when `ENABLE_VITS2_TRT=1` (the Dockerfile default). Without it this degrades
+to a **warning, not a refusal**: Chinese digits get read by espeak in the selected
+voice — wrong, but audible and confined to numbers. Contrast the Thai frontend, which
+*does* refuse without pythainlp, because there the digits vanish from the audio
+entirely.
+
+Known limitation, sherpa's FSTs rather than this code: `电话13800138000` becomes
+`一百三十八亿零一十三万八千` — `phone-zh.fst` does not match a bare number, so
+`number-zh.fst` reads it as a quantity. And a bare `2026.` with no `年` reads as
+`二千零二十六`; the year form needs the context character.
+
 ### `kokoro-multi`, the multilingual voice
 
 [Kokoro-82M](https://huggingface.co/hexgrad/Kokoro-82M) **v1.0**, added because
@@ -151,13 +208,30 @@ made `en-gb` look like it ought to work. Hence a closed map rather than passing 
 configured label through, and a construction-time probe that refuses to load if the
 resolved voice produces no audio.
 
-**Language and voice are independent.** `lang` picks the pronunciation;
-`speaker_id` picks the timbre. 54 voices: **0–19 `en-us`, 20–27 `en-gb`, 28–29 + 53
-`es`, 30 `fr`, 31–34 `hi`, 35–36 `it`, 37–41 `ja`, 42–44 `pt-br`, 45–52 `zh`**.
-`af_heart` (3) and `af_bella` (2) are the highest-graded English voices. A voice from
-a *different* language is legal and gives an accented result, so the adapter warns
-rather than refuses — except for `zh`, which is exempt in both directions because a
-Chinese voice with `en-us` is the correct Chinese setup, not a mistake.
+**`speaker_id` is an index within the selected language, not a global voice number.**
+`speaker_id: 0` is the first voice of whatever `tts_language` is set to, so switching
+language moves the voice with it and the two cannot end up disagreeing. The model's
+own numbering is not learnable — Japanese starts at 37 and Spanish is 28, 29 **and**
+53 — and exposing it made it easy to pick an American voice, switch to Japanese, and
+wonder why the result sounded wrong. That class of mistake is now unrepresentable
+rather than warned about.
+
+| `tts_language` | voices | `speaker_id: 0` is |
+|---|---|---|
+| `en-us` | 20 | `af_alloy` (`af_heart` is 3, `af_bella` 2 — the highest-graded) |
+| `en-gb` | 8 | `bf_alice` |
+| `zh` | 8 | `zf_xiaobei` |
+| `ja` | 5 | `jf_alpha` |
+| `hi` | 4 | `hf_alpha` |
+| `es` / `pt-br` | 3 | `ef_dora` / `pf_dora` |
+| `it` | 2 | `if_sara` |
+| `fr` | 1 | `ff_siwis` |
+
+Out of range at load is a `ValueError` naming the language and its count. Out of
+range *after* a language switch clamps to voice 0 with a warning instead — language
+is a free per-utterance setting and must not be able to fail, and `fr` has exactly
+one voice. The requested index is remembered, so switching back restores it. Logs and
+`info` report the resolved name (`af_heart`), not the number.
 
 > **Only `en-us`, `en-gb` and `zh` have been listened to.** sherpa-onnx's own
 > documentation says of this model "it is a multi-lingual model, but we only add
@@ -165,6 +239,13 @@ Chinese voice with `en-us` is the correct Chinese setup, not a mistake.
 > the other six the espeak phoneme set is not guaranteed to be the one the acoustic
 > model learned. All nine produce audio of a plausible length on device; treat the
 > rest as best-effort until someone who reads the language has heard them.
+>
+> **`ja` is known to be wrong, not merely unverified.** sherpa-onnx's frontend routes
+> every character in `[一-鿿]` to its *Chinese* branch with no language check, and
+> Japanese kanji live in exactly that range — `展` is U+5C55, `示` is U+793A. So
+> `こんにちは、25の展示があります。` reaches the model as Japanese kana through
+> espeak-ja plus kanji pronounced in **Mandarin** from `lexicon-zh.txt`. Nothing here
+> can fix that; it needs a Japanese lexicon in sherpa-onnx.
 
 #### Measured on Orin 6 (jp6.1), fp32 on gpu
 

--- a/perception/README.md
+++ b/perception/README.md
@@ -318,67 +318,93 @@ down with it. Same hazard `_validate_thai_manifest` exists for. It also refuses 
 `model_version` of 1 (v0.19 ignores `lang`, so the dropdown would be visibly present
 and silently inert) and any `sample_rate` other than 24000.
 
-### `ja` needs its own frontend, or it comes out in Mandarin
+### `ja`: why it is hard, and how far this gets
 
-sherpa-onnx's Kokoro frontend splits text on `[一-鿿]` and sends everything in that
-range to `ConvertChineseToTokenIDs`, which reads `lexicon-zh.txt`. **That function
-never receives the requested language** — only the non-Chinese branch does. Japanese
-kanji are inside that range (`今` U+4ECA, `私` U+79C1, `何` U+4F55), so raw Japanese
-reaches the model as Mandarin-pronounced kanji plus espeak-ja kana. That is what
-"the Japanese sounds Chinese" turned out to be.
+Two separate problems, and the second is only partly solved.
 
-Measured on Orin 6, and this is the whole argument:
+**1. Raw Japanese is read in Mandarin.** sherpa-onnx's Kokoro frontend splits text on
+`[一-鿿]` and sends that range to `ConvertChineseToTokenIDs`, which reads
+`lexicon-zh.txt`. **That function never receives the requested language.** Japanese
+kanji are inside the range (`今` U+4ECA, `私` U+79C1, `何` U+4F55), so kanji are
+pronounced in Mandarin whatever `tts_language` says. Measured on Orin 6:
 
 | text | `ja` | `en-us` | `es` | `fr` |
 |---|---|---|---|---|
 | `今日私何` (kanji only) | 30682 | 30682 | 30682 | 30682 |
 | `こんにちは` (kana only) | 28908 | 114986 | — | — |
 
-Identical sample counts for kanji under every language: `lang` has **no effect** on
-them. Kana, by contrast, change 4x. No sherpa-onnx release ships a Japanese lexicon
-(checked v0_19, v1_0 and v1_1), so the fix has to happen before the engine sees the
-text.
+Identical sample counts for kanji under every language; kana change 4x. `lang` has no
+effect on kanji at all.
 
-`plugins/ja_text_norm.py` converts every kanji to kana, so nothing is left in the
-CJK range and the whole utterance takes the espeak-ja path. Same role as
-`plugins/thai_frontend.py`. Two stages, and the second is not optional:
+**2. Kana are read with holes.** Kokoro's 114-token table *is* the misaki phoneme
+inventory — it contains `ʣ ʥ ʦ ʨ ᵝ`, so the model was trained to speak Japanese. But
+it has no `ʑ`, and espeak-ja emits exactly that for じ, plus combining diacritics
+`U+0308` and `U+031E`. sherpa phonemises with espeak and looks the result up in a
+misaki-derived table, silently discarding what is missing: **12 phonemes dropped from
+one sentence**, audible as gaps, and unintelligible.
 
-1. **Dates, times and counters, by rule.** Japanese counter readings are irregular
-   and context-dependent, and a morphological analyser gives the isolated-morpheme
-   reading instead — Janome renders `10月` as `ツキ` and `1日` as `ニチ`, where a
-   speaker says `ジュウガツ` and `ツイタチ`. Also `4月`=シガツ (not ヨンガツ),
-   `4時`=ヨジ, `30分`=サンジュップン. The irregular follows the **trailing** digit,
-   so a flat table keyed on the whole number gets `14時` and `30分` wrong —
-   `tests/test_ja_text_norm.py` pins both, and caught exactly that mistake.
-2. **Everything else, via Janome.** Apache-2.0, `py3-none-any`, its own IPADIC
-   dictionary, verified to import *and convert correctly* on cp38/jp5.11 **and**
-   cp310/jp6.1 before it was chosen. `pykakasi` does the same job but is GPL-3.0;
-   `fugashi`/`cutlet` declare `requires_python >= 3.9` and cannot run on jp5.11.
+**The root cause of (2) is that upstream Kokoro and sherpa-onnx use different G2P.**
+Upstream drives Kokoro with misaki, whose phonemes are the table the model was trained
+on. sherpa-onnx uses espeak-ng, whose inventory does not match. This is not a
+limitation of the model.
 
-Result on the sentence that prompted this:
+`plugins/ja_text_norm.py` works around both: kanji→kana via Janome, dates and counters
+by rule, then **kana→Hepburn romaji**, so nothing is left in the CJK range and the
+text is phonemised by a Latin-script voice whose output Kokoro can represent.
+`LANGUAGE_VOICES["ja"]` is therefore `"it"`, not `"ja"` — the voice is chosen for its
+**phoneme inventory**, not its language. Measured on the reported sentence:
 
-```
-こんにちは！今日は2026年10月1日です。私はシャオ・ファンと申します。何かお手伝いしましょうか？
-  -> コンニチハ！キョウハニセンニジュウロクネンジュウガツツイタチデス。
-     ワタシハシャオ・ファントモウシマス。ナニカオテツダイシマショウカ？
-  kanji left: none
-```
+| | dropped | duration |
+|---|---|---|
+| kana + espeak `ja` | **12** | 12.11 s |
+| romaji + espeak `ja` | 0 | 14.78 s — spelled out letter by letter |
+| **romaji + espeak `it`** | **0** | **7.85 s** |
 
-Janome costs **~180 MB installed** and is gated by `ENABLE_JA_TTS` (default 1),
-placed last among the Dockerfile's dependency layers for the same build-cache reason
-as `ENABLE_THAI_TTS`. The frontend is built lazily on the first switch to `ja`, so a
-Chinese or English deployment never loads that dictionary — but eagerly enough (at
-construction and in `set_language`) that a missing janome is a load error naming the
-build flag, rather than a card that comes up `running` and speaks Mandarin. That is
-the one place this refuses instead of degrading, and for the same reason the Thai
-adapter refuses without pythainlp.
+Two details cost more than they look:
 
-Remaining caveat, measured rather than assumed: espeak-ja emits a few phonemes
-Kokoro's token table does not contain — `U+0308`, `U+031E` and `ʑ` `U+0291` — and
-sherpa drops them ("Skip unknown phonemes"), about a dozen in a long sentence.
-Japanese is now unmistakably Japanese, but Kokoro's tokens were built for misaki's
-phoneme set rather than espeak's, so it is not as clean as English or Chinese.
+- **Word boundaries.** Japanese has none, but the romaji is read by a Latin-script
+  voice, and one unbroken `kyoowanisennijuurokunen…` is a single enormous word whose
+  stress espeak has to guess: 7.62 s unspaced against 4.60 s spaced. Janome has
+  already found the morpheme boundaries, so they are kept — except before a lone
+  `ウ`/`ー`, since Janome splits `マショウ` into `マショ`+`ウ` and a space there gives
+  `masho u` rather than `mashoo`.
+- **Long vowels are doubled, not written as digraphs.** `キョウ` becomes `kyoo`, never
+  `kyou`, which Italian and Spanish read as two syllables.
 
+Also corrected here: the particle `は` is *read* `ハ` but *pronounced* わ — `今日は` is
+`kyoo wa`, never `kyoo ha` — and full-width `。！？` become ASCII so espeak can find
+sentence boundaries.
+
+> **Honest limit: this sounds like a non-native speaker reading Japanese.** Verified by
+> ear, not inferred. Zero phonemes are dropped and it is intelligible, which the kana
+> version was not, but Italian phonemes are not Japanese ones. Making it sound native
+> needs misaki-compatible phonemes reaching the model, which sherpa-onnx offers no path
+> for today — its only phoneme-level entry point is the lexicon, and
+> `ConvertNonChineseToTokenIDs` bypasses the lexicon whenever `lang` is non-empty,
+> which it always is because it falls back to the model's own `meta_data.voice`.
+>
+> An earlier version of this section claimed the output was "unmistakably Japanese".
+> That was inferred from "no kanji left in the text" without listening, and it was
+> wrong.
+
+### Chinese: use `vits2-zh-en`, and why Kokoro's Chinese is not broken
+
+Chinese takes a different path from Japanese and loses nothing. `Skip unknown phonemes`
+counts on Orin 6:
+
+| text | dropped |
+|---|---|
+| Chinese, ordinary | **0** |
+| Chinese with embedded English | **0** |
+| Chinese, rare characters (`饕餮纹鼎鬲甗簋簠盨匜盘`) | **0** |
+| English | **0** |
+| Japanese kana (for contrast) | **12** |
+
+`ConvertChineseToTokenIDs` reads `lexicon-zh.txt`, whose entries are already misaki
+phonemes (`七 ʨ ʰ i →`), and never touches espeak — so there is no bug here to fix.
+What remains is that Kokoro is one 82 M model covering nine languages, while
+`vits2-zh-en` is a **purpose-trained 16 kHz Chinese voice** and is already the default
+engine. Prefer it for Chinese; `kokoro-multi` exists for English.
 
 ### `mms-th`, and why it cannot be handed raw text
 

--- a/perception/README.md
+++ b/perception/README.md
@@ -90,6 +90,7 @@ and `mms-th` both run on sherpa-onnx, so `sherpa_onnx` identified neither.
 | `vits2-zh-en` (default) | VITS2 16 kHz | 中 / 英, code-switching | TensorRT | `/models/vits2` |
 | `matcha-zh-en` | matcha-icefall-zh-en + vocos | 中 / 英 | ONNX Runtime | `/models/sherpa-onnx/tts` |
 | `mms-th` | MMS-TTS-THAI-MALE-NARRATOR | ไทย only | ONNX Runtime | `/models/mms-th` |
+| `kokoro-multi` | Kokoro-82M v1.0 | 英 / 中 / 日 / 西 / 法 / 意 / 葡 / 印地, code-switching | ONNX Runtime | `/models/kokoro-multi/<device>` |
 
 `vits2_trt` and `sherpa_onnx` still resolve, via `ENGINE_ALIASES` in
 `plugins/tts.py`, and underscores fold to hyphens first so `vits2_zh_en` works too.
@@ -100,6 +101,147 @@ unknown engine — so dropping them would put every existing TTS card into
 
 Only one engine is resident at a time. Switching disposes the outgoing one's nodes
 first, because two live publishers on one audio topic play both voices at once.
+
+### `kokoro-multi`, the multilingual voice
+
+[Kokoro-82M](https://huggingface.co/hexgrad/Kokoro-82M) **v1.0**, added because
+`vits2-zh-en` is a Chinese male voice whose English is the weaker half, and there was
+no engine good enough to put in front of an English-speaking audience. 82 M
+parameters, Apache-2.0, and it needs no new framework: sherpa-onnx already ships
+`OfflineTtsKokoroModelConfig`, so this engine added **no Dockerfile change** — only
+Python, a COS artefact and tests.
+
+Named `kokoro-multi`, not `kokoro-zh-en`: it has voices for nine languages, and a
+name claiming two would mislead every operator reading the dropdown. `multi` is also
+what upstream calls the release (`kokoro-multi-lang-v1_0`).
+
+**Language is a runtime dropdown, and switching it is free.** `tts_language`
+(`plugins.tts.language` in `config.yaml`) takes `en-us`, `en-gb`, `zh`, `ja`, `es`,
+`fr`, `it`, `pt-br` or `hi`. sherpa-onnx reads it from
+`GenerationConfig.extra["lang"]` on *every* `generate()` call, so it is a scale on
+the resident model exactly like `speed` — it is deliberately **absent from
+`_session_keys`**, because putting it there would tear down and reload a 310 MB fp32
+CUDA session every time someone changed the dropdown. Verified on the shipped wheels
+for both Python ABIs (cp38/jp5.11 and cp310/jp6.1): `extra` accepts a plain dict and
+round-trips.
+
+**What the field actually selects is the espeak-ng voice for the *non-Chinese* runs
+of the text.** Chinese is phonemised from `lexicon-zh.txt` on every setting, because
+that branch of sherpa-onnx's frontend never consults `lang`. Two consequences:
+
+- Mixed zh/en in one sentence code-switches on its own, with no Python-side
+  detection — `KokoroMultiLangLexicon` splits the text on Chinese vs non-Chinese
+  character runs and phonemises each separately.
+- **`zh` maps to an English espeak voice on purpose**, and is not redundant with
+  `en-us`: it only decides how *embedded Latin* in a Chinese sentence is read, and
+  English is the right answer. Digits are already converted to Chinese characters
+  upstream by the ZH rule FSTs.
+
+**The espeak voice names in `LANGUAGE_VOICES` are measured, not guessed.** Getting
+one wrong fails in two ways, both silent on the robot:
+
+| configured | espeak voice | what a guess did |
+|---|---|---|
+| `en-gb` | `en-gb-x-rp` | plain `en-GB` is **not a voice espeak-ng ships** → "Failed to set eSpeak-ng voice", **no audio at all** |
+| `pt-br` | `pt-BR` | — |
+| `fr` | `fr` | `fr-FR` **silently truncates**: 18280 samples where `fr` gave 63277 on the same sentence, nothing raised, nothing logged |
+
+espeak matching is case-insensitive, which is why `en-us` resolves to `en-US` and
+made `en-gb` look like it ought to work. Hence a closed map rather than passing the
+configured label through, and a construction-time probe that refuses to load if the
+resolved voice produces no audio.
+
+**Language and voice are independent.** `lang` picks the pronunciation;
+`speaker_id` picks the timbre. 54 voices: **0–19 `en-us`, 20–27 `en-gb`, 28–29 + 53
+`es`, 30 `fr`, 31–34 `hi`, 35–36 `it`, 37–41 `ja`, 42–44 `pt-br`, 45–52 `zh`**.
+`af_heart` (3) and `af_bella` (2) are the highest-graded English voices. A voice from
+a *different* language is legal and gives an accented result, so the adapter warns
+rather than refuses — except for `zh`, which is exempt in both directions because a
+Chinese voice with `en-us` is the correct Chinese setup, not a mistake.
+
+> **Only `en-us`, `en-gb` and `zh` have been listened to.** sherpa-onnx's own
+> documentation says of this model "it is a multi-lingual model, but we only add
+> English and Chinese support for it" — Kokoro was trained with misaki G2P, and for
+> the other six the espeak phoneme set is not guaranteed to be the one the acoustic
+> model learned. All nine produce audio of a plausible length on device; treat the
+> rest as best-effort until someone who reads the language has heard them.
+
+#### Measured on Orin 6 (jp6.1), fp32 on gpu
+
+| lang | sid | audio | synth | RTF | resample |
+|---|---|---|---|---|---|
+| `en-us` | 3 | 8.46 s | 0.78 s | **0.092** | 26 ms |
+| `en-gb` | 26 | 10.62 s | 0.85 s | 0.080 | 36 ms |
+| `zh` | 47 | 9.02 s | 0.89 s | 0.099 | 27 ms |
+| `ja` | 37 | 6.44 s | 0.54 s | 0.085 | 18 ms |
+| `es` / `fr` / `it` / `pt-br` / `hi` | — | ~4-6 s | 0.31-0.44 s | 0.070-0.083 | 11-22 ms |
+
+Session build 2.6 s (well inside `ENGINE_SWITCH_WAIT_S = 20`), warmup probe 0.93 s,
+and the resampler costs 3-4% of synthesis — not worth a polyphase rewrite.
+
+**`cpu` is not viable for streaming.** int8 on the same box measured **RTF 1.6** —
+slower than real time, so the audio cannot keep up with the frame clock. That is why
+`ENGINE_DEVICE_DEFAULTS` puts this engine on **gpu**; `cpu` exists for hosts with no
+CUDA wheel and for offline synthesis, not for live speech. (Note the dashboard form
+still renders the schema's `cpu` default, since JSON Schema cannot express a
+per-engine one.)
+
+**It is the only engine whose sample rate is not the pipeline's** — Kokoro is
+24 kHz, everything downstream is 16 kHz, and `AudioChunk` has no way to be told
+otherwise (the rate lives inside the `audio/pcm-16k` format string, and the
+publisher's pacing derives from `SAMPLE_RATE`). So the adapter downsamples
+internally, in `utils/resample.py`: 24000 → 16000 is exactly 2:3, so it upsamples by
+2, lowpasses at 8 kHz with a 97-tap Blackman-windowed sinc, and decimates by 3 —
+numpy only, because scipy would pull its own numpy pin and every plugin
+requirements file here exists partly to prevent that. Nothing outside the adapter
+knows Kokoro is 24 kHz.
+
+Checked against `scipy.signal.resample_poly` on a real 8.5 s utterance: correlation
+**0.999997**, peak error −39.6 dB, and the residual confined to the 7–8 kHz
+transition band (error/signal 3.8e-3 there against ~1e-6 below 6 kHz). The ~2-5% DC
+offset in the output is **Kokoro's own** — the raw 24 kHz is +0.0236 and the
+resampled 16 kHz is +0.0236, which is what a unity-DC-gain lowpass should do.
+
+Two details in that resampler are load-bearing and are pinned by
+`tests/test_resample.py`: the whole utterance is resampled *before* being framed
+(doing it per 3200-byte frame restarts the filter every 100 ms, which is ten clicks
+a second), and clipping happens in float before the int16 cast (`astype(np.int16)`
+on an out-of-range value wraps, turning an overshoot into a full-scale *opposite*
+polarity tick on the loudest part of the utterance). A third was found by those
+tests rather than by ear: `np.convolve(mode="same")` returns
+`max(len(signal), len(taps))`, so an utterance shorter than the 97-tap filter came
+back padded out to 97 samples of filter tail — which a punctuation-only chunk hits.
+
+**`device` selects different weight files here, not just a provider.** `gpu` gets
+fp32 and `cpu` gets int8, because `provider_for_device` refuses int8 on CUDA (the
+CUDA provider falls back to CPU per quantised node). So the two are separate pinned
+archives that unpack into `/models/kokoro-multi/gpu` and `.../cpu` — flipping the
+field downloads the other one and leaves the first in place.
+
+The release is repacked from sherpa-onnx's `kokoro-multi-lang-v1_0` by
+`tools/repack_kokoro_v1_0.py` and mirrored to COS, pinned by size + SHA256 like
+every other model here. Two things upstream ships are dropped:
+
+- `lexicon-us-en.txt` / `lexicon-gb-en.txt` (11.6 MB) — **unreachable.** For
+  non-Chinese runs sherpa-onnx short-circuits to espeak whenever `lang` is
+  non-empty, and `lang` falls back to the model's own `meta_data.voice` (`"en-us"`)
+  when unset, so it never is. English pronunciation here comes from espeak-ng, not
+  from a dictionary.
+- `dict/` (14 MB, the jieba dictionary) — ignored since sherpa-onnx v1.12.15, which
+  logs "you don't need to provide dict_dir" if you pass one.
+
+`lexicon-zh.txt` stays: the Chinese branch does *not* consult `lang`, so it is
+genuinely used. The three ZH rule FSTs stay for number/date/phone normalisation.
+Result: **~358 MB unpacked on gpu, ~157 MB on cpu** (from 384 MB / 183 MB upstream).
+
+`_validate_kokoro_manifest` checks the release *before* `OfflineTts` is
+constructed, and one of those checks is not optional: for a `version >= 2` Kokoro
+model with **both `lexicon` and `lang` empty**, sherpa-onnx's `InitFrontend` calls
+`SHERPA_ONNX_EXIT(-1)` — a **process exit**, so `main.py`'s try/except around the
+TTS plugin cannot turn it into a card in `state: error`; it takes ASR, VOP and OCR
+down with it. Same hazard `_validate_thai_manifest` exists for. It also refuses a
+`model_version` of 1 (v0.19 ignores `lang`, so the dropdown would be visibly present
+and silently inert) and any `sample_rate` other than 24000.
 
 ### `mms-th`, and why it cannot be handed raw text
 

--- a/perception/README.md
+++ b/perception/README.md
@@ -387,6 +387,64 @@ sentence boundaries.
 > That was inferred from "no kanji left in the text" without listening, and it was
 > wrong.
 
+#### Superseded: Japanese now bypasses sherpa entirely (`plugins/kokoro_direct.py`)
+
+The romaji route above is what the accent limit was measured on. It is no longer the
+shipping path — the limit was the *phoneme alphabet*, so the fix is to stop letting
+espeak choose it. `kokoro_direct.py` loads the same `model.onnx` with onnxruntime and
+feeds it misaki phonemes directly, the way upstream Kokoro is driven:
+
+```
+kana --(plugins/ja_phonemes.py, vendored misaki mora table)--> phonemes --> tokens.txt ids --> ONNX
+```
+
+The mora table is pinned to misaki at **`fdc9c5e5e` (2025-01-13)**, the commit that
+matches Kokoro v1.0. This pin is the whole point and `pip install misaki` is the wrong
+thing to do here — current misaki targets a newer Kokoro with a larger vocabulary:
+
+| misaki `ja.py` | distinct phonemes | missing from our `tokens.txt` |
+|---|---|---|
+| **2025-01-13 (pinned)** | 31 | **0** |
+| 2025-04-05 (what pip gives) | 39 | 12 — `G K g ƫ ᶀ ᶁ ᶃ ᶄ ᶆ ᶈ ᶉ` |
+
+A test asserts every phoneme the table can emit exists in `tokens.txt`. The absence of
+that assertion is what let the original 12-drop bug ship.
+
+**This session is CPU-only by construction, and that is not a tuning decision.** On
+jp6.1 the standalone onnxruntime (1.18.0) and sherpa's bundled one (1.18.1) share a
+single `libonnxruntime_providers_cuda.so` — the Dockerfile copies sherpa's into
+`onnxruntime/capi/` to get the face plugin onto the GPU, and the soname collides so the
+first `dlopen` wins. Separate graphs coexist fine, but a *second* CUDA session on the
+**Kokoro** graph fails in whichever runtime did not load the provider, symmetrically:
+
+| order | result |
+|---|---|
+| sherpa's CUDA session first | the standalone one fails, error names `/home/tian/Yxh/…` |
+| the standalone one first | **sherpa** fails, error names `/home/yifanl/…` |
+
+both with `Error mapping output names: Could not find OrtValue with name
+'/Squeeze_2_output_0'`. Order does not save it; staying off CUDA does. `KokoroDirect`
+therefore takes **no device argument**, so it cannot be asked.
+
+The cost is confined to Japanese, and it is affordable. Measured on Orin 6, one process,
+Japanese synthesized first so its CPU session is live throughout:
+
+| language | runtime | RTF |
+|---|---|---|
+| en-us / en-gb | sherpa, cuda | 0.31 / 0.21 |
+| zh | sherpa, cuda | 0.14 |
+| es / fr / it / pt-br / hi | sherpa, cuda | 0.10 – 0.11 |
+| **ja** | **direct ONNX, cpu** | **0.54** |
+
+Real time with margin, and the other eight languages keep the GPU. Threads are the only
+lever left for Japanese and they matter — `intra_op_num_threads` defaults to one per
+core (RTF 0.52); the ORT default of 2 gives 1.17, i.e. slower than real time.
+
+**Pitch accent is not implemented and cannot be with this model.** The pinned misaki has
+no accent code at all (it arrived in 2025-04, alongside the larger vocabulary above),
+and sherpa's v1.1 token table is a symlink to v1.0's. Japanese here is correctly
+*phonemised* but flat. Fixing it needs a newer Kokoro, which is a different change.
+
 ### Chinese: use `vits2-zh-en`, and why Kokoro's Chinese is not broken
 
 Chinese takes a different path from Japanese and loses nothing. `Skip unknown phonemes`

--- a/perception/README.md
+++ b/perception/README.md
@@ -233,19 +233,13 @@ is a free per-utterance setting and must not be able to fail, and `fr` has exact
 one voice. The requested index is remembered, so switching back restores it. Logs and
 `info` report the resolved name (`af_heart`), not the number.
 
-> **Only `en-us`, `en-gb` and `zh` have been listened to.** sherpa-onnx's own
-> documentation says of this model "it is a multi-lingual model, but we only add
-> English and Chinese support for it" — Kokoro was trained with misaki G2P, and for
-> the other six the espeak phoneme set is not guaranteed to be the one the acoustic
-> model learned. All nine produce audio of a plausible length on device; treat the
-> rest as best-effort until someone who reads the language has heard them.
->
-> **`ja` is known to be wrong, not merely unverified.** sherpa-onnx's frontend routes
-> every character in `[一-鿿]` to its *Chinese* branch with no language check, and
-> Japanese kanji live in exactly that range — `展` is U+5C55, `示` is U+793A. So
-> `こんにちは、25の展示があります。` reaches the model as Japanese kana through
-> espeak-ja plus kanji pronounced in **Mandarin** from `lexicon-zh.txt`. Nothing here
-> can fix that; it needs a Japanese lexicon in sherpa-onnx.
+> **Only `en-us`, `en-gb`, `zh` and `ja` have been exercised on device.**
+> sherpa-onnx's own documentation says of this model "it is a multi-lingual model,
+> but we only add English and Chinese support for it" — Kokoro was trained with
+> misaki G2P, and for `es` / `fr` / `it` / `pt-br` / `hi` the espeak phoneme set is
+> not guaranteed to be the one the acoustic model learned. All of them produce audio
+> of a plausible length; treat those five as best-effort until someone who reads the
+> language has heard them.
 
 #### Measured on Orin 6 (jp6.1), fp32 on gpu
 
@@ -323,6 +317,68 @@ TTS plugin cannot turn it into a card in `state: error`; it takes ASR, VOP and O
 down with it. Same hazard `_validate_thai_manifest` exists for. It also refuses a
 `model_version` of 1 (v0.19 ignores `lang`, so the dropdown would be visibly present
 and silently inert) and any `sample_rate` other than 24000.
+
+### `ja` needs its own frontend, or it comes out in Mandarin
+
+sherpa-onnx's Kokoro frontend splits text on `[一-鿿]` and sends everything in that
+range to `ConvertChineseToTokenIDs`, which reads `lexicon-zh.txt`. **That function
+never receives the requested language** — only the non-Chinese branch does. Japanese
+kanji are inside that range (`今` U+4ECA, `私` U+79C1, `何` U+4F55), so raw Japanese
+reaches the model as Mandarin-pronounced kanji plus espeak-ja kana. That is what
+"the Japanese sounds Chinese" turned out to be.
+
+Measured on Orin 6, and this is the whole argument:
+
+| text | `ja` | `en-us` | `es` | `fr` |
+|---|---|---|---|---|
+| `今日私何` (kanji only) | 30682 | 30682 | 30682 | 30682 |
+| `こんにちは` (kana only) | 28908 | 114986 | — | — |
+
+Identical sample counts for kanji under every language: `lang` has **no effect** on
+them. Kana, by contrast, change 4x. No sherpa-onnx release ships a Japanese lexicon
+(checked v0_19, v1_0 and v1_1), so the fix has to happen before the engine sees the
+text.
+
+`plugins/ja_text_norm.py` converts every kanji to kana, so nothing is left in the
+CJK range and the whole utterance takes the espeak-ja path. Same role as
+`plugins/thai_frontend.py`. Two stages, and the second is not optional:
+
+1. **Dates, times and counters, by rule.** Japanese counter readings are irregular
+   and context-dependent, and a morphological analyser gives the isolated-morpheme
+   reading instead — Janome renders `10月` as `ツキ` and `1日` as `ニチ`, where a
+   speaker says `ジュウガツ` and `ツイタチ`. Also `4月`=シガツ (not ヨンガツ),
+   `4時`=ヨジ, `30分`=サンジュップン. The irregular follows the **trailing** digit,
+   so a flat table keyed on the whole number gets `14時` and `30分` wrong —
+   `tests/test_ja_text_norm.py` pins both, and caught exactly that mistake.
+2. **Everything else, via Janome.** Apache-2.0, `py3-none-any`, its own IPADIC
+   dictionary, verified to import *and convert correctly* on cp38/jp5.11 **and**
+   cp310/jp6.1 before it was chosen. `pykakasi` does the same job but is GPL-3.0;
+   `fugashi`/`cutlet` declare `requires_python >= 3.9` and cannot run on jp5.11.
+
+Result on the sentence that prompted this:
+
+```
+こんにちは！今日は2026年10月1日です。私はシャオ・ファンと申します。何かお手伝いしましょうか？
+  -> コンニチハ！キョウハニセンニジュウロクネンジュウガツツイタチデス。
+     ワタシハシャオ・ファントモウシマス。ナニカオテツダイシマショウカ？
+  kanji left: none
+```
+
+Janome costs **~180 MB installed** and is gated by `ENABLE_JA_TTS` (default 1),
+placed last among the Dockerfile's dependency layers for the same build-cache reason
+as `ENABLE_THAI_TTS`. The frontend is built lazily on the first switch to `ja`, so a
+Chinese or English deployment never loads that dictionary — but eagerly enough (at
+construction and in `set_language`) that a missing janome is a load error naming the
+build flag, rather than a card that comes up `running` and speaks Mandarin. That is
+the one place this refuses instead of degrading, and for the same reason the Thai
+adapter refuses without pythainlp.
+
+Remaining caveat, measured rather than assumed: espeak-ja emits a few phonemes
+Kokoro's token table does not contain — `U+0308`, `U+031E` and `ʑ` `U+0291` — and
+sherpa drops them ("Skip unknown phonemes"), about a dozen in a long sentence.
+Japanese is now unmistakably Japanese, but Kokoro's tokens were built for misaki's
+phoneme set rather than espeak's, so it is not as clean as English or Chinese.
+
 
 ### `mms-th`, and why it cannot be handed raw text
 

--- a/perception/config.yaml
+++ b/perception/config.yaml
@@ -53,6 +53,11 @@ plugins:
     engine: vits2-zh-en
     backend: trt
     model_dir: /models/vits2
+    # vits2-zh-en and mms-th support 0 only. For kokoro-multi this is an index
+    # *within* the selected language — 0 is that language's first voice — so the
+    # voice moves with `language` and cannot end up mismatched with it. The global
+    # ids are not guessable (Japanese starts at 37, Spanish is 28, 29 and 53), which
+    # is why they are not what this field takes.
     speaker_id: 0
     speed: 1.0
     warmup: true
@@ -74,9 +79,10 @@ plugins:
     # It selects the espeak voice for the NON-Chinese runs of the text; Chinese is
     # phonemised from lexicon-zh.txt on every setting, so mixed zh/en code-switches
     # on its own and `zh` deliberately maps to an English voice (that only affects
-    # how embedded Latin is read). Pick a speaker_id from the same language, or the
-    # voice's accent will not match: 0-19 en-us, 20-27 en-gb, 28-29/53 es, 30 fr,
-    # 31-34 hi, 35-36 it, 37-41 ja, 42-44 pt-br, 45-52 zh.
+    # how embedded Latin is read).
+    #
+    # `speaker_id` is an index relative to this, so the voice follows the language
+    # and the two cannot end up disagreeing.
     #
     # Only en-us / en-gb / zh have been listened to — sherpa-onnx documents English
     # and Chinese as this model's supported pair, so the rest are best-effort.

--- a/perception/config.yaml
+++ b/perception/config.yaml
@@ -57,10 +57,30 @@ plugins:
     speed: 1.0
     warmup: true
     max_chunk_tokens: 256
-    # matcha-zh-en / mms-th only — vits2-zh-en runs on TensorRT and ignores this.
-    # Matcha is fp32, so both devices load the same weights and only the provider
-    # changes; gpu measured ~4.3x faster at num_threads=2.
+    # matcha-zh-en / mms-th / kokoro-multi only — vits2-zh-en runs on TensorRT and
+    # ignores this. Matcha is fp32, so both devices load the same weights and only
+    # the provider changes; gpu measured ~4.3x faster at num_threads=2.
+    #
+    # Left unset for kokoro-multi on purpose: it is the one engine whose two
+    # devices load *different weight files* (fp32 on gpu, int8 on cpu, because the
+    # CUDA provider falls back per node on quantised ops), so it carries its own
+    # default in ENGINE_DEVICE_DEFAULTS — gpu. An explicit `cpu` here would apply
+    # to every engine and quietly override that.
     device: cpu
+    # kokoro-multi only: pronunciation language. One of en-us, en-gb, zh, ja, es,
+    # fr, it, pt-br, hi — every language Kokoro v1.0 has voices for. Read per
+    # generate() call, so changing it costs nothing.
+    #
+    # It selects the espeak voice for the NON-Chinese runs of the text; Chinese is
+    # phonemised from lexicon-zh.txt on every setting, so mixed zh/en code-switches
+    # on its own and `zh` deliberately maps to an English voice (that only affects
+    # how embedded Latin is read). Pick a speaker_id from the same language, or the
+    # voice's accent will not match: 0-19 en-us, 20-27 en-gb, 28-29/53 es, 30 fr,
+    # 31-34 hi, 35-36 it, 37-41 ja, 42-44 pt-br, 45-52 zh.
+    #
+    # Only en-us / en-gb / zh have been listened to — sherpa-onnx documents English
+    # and Chinese as this model's supported pair, so the rest are best-effort.
+    language: en-us
 
   vop:
     enabled: true

--- a/perception/plugins/face_runtime.py
+++ b/perception/plugins/face_runtime.py
@@ -35,6 +35,37 @@ from utils.cv2_compat import load_cv2
 from utils.model_downloader import ensure_face_model
 from utils.onnx_provider import ort_providers_for_device, warn_on_parked_cores
 
+# Imported at module scope, not lazily inside FaceAnalyzer, and that placement is
+# load-bearing.
+#
+# This process ends up with **two builds of ONNX Runtime**: sherpa-onnx bundles its
+# own libonnxruntime.so in its wheel, and this plugin uses the standalone
+# `onnxruntime` package. They export the same symbols, so whichever one is brought
+# in first wins symbol resolution for both. If sherpa gets there first and the
+# standalone library is loaded afterwards, sherpa's later inferences execute
+# against the wrong implementation and fail an internal type check:
+#
+#   Non-zero status code returned while running SequenceInsert node ...
+#   TensorSeq::Add ... IsSameDataType(tensor) was false
+#
+# Measured on Orin 6: Kokoro TTS synthesizes fine, the face card is then started,
+# and every subsequent Kokoro utterance fails — with the real cause visible one
+# line earlier as espeak losing its voice ("Unknown phoneme table: ''"). Importing
+# here instead is enough on its own; no session has to be created. `main.py`
+# imports plugins.face (and so this module) during startup, before any plugin
+# builds a model, so this lands first.
+#
+# Only ASR/TTS graphs that use the sequence ops are affected, which is why the
+# conflict lay dormant until Kokoro — the first model here whose graph has a
+# Loop/SequenceInsert. sherpa's sensevoice ASR was measured unaffected.
+#
+# Guarded because the host test suite imports this module without onnxruntime
+# installed; FaceAnalyzer raises a clear error if it is genuinely missing.
+try:
+    import onnxruntime as ort
+except ImportError:  # pragma: no cover - exercised on dev hosts, not on device
+    ort = None
+
 log = logging.getLogger(__name__)
 
 DEFAULT_FACE_MODEL_DIR = "/models/face/buffalo_sc"
@@ -214,8 +245,12 @@ class FaceAnalyzer:
         num_threads: int = 2,
         warmup: bool = True,
     ):
-        import onnxruntime as ort
-
+        if ort is None:
+            raise RuntimeError(
+                "the face plugin needs the standalone onnxruntime package; it is "
+                "imported at the top of plugins/face_runtime.py, and that import "
+                "must keep happening there — see the comment on it"
+            )
         self._cv2 = load_cv2()
         self._requested_device = (device or "auto").strip().lower()
         self._det_thresh = float(det_thresh)

--- a/perception/plugins/ja_phonemes.py
+++ b/perception/plugins/ja_phonemes.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+"""
+plugins/ja_phonemes.py — Japanese kana to Kokoro's own phoneme alphabet.
+
+Why this exists, in one line: **Kokoro was trained on misaki's phonemes, and
+sherpa-onnx drives it with espeak's.** The two alphabets disagree, sherpa silently
+discards whatever it cannot look up, and Japanese came out full of holes — 12
+phonemes dropped from a single sentence.
+
+The earlier workaround romanised the text and let a Latin-script voice read it. That
+dropped nothing and was intelligible, but it sounded like a non-native speaker,
+because Italian phonemes are not Japanese ones. This module produces the *actual*
+phonemes the model was trained on. Feeding them to it needs plugins/kokoro_direct,
+since sherpa-onnx has no phoneme input path.
+
+Everything here is pure text and is testable without a model, a device, or janome.
+That matters: the failure mode is silence and gaps, which nobody notices in a diff.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+
+log = logging.getLogger(__name__)
+
+
+# ── misaki-compatible Japanese phonemes ──────────────────────────────────────
+#
+# Ported from misaki's `ja.py` at commit fdc9c5e5e (2025-01-13), the revision
+# contemporary with Kokoro v1.0 — which is the release we ship. Apache-2.0, same as
+# this repo's other vendored tables.
+#
+# The version matters more than anything else here. misaki's phoneme set has grown
+# since, and `pip install misaki` today gives a table built for a **newer** Kokoro:
+#
+#   misaki 2025-01-13   31 distinct phonemes   0 missing from our vocab
+#   misaki 2025-04-05   39 distinct phonemes  12 missing (G K g ƫ ᶀ ᶁ ᶃ ᶄ ᶆ ᶈ ᶉ)
+#
+# Twelve missing phonemes is exactly the failure this whole module exists to avoid,
+# so the table is vendored and pinned rather than imported. Every character below is
+# asserted against the model's own `tokens.txt` in tests/test_ja_phonemes.py.
+#
+# Keys are **hiragana** (misaki's own convention), so katakana readings from Janome
+# are converted down first. Values are IPA in Kokoro's vocabulary.
+
+_MORA_SINGLE = {
+    "ぁ": "a", "あ": "a", "ぃ": "i", "い": "i", "ぅ": "ɯ", "う": "ɯ",
+    "ぇ": "e", "え": "e", "ぉ": "o", "お": "o", "か": "ka", "が": "ɡa",
+    "き": "kʲi", "ぎ": "ɡʲi", "く": "kɯ", "ぐ": "ɡɯ", "け": "ke", "げ": "ɡe",
+    "こ": "ko", "ご": "ɡo", "さ": "sa", "ざ": "ʣa", "し": "ɕi", "じ": "ʥi",
+    "す": "sɨ", "ず": "zɨ", "せ": "se", "ぜ": "ʣe", "そ": "so", "ぞ": "ʣo",
+    "た": "ta", "だ": "da", "ち": "ʨi", "ぢ": "ʥi", "つ": "ʦɨ", "づ": "zɨ",
+    "て": "te", "で": "de", "と": "to", "ど": "do", "な": "na", "に": "ɲi",
+    "ぬ": "nɯ", "ね": "ne", "の": "no", "は": "ha", "ば": "ba", "ぱ": "pa",
+    "ひ": "çi", "び": "bʲi", "ぴ": "pʲi", "ふ": "ɸɯ", "ぶ": "bɯ", "ぷ": "pɯ",
+    "へ": "he", "べ": "be", "ぺ": "pe", "ほ": "ho", "ぼ": "bo", "ぽ": "po",
+    "ま": "ma", "み": "mʲi", "む": "mɯ", "め": "me", "も": "mo", "ゃ": "ja",
+    "や": "ja", "ゅ": "jɯ", "ゆ": "jɯ", "ょ": "jo", "よ": "jo", "ら": "ɾa",
+    "り": "ɾʲi", "る": "ɾɯ", "れ": "ɾe", "ろ": "ɾo", "ゎ": "βa", "わ": "βa",
+    "ゐ": "i", "ゑ": "e", "を": "o", "ゔ": "vɯ", "ゕ": "ka", "ゖ": "ke",
+    "ヷ": "va", "ヸ": "vʲi", "ヹ": "ve", "ヺ": "vo",
+}
+
+# Digraphs: a base kana plus a small kana (sutegana), which form one mora together.
+# Matched before singles, longest-first.
+_MORA_DIGRAPH = {
+    "いぇ": "je", "うぃ": "βi", "うぇ": "βe", "うぉ": "βo", "きぇ": "kʲe",
+    "きゃ": "kʲa", "きゅ": "kʲɨ", "きょ": "kʲo", "ぎゃ": "ɡʲa", "ぎゅ": "ɡʲɨ",
+    "ぎょ": "ɡʲo", "くぁ": "kᵝa", "くぃ": "kᵝi", "くぇ": "kᵝe", "くぉ": "kᵝo",
+    "ぐぁ": "ɡᵝa", "ぐぃ": "ɡᵝi", "ぐぇ": "ɡᵝe", "ぐぉ": "ɡᵝo", "しぇ": "ɕe",
+    "しゃ": "ɕa", "しゅ": "ɕɨ", "しょ": "ɕo", "じぇ": "ʥe", "じゃ": "ʥa",
+    "じゅ": "ʥɨ", "じょ": "ʥo", "ちぇ": "ʨe", "ちゃ": "ʨa", "ちゅ": "ʨɨ",
+    "ちょ": "ʨo", "ぢゃ": "ʥa", "ぢゅ": "ʥɨ", "ぢょ": "ʥo", "つぁ": "ʦa",
+    "つぃ": "ʦʲi", "つぇ": "ʦe", "つぉ": "ʦo", "てぃ": "tʲi", "てゅ": "tʲɨ",
+    "でぃ": "dʲi", "でゅ": "dʲɨ", "とぅ": "tɯ", "どぅ": "dɯ", "にぇ": "ɲe",
+    "にゃ": "ɲa", "にゅ": "ɲɨ", "にょ": "ɲo", "ひぇ": "çe", "ひゃ": "ça",
+    "ひゅ": "çɨ", "ひょ": "ço", "びゃ": "bʲa", "びゅ": "bʲɨ", "びょ": "bʲo",
+    "ぴゃ": "pʲa", "ぴゅ": "pʲɨ", "ぴょ": "pʲo", "ふぁ": "ɸa", "ふぃ": "ɸʲi",
+    "ふぇ": "ɸe", "ふぉ": "ɸo", "ふゅ": "ɸʲɨ", "ふょ": "ɸʲo", "みゃ": "mʲa",
+    "みゅ": "mʲɨ", "みょ": "mʲo", "りゃ": "ɾʲa", "りゅ": "ɾʲɨ", "りょ": "ɾʲo",
+    "ゔぁ": "va", "ゔぃ": "vʲi", "ゔぇ": "ve", "ゔぉ": "vo", "ゔゅ": "bʲɨ",
+    "ゔょ": "bʲo",
+}
+
+# Not in the table, because each depends on what follows it.
+_SOKUON = "っ"      # -> glottal stop
+_CHOONPU = "ー"     # -> length mark on the previous vowel
+_MORAIC_N = "ん"    # -> assimilates to the following consonant
+
+# ん assimilates, and misaki spells the rule out; keeping it explicit rather than
+# deriving it, because the categories are phonological, not orthographic.
+#   m  before m, p, b        ŋ  before k, g
+#   ɲ  before ɲ, ʨ, ʥ        n  before n, t, d, ɾ, z
+#   ɴ  otherwise (utterance-final, before vowels and fricatives)
+_N_BEFORE_LABIAL = "mpb"
+_N_BEFORE_VELAR = "kɡ"
+_N_BEFORE_PALATAL = ("ɲ", "ʨ", "ʥ")
+_N_BEFORE_ALVEOLAR = "ntdɾz"
+
+# A word or phrase boundary. ん before one of these is utterance-final for
+# assimilation purposes and stays uvular.
+_BOUNDARY = frozenset(' \t\n、。！？，．・「」『』（）,.!?;:()"“”')
+
+# CJK punctuation mapped onto the tokens the model actually has. Kokoro's vocabulary
+# contains `; : , . ! ? — … " ( ) “ ”` and a space, and nothing else — so anything
+# left as its full-width form would be looked up, missed, and dropped, which is the
+# same silent failure this module exists to prevent. `・` becomes a space because it
+# separates the parts of a name (シャオ・ファン) and is a boundary, not a sound.
+_PUNCT = {
+    "、": ",", "，": ",", "。": ".", "．": ".", "！": "!", "？": "?",
+    "：": ":", "；": ";", "（": "(", "）": ")",
+    "「": "“", "」": "”", "『": "“", "』": "”", "〈": "“", "〉": "”",
+    "《": "“", "》": "”", "【": "(", "】": ")",
+    "・": " ", "〜": "—", "ー": "ː",
+}
+
+
+def _to_hiragana(text: str) -> str:
+    """Katakana -> hiragana. The table is keyed on hiragana, as misaki's is."""
+    return "".join(chr(ord(c) - 0x60) if 0x30A1 <= ord(c) <= 0x30F6 else c
+                   for c in text)
+
+
+def split_moras(kana: str) -> list:
+    """Split kana into moras, longest match first.
+
+    Digraphs are two characters that form one mora (`きゃ` = kya, one beat, not two),
+    so they must be matched before the singles or `き` would consume the `き` and
+    leave `ゃ` stranded.
+    """
+    kana = _to_hiragana(kana)
+    moras = []
+    i = 0
+    while i < len(kana):
+        pair = kana[i:i + 2]
+        if pair in _MORA_DIGRAPH:
+            moras.append(pair)
+            i += 2
+            continue
+        moras.append(kana[i])
+        i += 1
+    return moras
+
+
+def _phoneme_for(mora: str) -> str:
+    return _MORA_DIGRAPH.get(mora) or _MORA_SINGLE.get(mora, "")
+
+
+def _moraic_n(next_phonemes: str) -> str:
+    """ん takes the place of articulation of whatever follows it.
+
+    Utterance-final and before a vowel it is the uvular ɴ, which is why the fallback
+    is not simply `n`.
+    """
+    if next_phonemes:
+        head = next_phonemes[0]
+        if head in _N_BEFORE_LABIAL:
+            return "m"
+        if head in _N_BEFORE_VELAR:
+            return "ŋ"
+        if any(next_phonemes.startswith(p) for p in _N_BEFORE_PALATAL):
+            return "ɲ"
+        if head in _N_BEFORE_ALVEOLAR:
+            return "n"
+    return "ɴ"
+
+
+def kana_to_phonemes(kana: str) -> str:
+    """Kana -> a Kokoro phoneme string.
+
+    Non-kana characters (punctuation, Latin, digits) pass through untouched; the
+    caller has already normalised numbers and dates, and punctuation is in the
+    model's vocabulary as its own tokens.
+    """
+    if not kana:
+        return ""
+    moras = split_moras(kana)
+    out = []
+    for i, mora in enumerate(moras):
+        if mora == _SOKUON:
+            # The geminate. misaki writes it as a glottal stop rather than doubling
+            # the next consonant, and the model was trained that way.
+            out.append("ʔ")
+            continue
+        if mora == _CHOONPU:
+            # Length mark on whatever vowel preceded it. Dropped when it leads,
+            # since there is nothing to lengthen.
+            if out:
+                out.append("ː")
+            continue
+        if mora == _MORAIC_N:
+            # Look only at the *next* mora, and only within the word. misaki
+            # assimilates per word (its `_romaji_word` never sees the next one), so
+            # scanning past a space or punctuation would turn a word-final ん into
+            # whatever the next word starts with — `ねん じゅう` came out `neɲ` where
+            # it should be `neɴ`.
+            nxt = ""
+            if i + 1 < len(moras):
+                candidate = moras[i + 1]
+                if candidate not in _BOUNDARY:
+                    nxt = _phoneme_for(candidate)
+            out.append(_moraic_n(nxt))
+            continue
+        phonemes = _phoneme_for(mora)
+        if phonemes:
+            out.append(phonemes)
+            continue
+        mapped = _PUNCT.get(mora)
+        if mapped is not None:
+            out.append(mapped)
+            continue
+        # Latin, digits and anything already in the vocabulary passes through; the
+        # caller has normalised numbers and dates before this point.
+        out.append(mora)
+    # The date rules and Janome's token joining both insert spaces; runs of them
+    # would be separate tokens and read as separate pauses.
+    return re.sub(r" {2,}", " ", "".join(out)).strip()
+
+
+def phoneme_chars(text: str) -> set:
+    """Every distinct character in a phoneme string, for vocabulary checks."""
+    return set(text)
+
+
+def all_table_phonemes() -> set:
+    """Every character the table can ever emit.
+
+    Used by the test that asserts the whole table is representable in the model's
+    vocabulary — the check whose absence caused this module to be needed.
+    """
+    chars = set()
+    for value in list(_MORA_SINGLE.values()) + list(_MORA_DIGRAPH.values()):
+        chars.update(value)
+    chars.update("ʔːɴmŋɲn")     # the four context-dependent outputs above
+    return chars

--- a/perception/plugins/ja_text_norm.py
+++ b/perception/plugins/ja_text_norm.py
@@ -447,6 +447,24 @@ class JapaneseFrontend:
             parts.append(reading)
         return "".join(parts)
 
+    def to_kana_only(self, text: str) -> str:
+        """Counters, then leftover numbers, then kanji->kana — stopping at kana.
+
+        `normalize` continues on to romaji, which is what a Latin-script espeak voice
+        needs. The direct runtime wants kana instead, because plugins/ja_phonemes maps
+        kana to the phonemes the model was actually trained on. Same first three
+        stages either way.
+        """
+        if not text:
+            return text
+        kana = self.to_kana(normalize_numbers(normalize_dates(text)))
+        if has_kanji(kana):
+            log.warning(
+                "[tts] Japanese text still contains kanji after conversion (%s); "
+                "those characters have no phoneme mapping and will be dropped",
+                "".join(sorted(set(_CJK.findall(kana))))[:20])
+        return kana
+
     def normalize(self, text: str) -> str:
         """Counters, then leftover numbers, then kanji->kana, then kana->romaji.
 

--- a/perception/plugins/ja_text_norm.py
+++ b/perception/plugins/ja_text_norm.py
@@ -1,0 +1,259 @@
+"""Japanese text normalisation for the Kokoro TTS engine.
+
+Why this exists at all, and why it cannot be skipped:
+
+sherpa-onnx's Kokoro frontend splits text on `[一-鿿]` and sends everything in that
+range to `ConvertChineseToTokenIDs`, which reads `lexicon-zh.txt`. That function
+never receives the requested language — only the *non*-Chinese branch does. Japanese
+kanji sit inside that range (`今` U+4ECA, `私` U+79C1, `何` U+4F55), so Japanese
+arrives at the model as **Mandarin-pronounced kanji plus espeak-ja kana**. Measured
+on Orin 6: `今日私何` produces 30682 samples under `ja`, `en-us`, `es` and `fr`
+alike — the language setting has no effect on kanji whatsoever, while kana-only text
+changes length 4x between `ja` and `en-us`.
+
+No sherpa-onnx release ships a Japanese lexicon, so the fix has to happen before the
+text reaches the engine: convert every kanji to kana here, leaving nothing in the CJK
+range, so the whole utterance takes the espeak-ja path.
+
+Same role as plugins/thai_frontend.py, which exists because sherpa-onnx could not be
+handed raw Thai either.
+
+Two stages, and the second is not optional:
+
+1. **Dates and counters**, by rule. Japanese counter readings are irregular and
+   context-dependent, and a morphological analyser gives the isolated-morpheme
+   reading instead: Janome renders `10月` as `ツキ` and `1日` as `ニチ`, where a
+   Japanese speaker says `ジュウガツ` and `ツイタチ`. Those have to be rewritten
+   before tokenisation, from an explicit table.
+2. **Everything else**, via Janome (Apache-2.0, pure Python, verified importable on
+   cp38/jp5.11 and cp310/jp6.1). pykakasi does the same job but is GPL-3.0;
+   fugashi/cutlet declare `requires_python >= 3.9` and so cannot run on jp5.11.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+
+log = logging.getLogger(__name__)
+
+# ── numbers ───────────────────────────────────────────────────────────────────
+
+_DIGITS = ("", "イチ", "ニ", "サン", "ヨン", "ゴ", "ロク", "ナナ", "ハチ", "キュウ")
+
+# Sino-Japanese numerals, which is what counters take. Deliberately not the native
+# ひとつ/ふたつ series — those go with different counters and are not what a date or
+# a measurement uses.
+_TENS = "ジュウ"
+_HUNDREDS = "ヒャク"
+_THOUSANDS = "セン"
+
+# Irregular readings caused by sound changes; writing them out is shorter than
+# encoding the euphonic rules, and these are the only cases below 10000.
+_HUNDRED_IRREGULAR = {3: "サンビャク", 6: "ロッピャク", 8: "ハッピャク"}
+_THOUSAND_IRREGULAR = {3: "サンゼン", 8: "ハッセン"}
+
+
+def _read_under_10000(n: int) -> str:
+    """0-9999 as Sino-Japanese numerals in katakana."""
+    if n == 0:
+        return "ゼロ"
+    out = []
+    thousands, n = divmod(n, 1000)
+    hundreds, n = divmod(n, 100)
+    tens, ones = divmod(n, 10)
+    if thousands:
+        out.append(_THOUSAND_IRREGULAR.get(thousands)
+                   or ((_DIGITS[thousands] if thousands > 1 else "") + _THOUSANDS))
+    if hundreds:
+        out.append(_HUNDRED_IRREGULAR.get(hundreds)
+                   or ((_DIGITS[hundreds] if hundreds > 1 else "") + _HUNDREDS))
+    if tens:
+        out.append((_DIGITS[tens] if tens > 1 else "") + _TENS)
+    if ones:
+        out.append(_DIGITS[ones])
+    return "".join(out)
+
+
+def read_number(n: int) -> str:
+    """Any non-negative integer as katakana, grouped in Japanese 万/億 units.
+
+    Japanese groups by four digits, not three, so 20260000 is ニセンニヒャクロクジュウ
+    マン and not "twenty million". Getting the grouping wrong is the classic mistake
+    when porting a Western number reader.
+    """
+    if n < 0:
+        return "マイナス" + read_number(-n)
+    if n < 10000:
+        return _read_under_10000(n)
+    units = ["", "マン", "オク", "チョウ"]
+    parts = []
+    idx = 0
+    while n and idx < len(units):
+        n, group = n // 10000, n % 10000
+        if group:
+            parts.append(_read_under_10000(group) + units[idx])
+        idx += 1
+    return "".join(reversed(parts))
+
+
+# ── dates and counters ────────────────────────────────────────────────────────
+
+# 月: 4, 7 and 9 are irregular (シ / シチ / ク, never ヨン / ナナ / キュウ).
+_MONTHS = {
+    1: "イチガツ", 2: "ニガツ", 3: "サンガツ", 4: "シガツ", 5: "ゴガツ", 6: "ロクガツ",
+    7: "シチガツ", 8: "ハチガツ", 9: "クガツ", 10: "ジュウガツ", 11: "ジュウイチガツ",
+    12: "ジュウニガツ",
+}
+
+# 日: the first ten days, plus 14/20/24, use native readings. Every other day is
+# just the number + ニチ — 18 and 28 are regular, so the table below is complete.
+_DAYS = {
+    1: "ツイタチ", 2: "フツカ", 3: "ミッカ", 4: "ヨッカ", 5: "イツカ", 6: "ムイカ",
+    7: "ナノカ", 8: "ヨウカ", 9: "ココノカ", 10: "トオカ", 14: "ジュウヨッカ",
+    20: "ハツカ", 24: "ニジュウヨッカ",
+}
+
+
+def _read_month(n: int) -> str:
+    return _MONTHS.get(n, read_number(n) + "ガツ")
+
+
+def _read_day(n: int) -> str:
+    return _DAYS.get(n, read_number(n) + "ニチ")
+
+
+# Ordered longest-first so 年月日 is consumed as a date before 年 alone matches.
+_DATE_FULL = re.compile(r"(\d{1,4})\s*年\s*(\d{1,2})\s*月\s*(\d{1,2})\s*日")
+_DATE_MD = re.compile(r"(\d{1,2})\s*月\s*(\d{1,2})\s*日")
+_YEAR = re.compile(r"(\d{1,4})\s*年")
+_MONTH = re.compile(r"(\d{1,2})\s*月")
+_DAY = re.compile(r"(\d{1,2})\s*日")
+_TIME = re.compile(r"(\d{1,2})\s*時\s*(\d{1,2})\s*分")
+_HOUR = re.compile(r"(\d{1,2})\s*時")
+_MINUTE = re.compile(r"(\d{1,2})\s*分")
+
+# 時 and 分 irregulars are driven by the **trailing** digit, not by the whole value,
+# so these tables cover the ones place and the readers below apply them positionally.
+# A flat lookup keyed on the whole number gets 14時 (ジュウヨジ, not ジュウヨンジ) and
+# 30分 (サンジュップン, not サンジュウフン) wrong.
+_HOUR_ONES = {4: "ヨジ", 7: "シチジ", 9: "クジ"}
+_MINUTE_ONES = {1: "イップン", 3: "サンプン", 4: "ヨンプン", 6: "ロップン",
+                8: "ハップン"}
+
+
+def _read_hour(n: int) -> str:
+    tens, ones = divmod(n, 10)
+    head = read_number(tens * 10) if tens else ""
+    if ones in _HOUR_ONES:
+        return head + _HOUR_ONES[ones]
+    if ones == 0:
+        return read_number(n) + "ジ"
+    return head + read_number(ones) + "ジ"
+
+
+def _read_minute(n: int) -> str:
+    tens, ones = divmod(n, 10)
+    if ones == 0 and tens:
+        # 10分 ジュップン, 20分 ニジュップン, 30分 サンジュップン — the ジュウ
+        # contracts to ジュッ before プン.
+        base = read_number(n)
+        assert base.endswith("ジュウ"), base
+        return base[:-1] + "ップン"
+    head = read_number(tens * 10) if tens else ""
+    if ones in _MINUTE_ONES:
+        return head + _MINUTE_ONES[ones]
+    return head + read_number(ones) + "フン"
+
+
+def normalize_dates(text: str) -> str:
+    """Rewrite dates, times and their counters into katakana.
+
+    Runs before Janome because Janome would give `月` the isolated reading `ツキ`
+    and `日` the reading `ニチ`, so `10月1日` came out `10ツキ1ニチ` where a speaker
+    says `ジュウガツツイタチ`.
+    """
+    text = _DATE_FULL.sub(
+        lambda m: (read_number(int(m.group(1))) + "ネン"
+                   + _read_month(int(m.group(2))) + _read_day(int(m.group(3)))), text)
+    text = _DATE_MD.sub(
+        lambda m: _read_month(int(m.group(1))) + _read_day(int(m.group(2))), text)
+    text = _TIME.sub(
+        lambda m: _read_hour(int(m.group(1))) + _read_minute(int(m.group(2))), text)
+    text = _YEAR.sub(lambda m: read_number(int(m.group(1))) + "ネン", text)
+    text = _MONTH.sub(lambda m: _read_month(int(m.group(1))), text)
+    text = _DAY.sub(lambda m: _read_day(int(m.group(1))), text)
+    text = _HOUR.sub(lambda m: _read_hour(int(m.group(1))), text)
+    text = _MINUTE.sub(lambda m: _read_minute(int(m.group(1))), text)
+    return text
+
+
+# Any remaining bare integer. Left until after the counters, so a date's digits are
+# never read twice.
+_BARE_NUMBER = re.compile(r"\d+")
+
+
+def normalize_numbers(text: str) -> str:
+    """Read any leftover digit run as a Japanese numeral."""
+    return _BARE_NUMBER.sub(lambda m: read_number(int(m.group(0))), text)
+
+
+# ── kanji ─────────────────────────────────────────────────────────────────────
+
+_CJK = re.compile(r"[一-鿿]")
+
+
+def has_kanji(text: str) -> bool:
+    """True when anything would still reach sherpa-onnx's Chinese branch."""
+    return bool(_CJK.search(text))
+
+
+class JapaneseFrontend:
+    """Turns Japanese text into kana so it takes the espeak-ja path.
+
+    Holds the Janome tokenizer, which loads a ~180 MB dictionary on construction —
+    so build once per adapter, never per utterance.
+    """
+
+    def __init__(self):
+        self._tokenizer = None
+        try:
+            from janome.tokenizer import Tokenizer
+        except ImportError as error:
+            # Refuse rather than warn, unlike the Chinese normaliser. Without this
+            # the kanji do not merely lose their numbers — they are pronounced in
+            # Mandarin, so the card would come up `running` and speak the wrong
+            # language. Same call the Thai adapter makes about pythainlp.
+            raise RuntimeError(
+                "the Japanese voice needs janome (installed when ENABLE_JA_TTS=1); "
+                "without it, kanji reach sherpa-onnx's Chinese branch and are "
+                f"pronounced in Mandarin: {error}"
+            ) from error
+        self._tokenizer = Tokenizer()
+        log.info("[tts] Japanese frontend ready (janome)")
+
+    def to_kana(self, text: str) -> str:
+        """Kanji -> katakana, via Janome's per-token readings."""
+        parts = []
+        for token in self._tokenizer.tokenize(text):
+            reading = token.reading
+            if not reading or reading == "*":
+                # Punctuation, Latin and anything out-of-dictionary keep their
+                # surface form; only kanji actually need converting.
+                reading = token.surface
+            parts.append(reading)
+        return "".join(parts)
+
+    def normalize(self, text: str) -> str:
+        """Full pipeline: counters, then leftover numbers, then kanji."""
+        if not text:
+            return text
+        out = self.to_kana(normalize_numbers(normalize_dates(text)))
+        if has_kanji(out):
+            # Not fatal — partial kana is still better than all-Mandarin — but it
+            # means those characters will be read in Chinese, so say so once.
+            log.warning(
+                "[tts] Japanese text still contains kanji after conversion (%s); "
+                "those characters will be pronounced in Mandarin",
+                "".join(sorted(set(_CJK.findall(out))))[:20])
+        return out

--- a/perception/plugins/ja_text_norm.py
+++ b/perception/plugins/ja_text_norm.py
@@ -172,14 +172,22 @@ def normalize_dates(text: str) -> str:
     Runs before Janome because Janome would give `月` the isolated reading `ツキ`
     and `日` the reading `ニチ`, so `10月1日` came out `10ツキ1ニチ` where a speaker
     says `ジュウガツツイタチ`.
+
+    Components are joined with **spaces**. Running before Janome means the result is
+    one unknown token to it, so nothing downstream will ever break the pieces apart —
+    `ニセンニジュウロクネンジュウガツツイタチ` reached espeak as a single 33-character
+    "word" and was read as one. The spaces are the only chance to say otherwise.
     """
     text = _DATE_FULL.sub(
-        lambda m: (read_number(int(m.group(1))) + "ネン"
-                   + _read_month(int(m.group(2))) + _read_day(int(m.group(3)))), text)
+        lambda m: (read_number(int(m.group(1))) + "ネン "
+                   + _read_month(int(m.group(2))) + " "
+                   + _read_day(int(m.group(3)))), text)
     text = _DATE_MD.sub(
-        lambda m: _read_month(int(m.group(1))) + _read_day(int(m.group(2))), text)
+        lambda m: _read_month(int(m.group(1))) + " " + _read_day(int(m.group(2))),
+        text)
     text = _TIME.sub(
-        lambda m: _read_hour(int(m.group(1))) + _read_minute(int(m.group(2))), text)
+        lambda m: _read_hour(int(m.group(1))) + " " + _read_minute(int(m.group(2))),
+        text)
     text = _YEAR.sub(lambda m: read_number(int(m.group(1))) + "ネン", text)
     text = _MONTH.sub(lambda m: _read_month(int(m.group(1))), text)
     text = _DAY.sub(lambda m: _read_day(int(m.group(1))), text)
@@ -208,6 +216,172 @@ def has_kanji(text: str) -> bool:
     return bool(_CJK.search(text))
 
 
+# ── katakana -> Hepburn romaji ────────────────────────────────────────────────
+#
+# The last stage, and the one that makes Japanese audible at all.
+#
+# Kana are *not* fed to the model. Kokoro's 114-token table is the misaki phoneme
+# inventory — it has `ʣ ʥ ʦ ʨ ᵝ`, so the model was trained to speak Japanese — but it
+# does **not** contain `ʑ`, which is exactly what espeak-ja emits for じ, along with
+# combining diacritics U+0308 and U+031E. sherpa phonemises with espeak and looks the
+# result up in that misaki-derived table, and silently discards whatever is missing.
+# Measured on Orin 6: 12 phonemes dropped from one sentence, kana or hiragana alike.
+# Those drops are audible holes, and they made the output unintelligible.
+#
+# Romanising instead and phonemising with a Latin-script voice drops **nothing** —
+# measured 0 for `it`, `es` and `en-us`, at the same duration as the kana version
+# (4.60-4.83 s vs 4.81 s), so it reads words rather than spelling them out. Feeding
+# romaji to espeak-`ja` does *not* work: it spells the letters, 14.78 s for the same
+# sentence.
+#
+# Hand-rolled rather than via `jaconv`: one fewer dependency, and the romanisation is
+# the tuning surface for how the chosen voice reads it (`tsu` not `tu`, doubled
+# vowels not digraphs). A library would hide exactly the decisions that matter here.
+# Same call plugins/thai_frontend.py made.
+
+_ROMAJI_DIGRAPHS = {
+    "キャ": "kya", "キュ": "kyu", "キョ": "kyo", "シャ": "sha", "シュ": "shu",
+    "ショ": "sho", "チャ": "cha", "チュ": "chu", "チョ": "cho", "ニャ": "nya",
+    "ニュ": "nyu", "ニョ": "nyo", "ヒャ": "hya", "ヒュ": "hyu", "ヒョ": "hyo",
+    "ミャ": "mya", "ミュ": "myu", "ミョ": "myo", "リャ": "rya", "リュ": "ryu",
+    "リョ": "ryo", "ギャ": "gya", "ギュ": "gyu", "ギョ": "gyo", "ジャ": "ja",
+    "ジュ": "ju", "ジョ": "jo", "ヂャ": "ja", "ヂュ": "ju", "ヂョ": "jo",
+    "ビャ": "bya", "ビュ": "byu", "ビョ": "byo", "ピャ": "pya", "ピュ": "pyu",
+    "ピョ": "pyo",
+    # Katakana-only combinations, common in loanwords and names (シャオ・ファン).
+    "ファ": "fa", "フィ": "fi", "フェ": "fe", "フォ": "fo", "ヴァ": "va",
+    "ヴィ": "vi", "ヴェ": "ve", "ヴォ": "vo", "ウィ": "wi", "ウェ": "we",
+    "ウォ": "wo", "ティ": "ti", "ディ": "di", "トゥ": "tu", "ドゥ": "du",
+    "チェ": "che", "ジェ": "je", "シェ": "she",
+}
+
+_ROMAJI = {
+    "ア": "a", "イ": "i", "ウ": "u", "エ": "e", "オ": "o",
+    "カ": "ka", "キ": "ki", "ク": "ku", "ケ": "ke", "コ": "ko",
+    "サ": "sa", "シ": "shi", "ス": "su", "セ": "se", "ソ": "so",
+    "タ": "ta", "チ": "chi", "ツ": "tsu", "テ": "te", "ト": "to",
+    "ナ": "na", "ニ": "ni", "ヌ": "nu", "ネ": "ne", "ノ": "no",
+    "ハ": "ha", "ヒ": "hi", "フ": "fu", "ヘ": "he", "ホ": "ho",
+    "マ": "ma", "ミ": "mi", "ム": "mu", "メ": "me", "モ": "mo",
+    "ヤ": "ya", "ユ": "yu", "ヨ": "yo",
+    "ラ": "ra", "リ": "ri", "ル": "ru", "レ": "re", "ロ": "ro",
+    "ワ": "wa", "ヲ": "o", "ン": "n",
+    "ガ": "ga", "ギ": "gi", "グ": "gu", "ゲ": "ge", "ゴ": "go",
+    "ザ": "za", "ジ": "ji", "ズ": "zu", "ゼ": "ze", "ゾ": "zo",
+    "ダ": "da", "ヂ": "ji", "ヅ": "zu", "デ": "de", "ド": "do",
+    "バ": "ba", "ビ": "bi", "ブ": "bu", "ベ": "be", "ボ": "bo",
+    "パ": "pa", "ピ": "pi", "プ": "pu", "ペ": "pe", "ポ": "po",
+    "ヴ": "vu",
+    # Small kana left stranded by an unmatched digraph — better a vowel than a hole.
+    "ァ": "a", "ィ": "i", "ゥ": "u", "ェ": "e", "ォ": "o",
+    "ャ": "ya", "ュ": "yu", "ョ": "yo",
+    "・": " ",
+}
+
+_VOWELS = "aiueo"
+_SOKUON = "ッ"
+_CHOONPU = "ー"
+
+# Readings a dictionary gives as written rather than as spoken. Applied only to
+# tokens Janome tags 助詞 (particle), so the は inside a word like コンニチハ is not
+# touched — that one is handled by _GREETINGS below.
+_PARTICLE_READINGS = {"ハ": "ワ", "ヘ": "エ"}
+
+# Lexicalised exceptions: single tokens whose dictionary reading keeps a は that is
+# nevertheless pronounced わ. These are greetings, and they are frequent enough in a
+# guide robot's script that getting them wrong is immediately noticeable.
+_GREETINGS = {"コンニチハ": "コンニチワ", "コンバンハ": "コンバンワ"}
+
+# Tokens that must not be pushed away from the word before them.
+_LEADING_PUNCT = re.compile(r"^[、。！？，．!?,.\)）」』]")
+
+# Tokens that are not words but the tail of the previous one. Janome splits the
+# volitional `マショウ` into `マショ` + `ウ`, and `ー` can arrive alone; a space
+# before either invents a boundary and blocks the long-vowel rule.
+_VOWEL_CONTINUATIONS = {"ウ", "ー"}
+
+# Full-width punctuation carries no meaning to a Latin-script espeak voice, which
+# needs ASCII to find sentence boundaries — without this it runs the whole utterance
+# together as one breath group.
+_PUNCT_TO_ASCII = {"。": ".", "、": ",", "！": "!", "？": "?", "：": ":",
+                   "；": ";", "（": "(", "）": ")", "「": '"', "」": '"',
+                   "『": '"', "』": '"', "・": " "}
+
+
+def _to_hiragana(text: str) -> str:
+    """Katakana -> hiragana, so one table serves both."""
+    return "".join(chr(ord(c) - 0x60) if 0x30A1 <= ord(c) <= 0x30F6 else c
+                   for c in text)
+
+
+def _to_katakana(text: str) -> str:
+    return "".join(chr(ord(c) + 0x60) if 0x3041 <= ord(c) <= 0x3096 else c
+                   for c in text)
+
+
+def to_romaji(text: str) -> str:
+    """Kana -> Hepburn romaji, with gemination and long vowels spelled out.
+
+    Three rules beyond the table, each chosen for how a Latin-script espeak voice
+    will read the result rather than for orthographic tradition:
+
+    - `ッ` doubles the next consonant (`ツイタチ` stays `tsuitachi`, but `ニッキ`
+      becomes `nikki`). Italian reads doubled consonants as geminates natively,
+      which is what Japanese actually does with them.
+    - `ー` doubles the preceding vowel, and so does a vowel that simply repeats
+      (`キョウ` -> `kyoo`, not `kyou`). `ou` would be read as two syllables.
+    - `ン` is a bare `n`.
+    """
+    text = _to_katakana(text)
+    out = []
+    i = 0
+    while i < len(text):
+        pair = text[i:i + 2]
+        if pair in _ROMAJI_DIGRAPHS:
+            out.append(_ROMAJI_DIGRAPHS[pair])
+            i += 2
+            continue
+        ch = text[i]
+        if ch == _SOKUON:
+            # Double whatever consonant comes next; a trailing ッ is dropped.
+            nxt = text[i + 1:i + 3]
+            syllable = (_ROMAJI_DIGRAPHS.get(nxt)
+                        or _ROMAJI.get(text[i + 1:i + 2], ""))
+            if syllable and syllable[0] not in _VOWELS:
+                out.append(syllable[0])
+            i += 1
+            continue
+        if ch == _CHOONPU:
+            # Lengthen by repeating the vowel we just emitted.
+            if out and out[-1] and out[-1][-1] in _VOWELS:
+                out.append(out[-1][-1])
+            i += 1
+            continue
+        mapped = _ROMAJI.get(ch)
+        if mapped is None:
+            # Punctuation, digits, Latin — pass through, translating full-width
+            # punctuation to ASCII so espeak can find the sentence boundaries.
+            out.append(_PUNCT_TO_ASCII.get(ch, ch))
+            i += 1
+            continue
+        prev = out[-1][-1] if (out and out[-1]) else ""
+        if prev in _VOWELS and (mapped == prev
+                                or (ch == "ウ" and prev in "ou")):
+            # A long vowel, written two ways in kana and needing one spelling here:
+            #   オオ / ウウ  -> a repeated vowel
+            #   オウ         -> the ordinary way to write long o (キョウ = kyoo)
+            # Both become a doubled vowel, because `kyou` reads as two syllables in
+            # Italian and Spanish while `kyoo` reads as one long one.
+            out.append(prev)
+            i += 1
+            continue
+        out.append(mapped)
+        i += 1
+    # Collapse the runs of spaces the interpunct and token joining can leave.
+    return re.sub(r" {2,}", " ", "".join(out)).strip()
+
+
+
 class JapaneseFrontend:
     """Turns Japanese text into kana so it takes the espeak-ja path.
 
@@ -233,7 +407,25 @@ class JapaneseFrontend:
         log.info("[tts] Japanese frontend ready (janome)")
 
     def to_kana(self, text: str) -> str:
-        """Kanji -> katakana, via Janome's per-token readings."""
+        """Kanji -> katakana, via Janome's per-token readings.
+
+        Two readings are corrected here, because a dictionary gives the *written*
+        kana and Japanese pronounces these two differently as particles:
+
+            は as a particle -> ワ (wa), not ハ
+            へ as a particle -> エ (e),  not ヘ
+
+        `今日は` is `kyoo wa`, never `kyoo ha`. Janome tags the part of speech, so
+        this is a lookup rather than a guess — and it has to happen here, where the
+        tags exist, not in the romaji table, which sees only kana.
+
+        Tokens are joined with **spaces**, which matters more than it looks. Japanese
+        is written without them, but the romaji is read by a Latin-script espeak
+        voice, and one unbroken `kyoowanisennijuurokunenjuugatsutsuitachidesu` is a
+        single enormous "word" it has to guess the stress of. Measured on the
+        reported sentence: 7.62 s unspaced against 4.60 s spaced, for the same text.
+        Janome has already found the morpheme boundaries; this just keeps them.
+        """
         parts = []
         for token in self._tokenizer.tokenize(text):
             reading = token.reading
@@ -241,19 +433,36 @@ class JapaneseFrontend:
                 # Punctuation, Latin and anything out-of-dictionary keep their
                 # surface form; only kanji actually need converting.
                 reading = token.surface
+            if token.part_of_speech.split(",")[0] == "助詞":
+                reading = _PARTICLE_READINGS.get(reading, reading)
+            reading = _GREETINGS.get(reading, reading)
+            # No space before punctuation, or espeak reads the gap as a pause.
+            # Nor before a bare ウ / ー: Janome splits `マショウ` (mashoo) into
+            # `マショ` + `ウ`, and a space there both invents a word boundary that
+            # is not there and stops the long-vowel rule from firing, giving
+            # `masho u` instead of `mashoo`.
+            if (parts and not _LEADING_PUNCT.match(reading)
+                    and reading not in _VOWEL_CONTINUATIONS):
+                parts.append(" ")
             parts.append(reading)
         return "".join(parts)
 
     def normalize(self, text: str) -> str:
-        """Full pipeline: counters, then leftover numbers, then kanji."""
+        """Counters, then leftover numbers, then kanji->kana, then kana->romaji.
+
+        The output is **romaji, not kana**, and that is deliberate: see the
+        katakana->romaji section above. Kana handed to espeak-ja produce phonemes
+        Kokoro's token table cannot represent, and sherpa drops them, which is what
+        made the first version of this unintelligible.
+        """
         if not text:
             return text
-        out = self.to_kana(normalize_numbers(normalize_dates(text)))
-        if has_kanji(out):
-            # Not fatal — partial kana is still better than all-Mandarin — but it
-            # means those characters will be read in Chinese, so say so once.
+        kana = self.to_kana(normalize_numbers(normalize_dates(text)))
+        if has_kanji(kana):
+            # Not fatal — partial conversion still beats all-Mandarin — but those
+            # characters stay in the CJK range and will be read in Chinese.
             log.warning(
                 "[tts] Japanese text still contains kanji after conversion (%s); "
                 "those characters will be pronounced in Mandarin",
-                "".join(sorted(set(_CJK.findall(out))))[:20])
-        return out
+                "".join(sorted(set(_CJK.findall(kana))))[:20])
+        return to_romaji(kana)

--- a/perception/plugins/kokoro_direct.py
+++ b/perception/plugins/kokoro_direct.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""
+plugins/kokoro_direct.py — run Kokoro's ONNX graph ourselves, with our own phonemes.
+
+sherpa-onnx offers no way to hand a model phonemes. Its Kokoro frontend phonemises
+with espeak-ng and looks the result up in Kokoro's vocabulary, which was built for
+**misaki**; the two alphabets disagree and everything that misses is silently dropped.
+For Japanese that was 12 phonemes in one sentence, audible as holes. The only
+phoneme-level entry point is the lexicon, and it is unreachable — `lang` falls back to
+`meta_data.voice`, which the metadata macro forbids from being empty.
+
+So this module bypasses sherpa for the one case that needs it, exactly as
+`plugins/vits2_tts_trt/` already bypasses it for VITS2: own runtime, own frontend, own
+tokenisation. Everything else keeps going through `KokoroTTSAdapter`.
+
+The graph is small and fully specified:
+
+    tokens  int64 [1, seq]     style  float [1, 256]     speed  float [1]
+        -> audio  float [audio_length]                   at 24 kHz
+
+Two conventions are copied from sherpa's own `OfflineTtsKokoroModel::Run`, because
+getting either wrong produces audio that is merely *wrong* rather than absent:
+
+  - tokens are wrapped in a leading and trailing 0;
+  - the style vector is indexed by **speaker and by inner token count** —
+    `styles[sid][len(ids)]` — so the 510 axis in voices.bin is not padding.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+import numpy as np
+
+log = logging.getLogger(__name__)
+
+# voices.bin is (n_speakers, 510, 1, 256) float32. 510 is the maximum inner token
+# count the style table covers; sherpa hard-exits above it, so we refuse instead.
+STYLE_LENGTHS = 510
+STYLE_DIM = 256
+SAMPLE_RATE = 24000
+
+
+class KokoroDirect:
+    """A Kokoro session driven by phonemes rather than text.
+
+    Construct once per adapter — the ONNX session and the 27 MB style table are both
+    held for the lifetime of the object.
+    """
+
+    def __init__(self, model_dir: str, weights: str, provider: str = "cpu",
+                 num_threads: int = 0):
+        """`num_threads=0` means one per core, which is the difference between
+        usable and not.
+
+        This runs on the **CPU whatever `provider` says**: the standalone
+        `onnxruntime` package is a CPU-only build, and the CUDA provider .so the
+        Dockerfile copies into `onnxruntime/capi/` cannot register with it because
+        the pybind layer was not compiled with CUDA support. (sherpa's bundled
+        onnxruntime does have it, but exposes no generic session to Python.)
+
+        So threads are the only lever, and they matter. Measured on Orin 6 (6 cores),
+        one 9.35 s Japanese utterance:
+
+            2 threads  RTF 1.171   <- slower than real time
+            4 threads  RTF 0.646
+            6 threads  RTF 0.521
+            8 threads  RTF 0.644   <- oversubscribed
+
+        The default was 2 and made Japanese unusable for streaming.
+        """
+        import onnxruntime as ort
+
+        model_path = os.path.join(model_dir, weights)
+        tokens_path = os.path.join(model_dir, "tokens.txt")
+        voices_path = os.path.join(model_dir, "voices.bin")
+        for path in (model_path, tokens_path, voices_path):
+            if not os.path.exists(path):
+                raise FileNotFoundError(f"Kokoro release is incomplete: {path}")
+
+        self._token_to_id = _read_tokens(tokens_path)
+
+        opts = ort.SessionOptions()
+        # 0 lets ORT pick one thread per core, which measured fastest; an explicit
+        # value is honoured so a busy robot can be told to use fewer.
+        opts.intra_op_num_threads = int(num_threads or 0)
+        providers = (["CUDAExecutionProvider", "CPUExecutionProvider"]
+                     if provider in ("cuda", "gpu") else ["CPUExecutionProvider"])
+        self._session = ort.InferenceSession(model_path, opts, providers=providers)
+        actual = self._session.get_providers()
+
+        styles = np.fromfile(voices_path, dtype=np.float32)
+        if styles.size % (STYLE_LENGTHS * STYLE_DIM):
+            raise RuntimeError(
+                f"{voices_path} is {styles.size} floats, not a multiple of "
+                f"{STYLE_LENGTHS}x{STYLE_DIM}; it does not match this model")
+        self._n_speakers = styles.size // (STYLE_LENGTHS * STYLE_DIM)
+        self._styles = styles.reshape(self._n_speakers, STYLE_LENGTHS, STYLE_DIM)
+        # Ids of sentence punctuation, so a long utterance can be split at a comma
+        # rather than mid-word. Read from the release rather than hardcoded.
+        self._break_ids = {self._token_to_id[c] for c in ".,;:!?"
+                           if c in self._token_to_id}
+
+        log.info("[tts] kokoro_direct ready: %s, %d tokens, %d speakers, providers=%s",
+                 os.path.basename(model_path), len(self._token_to_id),
+                 self._n_speakers, actual)
+
+    @property
+    def num_speakers(self) -> int:
+        return self._n_speakers
+
+    @property
+    def sample_rate(self) -> int:
+        return SAMPLE_RATE
+
+    def encode(self, phonemes: str):
+        """Phonemes -> token ids, reporting anything the vocabulary cannot hold.
+
+        Returns `(ids, unknown)`. Unknown characters are **not** silently dropped the
+        way sherpa drops them — the caller decides, and the tests assert the list is
+        empty for everything the Japanese table can produce.
+        """
+        ids, unknown = [], []
+        for ch in phonemes:
+            token_id = self._token_to_id.get(ch)
+            if token_id is None:
+                unknown.append(ch)
+                continue
+            ids.append(token_id)
+        return ids, unknown
+
+    def synthesize(self, phonemes: str, speaker_id: int = 0, speed: float = 1.0):
+        """Phoneme string -> float32 waveform at 24 kHz.
+
+        Splits on the style table's capacity rather than truncating: an utterance
+        longer than 510 tokens is synthesized in chunks and concatenated, because
+        sherpa's equivalent calls SHERPA_ONNX_EXIT(-1) at that boundary and losing a
+        long sentence is worse than a seam in it.
+        """
+        ids, unknown = self.encode(phonemes)
+        if unknown:
+            log.warning("[tts] kokoro_direct: %d phoneme(s) not in the vocabulary "
+                        "and skipped: %s", len(unknown), "".join(sorted(set(unknown))))
+        if not ids:
+            return np.zeros(0, dtype=np.float32)
+        if not 0 <= speaker_id < self._n_speakers:
+            raise ValueError(
+                f"speaker_id must be 0..{self._n_speakers - 1}, got {speaker_id}")
+
+        pieces = [self._run(chunk, speaker_id, speed)
+                  for chunk in chunk_ids(ids, STYLE_LENGTHS - 1, self._break_ids)]
+        return np.concatenate(pieces) if len(pieces) > 1 else pieces[0]
+
+    def _run(self, ids, speaker_id: int, speed: float):
+        # A leading and trailing 0, and the style row is chosen by the *inner* count —
+        # both copied from sherpa's OfflineTtsKokoroModel::Run.
+        tokens = np.asarray([[0, *ids, 0]], dtype=np.int64)
+        style = self._styles[speaker_id, len(ids)].reshape(1, STYLE_DIM)
+        outputs = self._session.run(
+            None,
+            {"tokens": tokens,
+             "style": style.astype(np.float32),
+             "speed": np.asarray([speed], dtype=np.float32)},
+        )
+        return np.asarray(outputs[0], dtype=np.float32).reshape(-1)
+
+
+def _read_tokens(path: str) -> dict:
+    """Parse `tokens.txt`: one `<token> <id>` per line.
+
+    Split from the right, because the token itself may be a space — `" 16"` is the
+    space token, not a malformed line.
+    """
+    table = {}
+    with open(path, encoding="utf-8") as handle:
+        for line in handle:
+            line = line.rstrip("\n")
+            if not line:
+                continue
+            token, _, token_id = line.rpartition(" ")
+            if not token_id.lstrip("-").isdigit():
+                continue
+            table[token] = int(token_id)
+    if not table:
+        raise RuntimeError(f"{path} yielded no tokens")
+    return table
+
+
+def chunk_ids(ids, limit: int, break_ids=frozenset()):
+    """Split into runs of at most `limit`, preferring a punctuation boundary.
+
+    A seam mid-word is audible; a seam at a comma is not. Falls back to a hard split
+    only when a single clause exceeds the limit.
+    """
+    if len(ids) <= limit:
+        return [ids]
+    chunks, start = [], 0
+    while start < len(ids):
+        end = min(start + limit, len(ids))
+        if end < len(ids):
+            window = ids[start:end]
+            cut = max((i for i, t in enumerate(window) if t in break_ids), default=-1)
+            if cut > limit // 4:
+                end = start + cut + 1
+        chunks.append(ids[start:end])
+        start = end
+    return chunks
+

--- a/perception/plugins/kokoro_direct.py
+++ b/perception/plugins/kokoro_direct.py
@@ -49,16 +49,32 @@ class KokoroDirect:
     held for the lifetime of the object.
     """
 
-    def __init__(self, model_dir: str, weights: str, provider: str = "cpu",
-                 num_threads: int = 0):
-        """`num_threads=0` means one per core, which is the difference between
-        usable and not.
+    def __init__(self, model_dir: str, weights: str, num_threads: int = 0):
+        """Always CPU. `num_threads=0` means one per core, which is the difference
+        between usable and not.
 
-        This runs on the **CPU whatever `provider` says**: the standalone
-        `onnxruntime` package is a CPU-only build, and the CUDA provider .so the
-        Dockerfile copies into `onnxruntime/capi/` cannot register with it because
-        the pybind layer was not compiled with CUDA support. (sherpa's bundled
-        onnxruntime does have it, but exposes no generic session to Python.)
+        **This session must not use CUDA, and it takes no `provider` argument so it
+        cannot be asked to.** Two ONNX Runtime builds live in this process — sherpa's
+        bundled 1.18.1 and the standalone 1.18.0 wheel — and on jp6.1 they share one
+        copy of `libonnxruntime_providers_cuda.so`, because the Dockerfile puts
+        sherpa's into `onnxruntime/capi/` and the soname collides. Whichever runtime
+        dlopens it first owns it, and the *second* CUDA session built on the Kokoro
+        graph then fails in the other runtime's code. Measured on Orin 6, both orders,
+        with the error naming the build it landed in:
+
+            sherpa's CUDA session first  -> this one fails   (/home/tian/Yxh/...)
+            this one first               -> sherpa fails     (/home/yifanl/...)
+
+            "Error mapping output names: Could not find OrtValue with
+             name '/Squeeze_2_output_0'"
+
+        Order does not save it; only staying off CUDA does. A standalone CUDA session
+        on the *face* model is unaffected and keeps its 3x — that graph has none of
+        the fused squeeze outputs this one trips over.
+
+        An earlier version of this docstring said the CUDA request was harmless
+        because the standalone wheel was CPU-only. That stopped being true the moment
+        the Dockerfile started installing the GPU wheel, and this is how it failed.
 
         So threads are the only lever, and they matter. Measured on Orin 6 (6 cores),
         one 9.35 s Japanese utterance:
@@ -85,9 +101,8 @@ class KokoroDirect:
         # 0 lets ORT pick one thread per core, which measured fastest; an explicit
         # value is honoured so a busy robot can be told to use fewer.
         opts.intra_op_num_threads = int(num_threads or 0)
-        providers = (["CUDAExecutionProvider", "CPUExecutionProvider"]
-                     if provider in ("cuda", "gpu") else ["CPUExecutionProvider"])
-        self._session = ort.InferenceSession(model_path, opts, providers=providers)
+        self._session = ort.InferenceSession(
+            model_path, opts, providers=["CPUExecutionProvider"])
         actual = self._session.get_providers()
 
         styles = np.fromfile(voices_path, dtype=np.float32)

--- a/perception/plugins/requirements.ja.txt
+++ b/perception/plugins/requirements.ja.txt
@@ -1,0 +1,24 @@
+# Japanese TTS frontend — plugins/ja_text_norm.py
+#
+# Kanji have to leave the text before it reaches sherpa-onnx: its Kokoro frontend
+# routes everything in [一-鿿] to lexicon-zh.txt with no language check, so Japanese
+# kanji are otherwise pronounced in Mandarin. Measured on Orin 6: 今日私何 produces
+# 30682 samples under ja, en-us, es and fr alike — the language setting has no
+# effect on kanji at all.
+#
+# janome, and not the two obvious alternatives:
+#
+#   pykakasi        same job, but GPL-3.0-or-later.
+#   fugashi/cutlet  declare requires_python >= 3.9, so they cannot run on jp5.11's
+#                   cp38 at all.
+#
+# janome is Apache-2.0, ships as `py3-none-any` with its own IPADIC dictionary (no
+# MeCab, no compiler, no build-time model fetch), and was verified to import and
+# convert on cp38/jp5.11 and cp310/jp6.1 before being chosen.
+#
+# Pinned, like every other frontend dep here: the readings this produces are the
+# audio, so a silent dictionary change between versions would alter how the robot
+# pronounces things with nothing in the diff to show it. The Dockerfile's import
+# check runs a real conversion and asserts no kanji survive, which catches the
+# cp38-installs-then-fails-at-import trap requirements.thai.txt documents.
+janome==0.5.0

--- a/perception/plugins/tts.py
+++ b/perception/plugins/tts.py
@@ -677,7 +677,29 @@ class KokoroTTSAdapter(TTSAdapter):
         "en-us": "en-us",       # ids 0-19   af_*/am_*
         "en-gb": "en-gb-x-rp",  # ids 20-27  bf_*/bm_*
         "zh": "en-us",          # ids 45-52  zf_*/zm_*  (see above)
-        "ja": "ja",             # ids 37-41  jf_*/jm_*
+        # NOT "ja", and this is the one entry that must not be "corrected".
+        #
+        # Kokoro's 114-token table is the misaki phoneme inventory — it has
+        # `ʣ ʥ ʦ ʨ ᵝ`, so the model was trained to speak Japanese — but it does not
+        # contain `ʑ`, which is exactly what espeak-ja emits for じ, along with the
+        # combining diacritics U+0308 and U+031E. sherpa phonemises with espeak and
+        # looks the result up in that table, silently discarding whatever is missing.
+        # Measured on Orin 6: 12 phonemes dropped from one sentence, and the audible
+        # holes made it unintelligible.
+        #
+        # plugins/ja_text_norm.py therefore emits **romaji**, and this picks the
+        # espeak voice by its phoneme inventory rather than by its language. Measured
+        # on the same sentence, dropped-phoneme count and duration:
+        #
+        #     kana    + ja      12 dropped   4.81 s
+        #     romaji  + ja       0 dropped  14.78 s   (spelled out letter by letter)
+        #     romaji  + it       0 dropped   4.60 s
+        #     romaji  + es       0 dropped   4.83 s
+        #     romaji  + en-us    0 dropped   5.19 s
+        #
+        # Italian of the three: five pure vowels like Japanese, and native geminate
+        # consonants for っ (`nikki`), which Spanish lacks and English would reduce.
+        "ja": "it",             # ids 37-41  jf_*/jm_*
         "es": "es",             # ids 28-29, 53  ef_*/em_*
         "fr": "fr",             # id  30     ff_siwis
         "it": "it",             # ids 35-36  if_*/im_*

--- a/perception/plugins/tts.py
+++ b/perception/plugins/tts.py
@@ -992,14 +992,19 @@ class KokoroTTSAdapter(TTSAdapter):
     def _direct(self):
         """The phoneme-driven ONNX runtime, built on first Japanese utterance.
 
-        A second session on the same weights, so it costs another CUDA context —
-        which is why it is lazy and only Japanese pays for it. Everything else keeps
-        using sherpa, which is correct for those languages and better tested.
+        A second session on the same weights, so it is lazy and only Japanese pays
+        for it. Everything else keeps using sherpa, which is correct for those
+        languages and better tested.
+
+        It is deliberately given no device: `KokoroDirect` is CPU-only by
+        construction, because a second *CUDA* session on this graph collides with
+        sherpa's inside the shared CUDA provider library. That is not a tuning
+        choice — see the reasoning and the measurements in `kokoro_direct.py`.
         """
         if self._direct_runtime is None:
             from plugins.kokoro_direct import KokoroDirect
             self._direct_runtime = KokoroDirect(
-                self._model_dir, self._weights_name, provider=self._provider)
+                self._model_dir, self._weights_name)
         return self._direct_runtime
 
     def synthesize(self, text: str) -> bytes:

--- a/perception/plugins/tts.py
+++ b/perception/plugins/tts.py
@@ -955,7 +955,22 @@ class KokoroTTSAdapter(TTSAdapter):
             # Per-utterance, which is the whole reason language is not a session
             # key. Empty would fall back to meta_data.voice, but we always set it.
             config.extra = {"lang": self._voice}
-            audio = self._tts.generate(text, config)
+            try:
+                audio = self._tts.generate(text, config)
+            except Exception as error:
+                # Re-raise with the input attached. ONNX Runtime's own message names
+                # a graph node ("SequenceInsert", "Loop") and nothing about what was
+                # being said, so a failure in the field arrives as a stack trace with
+                # no way to reproduce it. One robot hit
+                # "SequenceInsert ... tensor to be added has a different data type"
+                # on a sentence that synthesizes fine on both Orins, and the log gave
+                # no voice, language or text to work from.
+                raise RuntimeError(
+                    f"kokoro generate failed (language={self._language}, espeak="
+                    f"{self._voice}, speaker={self._voice_index}/{self.voice_name}, "
+                    f"global_sid={self._sid}, {len(text)} chars): {error}\n"
+                    f"  text: {text!r}"
+                ) from error
 
         samples = np.asarray(audio.samples, dtype=np.float32)
         if samples.size == 0:

--- a/perception/plugins/tts.py
+++ b/perception/plugins/tts.py
@@ -4,8 +4,9 @@ plugins/tts.py — the TTS tool contract and its ONNX Runtime engines.
 
 Engines are named `<model>-<languages>`, the same shape `asr_model` uses:
 `vits2-zh-en` (TensorRT, implemented in plugins/vits2_tts_trt), `matcha-zh-en`
-(Matcha-icefall) and `mms-th` (MMS VITS). The last two both run on sherpa-onnx,
-which is why naming either of them after the framework did not work.
+(Matcha-icefall), `mms-th` (MMS VITS) and `kokoro-multi` (Kokoro-82M v1.0). The
+last three all run on sherpa-onnx, which is why naming any of them after the
+framework did not work.
 """
 
 from __future__ import annotations
@@ -18,16 +19,24 @@ import time
 from abc import ABC, abstractmethod
 from typing import Optional
 
+import numpy as np
 import rclpy
 from rclpy.node import Node
 from rclpy.qos import QoSProfile, ReliabilityPolicy, HistoryPolicy, DurabilityPolicy
 from std_msgs.msg import String
+
+from utils.resample import downsample_24k_to_16k
 
 log = logging.getLogger(__name__)
 
 SAMPLE_RATE = 16000
 CHUNK_BYTES = 3200  # 100ms @ 16kHz 16-bit mono
 PCM_FRAME_S = CHUNK_BYTES / (SAMPLE_RATE * 2)  # 0.1s of audio per frame
+
+# Kokoro's native rate. The only engine here that is not SAMPLE_RATE: its adapter
+# resamples 24000 -> 16000 internally (utils/resample.py) so that the topic stays
+# audio/pcm-16k and nothing downstream has to learn a second rate.
+KOKORO_SAMPLE_RATE = 24000
 
 # Frames held back before pacing starts, then published in one burst, so the
 # consumer begins with a real cushion. 5 frames = 500ms, matching the
@@ -177,21 +186,57 @@ TOOLS = [
                 # exists solely as a baked YAML key cannot be seen or switched
                 # without rebuilding the image. Mirrors asr_model in asr.py.
                 "tts_engine": {"type": "string",
-                               "enum": ["vits2-zh-en", "matcha-zh-en", "mms-th"],
+                               "enum": ["vits2-zh-en", "matcha-zh-en", "mms-th",
+                                        "kokoro-multi"],
                                "description": "TTS engine, named <model>-<languages> to match "
                                               "asr_model (vits2-zh-en = VITS2 on TensorRT, "
                                               "matcha-zh-en = Matcha-icefall, "
-                                              "mms-th = MMS Thai)",
+                                              "mms-th = MMS Thai, "
+                                              "kokoro-multi = Kokoro-82M v1.0)",
                                "default": "vits2-zh-en", "scope": "shared"},
-                # matcha-zh-en and mms-th only — vits2-zh-en is a TensorRT engine
-                # and never touches ONNX Runtime, so this field does nothing for it.
-                # Matcha's weights are fp32, so both devices load the same files and
-                # only the provider changes; measured 4.3x faster on gpu.
+                # matcha-zh-en, mms-th and kokoro-multi only — vits2-zh-en is a
+                # TensorRT engine and never touches ONNX Runtime, so this field does
+                # nothing for it. Matcha's weights are fp32, so both devices load the
+                # same files and only the provider changes; measured 4.3x faster on
+                # gpu. kokoro-multi is the first engine where the two devices load
+                # *different weight files* — fp32 for gpu, int8 for cpu, because
+                # provider_for_device refuses int8 on CUDA — so changing this one
+                # downloads a different archive, not just a different provider.
                 "device":      {"type": "string", "enum": ["cpu", "gpu"],
                                 "description": "Inference device for the ONNX Runtime engines "
-                                               "(gpu needs the CUDA sherpa-onnx wheel; ~4.3x faster)",
+                                               "(gpu needs the CUDA sherpa-onnx wheel; ~4.3x faster). "
+                                               "kokoro-multi defaults to gpu and loads fp32 there, "
+                                               "int8 on cpu",
                                 "default": "cpu", "scope": "shared",
-                                "x-show-when": {"tts_engine": ["matcha-zh-en", "mms-th"]}},
+                                "x-show-when": {"tts_engine": ["matcha-zh-en", "mms-th",
+                                                               "kokoro-multi"]}},
+                # Kokoro takes `lang` per generate() call, so this is a scale on the
+                # resident model like `speed` — not a session key.
+                #
+                # Every language Kokoro v1.0 has voices for. The value selects the
+                # espeak voice for the **non-Chinese** runs of the text; Chinese is
+                # phonemised from lexicon-zh.txt on every setting, so a mixed zh/en
+                # sentence code-switches on its own. `zh` maps to an English voice for
+                # exactly that reason — see KokoroTTSAdapter.LANGUAGE_VOICES, which
+                # also records that these espeak names are measured, not guessed
+                # (`en-gb` produces no audio and `fr-FR` silently truncates).
+                #
+                # Only en-us/en-gb/zh have been listened to; sherpa-onnx documents
+                # English and Chinese as the supported pair for this model, so the
+                # rest are offered as best-effort. Kept in one enum rather than split
+                # into "supported" and "experimental" fields because the dashboard
+                # renders one dropdown and the caveat belongs in the docs.
+                "tts_language": {
+                    "type": "string",
+                    "enum": ["en-us", "en-gb", "zh", "ja", "es", "fr", "it",
+                             "pt-br", "hi"],
+                    "description": "Pronunciation language for kokoro-multi. Independent of "
+                                   "the voice — pick a matching speaker_id (0-19 en-us, "
+                                   "20-27 en-gb, 28-29/53 es, 30 fr, 31-34 hi, 35-36 it, "
+                                   "37-41 ja, 42-44 pt-br, 45-52 zh). Chinese is spoken "
+                                   "correctly on any setting",
+                    "default": "en-us", "scope": "shared",
+                    "x-show-when": {"tts_engine": ["kokoro-multi"]}},
                 # Thai has no spaces between words, and MMS was trained on text
                 # that spaced only phrase boundaries. Segmenting every word may
                 # help prosody or hurt it — off until it has been A/B'd on device.
@@ -201,7 +246,7 @@ TOOLS = [
                                    "experimental — may change prosody either way)",
                     "default": False, "scope": "shared",
                     "x-show-when": {"tts_engine": "mms-th"}},
-                "speaker_id": {"type": "integer", "description": "Speaker ID (vits2-zh-en and mms-th support 0 only)", "default": 0, "scope": "shared"},
+                "speaker_id": {"type": "integer", "description": "Speaker ID (vits2-zh-en and mms-th support 0 only; kokoro-multi has 54 voices — 0-19 en-us, 20-27 en-gb, 45-52 zh)", "default": 0, "scope": "shared"},
                 "speed":      {"type": "number", "description": "Speech speed (1.0 = normal)", "default": 1.0, "scope": "shared"},
             },
             "required": []
@@ -262,6 +307,17 @@ class TTSAdapter(ABC):
         `config` used to rebuild the session for any change at all.
         """
         del speed
+
+    def set_language(self, language: str) -> None:
+        """Change the pronunciation language on the resident model, if it has one.
+
+        A no-op by default, so `_config` can call it unconditionally: only Kokoro
+        takes a language, and only because sherpa-onnx reads `lang` out of
+        GenerationConfig.extra per call. An engine whose language is baked into the
+        checkpoint (Matcha, MMS Thai, VITS2) has nothing to change, and its
+        configSchema field is hidden by `x-show-when` anyway.
+        """
+        del language
 
 
 class MatchaTTSAdapter(TTSAdapter):
@@ -548,20 +604,438 @@ def _read_token_chars(tokens_path: str) -> set:
     return chars
 
 
+class KokoroTTSAdapter(TTSAdapter):
+    """On-device TTS using sherpa-onnx Kokoro (Kokoro-82M v1.0, 24 kHz).
+
+    A third adapter rather than a flag on either existing one, for three reasons
+    that are all structural:
+
+    - It is configured through `OfflineTtsKokoroModelConfig`, which shares no field
+      with the Matcha or VITS ones: the voice is a style vector read out of a
+      separate `voices.bin`, not a speaker embedding inside the graph.
+    - Its text frontend is sherpa-onnx's own `KokoroMultiLangLexicon`, which splits
+      the text on Chinese vs non-Chinese character runs and phonemises each
+      separately. So zh/en code-switching inside one sentence works without any
+      Python-side detection — unlike mms-th, which needs plugins/thai_frontend.py.
+    - **It is the only engine whose sample rate is not the pipeline's.** Kokoro is
+      24 kHz; everything downstream is 16 kHz and has no way to be told otherwise
+      (AudioChunk carries the rate inside its `format` string, and the publisher's
+      pacing derives from SAMPLE_RATE). The conversion therefore happens here, in
+      utils/resample.py, and what leaves this adapter is 16 kHz like every other
+      engine's output. Nothing outside this class knows Kokoro is 24 kHz.
+
+    Language is a per-utterance argument, not a session key: sherpa-onnx reads it
+    from `GenerationConfig.extra["lang"]` on every call. So `set_language` is a
+    field assignment, the same shape as `set_speed`, and switching language costs
+    nothing. Verified on the shipped wheels for both Python ABIs (cp38/jp5.11 and
+    cp310/jp6.1): `extra` accepts a plain dict and round-trips.
+    """
+
+    # Not the inherited ".". Kokoro's frontend has an explicit punctuation branch
+    # that turns "." into a three-token near-silent sequence, and _TTSNode.start()
+    # refuses to declare `running` unless the probe produced audio — the same trap
+    # that made every Thai start fail. "ok" is one syllable, is phonemised by
+    # espeak on every language setting (routing is by character class, so an
+    # English probe exercises the espeak path even when lang=zh), and is audible.
+    dry_run_text = "ok"
+
+    # Every language Kokoro v1.0 has voices for. The value on the left is what the
+    # dashboard and config.yaml use; the value on the right is the espeak-ng voice
+    # name that phonemises the non-Chinese runs of the text.
+    #
+    # The right-hand names are **measured, not guessed** — each was checked on
+    # Orin 6 against this release's espeak-ng-data with a sentence in that language
+    # containing digits. Guessing is not safe here, in two distinct ways:
+    #
+    #   en-gb  -> "Failed to set eSpeak-ng voice", no samples at all. The data ships
+    #             en-GB-x-rp, en-GB-scotland, en-GB-x-gbclan, en-GB-x-gbcwmd and
+    #             en-029, but no plain en-GB. (Matching is case-insensitive, which
+    #             is why en-us resolves to en-US and made en-gb look plausible.)
+    #   fr-FR  -> *worse*: it "works" and silently truncates. 18280 samples against
+    #             63277 for `fr` on the same sentence — most of the utterance simply
+    #             missing, with nothing raised and nothing logged.
+    #
+    # `zh` maps to an English voice on purpose, and is not redundant with `en-us`.
+    # Chinese is phonemised from lexicon-zh.txt on every setting — that branch of
+    # sherpa-onnx's frontend never consults `lang` — so this field only decides how
+    # the *embedded Latin* in a Chinese sentence is read, and English is the right
+    # answer for that. Digits are already converted to Chinese characters upstream
+    # by the ZH rule FSTs. The label exists because an operator setting up a Chinese
+    # robot looks for it, and its absence reads as "Chinese is unsupported".
+    #
+    # CAVEAT, and it is a real one: sherpa-onnx's own documentation says of this
+    # model "it is a multi-lingual model, but we only add English and Chinese
+    # support for it". Kokoro was trained with misaki G2P, and for the languages
+    # below other than English the espeak phoneme set is not guaranteed to be the
+    # one the acoustic model learned. All nine produce audio of a plausible length;
+    # en-us, en-gb and zh are the ones that have been listened to. Treat the rest as
+    # best-effort until someone who reads the language has heard them.
+    LANGUAGE_VOICES = {
+        "en-us": "en-us",       # ids 0-19   af_*/am_*
+        "en-gb": "en-gb-x-rp",  # ids 20-27  bf_*/bm_*
+        "zh": "en-us",          # ids 45-52  zf_*/zm_*  (see above)
+        "ja": "ja",             # ids 37-41  jf_*/jm_*
+        "es": "es",             # ids 28-29, 53  ef_*/em_*
+        "fr": "fr",             # id  30     ff_siwis
+        "it": "it",             # ids 35-36  if_*/im_*
+        "pt-br": "pt-BR",       # ids 42-44  pf_*/pm_*
+        "hi": "hi",             # ids 31-34  hf_*/hm_*
+    }
+    LANGUAGES = tuple(LANGUAGE_VOICES)
+    DEFAULT_LANGUAGE = "en-us"
+
+    # Spellings that are not the canonical label but are what someone would write.
+    # `cn` is accepted here even though the repo's naming rule rejects it as an
+    # engine-name component — refusing an operator's config is not the place to make
+    # that point, and the alternative is a Chinese robot silently speaking English.
+    LANGUAGE_ALIASES = {
+        "en": "en-us", "en-au": "en-us", "en-029": "en-gb", "en-gb-x-rp": "en-gb",
+        "zh-cn": "zh", "cmn": "zh", "cn": "zh", "zh-hans": "zh",
+        "pt": "pt-br", "pt-pt": "pt-br",
+        "es-419": "es", "es-es": "es",
+        "fr-fr": "fr", "fr-ca": "fr",
+        "jp": "ja", "ja-jp": "ja",
+        "hi-in": "hi", "it-it": "it",
+    }
+
+    def __init__(self, model_dir: str, speaker_id: int = 0, speed: float = 1.0,
+                 device: str = "gpu", language: str = DEFAULT_LANGUAGE):
+        import os
+        from utils.model_downloader import ensure_kokoro_model
+        from utils.onnx_provider import normalize_device, pick_weights, provider_for_device
+
+        device = normalize_device(device)
+        language = self._normalize_language(language)
+
+        model_dir = ensure_kokoro_model(model_dir, device)
+        # gpu directories hold fp32, cpu directories hold int8 — pick_weights'
+        # documented behaviour of falling back to the *last* candidate means a
+        # missing file produces an error naming the one this device wanted.
+        candidates = (("model.onnx", "model.int8.onnx") if device == "gpu"
+                      else ("model.int8.onnx", "model.onnx"))
+        model_path = pick_weights(model_dir, *candidates)
+        voices_path = os.path.join(model_dir, "voices.bin")
+        tokens_path = os.path.join(model_dir, "tokens.txt")
+        data_dir = os.path.join(model_dir, "espeak-ng-data")
+        lexicon_path = os.path.join(model_dir, "lexicon-zh.txt")
+
+        manifest = _validate_kokoro_manifest(model_dir)
+
+        for path in (model_path, voices_path, tokens_path):
+            if not os.path.exists(path):
+                raise FileNotFoundError(f"Kokoro release is incomplete: {path} is missing")
+        # The four files sherpa-onnx's own Validate() checks for inside data_dir.
+        # Checking them here turns a missing espeak tree into an exception naming
+        # the file, instead of a Validate() failure during OfflineTts construction.
+        missing = [name for name in ("phontab", "phonindex", "phondata", "intonations")
+                   if not os.path.exists(os.path.join(data_dir, name))]
+        if missing:
+            raise FileNotFoundError(
+                f"{data_dir} is not an espeak-ng data directory (missing "
+                f"{', '.join(missing)}); sherpa-onnx requires all four"
+            )
+
+        # Only lexicon-zh.txt. The two English lexicons upstream ships can never be
+        # read: for non-Chinese runs sherpa-onnx short-circuits to espeak whenever
+        # `lang` is non-empty, and `lang` falls back to the model's own
+        # meta_data.voice ("en-us") when unset, so it never is. The Chinese branch
+        # does not consult `lang`, which is why this one is load-bearing.
+        lexicon = lexicon_path if os.path.exists(lexicon_path) else ""
+
+        # THE process-exit guard. For a version >= 2 Kokoro model with *both*
+        # `lexicon` and `lang` empty, sherpa-onnx's InitFrontend logs and calls
+        # SHERPA_ONNX_EXIT(-1) — a process exit, not an exception, so main.py's
+        # try/except around the TTS plugin cannot turn it into a card in
+        # `state: error`; it takes ASR, VOP and OCR down with it. `language` is
+        # normalised to a non-empty value above, so this can only fire if someone
+        # later makes it optional.
+        if not lexicon and not language:
+            raise RuntimeError(
+                "Kokoro v1.0 needs a lexicon or a language; with neither, "
+                "sherpa-onnx exits the whole process instead of raising"
+            )
+
+        n_speakers = int(manifest.get("n_speakers") or 0)
+        if n_speakers and not 0 <= int(speaker_id) < n_speakers:
+            raise ValueError(
+                f"speaker_id must be 0..{n_speakers - 1} for kokoro-multi, "
+                f"got {speaker_id}"
+            )
+
+        import sherpa_onnx
+
+        provider = provider_for_device(device, (model_path,))
+
+        # The same three ZH rule FSTs Matcha loads opportunistically — number, date
+        # and phone normalisation for Chinese text. Absent for an English-only
+        # release, which is why this is a filter and not a requirement.
+        rule_fsts = [os.path.join(model_dir, name)
+                     for name in ("date-zh.fst", "number-zh.fst", "phone-zh.fst")
+                     if os.path.exists(os.path.join(model_dir, name))]
+
+        tts_config = sherpa_onnx.OfflineTtsConfig(
+            model=sherpa_onnx.OfflineTtsModelConfig(
+                kokoro=sherpa_onnx.OfflineTtsKokoroModelConfig(
+                    model=model_path,
+                    voices=voices_path,
+                    tokens=tokens_path,
+                    lexicon=lexicon,
+                    data_dir=data_dir,
+                    # Ignored since sherpa-onnx v1.12.15 (it logs "you don't need to
+                    # provide dict_dir" if given), so the release ships no dict/.
+                    dict_dir="",
+                    length_scale=1.0 / speed if speed else 1.0,
+                    # Also set at construction, not only per call: it is what makes
+                    # the InitFrontend check above pass, and it is the fallback if a
+                    # generate() ever arrives without extra["lang"]. The espeak
+                    # voice name, not the configured label — see LANGUAGE_VOICES.
+                    lang=self.LANGUAGE_VOICES[language],
+                ),
+                num_threads=2,
+                provider=provider,
+            ),
+            rule_fsts=",".join(rule_fsts) if rule_fsts else "",
+        )
+        self._tts = sherpa_onnx.OfflineTts(tts_config)
+
+        model_rate = int(getattr(self._tts, "sample_rate", 0) or 0)
+        if model_rate and model_rate != KOKORO_SAMPLE_RATE:
+            # utils/resample.py's filter is designed for exactly 24000 -> 16000
+            # (2:3). Another rate would need its own filter, and using this one
+            # would resample by the wrong ratio — audio at the wrong pitch that
+            # also drifts against the 100 ms frame clock.
+            raise RuntimeError(
+                f"Kokoro model is {model_rate} Hz but the adapter's resampler is "
+                f"built for {KOKORO_SAMPLE_RATE} Hz -> {SAMPLE_RATE} Hz"
+            )
+
+        # Re-check against the loaded graph, not just the manifest: the manifest is
+        # our own file and could have been written for a different voices.bin.
+        live_speakers = int(getattr(self._tts, "num_speakers", 0) or 0)
+        if live_speakers and not 0 <= int(speaker_id) < live_speakers:
+            raise ValueError(
+                f"speaker_id must be 0..{live_speakers - 1} for this Kokoro "
+                f"release, got {speaker_id}"
+            )
+
+        self._sid = int(speaker_id)
+        self._speed = speed
+        self._language = language
+        self._manifest = manifest
+        self._lock = threading.Lock()
+
+        speaker_name = manifest.get("id2speaker", {}).get(str(self._sid), "?")
+        log.info(f"[tts] sherpa-onnx Kokoro loaded: model_dir={model_dir}, "
+                 f"weights={os.path.basename(model_path)}, "
+                 f"speaker_id={self._sid} ({speaker_name}), language={language}, "
+                 f"speed={speed}, device={device}, provider={provider}, "
+                 f"model_rate={model_rate or KOKORO_SAMPLE_RATE} -> {SAMPLE_RATE}, "
+                 f"lexicon={'zh' if lexicon else 'none'}, rule_fsts={len(rule_fsts)}")
+        self._warn_if_voice_mismatches_language()
+
+        # Prove the espeak voice resolves before anything asks this adapter to
+        # speak. A bad voice name is close to invisible at runtime: sherpa-onnx
+        # writes "Failed to set eSpeak-ng voice" to stderr, `generate` returns no
+        # samples, and the utterance is silently skipped — which is how `en-gb`
+        # (a voice espeak-ng does not have; it is en-GB-x-rp) looked like a model
+        # problem. `dry_run_text` is Latin, so it exercises exactly this path.
+        #
+        # Same reasoning as the Thai adapter checking its probe survives the
+        # frontend, and it also pays the first-inference cost, so the warmup a
+        # moment later is cheap.
+        if not any(self.synthesize_stream(self.dry_run_text)):
+            raise RuntimeError(
+                f"Kokoro produced no audio for the probe {self.dry_run_text!r} with "
+                f"language={self._language} (espeak voice {self._voice!r}); the "
+                "voice name is probably not one this espeak-ng-data provides"
+            )
+
+    @classmethod
+    def _normalize_language(cls, value) -> str:
+        """Coerce a configured language to one this release can actually phonemize.
+
+        Falls back rather than raising, the way provider_for_device does: a stale
+        value in a baked config.yaml should degrade to a working voice, not stop the
+        card from loading. The dashboard's enum is the place that constrains it.
+
+        Aliases exist for the spellings someone would reasonably write — `en` for
+        `en-us`, `pt` for `pt-br`, `cmn` for `zh` — because the alternative is a
+        silent fall back to English on a Portuguese robot.
+        """
+        raw = str(value or "").strip().lower().replace("_", "-")
+        if raw in cls.LANGUAGE_VOICES:
+            return raw
+        alias = cls.LANGUAGE_ALIASES.get(raw)
+        if alias:
+            return alias
+        if raw:
+            log.warning("[tts] unknown kokoro language %r, using %s (supported: %s)",
+                        value, cls.DEFAULT_LANGUAGE, ", ".join(cls.LANGUAGES))
+        return cls.DEFAULT_LANGUAGE
+
+    @property
+    def _voice(self) -> str:
+        """The espeak-ng voice name for the configured language."""
+        return self.LANGUAGE_VOICES[self._language]
+
+    def _warn_if_voice_mismatches_language(self) -> None:
+        """Warn — never refuse — when the voice belongs to a different language.
+
+        A Spanish voice reading text phonemised as Italian is legal, produces a
+        recognisably wrong-accented result, and is what you get by changing one
+        dropdown and forgetting the other. Worth a log line, not a refusal.
+
+        `zh` is exempt in both directions. It maps to an English espeak voice by
+        design (Chinese comes from lexicon-zh.txt, which never consults `lang`), so a
+        Chinese voice with `en-us`, or an English voice with `zh`, is a normal and
+        correct configuration rather than a mistake. An earlier version of this check
+        compared against the selected language's id list alone and would have fired
+        on exactly that — the recommended Chinese setup.
+        """
+        languages = self._manifest.get("languages") or {}
+        if self._language == "zh" or self._sid in (languages.get("zh") or []):
+            return
+        for lang, ids in languages.items():
+            if lang in ("zh", self._language) or lang not in self.LANGUAGE_VOICES:
+                continue
+            if self._sid in (ids or []):
+                name = self._manifest.get("id2speaker", {}).get(str(self._sid), "?")
+                log.warning(
+                    "[tts] kokoro speaker_id=%d (%s) is a %s voice but the text is "
+                    "phonemised as %s; set tts_language=%s to match, or pick a %s "
+                    "voice", self._sid, name, lang, self._language, lang,
+                    self._language)
+                return
+
+    def synthesize(self, text: str) -> bytes:
+        return b''.join(self.synthesize_stream(text))
+
+    def synthesize_stream(self, text: str):
+        import sherpa_onnx
+
+        # One generate() at a time. sherpa-onnx's OfflineTts is not documented as
+        # thread-safe, and dispatch() runs on a ThreadingHTTPServer thread per
+        # tools/call, so a config-driven speak can overlap a topic-driven one.
+        with self._lock:
+            config = sherpa_onnx.GenerationConfig()
+            config.sid = self._sid
+            config.speed = self._speed
+            # Per-utterance, which is the whole reason language is not a session
+            # key. Empty would fall back to meta_data.voice, but we always set it.
+            config.extra = {"lang": self._voice}
+            audio = self._tts.generate(text, config)
+
+        samples = np.asarray(audio.samples, dtype=np.float32)
+        if samples.size == 0:
+            log.warning("[tts] kokoro produced no audio for %r", text)
+            return
+        # Resample the *whole* utterance, then frame it. Doing it per 3200-byte
+        # frame would restart the filter every 100 ms and inject a transient each
+        # time — see utils/resample.resample_poly.
+        pcm = downsample_24k_to_16k(samples)
+        for i in range(0, len(pcm), CHUNK_BYTES):
+            yield pcm[i:i + CHUNK_BYTES]
+
+    def set_speed(self, speed: float) -> None:
+        # Applied per generate() call, so nothing reloads — same as the other two.
+        self._speed = speed
+
+    def set_language(self, language: str) -> None:
+        """Change the pronunciation language on the resident model.
+
+        The point of the whole design: `lang` rides in GenerationConfig.extra, so
+        this costs a field assignment rather than the ~2.7 s session rebuild a
+        session key would. Which is why `tts_language` is deliberately absent from
+        _session_keys.
+        """
+        resolved = self._normalize_language(language)
+        if resolved == self._language:
+            return
+        self._language = resolved
+        log.info("[tts] kokoro language -> %s", resolved)
+        self._warn_if_voice_mismatches_language()
+
+
+def _validate_kokoro_manifest(model_dir: str) -> dict:
+    """Check the release before sherpa-onnx gets a chance to exit(-1) or mis-tune.
+
+    Mirrors _validate_thai_manifest above and _validate_manifest in
+    plugins/vits2_tts_trt/runtime/backends/trt_numpy_tts_engine.py: the release
+    carries a manifest written by the repack script from the ONNX graph's own
+    metadata, so a mismatched or hand-assembled directory fails here as an ordinary
+    exception rather than during model load.
+
+    Two of these checks cannot be made later:
+
+    - `model_version` must be 2. Only Kokoro >= 1.0 honours `lang`; on a v0.19
+      graph sherpa-onnx takes the PiperPhonemizeLexicon path and the language
+      selector would silently do nothing.
+    - `sample_rate` must be 24000, because utils/resample.py's filter is designed
+      for that ratio and nothing downstream can be told about another one.
+
+    Returns the parsed manifest, which the adapter uses for its speaker-name and
+    language-coherence checks.
+    """
+    import os
+
+    manifest_path = os.path.join(model_dir, "manifest.json")
+    if not os.path.exists(manifest_path):
+        raise FileNotFoundError(
+            f"{manifest_path} is missing; this release was not produced by "
+            "tools/repack_kokoro_v1_0.py and cannot be checked before load"
+        )
+    with open(manifest_path, encoding="utf-8") as handle:
+        manifest = json.load(handle)
+
+    version = int(manifest.get("model_version") or 0)
+    if version != 2:
+        raise RuntimeError(
+            f"Kokoro release declares model_version={version}; the language "
+            "selector needs 2 (Kokoro >= 1.0), and v0.19 ignores `lang` entirely"
+        )
+    rate = int(manifest.get("sample_rate") or 0)
+    if rate != KOKORO_SAMPLE_RATE:
+        raise RuntimeError(
+            f"Kokoro release is {rate} Hz but the adapter resamples "
+            f"{KOKORO_SAMPLE_RATE} Hz -> {SAMPLE_RATE} Hz; another rate needs its "
+            "own filter in utils/resample.py first"
+        )
+    if not manifest.get("id2speaker"):
+        raise RuntimeError(
+            "Kokoro release manifest has no id2speaker map; the adapter needs it "
+            "to check that the voice matches the language"
+        )
+    return manifest
+
+
 def _build_tts_adapter(cfg: dict) -> TTSAdapter:
     import os
     from utils.onnx_provider import normalize_device
     engine = str(cfg.get('engine', '')).lower()
-    default_dir = ('/models/mms-th' if engine == 'mms-th'
-                   else '/models/sherpa-onnx/tts')
+    default_dir = ENGINE_MODEL_DIRS.get(engine, '/models/sherpa-onnx/tts')
     model_dir = cfg.get('model_dir', default_dir)
     speaker_id = int(cfg.get('speaker_id', 0))
     speed = float(cfg.get('speed', 1.0))
-    device = normalize_device(cfg.get('device'), cfg.get('hw_provider'))
+    # An engine may want somewhere other than cpu when nothing is configured;
+    # normalize_device turns an absent value into 'cpu', so the default has to be
+    # applied before it, not after.
+    device = normalize_device(
+        cfg.get('device') or ENGINE_DEVICE_DEFAULTS.get(engine),
+        cfg.get('hw_provider'),
+    )
     if engine == 'mms-th':
         return MmsThaiTTSAdapter(
             model_dir, speaker_id, speed, device,
             phrase_spacing=bool(cfg.get('thai_phrase_spacing', False)),
+        )
+    if engine == 'kokoro-multi':
+        return KokoroTTSAdapter(
+            model_dir, speaker_id, speed, device,
+            # `tts_language` is the configSchema name the dashboard sends;
+            # `language` is the short form config.yaml uses. Both accepted, the
+            # same way the facade takes `tts_engine` or `engine`.
+            language=(cfg.get('tts_language') or cfg.get('language')
+                      or KokoroTTSAdapter.DEFAULT_LANGUAGE),
         )
     return MatchaTTSAdapter(model_dir, speaker_id, speed, device)
 
@@ -1243,16 +1717,29 @@ class SherpaOnnxTTSPlugin:
             # model for a slider change"). vits2 already behaved this way, which is
             # why only the two sherpa-onnx engines were slow.
             #
+            # `tts_language` is not in it either, for exactly the same reason:
+            # Kokoro reads `lang` out of GenerationConfig.extra on every call, so a
+            # language change is a field assignment. Putting it in _session_keys
+            # would cost a 310 MB fp32 session rebuild per dropdown change.
+            #
             # Values are normalised before comparing, or `speed: 1` from the
             # dashboard would differ from a stored `1.0` and defeat the check.
             incoming = _session_keys(cfg)
             speed = float(cfg['speed']) if 'speed' in cfg else None
+            language = str(cfg['tts_language']) if cfg.get('tts_language') else None
 
             needs_rebuild = any(self._cfg.get(key) != value
                                 for key, value in incoming.items())
             self._cfg.update(incoming)
+            # Both of these have to be written back explicitly, because they are
+            # absent from `incoming` by design and _build_tts_adapter reads them out
+            # of self._cfg. Without this, a rebuild triggered by some *other* key
+            # would construct the adapter with the default language rather than the
+            # one the operator selected.
             if speed is not None:
                 self._cfg['speed'] = speed
+            if language is not None:
+                self._cfg['tts_language'] = language
 
             if needs_rebuild or self._adapter is None:
                 changed = sorted(incoming) if needs_rebuild else ['(no model loaded)']
@@ -1264,8 +1751,13 @@ class SherpaOnnxTTSPlugin:
                 with self._nodes_lock:
                     for key in list(self._nodes.keys()):
                         self._dispose_node(self._nodes.pop(key), key)
-            elif speed is not None:
-                self._adapter.set_speed(speed)
+            else:
+                if speed is not None:
+                    self._adapter.set_speed(speed)
+                if language is not None:
+                    # A no-op on every engine but Kokoro; TTSAdapter defines it so
+                    # this does not need to know which one is resident.
+                    self._adapter.set_language(language)
             return {"status": "configured", "rebuilt": bool(needs_rebuild)}
 
         elif action == "interrupt":
@@ -1301,7 +1793,7 @@ DEFAULT_TTS_ENGINE = "vits2-zh-en"
 # `matcha` and `mms-th` both run on sherpa-onnx.
 #
 # Language codes, not country codes: `zh`, not `cn`.
-TTS_ENGINES = ("vits2-zh-en", "matcha-zh-en", "mms-th")
+TTS_ENGINES = ("vits2-zh-en", "matcha-zh-en", "mms-th", "kokoro-multi")
 # Older spellings, still accepted. `vits2_trt` and `sherpa_onnx` are not
 # decoration: both are already persisted in ConfigDB rows and in config.yaml on
 # every deployed robot, and _select_engine raises on an unknown engine — so
@@ -1327,6 +1819,22 @@ ENGINE_MODEL_DIRS = {
     # their weights by different names but share nothing, and pointing them at one
     # directory is the mistake ENGINE_MODEL_DIRS exists to prevent.
     "mms-th": "/models/mms-th",
+    # Its own tree, and the archives land in `<dir>/gpu` and `<dir>/cpu` beneath
+    # it: the two devices load different weight files (fp32 vs int8), so they are
+    # separate downloads that must not overwrite each other.
+    "kokoro-multi": "/models/kokoro-multi",
+}
+# Where an engine wants to run when nothing has been configured. Only Kokoro
+# differs: it is a 310 MB fp32 graph on gpu and the CUDA provider is worth having,
+# whereas Matcha and MMS are small enough that cpu is a reasonable default.
+#
+# Known wart: the dashboard renders the configSchema's `device.default` ("cpu"),
+# so the form and the effective default disagree until someone touches the field.
+# JSON Schema cannot express a per-engine default, and a second engine-specific
+# device field would be worse — the value is stated in the field description
+# instead.
+ENGINE_DEVICE_DEFAULTS = {
+    "kokoro-multi": "gpu",
 }
 # How long an `action=config` engine switch waits for the new engine before
 # answering `loading`. Sized so the bounded part of a build finishes inside it

--- a/perception/plugins/tts.py
+++ b/perception/plugins/tts.py
@@ -805,6 +805,12 @@ class KokoroTTSAdapter(TTSAdapter):
         # Built lazily on the first switch to `ja` — Janome loads a ~180 MB
         # dictionary, and a Chinese or English deployment must not pay for it.
         self._ja_frontend = None
+        # Japanese does not go through sherpa at all — see _synthesize_japanese —
+        # so the direct runtime needs to know which weights and provider to reuse.
+        self._direct_runtime = None
+        self._model_dir = model_dir
+        self._weights_name = os.path.basename(model_path)
+        self._provider = provider
 
         tts_config = sherpa_onnx.OfflineTtsConfig(
             model=sherpa_onnx.OfflineTtsModelConfig(
@@ -983,6 +989,19 @@ class KokoroTTSAdapter(TTSAdapter):
             self._ja_frontend = JapaneseFrontend()
         return self._ja_frontend
 
+    def _direct(self):
+        """The phoneme-driven ONNX runtime, built on first Japanese utterance.
+
+        A second session on the same weights, so it costs another CUDA context —
+        which is why it is lazy and only Japanese pays for it. Everything else keeps
+        using sherpa, which is correct for those languages and better tested.
+        """
+        if self._direct_runtime is None:
+            from plugins.kokoro_direct import KokoroDirect
+            self._direct_runtime = KokoroDirect(
+                self._model_dir, self._weights_name, provider=self._provider)
+        return self._direct_runtime
+
     def synthesize(self, text: str) -> bytes:
         return b''.join(self.synthesize_stream(text))
 
@@ -993,10 +1012,16 @@ class KokoroTTSAdapter(TTSAdapter):
         # comment in __init__. Non-Chinese text comes back untouched, so espeak
         # reads "2026" in whatever language it is phonemising.
         text = self._zh_norm.normalize(text)
+
         if self._language == "ja":
-            # Everything, not just the numbers: kanji have to leave the text
-            # entirely or sherpa routes them to lexicon-zh.txt and speaks Mandarin.
-            text = self._ja().normalize(text)
+            # Japanese leaves sherpa entirely. Its frontend phonemises with espeak,
+            # whose alphabet Kokoro's misaki-derived vocabulary cannot represent, and
+            # drops the misses — 12 phonemes from one sentence, audible as holes.
+            # plugins/ja_phonemes produces the phonemes the model was actually
+            # trained on, and plugins/kokoro_direct feeds them to the graph, because
+            # sherpa has no phoneme input path.
+            yield from self._synthesize_japanese(text)
+            return
 
         # One generate() at a time. sherpa-onnx's OfflineTts is not documented as
         # thread-safe, and dispatch() runs on a ThreadingHTTPServer thread per
@@ -1032,6 +1057,29 @@ class KokoroTTSAdapter(TTSAdapter):
         # Resample the *whole* utterance, then frame it. Doing it per 3200-byte
         # frame would restart the filter every 100 ms and inject a transient each
         # time — see utils/resample.resample_poly.
+        pcm = downsample_24k_to_16k(samples)
+        for i in range(0, len(pcm), CHUNK_BYTES):
+            yield pcm[i:i + CHUNK_BYTES]
+
+    def _synthesize_japanese(self, text: str):
+        """Kanji -> kana -> misaki phonemes -> the ONNX graph, bypassing sherpa."""
+        from plugins import ja_phonemes
+
+        kana = self._ja().to_kana_only(text)
+        phonemes = ja_phonemes.kana_to_phonemes(kana)
+        if not phonemes.strip():
+            log.warning("[tts] nothing speakable left in %r after Japanese "
+                        "normalisation", text)
+            return
+
+        with self._lock:
+            samples = self._direct().synthesize(
+                phonemes, speaker_id=self._sid, speed=self._speed)
+
+        if samples.size == 0:
+            log.warning("[tts] kokoro_direct produced no audio for %r (%r)",
+                        text, phonemes)
+            return
         pcm = downsample_24k_to_16k(samples)
         for i in range(0, len(pcm), CHUNK_BYTES):
             yield pcm[i:i + CHUNK_BYTES]

--- a/perception/plugins/tts.py
+++ b/perception/plugins/tts.py
@@ -776,6 +776,13 @@ class KokoroTTSAdapter(TTSAdapter):
         # 二千零二十六" in English, Spanish, Japanese, all of them.
         # plugins/zh_text_norm.py applies them only to the Chinese runs.
         self._zh_norm = ZhTextNormalizer(model_dir)
+        # Japanese needs the opposite treatment to Chinese: not "normalise the
+        # numbers", but "get every kanji out of the text". sherpa-onnx routes
+        # [一-鿿] to its Chinese branch with no language check, and Japanese kanji
+        # live in that range, so without this they are pronounced in Mandarin.
+        # Built lazily on the first switch to `ja` — Janome loads a ~180 MB
+        # dictionary, and a Chinese or English deployment must not pay for it.
+        self._ja_frontend = None
 
         tts_config = sherpa_onnx.OfflineTtsConfig(
             model=sherpa_onnx.OfflineTtsModelConfig(
@@ -839,6 +846,12 @@ class KokoroTTSAdapter(TTSAdapter):
                  f"model_rate={model_rate or KOKORO_SAMPLE_RATE} -> {SAMPLE_RATE}, "
                  f"lexicon={'zh' if lexicon else 'none'}, "
                  f"zh_text_norm={'on' if self._zh_norm.available else 'off'}")
+
+        if language == "ja":
+            # Build the Japanese frontend before the probe, so a missing janome is a
+            # load error naming the build flag rather than a card that comes up
+            # `running` and then speaks Mandarin.
+            self._ja()
 
         # Prove the espeak voice resolves before anything asks this adapter to
         # speak. A bad voice name is close to invisible at runtime: sherpa-onnx
@@ -934,6 +947,20 @@ class KokoroTTSAdapter(TTSAdapter):
         """The model's own name for the resident voice, e.g. `af_heart`."""
         return self._manifest.get("id2speaker", {}).get(str(self._sid), "?")
 
+    def _ja(self):
+        """The Japanese frontend, built on first use and then kept.
+
+        Lazy because Janome loads a ~180 MB dictionary and only `ja` needs it; a
+        Chinese or English deployment must not pay for it at every start. Built
+        eagerly at construction and in `set_language` when `ja` is selected, so a
+        missing janome surfaces as a load error naming the build flag rather than as
+        a failed utterance halfway through a tour.
+        """
+        if self._ja_frontend is None:
+            from plugins.ja_text_norm import JapaneseFrontend
+            self._ja_frontend = JapaneseFrontend()
+        return self._ja_frontend
+
     def synthesize(self, text: str) -> bytes:
         return b''.join(self.synthesize_stream(text))
 
@@ -944,6 +971,10 @@ class KokoroTTSAdapter(TTSAdapter):
         # comment in __init__. Non-Chinese text comes back untouched, so espeak
         # reads "2026" in whatever language it is phonemising.
         text = self._zh_norm.normalize(text)
+        if self._language == "ja":
+            # Everything, not just the numbers: kanji have to leave the text
+            # entirely or sherpa routes them to lexicon-zh.txt and speaks Mandarin.
+            text = self._ja().normalize(text)
 
         # One generate() at a time. sherpa-onnx's OfflineTts is not documented as
         # thread-safe, and dispatch() runs on a ThreadingHTTPServer thread per
@@ -1006,6 +1037,10 @@ class KokoroTTSAdapter(TTSAdapter):
             return
         self._language = resolved
         self._sid = self._resolve_sid(self._voice_index, resolved, strict=False)
+        if resolved == "ja":
+            # Build now, not on the first utterance: a missing janome should stop
+            # the config call with a clear error, not a speak.
+            self._ja()
         log.info("[tts] kokoro language -> %s (espeak %s), voice -> %s (global %d)",
                  resolved, self._voice, self.voice_name, self._sid)
 

--- a/perception/plugins/tts.py
+++ b/perception/plugins/tts.py
@@ -26,6 +26,7 @@ from rclpy.qos import QoSProfile, ReliabilityPolicy, HistoryPolicy, DurabilityPo
 from std_msgs.msg import String
 
 from utils.resample import downsample_24k_to_16k
+from plugins.zh_text_norm import ZhTextNormalizer
 
 log = logging.getLogger(__name__)
 
@@ -230,11 +231,9 @@ TOOLS = [
                     "type": "string",
                     "enum": ["en-us", "en-gb", "zh", "ja", "es", "fr", "it",
                              "pt-br", "hi"],
-                    "description": "Pronunciation language for kokoro-multi. Independent of "
-                                   "the voice — pick a matching speaker_id (0-19 en-us, "
-                                   "20-27 en-gb, 28-29/53 es, 30 fr, 31-34 hi, 35-36 it, "
-                                   "37-41 ja, 42-44 pt-br, 45-52 zh). Chinese is spoken "
-                                   "correctly on any setting",
+                    "description": "Pronunciation language for kokoro-multi. Chinese is "
+                                   "spoken correctly on any setting; this picks the espeak "
+                                   "voice for the non-Chinese parts of the text",
                     "default": "en-us", "scope": "shared",
                     "x-show-when": {"tts_engine": ["kokoro-multi"]}},
                 # Thai has no spaces between words, and MMS was trained on text
@@ -246,7 +245,7 @@ TOOLS = [
                                    "experimental — may change prosody either way)",
                     "default": False, "scope": "shared",
                     "x-show-when": {"tts_engine": "mms-th"}},
-                "speaker_id": {"type": "integer", "description": "Speaker ID (vits2-zh-en and mms-th support 0 only; kokoro-multi has 54 voices — 0-19 en-us, 20-27 en-gb, 45-52 zh)", "default": 0, "scope": "shared"},
+                "speaker_id": {"type": "integer", "description": "Speaker ID (vits2-zh-en and mms-th support 0 only; for kokoro-multi it is an index within the selected language — 0 is that language's first voice, and the voice moves with tts_language)", "default": 0, "scope": "shared"},
                 "speed":      {"type": "number", "description": "Speech speed (1.0 = normal)", "default": 1.0, "scope": "shared"},
             },
             "required": []
@@ -344,13 +343,13 @@ class MatchaTTSAdapter(TTSAdapter):
         # picks the provider — measured 4.3x faster on gpu at num_threads=2.
         provider = provider_for_device(device, (acoustic_model, vocoder))
 
-        # Gather rule FSTs
-        rule_fsts = []
-        for name in ("date-zh.fst", "number-zh.fst", "phone-zh.fst"):
-            p = os.path.join(model_dir, name)
-            if os.path.exists(p):
-                rule_fsts.append(p)
-
+        # The ZH number/date/phone FSTs are applied by us, in Python, not handed to
+        # sherpa-onnx as rule_fsts. sherpa runs rule_fsts over the *whole* text
+        # before its frontend decides what is Chinese, so passing them here rewrote
+        # every digit into Chinese characters and the frontend then read them in
+        # Chinese — "We have 25 exhibits" came out as "We have 二十五 exhibits".
+        # plugins/zh_text_norm.py applies them only to the Chinese runs.
+        self._zh_norm = ZhTextNormalizer(model_dir)
         tts_config = sherpa_onnx.OfflineTtsConfig(
             model=sherpa_onnx.OfflineTtsModelConfig(
                 matcha=sherpa_onnx.OfflineTtsMatchaModelConfig(
@@ -364,20 +363,24 @@ class MatchaTTSAdapter(TTSAdapter):
                 num_threads=2,
                 provider=provider,
             ),
-            rule_fsts=",".join(rule_fsts) if rule_fsts else "",
+            rule_fsts="",
         )
         self._tts = sherpa_onnx.OfflineTts(tts_config)
         self._sid = speaker_id
         self._speed = speed
         log.info(f"[tts] sherpa-onnx Matcha loaded: model_dir={model_dir}, "
                  f"speaker_id={speaker_id}, speed={speed}, "
-                 f"device={device}, provider={provider}")
+                 f"device={device}, provider={provider}, "
+                 f"zh_text_norm={'on' if self._zh_norm.available else 'off'}")
 
     def synthesize(self, text: str) -> bytes:
         return b''.join(self.synthesize_stream(text))
 
     def synthesize_stream(self, text: str):
         import struct
+        # Normalise before the engine sees the text, and only the Chinese parts of
+        # it — see the rule_fsts comment in __init__.
+        text = self._zh_norm.normalize(text)
         audio = self._tts.generate(text, sid=self._sid, speed=self._speed)
         float_samples = audio.samples
         # Matcha + vocos-16khz outputs 16kHz directly, no resampling needed
@@ -766,12 +769,13 @@ class KokoroTTSAdapter(TTSAdapter):
 
         provider = provider_for_device(device, (model_path,))
 
-        # The same three ZH rule FSTs Matcha loads opportunistically — number, date
-        # and phone normalisation for Chinese text. Absent for an English-only
-        # release, which is why this is a filter and not a requirement.
-        rule_fsts = [os.path.join(model_dir, name)
-                     for name in ("date-zh.fst", "number-zh.fst", "phone-zh.fst")
-                     if os.path.exists(os.path.join(model_dir, name))]
+        # The ZH number/date/phone FSTs are applied by us, not by sherpa-onnx. Given
+        # to it as rule_fsts they run over the *whole* text before the frontend
+        # splits it, so the digits become Chinese characters and are then read in
+        # Chinese whatever `lang` says — "opened in 2026" became "opened in
+        # 二千零二十六" in English, Spanish, Japanese, all of them.
+        # plugins/zh_text_norm.py applies them only to the Chinese runs.
+        self._zh_norm = ZhTextNormalizer(model_dir)
 
         tts_config = sherpa_onnx.OfflineTtsConfig(
             model=sherpa_onnx.OfflineTtsModelConfig(
@@ -794,7 +798,7 @@ class KokoroTTSAdapter(TTSAdapter):
                 num_threads=2,
                 provider=provider,
             ),
-            rule_fsts=",".join(rule_fsts) if rule_fsts else "",
+            rule_fsts="",
         )
         self._tts = sherpa_onnx.OfflineTts(tts_config)
 
@@ -809,29 +813,32 @@ class KokoroTTSAdapter(TTSAdapter):
                 f"built for {KOKORO_SAMPLE_RATE} Hz -> {SAMPLE_RATE} Hz"
             )
 
-        # Re-check against the loaded graph, not just the manifest: the manifest is
-        # our own file and could have been written for a different voices.bin.
-        live_speakers = int(getattr(self._tts, "num_speakers", 0) or 0)
-        if live_speakers and not 0 <= int(speaker_id) < live_speakers:
-            raise ValueError(
-                f"speaker_id must be 0..{live_speakers - 1} for this Kokoro "
-                f"release, got {speaker_id}"
-            )
-
-        self._sid = int(speaker_id)
         self._speed = speed
         self._language = language
         self._manifest = manifest
         self._lock = threading.Lock()
+        # `voice_index` is per language; `_sid` is the global index the model wants.
+        self._voice_index = int(speaker_id)
+        self._sid = self._resolve_sid(self._voice_index, language, strict=True)
 
-        speaker_name = manifest.get("id2speaker", {}).get(str(self._sid), "?")
+        # Re-check against the loaded graph, not just the manifest: the manifest is
+        # our own file and could have been written for a different voices.bin.
+        live_speakers = int(getattr(self._tts, "num_speakers", 0) or 0)
+        if live_speakers and not 0 <= self._sid < live_speakers:
+            raise ValueError(
+                f"resolved speaker index {self._sid} is outside this Kokoro "
+                f"release's 0..{live_speakers - 1}; the manifest does not match "
+                "voices.bin"
+            )
+
         log.info(f"[tts] sherpa-onnx Kokoro loaded: model_dir={model_dir}, "
                  f"weights={os.path.basename(model_path)}, "
-                 f"speaker_id={self._sid} ({speaker_name}), language={language}, "
+                 f"speaker_id={self._voice_index} ({self.voice_name}, global "
+                 f"{self._sid}), language={language} (espeak {self._voice}), "
                  f"speed={speed}, device={device}, provider={provider}, "
                  f"model_rate={model_rate or KOKORO_SAMPLE_RATE} -> {SAMPLE_RATE}, "
-                 f"lexicon={'zh' if lexicon else 'none'}, rule_fsts={len(rule_fsts)}")
-        self._warn_if_voice_mismatches_language()
+                 f"lexicon={'zh' if lexicon else 'none'}, "
+                 f"zh_text_norm={'on' if self._zh_norm.available else 'off'}")
 
         # Prove the espeak voice resolves before anything asks this adapter to
         # speak. A bad voice name is close to invisible at runtime: sherpa-onnx
@@ -878,40 +885,65 @@ class KokoroTTSAdapter(TTSAdapter):
         """The espeak-ng voice name for the configured language."""
         return self.LANGUAGE_VOICES[self._language]
 
-    def _warn_if_voice_mismatches_language(self) -> None:
-        """Warn — never refuse — when the voice belongs to a different language.
+    def _voice_ids(self, language: str) -> list:
+        """The model's global speaker ids for `language`, in order."""
+        return list(self._manifest.get("languages", {}).get(language) or [])
 
-        A Spanish voice reading text phonemised as Italian is legal, produces a
-        recognisably wrong-accented result, and is what you get by changing one
-        dropdown and forgetting the other. Worth a log line, not a refusal.
+    def _resolve_sid(self, voice_index: int, language: str, strict: bool) -> int:
+        """Map a per-language voice index to the model's global speaker id.
 
-        `zh` is exempt in both directions. It maps to an English espeak voice by
-        design (Chinese comes from lexicon-zh.txt, which never consults `lang`), so a
-        Chinese voice with `en-us`, or an English voice with `zh`, is a normal and
-        correct configuration rather than a mistake. An earlier version of this check
-        compared against the selected language's id list alone and would have fired
-        on exactly that — the recommended Chinese setup.
+        `speaker_id` is an index *within the selected language* — 0 is the first
+        voice of that language, whatever the model happens to number it. The global
+        ids are not learnable: Japanese starts at 37, Spanish is 28, 29 and 53.
+        Exposing them made it easy to pick an American voice, switch the language to
+        Japanese, and be left wondering why the Japanese sounded wrong.
+
+        Because the index is language-relative, an incoherent voice/language pair is
+        no longer *representable* — which is why this adapter has no mismatch
+        warning. An earlier version had one; designing the mistake out beats warning
+        about it.
+
+        `strict` separates the two callers. At construction an out-of-range value is
+        a configuration error and must be reported. On `set_language` it must not be:
+        language is a per-utterance setting that changes freely, the languages have
+        different voice counts (French has exactly one), and a language switch that
+        could fail would make the dropdown a trap.
         """
-        languages = self._manifest.get("languages") or {}
-        if self._language == "zh" or self._sid in (languages.get("zh") or []):
-            return
-        for lang, ids in languages.items():
-            if lang in ("zh", self._language) or lang not in self.LANGUAGE_VOICES:
-                continue
-            if self._sid in (ids or []):
-                name = self._manifest.get("id2speaker", {}).get(str(self._sid), "?")
-                log.warning(
-                    "[tts] kokoro speaker_id=%d (%s) is a %s voice but the text is "
-                    "phonemised as %s; set tts_language=%s to match, or pick a %s "
-                    "voice", self._sid, name, lang, self._language, lang,
-                    self._language)
-                return
+        ids = self._voice_ids(language)
+        if not ids:
+            raise RuntimeError(
+                f"the Kokoro release manifest lists no voices for {language!r}; "
+                f"it has {sorted(self._manifest.get('languages', {}))}"
+            )
+        if 0 <= voice_index < len(ids):
+            return ids[voice_index]
+        if strict:
+            raise ValueError(
+                f"speaker_id must be 0..{len(ids) - 1} for language {language!r} "
+                f"({len(ids)} voices); got {voice_index}. speaker_id is an index "
+                "within the selected language, not a global speaker number"
+            )
+        log.warning(
+            "[tts] kokoro speaker_id=%d is out of range for %s (%d voices); "
+            "using 0 (%s)", voice_index, language, len(ids),
+            self._manifest.get("id2speaker", {}).get(str(ids[0]), "?"))
+        return ids[0]
+
+    @property
+    def voice_name(self) -> str:
+        """The model's own name for the resident voice, e.g. `af_heart`."""
+        return self._manifest.get("id2speaker", {}).get(str(self._sid), "?")
 
     def synthesize(self, text: str) -> bytes:
         return b''.join(self.synthesize_stream(text))
 
     def synthesize_stream(self, text: str):
         import sherpa_onnx
+
+        # Normalise Chinese numbers here, not via sherpa's rule_fsts — see the
+        # comment in __init__. Non-Chinese text comes back untouched, so espeak
+        # reads "2026" in whatever language it is phonemising.
+        text = self._zh_norm.normalize(text)
 
         # One generate() at a time. sherpa-onnx's OfflineTts is not documented as
         # thread-safe, and dispatch() runs on a ThreadingHTTPServer thread per
@@ -947,13 +979,20 @@ class KokoroTTSAdapter(TTSAdapter):
         this costs a field assignment rather than the ~2.7 s session rebuild a
         session key would. Which is why `tts_language` is deliberately absent from
         _session_keys.
+
+        The voice moves with the language, because `speaker_id` is an index within
+        it — switching to `ja` gives voice 0 of Japanese, not whatever global id the
+        English voice 0 happened to occupy. Out of range clamps rather than raising:
+        French has one voice, and a free per-utterance setting must not be able to
+        fail. `sid` is a per-generate() argument, so none of this reloads anything.
         """
         resolved = self._normalize_language(language)
         if resolved == self._language:
             return
         self._language = resolved
-        log.info("[tts] kokoro language -> %s", resolved)
-        self._warn_if_voice_mismatches_language()
+        self._sid = self._resolve_sid(self._voice_index, resolved, strict=False)
+        log.info("[tts] kokoro language -> %s (espeak %s), voice -> %s (global %d)",
+                 resolved, self._voice, self.voice_name, self._sid)
 
 
 def _validate_kokoro_manifest(model_dir: str) -> dict:

--- a/perception/plugins/zh_text_norm.py
+++ b/perception/plugins/zh_text_norm.py
@@ -1,0 +1,236 @@
+"""Chinese text normalisation for the sherpa-onnx TTS engines, applied selectively.
+
+sherpa-onnx takes `rule_fsts` on `OfflineTtsConfig` and applies every FST to the
+**whole text before its frontend routes anything** (offline-tts-kokoro-impl.h:224 —
+`for (const auto &tn : tn_list_) text = tn->Normalize(text);`, then
+`ConvertTextToTokenIds` at :243). The frontend then splits on `[一-鿿]` to decide
+what is Chinese. So handing it the ZH number/date/phone FSTs rewrites the digits
+into Chinese characters *first*, and the frontend duly reads them in Chinese —
+in every language:
+
+    "...opened in 2026."               -> "...opened in 二千零二十六."
+    "We have 25 exhibits today."       -> "We have 二十五 exhibits today."
+    "Hola, tenemos 25 exposiciones."   -> "Hola, tenemos 二十五 exposiciones."
+
+Both `MatchaTTSAdapter` and `KokoroTTSAdapter` did exactly that. The fix is not to
+drop the FSTs — for Chinese they are good and load-bearing:
+
+    "2026年"          -> "二零二六年"
+    "2026年1月15日"   -> "二零二六年一月十五日"
+    "第25个展品"      -> "第二十五个展品"
+    "延迟200毫秒"     -> "延迟二百毫秒"
+
+— it is to run them here, before sherpa sees the text, and only on the parts that
+are actually Chinese. Callers therefore pass `rule_fsts=""` and call `normalize()`.
+
+Gating on the configured language would have been simpler and is worse in both
+directions: `matcha-zh-en` has no language field at all, and even for Kokoro the
+language is a property of the *speaker*, not reliably of the text — an operator on
+`en-us` still reads Chinese sign text, and a `zh` tour still says "agent core".
+Deciding per number, from its neighbours, gets both right.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+
+log = logging.getLogger(__name__)
+
+# The three FSTs sherpa-onnx ships beside its Chinese-capable releases. Order
+# matters: date before number, or "2026年1月15日" is consumed digit-group by
+# digit-group as three plain quantities instead of a date.
+FST_NAMES = ("date-zh.fst", "number-zh.fst", "phone-zh.fst")
+
+# Same range sherpa-onnx's own frontend uses to decide what is Chinese
+# (kokoro-multi-lang-lexicon.cc: "([\\u4e00-\\u9fff]+)"). Deliberately identical:
+# if this disagreed with the router, text could be normalised here and then routed
+# to espeak anyway, or vice versa.
+_CJK = r"一-鿿"
+
+_RUN = re.compile(
+    rf"(?P<cjk>[{_CJK}]+)"
+    r"|(?P<digit>\d+)"
+    r"|(?P<latin>[A-Za-z]+)"
+    r"|(?P<other>[^"
+    rf"{_CJK}"
+    r"\dA-Za-z]+)"
+)
+
+# Characters that carry no language of their own and so must not break the
+# adjacency test: "延迟 200 毫秒" and "第25，26个" both have a Chinese neighbour.
+# Full-width punctuation is *not* here — 。，、？！ are unambiguously Chinese and
+# are treated as CJK context below.
+_NEUTRAL = set(" \t\n\r\f\v.,:;!?()[]{}\"'`~@#$%^&*+=|\\/<>-_")
+
+# Full-width punctuation only ever appears in Chinese text, so it counts as
+# Chinese context on its own: "有 25 个。" and "2026年。" both read as Chinese even
+# when the adjacent run is the sentence end.
+_CJK_PUNCT = set("。，、；：？！（）《》【】“”‘’—…·")
+
+
+def _classify(text: str):
+    """Split into (kind, start, end) runs, kind in cjk/digit/latin/other."""
+    return [(m.lastgroup, m.start(), m.end()) for m in _RUN.finditer(text)]
+
+
+def _other_is_chinese_context(chunk: str) -> bool:
+    """True when an `other` run is Chinese punctuation rather than neutral filler."""
+    return any(c in _CJK_PUNCT for c in chunk)
+
+
+def _neighbour_is_cjk(runs, text: str, index: int, step: int) -> bool:
+    """Look outward from runs[index] for the first run that carries a language.
+
+    Neutral punctuation and whitespace are skipped; Chinese punctuation stops the
+    walk and answers yes. A Latin run stops it and answers no — that is what keeps
+    "we have 25 exhibits" out of the Chinese branch.
+    """
+    i = index + step
+    while 0 <= i < len(runs):
+        kind, start, end = runs[i]
+        chunk = text[start:end]
+        if kind == "cjk":
+            return True
+        if kind == "latin":
+            return False
+        if kind == "digit":
+            # A second number tells us nothing on its own; keep looking past it.
+            i += step
+            continue
+        if _other_is_chinese_context(chunk):
+            return True
+        if all(c in _NEUTRAL for c in chunk):
+            i += step
+            continue
+        return False
+    return False
+
+
+def _is_chinese_number(runs, text: str, index: int) -> bool:
+    """A digit run belongs to Chinese if *either* side is Chinese.
+
+    Either-side rather than one-side-wins because both of these are Chinese:
+
+        "延迟 200 毫秒"   (Chinese on both sides)
+        "共25 items"      (Chinese only before)
+        "In 2026 我们开业" (Chinese only after)
+
+    while "we have 25 exhibits" and "delay 200 ms" have Chinese on neither and stay
+    with espeak, which reads numbers correctly in each of its own languages.
+    """
+    return (_neighbour_is_cjk(runs, text, index, -1)
+            or _neighbour_is_cjk(runs, text, index, +1))
+
+
+def segment(text: str):
+    """Split `text` into ``(is_chinese, substring)`` pieces covering it exactly.
+
+    Pure text, no FST and no model — which is the point: this is the part of the
+    fix that is testable on any host, and the part most likely to be wrong.
+
+    Neutral runs join whichever segment is open, so punctuation never splits a
+    sentence into extra pieces. Concatenating the substrings reproduces the input.
+    """
+    runs = _classify(text)
+    if not runs:
+        return [(False, text)] if text else []
+
+    flags = []
+    for i, (kind, start, end) in enumerate(runs):
+        if kind == "cjk":
+            flags.append(True)
+        elif kind == "digit":
+            flags.append(_is_chinese_number(runs, text, i))
+        elif kind == "latin":
+            flags.append(False)
+        else:
+            chunk = text[start:end]
+            # Chinese punctuation is Chinese; anything else inherits the run before
+            # it so a trailing "." does not start a new segment.
+            flags.append(_other_is_chinese_context(chunk)
+                         or (flags[-1] if flags else False))
+
+    pieces = []
+    cur_flag, cur_start = flags[0], runs[0][1]
+    for i in range(1, len(runs)):
+        if flags[i] != cur_flag:
+            pieces.append((cur_flag, text[cur_start:runs[i][1]]))
+            cur_flag, cur_start = flags[i], runs[i][1]
+    pieces.append((cur_flag, text[cur_start:]))
+    return pieces
+
+
+class ZhTextNormalizer:
+    """Applies the ZH rule FSTs to the Chinese parts of mixed text.
+
+    Holds the loaded FSTs, so construct once per adapter rather than per utterance
+    (`kaldifst.TextNormalizer` compiles the FST on construction).
+    """
+
+    def __init__(self, model_dir: str, fst_names=FST_NAMES):
+        self._normalizers = []
+        self._available = False
+
+        paths = [os.path.join(model_dir, name) for name in fst_names]
+        paths = [p for p in paths if os.path.exists(p)]
+        if not paths:
+            log.info("[tts] no ZH rule FSTs in %s; numbers pass through to the "
+                     "engine's own frontend", model_dir)
+            return
+
+        try:
+            import kaldifst
+        except ImportError as error:
+            # A warning, not a refusal. Without this, Chinese digits are read by
+            # espeak in the selected voice — wrong, but audible and confined to
+            # numbers. (Contrast the Thai frontend, which refuses to load without
+            # pythainlp because there the digits are *dropped* from the audio.)
+            #
+            # kaldifst reaches the image through
+            # plugins/vits2_tts_trt/requirements.jetson.txt, installed when
+            # ENABLE_VITS2_TRT=1 — the Dockerfile default. A build with it off
+            # lands here.
+            log.warning(
+                "[tts] kaldifst is not installed (it ships with ENABLE_VITS2_TRT=1), "
+                "so Chinese numbers will not be normalised and will be read by "
+                "espeak instead: %s", error)
+            return
+
+        for path in paths:
+            try:
+                self._normalizers.append(kaldifst.TextNormalizer(path))
+            except Exception as error:  # noqa: BLE001 - a bad FST must not be fatal
+                log.warning("[tts] could not load %s: %s", os.path.basename(path), error)
+        self._available = bool(self._normalizers)
+        if self._available:
+            log.info("[tts] ZH text normalisation active (%d FSTs from %s)",
+                     len(self._normalizers), model_dir)
+
+    @property
+    def available(self) -> bool:
+        return self._available
+
+    def _normalize_chinese(self, chunk: str) -> str:
+        for normalizer in self._normalizers:
+            try:
+                chunk = normalizer.normalize(chunk)
+            except Exception as error:  # noqa: BLE001
+                log.warning("[tts] ZH normalisation failed on %r: %s", chunk, error)
+                return chunk
+        return chunk
+
+    def normalize(self, text: str) -> str:
+        """Return `text` with only its Chinese parts run through the ZH FSTs.
+
+        Whole segments are handed to the FSTs, never the bare digits: `date-zh.fst`
+        has to see the `年` to produce `二零二六年` rather than the quantity form
+        `二千零二十六`.
+        """
+        if not text or not self._available:
+            return text
+        out = []
+        for is_chinese, chunk in segment(text):
+            out.append(self._normalize_chinese(chunk) if is_chinese else chunk)
+        return "".join(out)

--- a/perception/plugins/zh_text_norm.py
+++ b/perception/plugins/zh_text_norm.py
@@ -76,6 +76,22 @@ _NEUTRAL = set(" \t\n\r\f\v.,:;!?()[]{}\"'`~@#$%^&*+=|\\/<>-_")
 # *did* rewrite punctuation would have turned it into a real bug.
 _CJK_PUNCT = set("。，、；：？！（）《》【】")
 
+# Hiragana and katakana. Their presence means the text is Japanese, not Chinese —
+# and Japanese kanji sit inside _CJK, so without this check the adjacency rule below
+# marks a Japanese sentence's numbers as Chinese and the ZH FSTs rewrite them:
+#
+#   今日は2026年10月1日です  ->  今日は二零二六年十月一日です
+#
+# which is then read in Mandarin. Japanese dates want ジュウガツ / ツイタチ, which
+# plugins/ja_text_norm.py handles. Chinese text does not contain kana, so treating
+# any kana as "this is not Chinese" is safe in the direction that matters.
+_KANA = re.compile(r"[぀-ヿ]")
+
+
+def has_kana(text: str) -> bool:
+    """True when the text contains hiragana or katakana, i.e. it is Japanese."""
+    return bool(_KANA.search(text))
+
 
 def _classify(text: str):
     """Split into (kind, start, end) runs, kind in cjk/digit/latin/other."""
@@ -139,7 +155,14 @@ def segment(text: str):
 
     Neutral runs join whichever segment is open, so punctuation never splits a
     sentence into extra pieces. Concatenating the substrings reproduces the input.
+
+    Japanese is excluded wholesale: kanji are inside the CJK range, so a Japanese
+    sentence would otherwise have its numbers rewritten into Chinese numerals and
+    read in Mandarin. See has_kana.
     """
+    if has_kana(text):
+        return [(False, text)] if text else []
+
     runs = _classify(text)
     if not runs:
         return [(False, text)] if text else []

--- a/perception/plugins/zh_text_norm.py
+++ b/perception/plugins/zh_text_norm.py
@@ -60,14 +60,21 @@ _RUN = re.compile(
 
 # Characters that carry no language of their own and so must not break the
 # adjacency test: "延迟 200 毫秒" and "第25，26个" both have a Chinese neighbour.
-# Full-width punctuation is *not* here — 。，、？！ are unambiguously Chinese and
-# are treated as CJK context below.
 _NEUTRAL = set(" \t\n\r\f\v.,:;!?()[]{}\"'`~@#$%^&*+=|\\/<>-_")
 
-# Full-width punctuation only ever appears in Chinese text, so it counts as
-# Chinese context on its own: "有 25 个。" and "2026年。" both read as Chinese even
-# when the adjacent run is the sentence end.
-_CJK_PUNCT = set("。，、；：？！（）《》【】“”‘’—…·")
+# Punctuation that only appears in CJK text, so it counts as Chinese context on its
+# own: "有 25 个。" and "2026年。" read as Chinese even when the adjacent run is the
+# sentence end.
+#
+# Deliberately excludes the characters an English typographer uses — the em dash
+# `—` (U+2014), ellipsis `…` (U+2026), curly quotes `“ ” ‘ ’` and the middle dot
+# `·`. Those were in here at first, which split
+# "a fundamental transition—from model-driven" into three segments and handed the
+# bare dash to the ZH FSTs as "Chinese". Harmless as it turned out (the FSTs leave
+# punctuation alone, so the text came back byte-identical), but it made an English
+# sentence look Chinese to every later reader of this code, and a future FST that
+# *did* rewrite punctuation would have turned it into a real bug.
+_CJK_PUNCT = set("。，、；：？！（）《》【】")
 
 
 def _classify(text: str):

--- a/perception/tests/test_ja_phonemes.py
+++ b/perception/tests/test_ja_phonemes.py
@@ -1,0 +1,155 @@
+"""
+tests/test_ja_phonemes.py — the check whose absence caused the whole Japanese saga.
+
+Kokoro was trained on misaki's phonemes; sherpa-onnx drives it with espeak's. The two
+alphabets disagree, sherpa silently discards what it cannot look up, and Japanese came
+out with 12 phonemes missing from a single sentence — audible as holes, and invisible
+in any diff.
+
+So the load-bearing test here is not "does it produce plausible output", it is **every
+character this table can emit exists in the model's vocabulary**. That runs with no
+model, no device and no janome.
+
+The vocabulary is checked against a copy of Kokoro's own token list, so the assertion
+does not depend on a downloaded release being present.
+
+Run: python -m pytest perception/tests -q
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+PERCEPTION_ROOT = Path(__file__).resolve().parents[1]
+if str(PERCEPTION_ROOT) not in sys.path:
+    sys.path.insert(0, str(PERCEPTION_ROOT))
+
+from plugins import ja_phonemes as jp  # noqa: E402
+
+# Kokoro-82M's vocabulary, verified byte-identical to upstream's own config.json
+# (114 tokens, zero difference) and to the tokens.txt inside the release we ship.
+# Inlined rather than read from /models so this test needs no download.
+KOKORO_VOCAB = set(
+    ';:,.!?—…"()“” ̃ʣʥʦʨᵝꭧAIOQSTWYᵊabcdefhijk'
+    'lmnopqrstuvwxyzɑɐɒæβɔɕçɖðʤəɚɛɜɟɡɥɨɪʝɯɰŋɳ'
+    'ɲɴøɸθœɹɾɻʁɽʂʃʈʧʊʋʌɣɤχʎʒʔˈˌːʰʲ↓→↗↘ᵻ'
+)
+
+
+def test_the_vocabulary_snapshot_is_the_right_size():
+    """If this drifts, the snapshot above no longer describes the shipped model."""
+    assert len(KOKORO_VOCAB) == 114, sorted(KOKORO_VOCAB)
+
+
+# ── the assertion that matters ────────────────────────────────────────────────
+
+def test_every_phoneme_the_table_can_emit_is_in_the_vocabulary():
+    """The check that was missing. 12 phonemes were being dropped without it.
+
+    `pip install misaki` today gives a table for a *newer* Kokoro whose vocabulary has
+    G, K, g, ƫ and the palatalised ᶀᶁᶃᶄᶆᶈᶉ. Ours does not. If someone "updates" the
+    vendored table to current misaki, this fails immediately instead of shipping
+    silence.
+    """
+    missing = sorted(c for c in jp.all_table_phonemes() if c not in KOKORO_VOCAB)
+    assert not missing, (
+        f"these phonemes are not in Kokoro's vocabulary and would be silently "
+        f"dropped: {missing}. The table is pinned to misaki fdc9c5e5e (2025-01-13) "
+        f"for exactly this reason — see the comment in plugins/ja_phonemes.py")
+
+
+@pytest.mark.parametrize("text", [
+    "コンニチハ", "キョウハニセンニジュウロクネン", "ワタシハシャオ・ファントモウシマス",
+    "ナニカオテツダイシマショウカ", "トウキョウ", "ラーメン", "ニッキ",
+    "シャシュショ", "チャチュチョ", "ジャジュジョ", "ヴァヴィヴェヴォ",
+])
+def test_real_sentences_stay_in_vocabulary(text):
+    out = jp.kana_to_phonemes(text)
+    missing = sorted(c for c in out if c not in KOKORO_VOCAB)
+    assert not missing, f"{text!r} -> {out!r} contains {missing}"
+
+
+def test_no_kana_survives():
+    """Anything left in kana would be looked up as a token and dropped."""
+    for text in ["コンニチハ", "キョウ", "ラーメン", "シャオ・ファン", "ヴィヴァ"]:
+        out = jp.kana_to_phonemes(text)
+        assert not any(0x3040 <= ord(c) <= 0x30FF for c in out), (text, out)
+
+
+# ── mora splitting ────────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("kana,expected", [
+    ("きゃ", ["きゃ"]),           # one mora, not two
+    ("きや", ["き", "や"]),       # full-size や is its own mora
+    ("しゃしゅしょ", ["しゃ", "しゅ", "しょ"]),
+    ("にっき", ["に", "っ", "き"]),
+    ("らーめん", ["ら", "ー", "め", "ん"]),
+])
+def test_digraphs_are_one_mora(kana, expected):
+    """`きゃ` is one beat. Matching singles first would strand the small kana."""
+    assert jp.split_moras(kana) == expected
+
+
+def test_katakana_and_hiragana_give_the_same_phonemes():
+    """The table is keyed on hiragana, as misaki's is; katakana converts down."""
+    assert jp.kana_to_phonemes("コンニチハ") == jp.kana_to_phonemes("こんにちは")
+
+
+# ── the three context-dependent moras ─────────────────────────────────────────
+
+@pytest.mark.parametrize("kana,expected", [
+    ("シンブン", "ɕimbɯɴ"),    # ん -> m before b
+    ("サンポ", "sampo"),        # ん -> m before p
+    ("ンゴ", "ŋɡo"),            # ん -> ŋ before ɡ
+    ("サンニン", "saɲɲiɴ"),     # ん -> ɲ before ɲ
+    ("ホンダ", "honda"),        # ん -> n before d
+    ("ラーメン", "ɾaːmeɴ"),     # utterance-final -> uvular ɴ
+])
+def test_moraic_n_assimilates_to_what_follows(kana, expected):
+    """ん takes the place of articulation of the next consonant.
+
+    Five outcomes, and the fallback is the uvular ɴ rather than plain n — which is
+    why the rule is spelled out rather than defaulted.
+    """
+    assert jp.kana_to_phonemes(kana) == expected
+
+
+def test_sokuon_is_a_glottal_stop_not_a_doubled_consonant():
+    """misaki writes っ as ʔ, and the model was trained that way.
+
+    The romaji stage doubled the consonant instead, which was right for an Italian
+    voice reading romaji and wrong here.
+    """
+    assert jp.kana_to_phonemes("ニッキ") == "ɲiʔkʲi"
+    assert jp.kana_to_phonemes("キッテ") == "kʲiʔte"
+
+
+def test_chounpu_lengthens_the_previous_vowel():
+    assert jp.kana_to_phonemes("ラーメン") == "ɾaːmeɴ"
+    assert jp.kana_to_phonemes("コーヒー") == "koːçiː"
+    # Leading ー has nothing to lengthen and is dropped rather than emitted bare.
+    assert not jp.kana_to_phonemes("ーア").startswith("ː")
+
+
+def test_punctuation_becomes_tokens_the_model_actually_has():
+    """Full-width 。、！？ are not in the vocabulary; their ASCII forms are.
+
+    Left alone they would be looked up, missed and dropped — the same silent failure
+    as the phonemes. `・` becomes a space because it separates name parts and is a
+    boundary, not a sound.
+    """
+    out = jp.kana_to_phonemes("コンニチハ、ゲンキ？")
+    assert "," in out and "?" in out, out
+    assert "、" not in out and "？" not in out, out
+    assert jp.kana_to_phonemes("シャオ・ファン") == "ɕao ɸaɴ"
+    for text in ["コンニチハ、ゲンキ？", "ソウデス。", "エッ！", "「ハイ」"]:
+        missing = sorted(c for c in jp.kana_to_phonemes(text) if c not in KOKORO_VOCAB)
+        assert not missing, (text, missing)
+
+
+def test_empty_input():
+    assert jp.kana_to_phonemes("") == ""
+    assert jp.split_moras("") == []

--- a/perception/tests/test_ja_text_norm.py
+++ b/perception/tests/test_ja_text_norm.py
@@ -1,0 +1,210 @@
+"""
+tests/test_ja_text_norm.py — Japanese numbers, dates and counters.
+
+The rules here exist because a morphological analyser gets counters wrong: Janome
+reads `10月` as `ツキ` and `1日` as `ニチ`, where a speaker says `ジュウガツ` and
+`ツイタチ`. Everything in this file is pure text, so it runs with no janome, no
+model and no device — which matters, because the alternative way to catch a wrong
+reading is to find someone who reads Japanese.
+
+The kanji->kana stage itself needs janome and is skipped without it.
+
+Run: python -m pytest perception/tests -q
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+PERCEPTION_ROOT = Path(__file__).resolve().parents[1]
+if str(PERCEPTION_ROOT) not in sys.path:
+    sys.path.insert(0, str(PERCEPTION_ROOT))
+
+from plugins import ja_text_norm as ja  # noqa: E402
+
+
+# ── Sino-Japanese numerals ────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("n,expected", [
+    (0, "ゼロ"),
+    (1, "イチ"),
+    (4, "ヨン"),
+    (7, "ナナ"),
+    (10, "ジュウ"),
+    (11, "ジュウイチ"),
+    (20, "ニジュウ"),
+    (25, "ニジュウゴ"),
+    (100, "ヒャク"),
+    (200, "ニヒャク"),
+    (1000, "セン"),
+    (2026, "ニセンニジュウロク"),
+])
+def test_numbers_read_as_sino_japanese(n, expected):
+    assert ja.read_number(n) == expected
+
+
+@pytest.mark.parametrize("n,expected", [
+    (300, "サンビャク"),   # not サンヒャク
+    (600, "ロッピャク"),   # not ロクヒャク
+    (800, "ハッピャク"),
+    (3000, "サンゼン"),    # not サンセン
+    (8000, "ハッセン"),
+])
+def test_the_euphonic_irregulars_are_not_derived_naively(n, expected):
+    """These sound changes are why the hundreds and thousands need a table."""
+    assert ja.read_number(n) == expected
+
+
+def test_numbers_group_by_four_digits_not_three():
+    """Japanese groups in 万/億, not thousands.
+
+    Porting a Western number reader and grouping by three is the classic way to get
+    this wrong; 20000 is ニマン, never "twenty thousand" spelled out in セン.
+    """
+    assert ja.read_number(10000) == "イチマン"
+    assert ja.read_number(20000) == "ニマン"
+    assert ja.read_number(100000000) == "イチオク"
+
+
+# ── dates: the case that started this ─────────────────────────────────────────
+
+def test_the_reported_date_reads_correctly():
+    """2026年10月1日 was read in Mandarin, then as ツキ/ニチ. Both are wrong."""
+    got = ja.normalize_dates("2026年10月1日")
+    assert got == "ニセンニジュウロクネンジュウガツツイタチ", got
+    assert "ツキ" not in got, "月 must be ガツ in a date, not the isolated ツキ"
+    assert "1ニチ" not in got
+
+
+@pytest.mark.parametrize("n,expected", [
+    (1, "イチガツ"),
+    (4, "シガツ"),        # not ヨンガツ
+    (7, "シチガツ"),      # not ナナガツ
+    (9, "クガツ"),        # not キュウガツ
+    (10, "ジュウガツ"),
+    (12, "ジュウニガツ"),
+])
+def test_month_readings_including_the_three_irregulars(n, expected):
+    assert ja.normalize_dates(f"{n}月") == expected
+
+
+@pytest.mark.parametrize("n,expected", [
+    (1, "ツイタチ"),
+    (2, "フツカ"),
+    (4, "ヨッカ"),
+    (8, "ヨウカ"),
+    (10, "トオカ"),
+    (14, "ジュウヨッカ"),
+    (20, "ハツカ"),
+    (24, "ニジュウヨッカ"),
+    (15, "ジュウゴニチ"),      # regular
+    (28, "ニジュウハチニチ"),  # regular despite 8 being irregular alone
+])
+def test_day_readings_are_native_for_the_first_ten_and_14_20_24(n, expected):
+    assert ja.normalize_dates(f"{n}日") == expected
+
+
+def test_a_full_date_is_consumed_before_the_单_counters_match():
+    """Ordering matters: 年月日 must not be eaten piecemeal by the 年 rule."""
+    assert ja.normalize_dates("2026年1月15日") == "ニセンニジュウロクネンイチガツジュウゴニチ"
+    assert ja.normalize_dates("10月1日") == "ジュウガツツイタチ"
+
+
+def test_times_use_their_own_irregulars():
+    assert ja.normalize_dates("4時") == "ヨジ"       # not ヨンジ
+    assert ja.normalize_dates("9時") == "クジ"
+    assert ja.normalize_dates("3分") == "サンプン"   # not サンフン
+    assert ja.normalize_dates("10分") == "ジュップン"
+    assert ja.normalize_dates("4時30分") == "ヨジサンジュップン"
+
+
+@pytest.mark.parametrize("n,expected", [
+    (4, "ヨジ"), (7, "シチジ"), (9, "クジ"),
+    (14, "ジュウヨジ"),      # not ジュウヨンジ — the irregular is on the ones digit
+    (17, "ジュウシチジ"),
+    (19, "ジュウクジ"),
+    (12, "ジュウニジ"),      # regular
+    (20, "ニジュウジ"),
+])
+def test_hour_irregulars_follow_the_trailing_digit(n, expected):
+    assert ja.normalize_dates(f"{n}時") == expected
+
+
+@pytest.mark.parametrize("n,expected", [
+    (1, "イップン"), (3, "サンプン"), (6, "ロップン"), (8, "ハップン"),
+    (2, "ニフン"), (5, "ゴフン"),
+    (10, "ジュップン"), (20, "ニジュップン"), (30, "サンジュップン"),
+    (21, "ニジュウイップン"),   # tens keep ジュウ, ones take the irregular
+    (34, "サンジュウヨンプン"),
+    (45, "ヨンジュウゴフン"),
+])
+def test_minute_irregulars_follow_the_trailing_digit(n, expected):
+    """A flat table keyed on the whole value gave サンジュウフン for 30分."""
+    assert ja.normalize_dates(f"{n}分") == expected
+
+
+def test_spacing_between_number_and_counter_is_tolerated():
+    assert ja.normalize_dates("2026 年 10 月 1 日") == "ニセンニジュウロクネンジュウガツツイタチ"
+
+
+# ── leftover numbers ──────────────────────────────────────────────────────────
+
+def test_bare_numbers_are_read_only_after_the_counters():
+    """Run in the other order and a date's digits get read twice."""
+    text = ja.normalize_dates("今日は2026年10月1日で、25個あります")
+    assert "2026" not in text, "the year should already be kana"
+    assert ja.normalize_numbers(text).count("ニジュウゴ") == 1
+
+
+def test_normalize_numbers_leaves_kana_alone():
+    assert ja.normalize_numbers("ジュウガツ") == "ジュウガツ"
+    assert ja.normalize_numbers("25") == "ニジュウゴ"
+
+
+# ── the kanji stage (needs janome) ────────────────────────────────────────────
+
+_HAS_JANOME = importlib.util.find_spec("janome") is not None
+janome_only = pytest.mark.skipif(not _HAS_JANOME, reason="janome not installed")
+
+
+def test_has_kanji_detects_what_would_reach_the_chinese_branch():
+    """[一-鿿] is exactly the range sherpa routes to lexicon-zh.txt."""
+    assert ja.has_kanji("今日")
+    assert ja.has_kanji("キョウハ今日")
+    assert not ja.has_kanji("キョウハニセンニジュウロクネン")
+    assert not ja.has_kanji("こんにちは")
+    assert not ja.has_kanji("")
+
+
+@janome_only
+def test_the_reported_sentence_leaves_no_kanji():
+    """The whole point: nothing may remain in [一-鿿], or it is read in Mandarin."""
+    frontend = ja.JapaneseFrontend()
+    out = frontend.normalize(
+        "こんにちは！今日は2026年10月1日です。私はシャオ・ファンと申します。"
+        "何かお手伝いしましょうか？")
+    assert not ja.has_kanji(out), f"kanji survived: {out}"
+    assert "ジュウガツ" in out and "ツイタチ" in out
+
+
+@janome_only
+def test_kanji_become_kana():
+    frontend = ja.JapaneseFrontend()
+    assert not ja.has_kanji(frontend.normalize("私は人形ロボットです"))
+    assert not ja.has_kanji(frontend.normalize("何かお手伝いしましょうか"))
+
+
+@pytest.mark.skipif(_HAS_JANOME, reason="janome is installed here")
+def test_without_janome_the_frontend_refuses_rather_than_degrading():
+    """Unlike the Chinese normaliser, which warns and passes text through.
+
+    Degrading here would not merely lose the numbers — every kanji would be spoken
+    in Mandarin, so the card would come up `running` and speak the wrong language.
+    Same call plugins/tts.py makes about pythainlp for Thai.
+    """
+    with pytest.raises(RuntimeError, match="janome"):
+        ja.JapaneseFrontend()

--- a/perception/tests/test_ja_text_norm.py
+++ b/perception/tests/test_ja_text_norm.py
@@ -75,7 +75,7 @@ def test_numbers_group_by_four_digits_not_three():
 def test_the_reported_date_reads_correctly():
     """2026年10月1日 was read in Mandarin, then as ツキ/ニチ. Both are wrong."""
     got = ja.normalize_dates("2026年10月1日")
-    assert got == "ニセンニジュウロクネンジュウガツツイタチ", got
+    assert got == "ニセンニジュウロクネン ジュウガツ ツイタチ", got
     assert "ツキ" not in got, "月 must be ガツ in a date, not the isolated ツキ"
     assert "1ニチ" not in got
 
@@ -108,10 +108,10 @@ def test_day_readings_are_native_for_the_first_ten_and_14_20_24(n, expected):
     assert ja.normalize_dates(f"{n}日") == expected
 
 
-def test_a_full_date_is_consumed_before_the_单_counters_match():
+def test_a_full_date_is_consumed_before_the_single_counters_match():
     """Ordering matters: 年月日 must not be eaten piecemeal by the 年 rule."""
-    assert ja.normalize_dates("2026年1月15日") == "ニセンニジュウロクネンイチガツジュウゴニチ"
-    assert ja.normalize_dates("10月1日") == "ジュウガツツイタチ"
+    assert ja.normalize_dates("2026年1月15日") == "ニセンニジュウロクネン イチガツ ジュウゴニチ"
+    assert ja.normalize_dates("10月1日") == "ジュウガツ ツイタチ"
 
 
 def test_times_use_their_own_irregulars():
@@ -119,7 +119,7 @@ def test_times_use_their_own_irregulars():
     assert ja.normalize_dates("9時") == "クジ"
     assert ja.normalize_dates("3分") == "サンプン"   # not サンフン
     assert ja.normalize_dates("10分") == "ジュップン"
-    assert ja.normalize_dates("4時30分") == "ヨジサンジュップン"
+    assert ja.normalize_dates("4時30分") == "ヨジ サンジュップン"
 
 
 @pytest.mark.parametrize("n,expected", [
@@ -148,7 +148,7 @@ def test_minute_irregulars_follow_the_trailing_digit(n, expected):
 
 
 def test_spacing_between_number_and_counter_is_tolerated():
-    assert ja.normalize_dates("2026 年 10 月 1 日") == "ニセンニジュウロクネンジュウガツツイタチ"
+    assert ja.normalize_dates("2026 年 10 月 1 日") == "ニセンニジュウロクネン ジュウガツ ツイタチ"
 
 
 # ── leftover numbers ──────────────────────────────────────────────────────────
@@ -178,6 +178,122 @@ def test_has_kanji_detects_what_would_reach_the_chinese_branch():
     assert not ja.has_kanji("キョウハニセンニジュウロクネン")
     assert not ja.has_kanji("こんにちは")
     assert not ja.has_kanji("")
+
+
+# ── katakana -> romaji ────────────────────────────────────────────────────────
+#
+# Kana are never fed to the model: espeak-ja emits phonemes Kokoro's token table
+# lacks (ʑ, U+0308, U+031E) and sherpa drops them, which is what made the first
+# version unintelligible. These assertions are auditable by anyone who reads
+# Japanese, which is the point — I cannot hear the result.
+
+@pytest.mark.parametrize("kana,expected", [
+    ("アイウエオ", "aiueo"),
+    ("カキクケコ", "kakikukeko"),
+    ("サシスセソ", "sashisuseso"),      # shi, not si
+    ("タチツテト", "tachitsuteto"),     # chi and tsu, not ti/tu
+    ("ハヒフヘホ", "hahifuheho"),       # fu, not hu
+    ("ザジズゼゾ", "zajizuzezo"),       # ji, not zi
+    ("ワヲン", "waon"),
+])
+def test_the_gojuon_uses_hepburn_spellings(kana, expected):
+    """Hepburn, because that is what a Latin-script voice reads correctly."""
+    assert ja.to_romaji(kana) == expected
+
+
+@pytest.mark.parametrize("kana,expected", [
+    ("キャキュキョ", "kyakyukyo"),
+    ("シャシュショ", "shashusho"),
+    ("チャチュチョ", "chachucho"),
+    ("ジャジュジョ", "jajujo"),
+    ("ファ", "fa"),          # loanword combinations, needed for names
+    ("ティ", "ti"),
+    ("シェ", "she"),
+])
+def test_digraphs_are_one_syllable(kana, expected):
+    assert ja.to_romaji(kana) == expected
+
+
+@pytest.mark.parametrize("kana,expected", [
+    ("ニッキ", "nikki"),        # sokuon doubles the next consonant
+    ("キッテ", "kitte"),
+    ("イッショ", "issho"),
+    ("ツイタチ", "tsuitachi"),  # no sokuon here; must not gain one
+])
+def test_sokuon_geminates_the_following_consonant(kana, expected):
+    """Doubled consonants are why Italian is the natural target voice."""
+    assert ja.to_romaji(kana) == expected
+
+
+@pytest.mark.parametrize("kana,expected", [
+    ("キョウ", "kyoo"),        # オウ is the ordinary long o — NOT kyou
+    ("トウキョウ", "tookyoo"),
+    ("ジュウ", "juu"),
+    ("オオキイ", "ookii"),
+    ("ラーメン", "raamen"),    # chounpu lengthens
+    ("コーヒー", "koohii"),
+])
+def test_long_vowels_are_doubled_not_written_as_digraphs(kana, expected):
+    """`kyou` reads as two syllables in Italian and Spanish; `kyoo` as one long one.
+
+    This is the rule that decides whether the output sounds Japanese or like
+    someone spelling out a transliteration.
+    """
+    assert ja.to_romaji(kana) == expected
+
+
+def test_punctuation_and_digits_pass_through():
+    assert ja.to_romaji("ABC123") == "ABC123"
+    assert ja.to_romaji("") == ""
+    # The interpunct between name parts becomes a space, or espeak runs them together.
+    assert ja.to_romaji("シャオ・ファン") == "shao fan"
+
+
+@pytest.mark.parametrize("kana,expected", [
+    ("コンニチワ！", "konnichiwa!"),
+    ("ソウデス。", "soodesu."),
+    ("アレ、コレ", "are,kore"),
+    ("ナニ？", "nani?"),
+])
+def test_full_width_punctuation_becomes_ascii(kana, expected):
+    """espeak finds sentence boundaries in ASCII punctuation, not in 。！？.
+
+    Left as full-width, the whole utterance is one breath group with no pauses.
+    """
+    assert ja.to_romaji(kana) == expected
+
+
+def test_the_particle_ha_is_read_wa():
+    """A dictionary gives the written kana; Japanese says something else.
+
+    `今日は` is `kyoo wa`, never `kyoo ha`. The correction happens in to_kana where
+    Janome's part-of-speech tags are available, so this test asserts the table those
+    tags select from — the wiring itself needs janome and is covered below.
+    """
+    assert ja._PARTICLE_READINGS["ハ"] == "ワ"
+    assert ja._PARTICLE_READINGS["ヘ"] == "エ"
+    assert ja.to_romaji("キョウワ") == "kyoowa"
+    assert ja._GREETINGS["コンニチハ"] == "コンニチワ"
+
+
+def test_the_reported_sentence_romanises():
+    """The whole pipeline's output, spelled out so a reader can check it."""
+    kana = "コンニチハ！キョウハニセンニジュウロクネンジュウガツツイタチデス。"
+    got = ja.to_romaji(kana)
+    assert "kyoo" in got, got
+    assert "nisen" in got and "nijuuroku" in got, got
+    assert "juugatsu" in got, got
+    assert "tsuitachi" in got, got
+    assert not any(0x3040 <= ord(c) <= 0x30FF for c in got), f"kana survived: {got}"
+
+
+def test_no_kana_survives_romanisation():
+    """Anything left in kana would reach espeak-ja and lose phonemes again."""
+    for kana in ["アイウエオ", "キャキュキョ", "ニッキ", "ラーメン",
+                 "シャオ・ファン", "ヴィヴァ"]:
+        got = ja.to_romaji(kana)
+        assert not any(0x3040 <= ord(c) <= 0x30FF for c in got), (kana, got)
+
 
 
 @janome_only

--- a/perception/tests/test_kokoro_direct.py
+++ b/perception/tests/test_kokoro_direct.py
@@ -152,3 +152,48 @@ def test_the_japanese_table_encodes_with_no_unknowns():
                  "ワタシハシャオ・ファントモウシマス", "ナニカオテツダイシマショウカ"]:
         _, unknown = direct.encode(ja_phonemes.kana_to_phonemes(text))
         assert unknown == [], (text, unknown)
+
+
+# ── the session must never ask for CUDA ───────────────────────────────────────
+
+def test_the_session_is_built_on_cpu_and_cannot_be_asked_for_cuda(tmp_path,
+                                                                  monkeypatch):
+    """A CUDA session here collides with sherpa's; the collision is not order-fixable.
+
+    Two ONNX Runtime builds share one `libonnxruntime_providers_cuda.so` on jp6.1,
+    and whichever of them builds the *second* CUDA session on this graph dies with
+    "Could not find OrtValue with name '/Squeeze_2_output_0'". Measured both ways
+    round on Orin 6.
+
+    This shipped once. The code requested CUDA while a stale docstring asserted the
+    request was inert because the wheel was CPU-only — true until the Dockerfile
+    started installing the GPU wheel, and untested either way. So assert the two
+    things that keep it from coming back: the providers list, and the absence of any
+    argument that could reintroduce a device.
+    """
+    import inspect
+
+    signature = inspect.signature(kd.KokoroDirect.__init__)
+    assert "provider" not in signature.parameters, (
+        "KokoroDirect must expose no device argument — see its docstring for why")
+
+    (tmp_path / "tokens.txt").write_text("a 1\n", encoding="utf-8")
+    (tmp_path / "voices.bin").write_bytes(
+        b"\0" * (kd.STYLE_LENGTHS * kd.STYLE_DIM * 4))
+    (tmp_path / "model.onnx").write_bytes(b"not a real model")
+
+    seen = {}
+
+    class _Session:
+        def __init__(self, path, opts, providers):
+            seen["providers"] = providers
+
+        def get_providers(self):
+            return seen["providers"]
+
+    fake_ort = type("ort", (), {"SessionOptions": lambda: type(
+        "o", (), {"intra_op_num_threads": 0})(), "InferenceSession": _Session})
+    monkeypatch.setitem(sys.modules, "onnxruntime", fake_ort)
+
+    kd.KokoroDirect(str(tmp_path), "model.onnx")
+    assert seen["providers"] == ["CPUExecutionProvider"], seen

--- a/perception/tests/test_kokoro_direct.py
+++ b/perception/tests/test_kokoro_direct.py
@@ -1,0 +1,154 @@
+"""
+tests/test_kokoro_direct.py — tokenisation and chunking for the direct ONNX runtime.
+
+The parts that need a 310 MB model are not covered here; the parts that silently
+produce *wrong* audio rather than no audio are. Two conventions are copied from
+sherpa's own `OfflineTtsKokoroModel::Run` and are easy to get subtly wrong:
+
+  - tokens are wrapped in a leading and trailing 0;
+  - the style row is indexed by the **inner** token count, `styles[sid][len(ids)]`,
+    so the 510 axis in voices.bin is a length table and not padding.
+
+Getting either wrong yields audio that plays and sounds off, which is exactly the
+class of bug this whole Japanese effort has been chasing.
+
+Run: python -m pytest perception/tests -q
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+PERCEPTION_ROOT = Path(__file__).resolve().parents[1]
+if str(PERCEPTION_ROOT) not in sys.path:
+    sys.path.insert(0, str(PERCEPTION_ROOT))
+
+from plugins import kokoro_direct as kd  # noqa: E402
+
+
+# ── tokens.txt parsing ────────────────────────────────────────────────────────
+
+def test_the_space_token_is_not_mistaken_for_a_malformed_line(tmp_path):
+    """`tokens.txt` has a line whose token IS a space, so split from the right.
+
+    Splitting from the left drops the space token, and a dropped space collapses
+    every word boundary in the utterance.
+    """
+    path = tmp_path / "tokens.txt"
+    path.write_text("; 1\n: 2\n  3\na 4\n", encoding="utf-8")
+    table = kd._read_tokens(str(path))
+    assert table[";"] == 1
+    assert table[" "] == 3, table
+    assert table["a"] == 4
+
+
+def test_blank_and_malformed_lines_are_skipped(tmp_path):
+    path = tmp_path / "tokens.txt"
+    path.write_text("a 1\n\nnot-an-id\nb 2\n", encoding="utf-8")
+    assert kd._read_tokens(str(path)) == {"a": 1, "b": 2}
+
+
+def test_an_empty_token_file_is_an_error(tmp_path):
+    path = tmp_path / "tokens.txt"
+    path.write_text("\n\n", encoding="utf-8")
+    with pytest.raises(RuntimeError, match="no tokens"):
+        kd._read_tokens(str(path))
+
+
+# ── chunking ──────────────────────────────────────────────────────────────────
+
+def test_short_input_is_one_chunk():
+    assert kd.chunk_ids([1, 2, 3], 10) == [[1, 2, 3]]
+    assert kd.chunk_ids([], 10) == [[]]
+
+
+def test_long_input_is_split_rather_than_truncated():
+    """sherpa hard-exits past the style table; losing the sentence is worse."""
+    ids = list(range(1, 1201))
+    chunks = kd.chunk_ids(ids, 509)
+    assert sum(len(c) for c in chunks) == len(ids), "audio was lost"
+    assert [t for c in chunks for t in c] == ids, "order changed"
+    assert all(len(c) <= 509 for c in chunks)
+
+
+def test_a_split_prefers_punctuation_over_mid_word():
+    """A seam at a comma is inaudible; a seam mid-word is not."""
+    period = 99
+    # 60 tokens, with a period at index 40 — the only sensible place to cut.
+    ids = [1] * 40 + [period] + [2] * 19
+    chunks = kd.chunk_ids(ids, 50, break_ids={period})
+    assert chunks[0][-1] == period, chunks[0][-5:]
+    assert len(chunks[0]) == 41
+
+
+def test_a_clause_longer_than_the_limit_still_splits():
+    """No punctuation anywhere: fall back to a hard cut rather than looping."""
+    ids = [7] * 1000
+    chunks = kd.chunk_ids(ids, 100, break_ids={99})
+    assert sum(len(c) for c in chunks) == 1000
+    assert all(len(c) <= 100 for c in chunks)
+
+
+def test_a_break_too_early_in_the_window_is_ignored():
+    """Cutting at token 2 of 500 would make a chunk of two tokens and stall."""
+    period = 99
+    ids = [1, 1, period] + [2] * 200
+    chunks = kd.chunk_ids(ids, 100, break_ids={period})
+    assert len(chunks[0]) > 3, chunks[0][:6]
+
+
+# ── the constants that describe the release ───────────────────────────────────
+
+def test_the_style_table_shape_matches_the_shipped_voices_bin():
+    """28 200 960 bytes = 54 speakers x 510 lengths x 256 floats, exactly."""
+    assert kd.STYLE_LENGTHS == 510
+    assert kd.STYLE_DIM == 256
+    assert 28_200_960 == 54 * kd.STYLE_LENGTHS * kd.STYLE_DIM * 4
+
+
+def test_the_model_rate_is_the_one_the_resampler_expects():
+    from plugins import tts
+    assert kd.SAMPLE_RATE == tts.KOKORO_SAMPLE_RATE == 24000
+
+
+# ── encode ────────────────────────────────────────────────────────────────────
+
+class _FakeDirect(kd.KokoroDirect):
+    """Only the token map, so encode() is testable without a 310 MB model."""
+
+    def __init__(self, table):
+        self._token_to_id = table
+
+
+def test_encode_reports_unknown_phonemes_instead_of_dropping_them():
+    """sherpa drops them silently; that is the bug this module exists for.
+
+    The Japanese table is asserted to be fully in-vocabulary elsewhere, so in
+    practice `unknown` is always empty — but if it ever is not, the caller finds out.
+    """
+    direct = _FakeDirect({"a": 1, "b": 2})
+    ids, unknown = direct.encode("aab")
+    assert ids == [1, 1, 2] and unknown == []
+
+    ids, unknown = direct.encode("axb")
+    assert ids == [1, 2], "known phonemes must still be encoded"
+    assert unknown == ["x"], "the miss must be reported, not swallowed"
+
+
+def test_encode_of_empty_input():
+    assert _FakeDirect({"a": 1}).encode("") == ([], [])
+
+
+def test_the_japanese_table_encodes_with_no_unknowns():
+    """End-to-end over the vocabulary, with no model: every phoneme maps."""
+    from plugins import ja_phonemes
+    from test_ja_phonemes import KOKORO_VOCAB
+
+    direct = _FakeDirect({c: i + 1 for i, c in enumerate(sorted(KOKORO_VOCAB))})
+    for text in ["コンニチハ", "キョウハニセンニジュウロクネンジュウガツツイタチデス",
+                 "ワタシハシャオ・ファントモウシマス", "ナニカオテツダイシマショウカ"]:
+        _, unknown = direct.encode(ja_phonemes.kana_to_phonemes(text))
+        assert unknown == [], (text, unknown)

--- a/perception/tests/test_kokoro_tts_engine.py
+++ b/perception/tests/test_kokoro_tts_engine.py
@@ -1,0 +1,469 @@
+"""
+tests/test_kokoro_tts_engine.py — the kokoro-multi engine's wiring and guards.
+
+Kokoro is the first engine here whose sample rate is not the pipeline's (24 kHz vs
+16 kHz) and the first with a *runtime* language selector. Both of those are easy to
+wire up in a way that looks fine and is wrong in a way only audible on a robot, so
+what is pinned here is the part that can be checked on a host with no model:
+
+  - `tts_language` reaches the resident adapter without rebuilding the session.
+    Kokoro reads `lang` out of GenerationConfig.extra on every generate() call, so
+    putting it in _session_keys would cost a 310 MB fp32 session rebuild for a
+    dropdown change — the same class of bug as "every speak takes 5 s" (PR that
+    added _session_keys), and the reason `speed` is excluded there too.
+  - The release validation that has to happen *before* OfflineTts is constructed.
+    A version >= 2 Kokoro model with both `lexicon` and `lang` empty makes
+    sherpa-onnx call SHERPA_ONNX_EXIT(-1) — a process exit that takes ASR, VOP and
+    OCR down with it, which main.py's try/except cannot catch.
+
+The adapter's actual synthesis is not covered here; it needs the model. See
+tests/test_resample.py for the 24 kHz -> 16 kHz conversion, which is the part of
+that path that *is* host-testable.
+
+Run: python -m pytest perception/tests -q
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from vision_stubs import _FakeExecutor  # noqa: F401
+
+import plugins.tts as tts  # noqa: E402
+
+_REAL_SHERPA_PLUGIN = tts.SherpaOnnxTTSPlugin
+
+
+class _LangCountingAdapter:
+    """Records rebuilds and per-call setter hits, like _CountingAdapter next door."""
+
+    builds = 0
+
+    def __init__(self, cfg):
+        type(self).builds += 1
+        self.cfg = dict(cfg)
+        self.speeds = []
+        self.languages = []
+
+    def synthesize(self, text):
+        return b"\x00" * 3200
+
+    def synthesize_stream(self, text):
+        yield b"\x00" * 3200
+
+    def warmup(self):
+        return 3200
+
+    def set_speed(self, speed):
+        self.speeds.append(speed)
+
+    def set_language(self, language):
+        self.languages.append(language)
+
+
+@pytest.fixture
+def _kokoro(monkeypatch):
+    """A real SherpaOnnxTTSPlugin configured as kokoro-multi, over a fake adapter."""
+    _LangCountingAdapter.builds = 0
+    holder = {}
+
+    def build(cfg):
+        holder["adapter"] = _LangCountingAdapter(cfg)
+        return holder["adapter"]
+
+    monkeypatch.setattr(tts, "_build_tts_adapter", build)
+    plugin = _REAL_SHERPA_PLUGIN(
+        {"engine": "kokoro-multi", "device": "gpu", "speed": 1.0,
+         "speaker_id": 3, "tts_language": "en-us"}, _FakeExecutor())
+    return plugin, holder
+
+
+# ── the language selector must not rebuild ────────────────────────────────────
+
+def test_language_is_not_a_session_key():
+    """The whole design in one assertion.
+
+    `lang` rides in GenerationConfig.extra per generate() call, so it is a scale on
+    the resident model. In _session_keys it would tear down and reload a 310 MB
+    fp32 CUDA session every time someone changed the dropdown.
+    """
+    keys = tts._session_keys({
+        "speaker_id": 3, "device": "gpu", "model_dir": "/models/kokoro-multi",
+        "tts_language": "zh", "speed": 1.0,
+    })
+    assert "tts_language" not in keys
+    assert "speed" not in keys, "speed is per-call for the same reason"
+    assert set(keys) == {"speaker_id", "device", "model_dir"}
+
+
+def test_language_is_still_carried_across_an_engine_switch():
+    """Absent from _session_keys, present in SHARED_CONFIG_KEYS — both are needed.
+
+    SHARED_CONFIG_KEYS is derived from configSchema precisely so a new shared field
+    cannot be forgotten; forgetting this one would build the new engine with the
+    default language and then rebuild on the next config.
+    """
+    assert "tts_language" in tts.SHARED_CONFIG_KEYS
+    assert "tts_engine" not in tts.SHARED_CONFIG_KEYS
+
+
+def test_changing_language_alone_updates_the_resident_model(_kokoro):
+    plugin, holder = _kokoro
+    result = plugin.dispatch("tts", {"action": "config", "tts_language": "en-gb"})
+    assert result["rebuilt"] is False
+    assert _LangCountingAdapter.builds == 1, "a language change rebuilt the session"
+    assert holder["adapter"].languages == ["en-gb"], "set_language was not applied"
+
+
+def test_repeating_the_same_language_still_does_not_rebuild(_kokoro):
+    """The dashboard re-applies a card's whole config around every speak."""
+    plugin, _ = _kokoro
+    same = {"action": "config", "device": "gpu", "speed": 1,
+            "speaker_id": 3, "tts_language": "en-us"}
+    for _ in range(3):
+        assert plugin.dispatch("tts", same)["rebuilt"] is False
+    assert _LangCountingAdapter.builds == 1
+
+
+def test_speed_and_language_can_change_in_one_config(_kokoro):
+    """Both are per-call, so neither may shadow the other."""
+    plugin, holder = _kokoro
+    result = plugin.dispatch("tts", {"action": "config", "speed": 1.4,
+                                     "tts_language": "zh"})
+    assert result["rebuilt"] is False
+    assert holder["adapter"].speeds == [1.4]
+    assert holder["adapter"].languages == ["zh"]
+
+
+def test_a_language_set_earlier_survives_a_later_rebuild(_kokoro):
+    """The reason `tts_language` is written back to self._cfg explicitly.
+
+    It is absent from `incoming` by design, and _build_tts_adapter reads it out of
+    self._cfg — so without that write-back, a rebuild triggered by some *other* key
+    would silently construct the adapter with the default language.
+    """
+    plugin, holder = _kokoro
+    plugin.dispatch("tts", {"action": "config", "tts_language": "zh"})
+    assert _LangCountingAdapter.builds == 1
+
+    # speaker_id IS a session key, so this one really does rebuild.
+    result = plugin.dispatch("tts", {"action": "config", "speaker_id": 47})
+    assert result["rebuilt"] is True
+    assert _LangCountingAdapter.builds == 2
+    assert holder["adapter"].cfg["tts_language"] == "zh", \
+        "the rebuild lost the selected language"
+    assert holder["adapter"].cfg["speaker_id"] == 47
+
+
+def test_every_adapter_accepts_set_language(_kokoro):
+    """_config calls it unconditionally, so the ABC must define a no-op.
+
+    Only Kokoro has a language; Matcha, MMS Thai and VITS2 bake theirs into the
+    checkpoint. A missing default would make a language field left over in a
+    deployment's config.yaml crash the *other* engines on load.
+    """
+    assert hasattr(tts.TTSAdapter, "set_language")
+    assert tts.MatchaTTSAdapter.set_language is tts.TTSAdapter.set_language
+    assert tts.MmsThaiTTSAdapter.set_language is tts.TTSAdapter.set_language
+    assert tts.KokoroTTSAdapter.set_language is not tts.TTSAdapter.set_language
+
+
+# ── configSchema ──────────────────────────────────────────────────────────────
+
+def test_the_language_field_is_exposed_and_scoped_to_kokoro():
+    props = tts.TOOLS[0]["configSchema"]["properties"]
+    field = props["tts_language"]
+    assert field["enum"] == list(tts.KokoroTTSAdapter.LANGUAGES)
+    assert field["default"] == tts.KokoroTTSAdapter.DEFAULT_LANGUAGE
+    assert field["scope"] == "shared"
+    # Hidden for every other engine, or the form offers a control that does nothing.
+    assert field["x-show-when"] == {"tts_engine": ["kokoro-multi"]}
+
+
+def test_the_device_field_is_revealed_for_kokoro():
+    """Kokoro is an ONNX Runtime engine, so `device` is meaningful for it.
+
+    Unlike Matcha it also selects *different weight files*, which is why the two
+    are not interchangeable in the form's help text.
+    """
+    device = tts.TOOLS[0]["configSchema"]["properties"]["device"]
+    assert "kokoro-multi" in device["x-show-when"]["tts_engine"]
+    assert "vits2-zh-en" not in device["x-show-when"]["tts_engine"]
+
+
+def test_kokoro_defaults_to_gpu_and_the_others_to_cpu(monkeypatch):
+    """provider_for_device refuses int8 on CUDA, so gpu implies the fp32 archive."""
+    seen = {}
+
+    class _Recorder:
+        LANGUAGES = tts.KokoroTTSAdapter.LANGUAGES
+        DEFAULT_LANGUAGE = tts.KokoroTTSAdapter.DEFAULT_LANGUAGE
+
+        def __init__(self, model_dir, speaker_id, speed, device, language=None):
+            seen.update(model_dir=model_dir, device=device, language=language)
+
+    monkeypatch.setattr(tts, "KokoroTTSAdapter", _Recorder)
+    monkeypatch.setattr(tts, "MatchaTTSAdapter",
+                        lambda md, sid, sp, dev: seen.update(device=dev) or object())
+
+    tts._build_tts_adapter({"engine": "kokoro-multi"})
+    assert seen["device"] == "gpu", "kokoro must default to gpu"
+    assert seen["model_dir"] == tts.ENGINE_MODEL_DIRS["kokoro-multi"]
+
+    seen.clear()
+    tts._build_tts_adapter({"engine": "matcha-zh-en"})
+    assert seen["device"] == "cpu", "only kokoro's default changed"
+
+    # An explicit device still wins over the per-engine default.
+    seen.clear()
+    tts._build_tts_adapter({"engine": "kokoro-multi", "device": "cpu"})
+    assert seen["device"] == "cpu"
+
+
+def test_config_yaml_and_dashboard_language_keys_are_both_accepted(monkeypatch):
+    """config.yaml says `language`; the dashboard sends `tts_language`.
+
+    Same split as `engine` vs `tts_engine`, which the facade already handles both
+    ways. A baked config.yaml must not be silently ignored.
+    """
+    seen = {}
+
+    class _Recorder:
+        DEFAULT_LANGUAGE = tts.KokoroTTSAdapter.DEFAULT_LANGUAGE
+
+        def __init__(self, model_dir, speaker_id, speed, device, language=None):
+            seen["language"] = language
+
+    monkeypatch.setattr(tts, "KokoroTTSAdapter", _Recorder)
+
+    tts._build_tts_adapter({"engine": "kokoro-multi", "language": "zh"})
+    assert seen["language"] == "zh", "config.yaml's `language` was ignored"
+
+    tts._build_tts_adapter({"engine": "kokoro-multi", "tts_language": "en-gb"})
+    assert seen["language"] == "en-gb"
+
+    # The dashboard's key wins when both are present: it is the live value.
+    tts._build_tts_adapter({"engine": "kokoro-multi",
+                            "language": "zh", "tts_language": "en-gb"})
+    assert seen["language"] == "en-gb"
+
+
+# ── language normalisation ────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("given,expected", [
+    ("en-us", "en-us"),
+    ("EN-US", "en-us"),
+    ("en_gb", "en-gb"),
+    ("zh", "zh"),
+    ("ja", "ja"),
+    ("pt-br", "pt-br"),
+    # aliases someone would plausibly write
+    ("en", "en-us"),
+    ("pt", "pt-br"),
+    ("cmn", "zh"),
+    ("cn", "zh"),
+    ("jp", "ja"),
+    ("es-419", "es"),
+    ("fr_FR", "fr"),
+])
+def test_known_languages_normalise(given, expected):
+    assert tts.KokoroTTSAdapter._normalize_language(given) == expected
+
+
+@pytest.mark.parametrize("given", ["", None, "klingon", "th", "de"])
+def test_an_unusable_language_falls_back_rather_than_raising(given):
+    """A stale value in a baked config.yaml should degrade to a working voice.
+
+    Same policy as provider_for_device: the dashboard's enum is what constrains
+    input, and refusing here would stop the card loading over a typo. `de` and `th`
+    are espeak voices but Kokoro has no voices for them, so they belong here.
+    """
+    assert (tts.KokoroTTSAdapter._normalize_language(given)
+            == tts.KokoroTTSAdapter.DEFAULT_LANGUAGE)
+
+
+def test_every_language_maps_to_an_espeak_voice_verified_on_device():
+    """The map is a closed set of *measured* espeak voice names, not passthrough.
+
+    Two failure modes made this necessary, both silent: `en-gb` is not a voice
+    espeak-ng ships (it has en-GB-x-rp) and produced no audio at all, and `fr-FR`
+    produced 18280 samples where `fr` produced 63277 — a truncated utterance with
+    nothing raised. Passing the configured label straight through would reintroduce
+    both.
+    """
+    adapter = tts.KokoroTTSAdapter
+    assert set(adapter.LANGUAGES) == set(adapter.LANGUAGE_VOICES)
+    assert adapter.DEFAULT_LANGUAGE in adapter.LANGUAGE_VOICES
+    # The two names that are NOT the obvious guess, pinned so a "tidy-up" cannot
+    # quietly restore the broken ones.
+    assert adapter.LANGUAGE_VOICES["en-gb"] == "en-gb-x-rp"
+    assert adapter.LANGUAGE_VOICES["pt-br"] == "pt-BR"
+    assert "en-gb" not in adapter.LANGUAGE_VOICES.values()
+    assert "fr-FR" not in adapter.LANGUAGE_VOICES.values()
+
+
+def test_chinese_maps_to_an_english_espeak_voice_on_purpose():
+    """Not a bug and not redundant with en-us.
+
+    Chinese is phonemised from lexicon-zh.txt, a branch that never consults `lang`,
+    so this field only decides how *embedded Latin* in a Chinese sentence is read —
+    and English is the right answer. A Chinese espeak voice here would produce no
+    audio for those runs, dropping every Latin word out of mixed text.
+    """
+    assert tts.KokoroTTSAdapter.LANGUAGE_VOICES["zh"] == "en-us"
+    assert "zh" in tts.KokoroTTSAdapter.LANGUAGES
+
+
+def test_the_schema_enum_matches_the_supported_languages():
+    field = tts.TOOLS[0]["configSchema"]["properties"]["tts_language"]
+    assert set(field["enum"]) == set(tts.KokoroTTSAdapter.LANGUAGES)
+    assert len(field["enum"]) == len(tts.KokoroTTSAdapter.LANGUAGES)
+
+
+# ── release validation, before sherpa-onnx can exit(-1) ───────────────────────
+
+def _write_manifest(tmp_path, **overrides):
+    manifest = {
+        "model_version": 2,
+        "sample_rate": 24000,
+        "n_speakers": 54,
+        "id2speaker": {"0": "af_alloy", "3": "af_heart", "47": "zf_xiaoxiao"},
+        "languages": {"en-us": list(range(20)), "en-gb": list(range(20, 28)),
+                      "zh": list(range(45, 53))},
+    }
+    manifest.update(overrides)
+    (tmp_path / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+    return manifest
+
+
+def test_a_valid_manifest_is_returned(tmp_path):
+    expected = _write_manifest(tmp_path)
+    assert tts._validate_kokoro_manifest(str(tmp_path)) == expected
+
+
+def test_a_missing_manifest_names_the_repack_script(tmp_path):
+    with pytest.raises(FileNotFoundError, match="repack_kokoro_v1_0"):
+        tts._validate_kokoro_manifest(str(tmp_path))
+
+
+def test_a_v0_19_release_is_refused(tmp_path):
+    """version 1 takes the PiperPhonemizeLexicon path and ignores `lang` entirely.
+
+    Loading one would leave the language dropdown visibly present and silently
+    inert, which is worse than refusing.
+    """
+    _write_manifest(tmp_path, model_version=1)
+    with pytest.raises(RuntimeError, match="model_version=1"):
+        tts._validate_kokoro_manifest(str(tmp_path))
+
+
+@pytest.mark.parametrize("rate", [16000, 22050, 48000, 0])
+def test_a_release_at_another_sample_rate_is_refused(tmp_path, rate):
+    """utils/resample.py's filter is built for 24000 -> 16000 (2:3) only.
+
+    Accepting another rate would resample by the wrong ratio: audio at the wrong
+    pitch that also drifts against the 100 ms frame clock. Note 16000 is refused
+    too — it would need no resampling at all, so the adapter's assumptions would
+    not hold either way.
+    """
+    _write_manifest(tmp_path, sample_rate=rate)
+    with pytest.raises(RuntimeError, match="Hz"):
+        tts._validate_kokoro_manifest(str(tmp_path))
+
+
+def test_a_manifest_without_the_speaker_map_is_refused(tmp_path):
+    """The map is what the voice/language coherence warning checks against."""
+    _write_manifest(tmp_path, id2speaker={})
+    with pytest.raises(RuntimeError, match="id2speaker"):
+        tts._validate_kokoro_manifest(str(tmp_path))
+
+
+def test_the_pipeline_rate_and_kokoro_rate_are_both_stated():
+    """Two named constants, so neither is a magic number in the adapter."""
+    assert tts.SAMPLE_RATE == 16000
+    assert tts.KOKORO_SAMPLE_RATE == 24000
+    from utils import resample
+    assert (resample.UP, resample.DOWN) == (2, 3)
+    assert tts.KOKORO_SAMPLE_RATE * resample.UP // resample.DOWN == tts.SAMPLE_RATE
+
+
+# ── the download: one archive per device, each in its own subdirectory ─────────
+
+@pytest.fixture
+def _downloader(monkeypatch):
+    """ensure_kokoro_model with the network stubbed and both variants pinned."""
+    from utils import model_downloader
+
+    calls = []
+    monkeypatch.setattr(
+        model_downloader, "ensure_verified_archive",
+        lambda name, model_dir, url, entry: calls.append(
+            {"name": name, "model_dir": model_dir, "url": url, "entry": entry}),
+    )
+    monkeypatch.setitem(model_downloader.KOKORO_MODEL_ARCHIVES, "gpu", {
+        "archive": "kokoro-multi-v1_0-24k-fp32.tar.gz", "size": 1, "sha256": "aa"})
+    monkeypatch.setitem(model_downloader.KOKORO_MODEL_ARCHIVES, "cpu", {
+        "archive": "kokoro-multi-v1_0-24k-int8.tar.gz", "size": 2, "sha256": "bb"})
+    return model_downloader, calls
+
+
+def test_each_device_gets_its_own_subdirectory(_downloader):
+    """gpu holds fp32 and cpu holds int8, so they cannot share one directory.
+
+    ensure_verified_archive stages then publishes into the directory it is given;
+    two installs in one tree would let the second take the first's weights with it.
+    Separate subdirectories also mean flipping `device` back finds its files intact
+    instead of re-downloading 330 MB.
+    """
+    downloader, calls = _downloader
+    root = tts.ENGINE_MODEL_DIRS["kokoro-multi"]
+
+    assert downloader.ensure_kokoro_model(root, "gpu") == f"{root}/gpu"
+    assert downloader.ensure_kokoro_model(root, "cpu") == f"{root}/cpu"
+
+    assert [c["model_dir"] for c in calls] == [f"{root}/gpu", f"{root}/cpu"]
+    # Distinct marker names, or the second install would see the first's
+    # `.installed` file and skip its own download.
+    assert [c["name"] for c in calls] == ["kokoro/gpu", "kokoro/cpu"]
+    assert "fp32" in calls[0]["url"] and "int8" in calls[1]["url"]
+
+
+@pytest.mark.parametrize("device,expected", [
+    ("gpu", "gpu"), ("GPU", "gpu"), ("cuda", "cpu"), ("cpu", "cpu"), ("", "cpu"),
+])
+def test_only_an_explicit_gpu_selects_the_fp32_archive(_downloader, device, expected):
+    """Deliberately literal, not normalize_device.
+
+    The caller has already run normalize_device (the adapter does, before calling
+    here), so anything else arriving is a config this function should not guess
+    about — and guessing wrong towards gpu would download 330 MB onto a host with
+    no CUDA wheel, where provider_for_device then falls back to cpu anyway.
+    """
+    downloader, _ = _downloader
+    root = tts.ENGINE_MODEL_DIRS["kokoro-multi"]
+    assert downloader.ensure_kokoro_model(root, device) == f"{root}/{expected}"
+
+
+def test_an_unpinned_archive_is_refused_rather_than_downloaded(monkeypatch):
+    """Every model here is size+SHA256 verified; a 330 MB hole would be the one.
+
+    Same rule ensure_thai_tts_model states. This also means the engine fails loudly
+    with a message naming the repack script until the artefact is actually published,
+    rather than half-working against an unverified blob.
+    """
+    from utils import model_downloader
+
+    monkeypatch.setitem(model_downloader.KOKORO_MODEL_ARCHIVES, "gpu", {
+        "archive": "kokoro-multi-v1_0-24k-fp32.tar.gz", "size": 0, "sha256": ""})
+    with pytest.raises(RuntimeError, match="repack_kokoro_v1_0"):
+        model_downloader.ensure_kokoro_model(
+            tts.ENGINE_MODEL_DIRS["kokoro-multi"], "gpu")
+
+
+def test_the_model_dir_cannot_escape_the_models_tree(_downloader):
+    """model_dir arrives over MCP config and the downloader runs as root."""
+    downloader, _ = _downloader
+    with pytest.raises(ValueError, match="must resolve under"):
+        downloader.ensure_kokoro_model("/etc/kokoro", "gpu")

--- a/perception/tests/test_kokoro_tts_engine.py
+++ b/perception/tests/test_kokoro_tts_engine.py
@@ -149,12 +149,12 @@ def test_a_language_set_earlier_survives_a_later_rebuild(_kokoro):
     assert _LangCountingAdapter.builds == 1
 
     # speaker_id IS a session key, so this one really does rebuild.
-    result = plugin.dispatch("tts", {"action": "config", "speaker_id": 47})
+    result = plugin.dispatch("tts", {"action": "config", "speaker_id": 5})
     assert result["rebuilt"] is True
     assert _LangCountingAdapter.builds == 2
     assert holder["adapter"].cfg["tts_language"] == "zh", \
         "the rebuild lost the selected language"
-    assert holder["adapter"].cfg["speaker_id"] == 47
+    assert holder["adapter"].cfg["speaker_id"] == 5
 
 
 def test_every_adapter_accepts_set_language(_kokoro):
@@ -387,6 +387,115 @@ def test_the_pipeline_rate_and_kokoro_rate_are_both_stated():
     from utils import resample
     assert (resample.UP, resample.DOWN) == (2, 3)
     assert tts.KOKORO_SAMPLE_RATE * resample.UP // resample.DOWN == tts.SAMPLE_RATE
+
+
+# ── speaker_id is an index within the language, not a global id ───────────────
+
+# The real manifest's shape, abbreviated. Note es is non-contiguous (28, 29, 53)
+# and fr has exactly one voice — both are why a global id is unguessable and why
+# the per-language range differs.
+_LANGS = {
+    "en-us": list(range(0, 20)),
+    "en-gb": list(range(20, 28)),
+    "es": [28, 29, 53],
+    "fr": [30],
+    "hi": [31, 32, 33, 34],
+    "it": [35, 36],
+    "ja": [37, 38, 39, 40, 41],
+    "pt-br": [42, 43, 44],
+    "zh": list(range(45, 53)),
+}
+_NAMES = {"0": "af_alloy", "3": "af_heart", "20": "bf_alice", "30": "ff_siwis",
+          "37": "jf_alpha", "45": "zf_xiaobei", "53": "em_santa"}
+
+
+def _bare_adapter(voice_index=0, language="en-us"):
+    """A KokoroTTSAdapter with only the fields the mapping logic touches.
+
+    Constructed without __init__ on purpose: resolving a voice index is pure
+    manifest arithmetic, and requiring a 310 MB model to test it would mean it never
+    got tested at all.
+    """
+    a = object.__new__(tts.KokoroTTSAdapter)
+    a._manifest = {"languages": _LANGS, "id2speaker": _NAMES}
+    a._language = language
+    a._voice_index = voice_index
+    a._sid = a._resolve_sid(voice_index, language, strict=True)
+    return a
+
+
+@pytest.mark.parametrize("language,index,expected", [
+    ("en-us", 0, 0),
+    ("en-us", 3, 3),
+    ("en-gb", 0, 20),      # not 0 — the global ids are unguessable
+    ("ja", 0, 37),
+    ("ja", 4, 41),
+    ("zh", 0, 45),
+    ("fr", 0, 30),
+    ("es", 2, 53),         # non-contiguous: es is 28, 29 and 53
+])
+def test_speaker_id_is_relative_to_the_language(language, index, expected):
+    assert _bare_adapter(index, language)._sid == expected
+
+
+def test_voice_zero_of_every_language_is_a_voice_of_that_language():
+    """The property that makes the mismatch warning unnecessary."""
+    for language, ids in _LANGS.items():
+        a = _bare_adapter(0, language)
+        assert a._sid == ids[0]
+        assert a._sid in ids
+
+
+@pytest.mark.parametrize("language,bad", [("fr", 1), ("it", 2), ("en-us", 20)])
+def test_out_of_range_at_construction_is_an_error(language, bad):
+    """A configuration mistake must be reported, naming the language's count."""
+    with pytest.raises(ValueError, match=f"language '{language}'"):
+        _bare_adapter(bad, language)
+
+
+def test_switching_language_moves_the_voice_with_it():
+    a = _bare_adapter(0, "en-us")
+    assert a._sid == 0
+    a.set_language("ja")
+    assert a._language == "ja"
+    assert a._sid == 37, "the voice stayed English while the phonemes went Japanese"
+    a.set_language("zh")
+    assert a._sid == 45
+
+
+def test_switching_into_a_language_with_fewer_voices_clamps(caplog):
+    """Language is per-utterance and free, so it must not be able to fail.
+
+    French has exactly one voice. Raising here would turn the language dropdown
+    into a trap for anyone who had picked voice 5 of English first.
+    """
+    a = _bare_adapter(5, "en-us")
+    assert a._sid == 5
+    with caplog.at_level("WARNING"):
+        a.set_language("fr")
+    assert a._sid == 30, "did not fall back to the language's first voice"
+    assert a._voice_index == 5, "the requested index is remembered, not overwritten"
+    assert "out of range" in caplog.text
+
+    # ...and coming back restores the original voice rather than the clamp.
+    a.set_language("en-us")
+    assert a._sid == 5
+
+
+def test_the_resolved_voice_is_named_for_logs_and_info():
+    """An operator reads `af_heart`, not `3`."""
+    assert _bare_adapter(3, "en-us").voice_name == "af_heart"
+    assert _bare_adapter(0, "ja").voice_name == "jf_alpha"
+    # Unknown ids degrade rather than raising — the map is only for display.
+    a = _bare_adapter(1, "en-us")
+    assert a.voice_name == "?"
+
+
+def test_a_language_absent_from_the_manifest_is_refused():
+    a = _bare_adapter(0, "en-us")
+    a._manifest = {"languages": {"en-us": [0]}, "id2speaker": {}}
+    with pytest.raises(RuntimeError, match="no voices for 'ja'"):
+        a._resolve_sid(0, "ja", strict=True)
 
 
 # ── the download: one archive per device, each in its own subdirectory ─────────

--- a/perception/tests/test_kokoro_tts_engine.py
+++ b/perception/tests/test_kokoro_tts_engine.py
@@ -304,6 +304,24 @@ def test_every_language_maps_to_an_espeak_voice_verified_on_device():
     assert "fr-FR" not in adapter.LANGUAGE_VOICES.values()
 
 
+def test_japanese_uses_a_latin_script_voice_on_purpose():
+    """`ja` must NOT map to espeak's `ja`, and that looks wrong until you measure it.
+
+    Kokoro's token table is the misaki inventory and lacks `ʑ`, which espeak-ja emits
+    for じ. sherpa drops what it cannot look up — 12 phonemes from one sentence,
+    audible as holes. plugins/ja_text_norm.py emits romaji instead, so the voice is
+    picked for its phoneme inventory rather than its language:
+
+        kana   + ja     12 dropped,  4.81 s
+        romaji + it      0 dropped,  4.60 s
+    """
+    voice = tts.KokoroTTSAdapter.LANGUAGE_VOICES["ja"]
+    assert voice != "ja", (
+        "espeak-ja emits phonemes Kokoro cannot represent; ja must use a "
+        "Latin-script voice against romanised text")
+    assert voice in ("it", "es", "en-us"), voice
+
+
 def test_chinese_maps_to_an_english_espeak_voice_on_purpose():
     """Not a bug and not redundant with en-us.
 

--- a/perception/tests/test_kokoro_tts_engine.py
+++ b/perception/tests/test_kokoro_tts_engine.py
@@ -380,6 +380,52 @@ def test_a_manifest_without_the_speaker_map_is_refused(tmp_path):
         tts._validate_kokoro_manifest(str(tmp_path))
 
 
+def test_the_face_plugin_imports_onnxruntime_at_module_scope():
+    """Guards a one-line placement that keeps Kokoro working at all.
+
+    perception ends up with two builds of ONNX Runtime in one process: sherpa-onnx
+    bundles its own libonnxruntime.so, and the face plugin uses the standalone
+    `onnxruntime` package. They export the same symbols, so whichever arrives first
+    wins resolution for both. Measured on Orin 6: Kokoro synthesizes fine, the face
+    card starts, and every later utterance dies with
+
+        SequenceInsert ... TensorSeq::Add ... IsSameDataType(tensor) was false
+
+    with the real cause one line above it — espeak losing its voice
+    ("Unknown phoneme table: ''"), producing no phonemes, so the graph's Loop gets
+    an empty sequence.
+
+    Importing at module scope is enough on its own (no session needed, +27 MB,
+    0.19 s) because main.py imports plugins.face during startup, before any plugin
+    builds a model. Moving it back inside FaceAnalyzer.__init__ — which is where it
+    was, and which looks tidier — reintroduces the bug, and nothing else would
+    catch that.
+    """
+    import ast
+    import inspect
+
+    from plugins import face_runtime
+
+    tree = ast.parse(inspect.getsource(face_runtime))
+    module_level = set()
+    nested = set()
+    for node in tree.body:                      # module scope only
+        for sub in ast.walk(node):
+            if isinstance(sub, ast.Import):
+                names = {a.name for a in sub.names}
+                if isinstance(node, (ast.Import, ast.Try)):
+                    module_level |= names
+                else:
+                    nested |= names
+
+    assert "onnxruntime" in module_level, (
+        "plugins/face_runtime.py must import onnxruntime at module scope, before "
+        "sherpa-onnx creates any session — see the comment on that import")
+    assert "onnxruntime" not in nested, (
+        "onnxruntime is imported lazily somewhere in face_runtime; that defers the "
+        "library load past sherpa's and breaks kokoro-multi")
+
+
 def test_the_pipeline_rate_and_kokoro_rate_are_both_stated():
     """Two named constants, so neither is a magic number in the adapter."""
     assert tts.SAMPLE_RATE == 16000

--- a/perception/tests/test_kokoro_tts_engine.py
+++ b/perception/tests/test_kokoro_tts_engine.py
@@ -461,13 +461,23 @@ def _bare_adapter(voice_index=0, language="en-us"):
     Constructed without __init__ on purpose: resolving a voice index is pure
     manifest arithmetic, and requiring a 310 MB model to test it would mean it never
     got tested at all.
+
+    `_ja_frontend` is pre-filled so switching to `ja` does not drag janome in — this
+    fixture is about the speaker mapping, and the Japanese frontend has its own
+    tests in test_ja_text_norm.py.
     """
     a = object.__new__(tts.KokoroTTSAdapter)
     a._manifest = {"languages": _LANGS, "id2speaker": _NAMES}
     a._language = language
     a._voice_index = voice_index
+    a._ja_frontend = _StubJapaneseFrontend()
     a._sid = a._resolve_sid(voice_index, language, strict=True)
     return a
+
+
+class _StubJapaneseFrontend:
+    def normalize(self, text):
+        return text
 
 
 @pytest.mark.parametrize("language,index,expected", [
@@ -507,6 +517,22 @@ def test_switching_language_moves_the_voice_with_it():
     assert a._sid == 37, "the voice stayed English while the phonemes went Japanese"
     a.set_language("zh")
     assert a._sid == 45
+
+
+def test_selecting_japanese_builds_the_frontend_eagerly():
+    """A missing janome must fail the config call, not the first utterance.
+
+    Kanji reach sherpa's Chinese branch without it, so the card would come up
+    `running` and speak Mandarin — the failure the Thai adapter refuses to ship for
+    the same reason.
+    """
+    import inspect
+
+    for src in (inspect.getsource(tts.KokoroTTSAdapter.set_language),
+                inspect.getsource(tts.KokoroTTSAdapter.__init__)):
+        assert "self._ja()" in src, (
+            "the Japanese frontend must be built when ja is selected, not lazily "
+            "on the first speak")
 
 
 def test_switching_into_a_language_with_fewer_voices_clamps(caplog):

--- a/perception/tests/test_resample.py
+++ b/perception/tests/test_resample.py
@@ -1,0 +1,151 @@
+"""
+Host-side unit tests for utils/resample (no sherpa-onnx and no model required).
+
+Run from the repo root:
+    python -m pytest perception/tests -q
+
+This is the only part of the Kokoro engine that can be proven without a Jetson,
+so it carries the weight: if the filter is wrong, the symptom on device is
+"the English voice sounds slightly metallic", which nobody would trace back to a
+resampler. The stopband test is the one that actually earns its keep — a plain
+`samples[::3]` decimation with no lowpass passes every other test in this file.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+PERCEPTION_ROOT = Path(__file__).resolve().parents[1]
+if str(PERCEPTION_ROOT) not in sys.path:
+    sys.path.insert(0, str(PERCEPTION_ROOT))
+
+from utils import resample  # noqa: E402
+
+SRC_RATE = 24000
+DST_RATE = 16000
+
+
+def _tone(freq: float, seconds: float = 0.5, rate: int = SRC_RATE,
+          amplitude: float = 0.5) -> np.ndarray:
+    t = np.arange(int(rate * seconds), dtype=np.float32) / rate
+    return (amplitude * np.sin(2 * np.pi * freq * t)).astype(np.float32)
+
+
+def _dominant_freq(samples: np.ndarray, rate: int) -> float:
+    """Frequency of the largest spectral peak, ignoring DC."""
+    spectrum = np.abs(np.fft.rfft(samples * np.hanning(len(samples))))
+    spectrum[0] = 0.0
+    return float(np.fft.rfftfreq(len(samples), 1.0 / rate)[int(np.argmax(spectrum))])
+
+
+def _power_at(samples: np.ndarray, rate: int, freq: float, width: float = 120.0) -> float:
+    """Summed spectral power in a narrow band around `freq`."""
+    spectrum = np.abs(np.fft.rfft(samples * np.hanning(len(samples)))) ** 2
+    freqs = np.fft.rfftfreq(len(samples), 1.0 / rate)
+    band = (freqs >= freq - width) & (freqs <= freq + width)
+    return float(spectrum[band].sum())
+
+
+# ── length arithmetic ─────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("n", [1, 2, 3, 4, 5, 100, 24000, 24001, 35999])
+def test_output_length_is_ceil_two_thirds(n):
+    """The pacing clock divides byte counts by 16000*2, so length must be exact."""
+    out = resample.resample_poly(np.zeros(n, dtype=np.float32))
+    assert len(out) == resample.resampled_length(n)
+    assert len(out) == -(-n * 2 // 3)  # ceil(n*2/3) without float rounding
+
+
+def test_one_second_in_is_one_second_out():
+    """Duration must survive, or audio drifts against the 100 ms frame clock."""
+    out = resample.resample_poly(_tone(1000.0, seconds=1.0))
+    assert abs(len(out) / DST_RATE - 1.0) < 1e-3
+
+
+def test_empty_input_is_not_an_error():
+    """A frontend can normalise a whole utterance away; that must not raise."""
+    assert resample.resample_poly(np.zeros(0, dtype=np.float32)).size == 0
+    assert resample.downsample_24k_to_16k(np.zeros(0, dtype=np.float32)) == b""
+
+
+# ── the filter actually filters ───────────────────────────────────────────────
+
+@pytest.mark.parametrize("freq", [200.0, 1000.0, 3000.0, 6000.0])
+def test_passband_tones_keep_their_pitch(freq):
+    """Wrong pitch is the failure a rate mismatch produces, so test for it."""
+    out = resample.resample_poly(_tone(freq, seconds=1.0))
+    assert abs(_dominant_freq(out, DST_RATE) - freq) < 15.0
+
+
+def test_a_tone_above_the_new_nyquist_is_attenuated_not_aliased():
+    """The test a bare `samples[::3]` fails.
+
+    11 kHz is above the 16 kHz output's 8 kHz Nyquist. Without a lowpass it folds
+    down to |16000 - 11000| = 5 kHz and lands in the middle of the speech band as
+    a phantom tone. With the lowpass it is simply gone.
+    """
+    out = resample.resample_poly(_tone(11000.0, seconds=1.0))
+
+    alias_power = _power_at(out, DST_RATE, 5000.0)
+    reference = _power_at(resample.resample_poly(_tone(5000.0, seconds=1.0)),
+                          DST_RATE, 5000.0)
+    # The alias must be far below what a genuine 5 kHz tone of the same amplitude
+    # looks like. 40 dB is a loose bound the Blackman design clears easily; it is
+    # written loose on purpose so a legitimate change of window or tap count does
+    # not fail it, while `[::3]` (which lands at roughly 0 dB) still does.
+    assert alias_power < reference / 10_000, (
+        f"alias power {alias_power:.3e} vs reference {reference:.3e} — "
+        "the lowpass is not attenuating above the output Nyquist"
+    )
+
+
+def test_dc_gain_is_unity():
+    """Zero-stuffing divides average power by UP; the taps must put it back."""
+    out = resample.resample_poly(np.full(6000, 0.5, dtype=np.float32))
+    # Ignore the filter's edge transients at both ends.
+    assert np.allclose(out[200:-200], 0.5, atol=1e-3)
+
+
+def test_taps_sum_to_the_upsampling_factor():
+    """Guards the normalisation directly, independent of any signal."""
+    assert resample._H.sum() == pytest.approx(resample.UP, abs=1e-5)
+    assert len(resample._H) == resample.TAPS
+    assert resample.TAPS % 2 == 1, "an even tap count gives a half-sample delay"
+
+
+# ── int16 conversion ──────────────────────────────────────────────────────────
+
+def test_pcm16_is_little_endian_signed_16_bit():
+    pcm = resample.float_to_pcm16(np.array([0.0, 1.0, -1.0], dtype=np.float32))
+    assert len(pcm) == 6
+    assert np.frombuffer(pcm, dtype="<i2").tolist() == [0, 32767, -32767]
+
+
+def test_overshoot_clips_instead_of_wrapping():
+    """astype(int16) on an out-of-range value wraps, flipping the sign.
+
+    A sample that overshot 1.0 would come out as full-scale *negative* — a tick
+    on the loudest part of the utterance. Clipping has to happen in float first.
+    """
+    pcm = resample.float_to_pcm16(np.array([1.5, -1.5, 12.0], dtype=np.float32))
+    assert np.frombuffer(pcm, dtype="<i2").tolist() == [32767, -32768, 32767]
+
+
+def test_downsample_returns_bytes_of_the_expected_frame_count():
+    """The adapter slices this into CHUNK_BYTES frames, so byte count matters."""
+    pcm = resample.downsample_24k_to_16k(_tone(440.0, seconds=1.0))
+    assert isinstance(pcm, bytes)
+    assert len(pcm) == resample.resampled_length(SRC_RATE) * 2
+    assert len(pcm) == DST_RATE * 2  # exactly one second of 16-bit mono
+
+
+def test_a_loud_utterance_survives_without_clipping_artefacts():
+    """Near-full-scale input is the realistic case; check it stays a clean tone."""
+    pcm = resample.downsample_24k_to_16k(_tone(700.0, seconds=0.5, amplitude=0.95))
+    out = np.frombuffer(pcm, dtype="<i2").astype(np.float32) / 32767.0
+    assert abs(_dominant_freq(out, DST_RATE) - 700.0) < 15.0
+    assert np.abs(out).max() < 1.0

--- a/perception/tests/test_tts_engine_switch.py
+++ b/perception/tests/test_tts_engine_switch.py
@@ -310,17 +310,28 @@ def test_each_engine_gets_its_own_model_dir(_fake_engines):
     assert (tts.ENGINE_MODEL_DIRS["mms-th"]
             != tts.ENGINE_MODEL_DIRS["matcha-zh-en"])
 
+    plugin.dispatch("tts", {"action": "config", "tts_engine": "kokoro-multi"})
+    assert _wait_until(lambda: "kokoro-multi" in _fake_engines)
+    assert (_fake_engines["kokoro-multi"].cfg["model_dir"]
+            == tts.ENGINE_MODEL_DIRS["kokoro-multi"])
+    # Its own tree too. Kokoro's archives land in `<dir>/gpu` and `<dir>/cpu`
+    # beneath it, so sharing a directory with another engine would put two
+    # independent ensure_verified_archive installs in one tree.
+    assert len(set(tts.ENGINE_MODEL_DIRS.values())) == len(tts.ENGINE_MODEL_DIRS)
+
 
 # ── legacy engine names (upgrade regression) ─────────────────────────────────
 
 def test_engines_are_named_after_the_model_not_the_runtime():
     """`<model>-<languages>`, the shape asr_model already uses.
 
-    Two engines run on sherpa-onnx, so a runtime name identifies neither. And the
-    dashboard renders the raw enum string, so this is what an operator reads in
-    the dropdown next to the ASR one — a second convention would be visible.
+    Three engines run on sherpa-onnx, so a runtime name identifies none of them.
+    And the dashboard renders the raw enum string, so this is what an operator
+    reads in the dropdown next to the ASR one — a second convention would be
+    visible.
     """
-    assert set(tts.TTS_ENGINES) == {"vits2-zh-en", "matcha-zh-en", "mms-th"}
+    assert set(tts.TTS_ENGINES) == {"vits2-zh-en", "matcha-zh-en", "mms-th",
+                                    "kokoro-multi"}
     assert tts.DEFAULT_TTS_ENGINE == "vits2-zh-en"
     for engine in tts.TTS_ENGINES:
         assert "_" not in engine, "asr_model uses hyphens; do not mix separators"

--- a/perception/tests/test_zh_text_norm.py
+++ b/perception/tests/test_zh_text_norm.py
@@ -1,0 +1,225 @@
+"""
+tests/test_zh_text_norm.py — which numbers count as Chinese, and which do not.
+
+The bug this guards: sherpa-onnx applies `rule_fsts` to the whole text *before* its
+frontend decides what is Chinese, so handing it the ZH number FSTs rewrote every
+digit into Chinese characters and the frontend then read them in Chinese — in
+English, Spanish, Japanese, everything. `2026` came out as `二千零二十六` in an
+English sentence.
+
+The fix decides per number from its neighbours. That decision is pure text, so it is
+testable here with no kaldifst, no model and no device — which matters, because the
+alternative way to find a mistake in it is to listen to nine languages.
+
+Run: python -m pytest perception/tests -q
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+PERCEPTION_ROOT = Path(__file__).resolve().parents[1]
+if str(PERCEPTION_ROOT) not in sys.path:
+    sys.path.insert(0, str(PERCEPTION_ROOT))
+
+from plugins import zh_text_norm  # noqa: E402
+
+
+def _chinese_parts(text: str):
+    return [chunk for is_zh, chunk in zh_text_norm.segment(text) if is_zh]
+
+
+def _has_chinese_number(text: str) -> bool:
+    """True when at least one digit ends up in a Chinese segment."""
+    return any(any(c.isdigit() for c in chunk) for chunk in _chinese_parts(text))
+
+
+# ── the segmentation is lossless ──────────────────────────────────────────────
+
+@pytest.mark.parametrize("text", [
+    "", "hello", "你好", "2026", "   ",
+    "Please follow me to the next exhibit, which opened in 2026.",
+    "今天是2026年1月15日，有25个展品。",
+    "agent core 延迟 200 毫秒。",
+    "Hola, tenemos 25 exposiciones hoy.",
+    "こんにちは、25の展示があります。",
+])
+def test_segments_reassemble_to_the_input(text):
+    """Every byte must survive; a normaliser that drops text is worse than the bug."""
+    assert "".join(chunk for _, chunk in zh_text_norm.segment(text)) == text
+
+
+def test_empty_input_produces_no_segments():
+    assert zh_text_norm.segment("") == []
+
+
+# ── numbers that must NOT become Chinese ──────────────────────────────────────
+
+@pytest.mark.parametrize("text", [
+    "Please follow me to the next exhibit, which opened in 2026.",
+    "We have 25 exhibits today.",
+    "Hola, tenemos 25 exposiciones hoy.",         # the Spanish case
+    "Bonjour, nous avons 25 expositions.",
+    "The meeting is on 2026-01-15.",
+    "delay 200 ms",
+    "Room 101, floor 3.",
+    "2026",                                       # bare, no context at all
+    "25 exhibits",                                # number leads the sentence
+    "exhibits 25",                                # number ends the sentence
+])
+def test_numbers_in_non_chinese_text_stay_untouched(text):
+    """This is the regression. Each of these read the number in Chinese before."""
+    assert not _has_chinese_number(text), (
+        f"{text!r} put a digit in a Chinese segment: {_chinese_parts(text)}")
+
+
+def test_a_purely_english_sentence_is_one_non_chinese_segment():
+    assert zh_text_norm.segment("We have 25 exhibits today.") == [
+        (False, "We have 25 exhibits today.")]
+
+
+# ── numbers that MUST become Chinese ──────────────────────────────────────────
+
+@pytest.mark.parametrize("text", [
+    "今天是2026年1月15日",
+    "第25个展品",
+    "延迟200毫秒",
+    "我在2026年出生",
+    "有 25 个",              # spaces must not break the adjacency
+    "延迟 200 毫秒",
+])
+def test_numbers_in_chinese_text_are_marked_chinese(text):
+    assert _has_chinese_number(text), (
+        f"{text!r} left its digits outside the Chinese segments: "
+        f"{zh_text_norm.segment(text)}")
+
+
+@pytest.mark.parametrize("text,expect_chinese", [
+    # Chinese on both sides.
+    ("agent core 延迟 200 毫秒", True),
+    # Chinese only before the number.
+    ("共25 items", True),
+    # Chinese only after the number.
+    ("In 2026 我们开业", True),
+    # Latin on both sides, inside an otherwise Chinese paragraph.
+    ("我们说 we have 25 exhibits 就这样", False),
+])
+def test_mixed_text_decides_per_number(text, expect_chinese):
+    """Either-side-Chinese wins; that is what makes both directions work.
+
+    The last case is the one a language-based gate could never get right: the
+    sentence is Chinese, but that particular number belongs to the English clause.
+    """
+    assert _has_chinese_number(text) is expect_chinese, zh_text_norm.segment(text)
+
+
+def test_full_width_punctuation_counts_as_chinese_context():
+    """"有25个。" ends in a Chinese full stop, not a neutral one."""
+    assert _has_chinese_number("2026年。")
+    assert _has_chinese_number("有25个，很多。")
+
+
+# ── the FST is fed whole segments, not bare digits ────────────────────────────
+
+class _RecordingNormalizer(zh_text_norm.ZhTextNormalizer):
+    """Bypasses kaldifst so the wiring is testable without the dependency."""
+
+    def __init__(self):
+        self.seen = []
+        self._normalizers = []
+        self._available = True
+
+    def _normalize_chinese(self, chunk):
+        self.seen.append(chunk)
+        return chunk.replace("2026", "二零二六").replace("25", "二十五")
+
+
+def test_the_normaliser_only_sees_the_chinese_segments():
+    n = _RecordingNormalizer()
+    out = n.normalize("We have 25 exhibits. 今天有25个展品。")
+    # The ". " between the two sentences stays with the English side: a neutral run
+    # inherits the segment already open, so punctuation never opens a third piece.
+    assert n.seen == ["今天有25个展品。"], n.seen
+    assert out == "We have 25 exhibits. 今天有二十五个展品。"
+
+
+def test_context_characters_reach_the_fst():
+    """date-zh.fst needs the 年 to say 二零二六年 instead of 二千零二十六.
+
+    Passing the bare digit run would silently downgrade every year to the quantity
+    form, which is the kind of thing only a Chinese speaker would catch by ear.
+    """
+    n = _RecordingNormalizer()
+    n.normalize("今天是2026年1月15日")
+    assert n.seen == ["今天是2026年1月15日"]
+    assert "年" in n.seen[0]
+
+
+def test_a_normaliser_without_kaldifst_is_a_passthrough(tmp_path):
+    """Degrades to a warning, not a refusal — see the class docstring."""
+    n = zh_text_norm.ZhTextNormalizer(str(tmp_path))   # no FSTs on disk
+    assert n.available is False
+    assert n.normalize("今天有25个展品。") == "今天有25个展品。"
+    assert n.normalize("") == ""
+
+
+def test_normalize_is_a_noop_when_there_is_nothing_chinese():
+    n = _RecordingNormalizer()
+    assert n.normalize("We have 25 exhibits today.") == "We have 25 exhibits today."
+    assert n.seen == []
+
+
+def test_the_cjk_range_matches_what_sherpa_routes_on():
+    """If these disagreed, text could be normalised here and routed to espeak.
+
+    sherpa-onnx's KokoroMultiLangLexicon splits on "([\\u4e00-\\u9fff]+)".
+    """
+    assert zh_text_norm._CJK == "一-鿿"
+    assert ord("一") == 0x4E00 and ord("鿿") == 0x9FFF
+
+
+def test_no_adapter_hands_rule_fsts_to_sherpa_onnx():
+    """The guard on the actual bug, checked in the source rather than by ear.
+
+    Any non-empty `rule_fsts=` re-introduces it: sherpa applies those FSTs to the
+    whole text before its frontend decides what is Chinese, so the digits are already
+    Chinese characters by the time anything is routed. There is no way to scope them
+    per language, which is why this module exists.
+
+    Parsed as AST rather than grepped, so the comments explaining the rule — which
+    necessarily contain the string `rule_fsts` — do not match.
+    """
+    import ast
+    import inspect
+
+    import plugins.tts as tts
+
+    tree = ast.parse(inspect.getsource(tts))
+    offenders = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.keyword) or node.arg != "rule_fsts":
+            continue
+        value = node.value
+        empty = isinstance(value, ast.Constant) and value.value == ""
+        if not empty:
+            offenders.append(ast.dump(value)[:120])
+    assert not offenders, (
+        "rule_fsts must be \"\" — the ZH FSTs are applied by plugins/zh_text_norm.py "
+        f"so they only touch Chinese text. Found: {offenders}")
+
+
+def test_both_sherpa_adapters_normalise_before_synthesising():
+    """A rule_fsts="" with no replacement call would silently drop ZH numbers."""
+    import inspect
+
+    import plugins.tts as tts
+
+    for adapter in (tts.MatchaTTSAdapter, tts.KokoroTTSAdapter):
+        source = inspect.getsource(adapter.synthesize_stream)
+        assert "_zh_norm.normalize" in source, (
+            f"{adapter.__name__}.synthesize_stream does not normalise its text; "
+            "Chinese numbers would reach the engine as bare digits")
+

--- a/perception/tests/test_zh_text_norm.py
+++ b/perception/tests/test_zh_text_norm.py
@@ -148,6 +148,42 @@ def test_the_cjk_punctuation_set_holds_only_cjk_only_characters():
         assert ch in zh_text_norm._CJK_PUNCT, f"{ch!r} only appears in CJK text"
 
 
+# ── Japanese must not be treated as Chinese ───────────────────────────────────
+
+@pytest.mark.parametrize("text", [
+    "今日は2026年10月1日です",
+    "こんにちは！今日は2026年10月1日です。私はシャオ・ファンと申します。",
+    "こんにちは、25の展示があります。",
+    "第1話",                       # kanji + digit, but kana-free? no: no kana here
+])
+def test_japanese_numbers_are_left_for_the_japanese_frontend(text):
+    """Kanji are inside the CJK range, so the adjacency rule would claim them.
+
+    Left alone, "今日は2026年10月1日です" became "今日は二零二六年十月一日です" and
+    was then read in Mandarin. Japanese dates want ジュウガツ / ツイタチ, which
+    plugins/ja_text_norm.py produces; the ZH FSTs must not get there first.
+    """
+    if not zh_text_norm.has_kana(text):
+        pytest.skip("no kana: this case is not distinguishable from Chinese")
+    assert zh_text_norm.segment(text) == [(False, text)], zh_text_norm.segment(text)
+    assert not _has_chinese_number(text)
+
+
+def test_kana_detection():
+    assert zh_text_norm.has_kana("こんにちは")          # hiragana
+    assert zh_text_norm.has_kana("シャオ")              # katakana
+    assert zh_text_norm.has_kana("今日は")              # mixed
+    assert not zh_text_norm.has_kana("今天有25个展品")   # Chinese
+    assert not zh_text_norm.has_kana("We have 25")
+    assert not zh_text_norm.has_kana("")
+
+
+def test_chinese_still_normalises_when_no_kana_present():
+    """The kana guard must not disarm the Chinese path it sits next to."""
+    assert _has_chinese_number("今天是2026年1月15日，有25个展品。")
+    assert _has_chinese_number("延迟200毫秒")
+
+
 # ── the FST is fed whole segments, not bare digits ────────────────────────────
 
 class _RecordingNormalizer(zh_text_norm.ZhTextNormalizer):

--- a/perception/tests/test_zh_text_norm.py
+++ b/perception/tests/test_zh_text_norm.py
@@ -122,6 +122,32 @@ def test_full_width_punctuation_counts_as_chinese_context():
     assert _has_chinese_number("有25个，很多。")
 
 
+@pytest.mark.parametrize("text", [
+    "a fundamental transition—from model-driven to a new engine",
+    "Wait… what happened?",
+    'He said “hello” to me.',
+    "It's a well-known fact — really.",
+])
+def test_english_typography_does_not_make_a_sentence_chinese(text):
+    """The em dash, ellipsis and curly quotes are English punctuation too.
+
+    They were in _CJK_PUNCT at first, which split an English sentence in three and
+    handed the bare dash to the ZH FSTs as "Chinese". It happened to be harmless —
+    the FSTs leave punctuation alone — but it made English text look Chinese to
+    anyone reading the segmentation, and an FST that did rewrite punctuation would
+    have made it a real bug.
+    """
+    assert zh_text_norm.segment(text) == [(False, text)], zh_text_norm.segment(text)
+
+
+def test_the_cjk_punctuation_set_holds_only_cjk_only_characters():
+    """Guards the rule rather than the four cases above."""
+    for ch in "—…“”‘’·":
+        assert ch not in zh_text_norm._CJK_PUNCT, f"{ch!r} is used in English too"
+    for ch in "。，、；：？！":
+        assert ch in zh_text_norm._CJK_PUNCT, f"{ch!r} only appears in CJK text"
+
+
 # ── the FST is fed whole segments, not bare digits ────────────────────────────
 
 class _RecordingNormalizer(zh_text_norm.ZhTextNormalizer):

--- a/perception/tools/repack_kokoro_v1_0.py
+++ b/perception/tools/repack_kokoro_v1_0.py
@@ -1,0 +1,293 @@
+#!/usr/bin/env python3
+"""Repack the sherpa-onnx Kokoro v1.0 release into the two archives we deploy.
+
+Upstream `kokoro-multi-lang-v1_0.tar.bz2` (fp32) and
+`kokoro-int8-multi-lang-v1_0.tar.bz2` are ~350 MB / ~132 MB and each carries three
+things this deployment can never read:
+
+  - `lexicon-us-en.txt`, `lexicon-gb-en.txt` — unreachable. In
+    `KokoroMultiLangLexicon::ConvertNonChineseToTokenIDs`, a non-empty `voice`
+    short-circuits straight to espeak and the lexicon is never consulted; `lang`
+    resolves to the model's own `meta_data.voice` ("en-us") when unset, so it is
+    never empty. Shipping 11.6 MB that cannot be opened invites the next person to
+    assume English pronunciation comes from a dictionary here. It does not.
+  - `dict/` — the jieba dictionary. Ignored since sherpa-onnx v1.12.15; passing
+    `dict_dir` now only logs "you don't need to provide dict_dir".
+
+`lexicon-zh.txt` is kept: the Chinese branch of that same function does not look at
+`voice`, so it is genuinely used, and `lang=zh` needs it. The three ZH rule FSTs are
+kept for number/date/phone normalisation.
+
+Also writes a `manifest.json`, mirroring tools/export_mms_thai_onnx.py. The adapter
+reads it *before* constructing OfflineTts, because a `version >= 2` Kokoro model with
+both `lexicon` and `lang` empty makes sherpa-onnx call `SHERPA_ONNX_EXIT(-1)` — a
+process exit that would take ASR, VOP and OCR down with it, not an exception
+main.py could catch.
+
+Every value in the manifest is read out of the ONNX metadata, never hardcoded: the
+point is to record what the shipped graph actually says, so a future upstream repack
+at a different sample rate fails the adapter's check instead of being pitch-shifted.
+
+Run on the x86 build host (root@172.18.66.241), which holds the COS credentials:
+
+    python3 tools/repack_kokoro_v1_0.py --work /tmp/kokoro --out /tmp/kokoro/dist
+
+then upload both tarballs to COS and record the size + SHA256 of the *uploaded*
+copies — re-download and hash those, not the local files. Hashing the source cannot
+catch a bad transfer, which is the whole reason the pins exist.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tarfile
+import urllib.request
+
+UPSTREAM = "https://github.com/k2-fsa/sherpa-onnx/releases/download/tts-models"
+
+# device -> (upstream archive, upstream weight filename, weight name we ship)
+VARIANTS = {
+    "fp32": ("kokoro-multi-lang-v1_0.tar.bz2", "model.onnx", "model.onnx"),
+    "int8": ("kokoro-int8-multi-lang-v1_0.tar.bz2", "model.int8.onnx", "model.int8.onnx"),
+}
+
+# Everything besides the weights that goes into every archive. espeak-ng-data is a
+# directory; the four files sherpa-onnx's Validate() insists on live inside it.
+SHARED_FILES = ("voices.bin", "tokens.txt", "lexicon-zh.txt",
+                "date-zh.fst", "number-zh.fst", "phone-zh.fst", "LICENSE")
+SHARED_DIRS = ("espeak-ng-data",)
+ESPEAK_REQUIRED = ("phontab", "phonindex", "phondata", "intonations")
+
+# Refuse anything else. The adapter downsamples 24000 -> 16000 with a filter
+# designed for exactly that 2:3 ratio; another rate would need its own filter, and
+# silently accepting one would ship audio at the wrong pitch.
+EXPECTED_SAMPLE_RATE = 24000
+EXPECTED_VERSION = 2
+
+# Which speaker ids belong to which language, so the adapter can warn when a
+# `lang`/voice pair is incoherent (e.g. an Italian voice reading Spanish phonemes).
+# Derived from the speaker names in the ONNX metadata rather than written out here.
+# The prefix convention is hexgrad's: first letter = language (a American, b
+# British, e Spanish, f French, h Hindi, i Italian, j Japanese, p Portuguese,
+# z Chinese), second = f/m for the speaker's voice.
+LANG_PREFIXES = {
+    "en-us": ("af_", "am_"),
+    "en-gb": ("bf_", "bm_"),
+    "es": ("ef_", "em_"),
+    "fr": ("ff_", "fm_"),
+    "hi": ("hf_", "hm_"),
+    "it": ("if_", "im_"),
+    "ja": ("jf_", "jm_"),
+    "pt-br": ("pf_", "pm_"),
+    "zh": ("zf_", "zm_"),
+}
+
+
+def _sha256(path: str) -> str:
+    digest = hashlib.sha256()
+    with open(path, "rb") as handle:
+        for block in iter(lambda: handle.read(1 << 20), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def _download(url: str, dest: str) -> None:
+    if os.path.exists(dest):
+        print(f"[repack] have {os.path.basename(dest)}")
+        return
+    print(f"[repack] downloading {url}")
+    tmp = dest + ".part"
+    urllib.request.urlretrieve(url, tmp)
+    os.replace(tmp, dest)
+
+
+def _extract(archive: str, dest: str) -> str:
+    if os.path.isdir(dest):
+        shutil.rmtree(dest)
+    os.makedirs(dest)
+    with tarfile.open(archive) as tar:
+        # Upstream tarballs are a single top-level directory; strip it so callers
+        # get a flat tree regardless of what that directory is called.
+        tar.extractall(dest)
+    entries = [e for e in os.listdir(dest) if not e.startswith(".")]
+    if len(entries) == 1 and os.path.isdir(os.path.join(dest, entries[0])):
+        return os.path.join(dest, entries[0])
+    return dest
+
+
+def _read_onnx_meta(model_path: str) -> dict:
+    """Read the metadata sherpa-onnx's scripts/kokoro/v1.0/add_meta_data.py wrote.
+
+    onnx.load() on a 310 MB graph would read the whole thing; onnxruntime's session
+    would build one. Neither is needed — a metadata-only read is enough, and
+    onnxruntime is present in the build host's perception environment.
+    """
+    import onnxruntime as ort
+
+    opts = ort.SessionOptions()
+    opts.log_severity_level = 3
+    session = ort.InferenceSession(model_path, opts, providers=["CPUExecutionProvider"])
+    return dict(session.get_modelmeta().custom_metadata_map)
+
+
+def _build_manifest(meta: dict, device: str, weights: str) -> dict:
+    sample_rate = int(meta.get("sample_rate") or 0)
+    version = int(meta.get("version") or 0)
+    if sample_rate != EXPECTED_SAMPLE_RATE:
+        raise SystemExit(
+            f"[repack] ERROR: graph declares sample_rate={sample_rate}, expected "
+            f"{EXPECTED_SAMPLE_RATE}. utils/resample.py's filter is designed for the "
+            "24000->16000 2:3 ratio; shipping another rate needs a new filter first."
+        )
+    if version != EXPECTED_VERSION:
+        raise SystemExit(
+            f"[repack] ERROR: graph declares version={version}, expected "
+            f"{EXPECTED_VERSION}. Only Kokoro >= 1.0 honours `lang`, which the "
+            "language selector depends on."
+        )
+
+    names = [n for n in (meta.get("speaker_names") or "").split(",") if n]
+    if not names:
+        raise SystemExit("[repack] ERROR: graph has no speaker_names metadata")
+    n_speakers = int(meta.get("n_speakers") or len(names))
+    if n_speakers != len(names):
+        raise SystemExit(
+            f"[repack] ERROR: n_speakers={n_speakers} but {len(names)} speaker_names"
+        )
+
+    languages = {
+        lang: [i for i, name in enumerate(names) if name.startswith(prefixes)]
+        for lang, prefixes in LANG_PREFIXES.items()
+    }
+    for lang, ids in languages.items():
+        if not ids:
+            raise SystemExit(f"[repack] ERROR: no speaker ids found for {lang}")
+
+    return {
+        "source": "sherpa-onnx tts-models/kokoro-multi-lang-v1_0",
+        "upstream": "https://huggingface.co/hexgrad/Kokoro-82M (v1.0)",
+        "model_version": version,
+        "sample_rate": sample_rate,
+        "n_speakers": n_speakers,
+        "voice_default": meta.get("voice") or "en-us",
+        "device": device,
+        "weights": weights,
+        "id2speaker": {str(i): name for i, name in enumerate(names)},
+        "languages": languages,
+        "dropped": ["lexicon-us-en.txt", "lexicon-gb-en.txt", "dict/", "README.md"],
+    }
+
+
+def _stage(src: str, staging: str, weight_src: str, weight_dst: str,
+           manifest: dict) -> None:
+    if os.path.isdir(staging):
+        shutil.rmtree(staging)
+    os.makedirs(staging)
+
+    shutil.copy2(os.path.join(src, weight_src), os.path.join(staging, weight_dst))
+    for name in SHARED_FILES:
+        path = os.path.join(src, name)
+        if os.path.exists(path):
+            shutil.copy2(path, os.path.join(staging, name))
+        elif name == "LICENSE":
+            print("[repack] WARNING: upstream has no LICENSE file")
+        else:
+            raise SystemExit(f"[repack] ERROR: upstream is missing {name}")
+    for name in SHARED_DIRS:
+        shutil.copytree(os.path.join(src, name), os.path.join(staging, name))
+
+    espeak = os.path.join(staging, "espeak-ng-data")
+    missing = [f for f in ESPEAK_REQUIRED if not os.path.exists(os.path.join(espeak, f))]
+    if missing:
+        raise SystemExit(
+            f"[repack] ERROR: espeak-ng-data lacks {missing}; sherpa-onnx's "
+            "Validate() checks for exactly these and would refuse the release"
+        )
+
+    with open(os.path.join(staging, "manifest.json"), "w", encoding="utf-8") as handle:
+        json.dump(manifest, handle, ensure_ascii=False, indent=2, sort_keys=True)
+        handle.write("\n")
+
+
+def _tar(staging: str, out_path: str) -> None:
+    """Flat gzip tarball — members at the root, matching ensure_verified_archive.
+
+    Sorted, and with uid/gid/mtime normalised, so rebuilding from the same input
+    gives the same bytes and a re-upload does not change the pin for no reason.
+    """
+    def _reset(info: tarfile.TarInfo) -> tarfile.TarInfo:
+        info.uid = info.gid = 0
+        info.uname = info.gname = ""
+        info.mtime = 0
+        return info
+
+    with tarfile.open(out_path, "w:gz") as tar:
+        for name in sorted(os.listdir(staging)):
+            tar.add(os.path.join(staging, name), arcname=name, filter=_reset,
+                    recursive=True)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--work", default="/tmp/kokoro-repack",
+                        help="scratch directory for downloads and extraction")
+    parser.add_argument("--out", default=None,
+                        help="where the finished tarballs go (default: <work>/dist)")
+    parser.add_argument("--variant", choices=sorted(VARIANTS), action="append",
+                        help="build only this variant (repeatable; default both)")
+    args = parser.parse_args()
+
+    work = os.path.abspath(args.work)
+    out = os.path.abspath(args.out or os.path.join(work, "dist"))
+    os.makedirs(work, exist_ok=True)
+    os.makedirs(out, exist_ok=True)
+
+    device_for = {"fp32": "gpu", "int8": "cpu"}
+    results = []
+
+    for variant in (args.variant or sorted(VARIANTS)):
+        archive, weight_src, weight_dst = VARIANTS[variant]
+        device = device_for[variant]
+        print(f"\n[repack] ===== {variant} ({device})")
+
+        local = os.path.join(work, archive)
+        _download(f"{UPSTREAM}/{archive}", local)
+        src = _extract(local, os.path.join(work, f"src-{variant}"))
+
+        meta = _read_onnx_meta(os.path.join(src, weight_src))
+        manifest = _build_manifest(meta, device, weight_dst)
+        print(f"[repack] rate={manifest['sample_rate']} version={manifest['model_version']} "
+              f"speakers={manifest['n_speakers']}")
+        for lang, ids in sorted(manifest["languages"].items()):
+            print(f"[repack]   {lang}: ids {min(ids)}-{max(ids)} ({len(ids)} voices)")
+
+        staging = os.path.join(work, f"stage-{variant}")
+        _stage(src, staging, weight_src, weight_dst, manifest)
+        staged_size = int(subprocess.check_output(["du", "-sb", staging]).split()[0])
+
+        out_path = os.path.join(out, f"kokoro-multi-v1_0-24k-{variant}.tar.gz")
+        _tar(staging, out_path)
+        results.append((out_path, os.path.getsize(out_path), _sha256(out_path),
+                        staged_size, device))
+
+    print("\n[repack] ===== paste into utils/model_downloader.py after uploading")
+    print("[repack] (record the size/sha256 of the RE-DOWNLOADED copy, not these)")
+    for path, size, digest, staged, device in results:
+        print(f'\n    "{device}": {{')
+        print(f'        "archive": "{os.path.basename(path)}",')
+        print(f'        "size": {size},')
+        print(f'        "sha256": "{digest}",')
+        print("    },")
+        print(f"    # unpacked {staged / 1e6:.0f} MB, archive {size / 1e6:.0f} MB")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/perception/utils/model_downloader.py
+++ b/perception/utils/model_downloader.py
@@ -819,3 +819,77 @@ def ensure_thai_tts_model(model_dir: str) -> str:
         THAI_TTS_ARCHIVE,
     )
     return model_dir
+
+
+# ── Kokoro TTS (Kokoro-82M v1.0, 24 kHz, ONNX; one archive per device) ─────────
+# Keyed by **device**, not by JetPack family: Kokoro is plain ONNX Runtime, so
+# unlike the VITS2 TensorRT plans above there is nothing tied to a TensorRT major
+# and select_bundle_family does not apply. What does differ per device is the
+# weights themselves — provider_for_device refuses int8 on CUDA (ONNX Runtime's
+# CUDA provider falls back to CPU per quantised node and measured slower than
+# fp32), so gpu must get fp32 and cpu wants int8. Two archives rather than one
+# holding both means a robot downloads ~330 MB or ~120 MB, not 450 MB of which
+# half is never loaded.
+#
+# Each extracts into its own `<device>/` subdirectory, the same shape
+# ensure_vits2_model uses for `engines/<family>/`. Sharing one directory would put
+# two ensure_verified_archive installs in the same tree, where the second's
+# staging replace could take the first's weights with it; separate subdirectories
+# make the question not arise, and flipping `device` back finds its files still
+# there.
+#
+# Repacked from the sherpa-onnx release asset kokoro-multi-lang-v1_0.tar.bz2 by
+# tools/repack_kokoro_v1_0.py, which drops three things upstream ships that this
+# deployment can never read:
+#   - lexicon-us-en.txt / lexicon-gb-en.txt — unreachable. sherpa-onnx takes the
+#     espeak path for non-Chinese text whenever `lang` is non-empty, and `lang`
+#     defaults to the model's own meta_data.voice ("en-us"), so it is never empty.
+#   - dict/ (the jieba dictionary) — ignored since sherpa-onnx v1.12.15; passing
+#     dict_dir now only logs a warning.
+# lexicon-zh.txt IS reachable (the Chinese branch does not consult `lang`) and is
+# required for lang=zh, so it stays, as do the three ZH rule FSTs.
+#
+# Licence: Apache-2.0, inherited from hexgrad/Kokoro-82M — see the LICENSE file
+# inside the archive.
+KOKORO_MODEL_BASE = os.environ.get("KOKORO_MODEL_BASE_URL", COS_BASE)
+KOKORO_MODEL_ARCHIVES = {
+    "gpu": {
+        "archive": "kokoro-multi-v1_0-24k-fp32.tar.gz",
+        "size": 0,
+        "sha256": "",
+    },
+    "cpu": {
+        "archive": "kokoro-multi-v1_0-24k-int8.tar.gz",
+        "size": 0,
+        "sha256": "",
+    },
+}
+
+
+def ensure_kokoro_model(model_dir: str, device: str = "gpu") -> str:
+    """Ensure the Kokoro release for `device` is installed; return its directory.
+
+    Returns `<model_dir>/<device>`, which is what the adapter passes to
+    sherpa-onnx — the caller never assembles the subdirectory itself.
+    """
+    model_dir = require_models_subpath(model_dir)
+    key = "gpu" if str(device).strip().lower() == "gpu" else "cpu"
+    entry = KOKORO_MODEL_ARCHIVES[key]
+    if not entry.get("sha256") or not entry.get("size"):
+        # Refuse rather than download unpinned, the same rule ensure_thai_tts_model
+        # states: every other model here is size+SHA256 verified, and an
+        # unauthenticated 330 MB blob would be the one hole in that.
+        raise RuntimeError(
+            f"KOKORO_MODEL_ARCHIVES[{key!r}] has no pinned size/sha256 — build the "
+            "tarball with tools/repack_kokoro_v1_0.py, publish it to COS, and "
+            "record the size and SHA256 of the *uploaded* copy here"
+        )
+    target = os.path.join(model_dir, key)
+    log.info(f"[model_downloader] kokoro: using {key} archive")
+    ensure_verified_archive(
+        f"kokoro/{key}",
+        target,
+        f"{KOKORO_MODEL_BASE.rstrip('/')}/{entry['archive']}",
+        entry,
+    )
+    return target

--- a/perception/utils/model_downloader.py
+++ b/perception/utils/model_downloader.py
@@ -853,15 +853,18 @@ def ensure_thai_tts_model(model_dir: str) -> str:
 # inside the archive.
 KOKORO_MODEL_BASE = os.environ.get("KOKORO_MODEL_BASE_URL", COS_BASE)
 KOKORO_MODEL_ARCHIVES = {
+    # Verified by re-downloading the uploaded object and hashing that copy, not the
+    # local file that was uploaded — the point of the pin is to catch a bad
+    # transfer, and hashing the source cannot. (Same note as THAI_TTS_ARCHIVE.)
     "gpu": {
         "archive": "kokoro-multi-v1_0-24k-fp32.tar.gz",
-        "size": 0,
-        "sha256": "",
+        "size": 337021832,
+        "sha256": "519afd6a443c5eb4c9c75d4f677c43beb0aa56f33c73c063d0456d4ceeb58156",
     },
     "cpu": {
         "archive": "kokoro-multi-v1_0-24k-int8.tar.gz",
-        "size": 0,
-        "sha256": "",
+        "size": 124706598,
+        "sha256": "ccf70f4fd809a1c697333c3a036c9d94799f1620aedf932271ea163cd72b97fc",
     },
 }
 

--- a/perception/utils/resample.py
+++ b/perception/utils/resample.py
@@ -1,0 +1,130 @@
+"""Sample-rate conversion for TTS engines whose model rate is not the pipeline's.
+
+The whole audio path is 16 kHz: `AudioChunk.msg` has no `sample_rate` field, the
+rate lives inside the `"audio/pcm-16k"` format string, and the publisher's pacing
+constants are derived from it (plugins/tts.py:28-30). Every engine before Kokoro
+either was natively 16 kHz or was *refused* — `MmsThaiTTSAdapter` raises rather
+than resample a 22.05 kHz voice, and `tools/export_mms_thai_onnx.py` refuses to
+export one.
+
+Kokoro is 24 kHz and worth having anyway, so the conversion happens here, inside
+the adapter's own output path. Nothing downstream learns about it: the topic is
+still `audio/pcm-16k` and still carries 16 kHz.
+
+Deliberately numpy-only. scipy, soxr, librosa and torchaudio are all absent from
+the perception image, and scipy in particular would pull its own numpy pin —
+which is the exact failure both plugin requirements files carry long comments
+about preventing (numpy is 1.24.4 on jp5.11/cp38 and 1.26.4 on jp6.1/cp310, and
+torch, cv2 and rapidocr are all built against those ABIs).
+"""
+
+import math
+
+import numpy as np
+
+# 24000 -> 16000 is exactly 2:3, which is why Kokoro is cheap to support and a
+# 22.05 kHz model would not be: that one is 160:441 and needs a 441-phase filter.
+UP = 2
+DOWN = 3
+
+# 6 * DOWN * 8 + 1. Odd, so the group delay is an exact integer number of samples
+# and `mode="same"` leaves no fractional offset.
+TAPS = 97
+
+# The target's Nyquist (8 kHz) expressed against the *upsampled* rate of
+# 24000 * UP = 48 kHz: 8000/48000 = 1/6.
+CUTOFF = 1.0 / 6
+
+
+def _design_lowpass(taps: int = TAPS, up: int = UP, cutoff: float = CUTOFF) -> np.ndarray:
+    """A windowed-sinc lowpass, normalised to unity DC gain after zero-stuffing.
+
+    Blackman rather than Kaiser because numpy has `np.blackman` and not
+    `scipy.signal.kaiser`; its ~-58 dB sidelobes are already well below a 16-bit
+    LSB (-90 dB is the floor, but the model's own noise sits far above -58 dB),
+    so the extra stopband depth a Kaiser would buy is inaudible here.
+
+    The `up` factor compensates the zero-stuffing in `resample_poly`: inserting
+    UP-1 zeros between samples divides the signal's average power by UP, and
+    normalising the taps to sum to `up` puts it back. Normalising by the actual
+    tap sum rather than the analytic 2*cutoff matters — the window truncates the
+    sinc, so the two differ by a fraction of a percent, and that difference would
+    show up as a small but real DC gain error.
+    """
+    n = np.arange(taps) - (taps - 1) / 2.0
+    h = 2 * cutoff * np.sinc(2 * cutoff * n) * np.blackman(taps)
+    return (h * (up / h.sum())).astype(np.float32)
+
+
+_H = _design_lowpass()
+
+
+def resample_poly(samples: np.ndarray, up: int = UP, down: int = DOWN,
+                  taps: np.ndarray = None) -> np.ndarray:
+    """Rational resampling by `up/down`: zero-stuff, lowpass, decimate.
+
+    `samples` must be the **whole** waveform for one synthesis call, not a frame
+    of one. The filter keeps no state between calls, so resampling 100 ms frames
+    independently would inject a transient at every frame boundary — ten clicks a
+    second. The adapters therefore resample what `generate()` returned and only
+    then slice it into CHUNK_BYTES frames.
+
+    The centred slice out of the `"full"` convolution drops the filter's
+    (taps-1)/2 samples of group delay, so the output is time-aligned with the
+    input and no leading silence is introduced.
+
+    Not `mode="same"`: numpy defines that as `max(len(signal), len(taps))`, so an
+    utterance shorter than the 97-tap filter comes back padded out to 97 samples
+    — the tail of the filter's own impulse response, resampled. A punctuation-only
+    chunk hits exactly that. Slicing the `"full"` result is what `"same"` does for
+    long inputs and stays correct for short ones.
+    """
+    if taps is None:
+        taps = _H
+    samples = np.asarray(samples, dtype=np.float32)
+    if samples.size == 0:
+        return samples
+    upsampled = np.zeros(samples.size * up, dtype=np.float32)
+    upsampled[::up] = samples
+    full = np.convolve(upsampled, taps, mode="full")
+    start = (len(taps) - 1) // 2
+    return full[start:start + upsampled.size][::down]
+
+
+def resampled_length(n: int, up: int = UP, down: int = DOWN) -> int:
+    """How many samples `resample_poly` returns for `n` inputs.
+
+    Exposed so a caller (or a test) can assert the arithmetic without running the
+    filter: `[::down]` over `n * up` points yields ceil(n * up / down).
+    """
+    return 0 if n <= 0 else math.ceil(n * up / down)
+
+
+def float_to_pcm16(samples: np.ndarray) -> bytes:
+    """Float samples in [-1, 1] -> little-endian signed 16-bit PCM bytes.
+
+    Clipping happens in float, before the cast: `astype(np.int16)` on a value
+    outside the int16 range is undefined in numpy and in practice wraps, so a
+    sample that overshot 1.0 would come out as full-scale *opposite* polarity —
+    an audible tick exactly on the loudest part of the utterance.
+
+    Scaled by 32767 rather than 32768 so that +1.0 maps to +32767 and cannot
+    reach the asymmetric negative rail.
+    """
+    samples = np.asarray(samples, dtype=np.float32)
+    if samples.size == 0:
+        return b""
+    scaled = np.clip(samples * 32767.0, -32768.0, 32767.0)
+    return scaled.astype("<i2").tobytes()
+
+
+def downsample_24k_to_16k(samples: np.ndarray) -> bytes:
+    """24 kHz float samples -> 16 kHz little-endian int16 PCM bytes.
+
+    The one function TTS adapters call. Kept as a named 24->16 wrapper rather than
+    leaving callers to pass `up`/`down` themselves, so the rate pair is stated in
+    one place and a future engine at another rate has to add its own entry point
+    (and think about its own filter) instead of quietly reusing this filter at a
+    ratio it was not designed for.
+    """
+    return float_to_pcm16(resample_poly(samples))


### PR DESCRIPTION
## What

Adds **`kokoro-multi`** — [Kokoro-82M](https://huggingface.co/hexgrad/Kokoro-82M) v1.0 — as a fourth TTS engine, with a runtime language dropdown covering all nine languages the model has voices for (`en-us`, `en-gb`, `zh`, `ja`, `es`, `fr`, `it`, `pt-br`, `hi`).

`vits2-zh-en` is a Chinese male voice whose English is the weaker half, and there was no engine here good enough to put in front of an English-speaking audience.

**No Dockerfile change, so no ~16 GB image rebuild.** sherpa-onnx 1.13.6 already ships `OfflineTtsKokoroModelConfig`; this is Python, a COS artefact and tests.

## COS artefacts are published and verified end to end

| device | archive | size | unpacked |
|---|---|---|---|
| gpu | `kokoro-multi-v1_0-24k-fp32.tar.gz` | 337.0 MB | 374 MB |
| cpu | `kokoro-multi-v1_0-24k-int8.tar.gz` | 124.7 MB | 163 MB |

Both pins are the sha256 of the **re-downloaded** copy, not the local file that was uploaded — hashing the source cannot catch a bad transfer, which is the point of the pin.

Verified on Orin 6 with nothing hand-staged: `ensure_kokoro_model` downloaded and verified the gpu archive in **67 s**, a warm re-check took **0.00 s** (the `.installed` marker works), the real `KokoroTTSAdapter` built in 3.3 s off it, and `en-us` plus mixed zh/en both synthesized with correct framing.

## Fixed after first review: English numbers were read in Chinese

`rule_fsts` is applied by sherpa-onnx to the **whole text before its frontend decides what is Chinese**, so handing it the ZH number/date/phone FSTs rewrote every digit into Chinese characters and the frontend then read them in Chinese — regardless of `lang`, in every language. `MatchaTTSAdapter` had the same bug (pre-existing).

| input | before | after |
|---|---|---|
| `...opened in 2026.` | `...opened in 二千零二十六.` | unchanged, espeak reads it |
| `We have 25 exhibits today.` | `We have 二十五 exhibits today.` | unchanged |
| `Hola, tenemos 25 exposiciones hoy.` | `Hola, tenemos 二十五 exposiciones.` | unchanged |

The FSTs are *good for Chinese* and are kept (`2026年` → `二零二六年`, `延迟200毫秒` → `延迟二百毫秒`). Both adapters now pass `rule_fsts=""` and call the new `plugins/zh_text_norm.py`, which runs the same FSTs in Python and only on the Chinese parts. **A digit run is Chinese when either neighbour is** — which beats gating on `tts_language`, since matcha has no language field and a sentence can mix both:

```
"延迟 200 毫秒"       -> Chinese both sides -> 二百
"共25 items"          -> Chinese before     -> 二十五
"In 2026 我们开业"    -> Chinese after      -> 二零二六
"we have 25 exhibits" -> Chinese neither    -> left to espeak
```

## `speaker_id` is now relative to the language

Global ids were unguessable (Japanese starts at 37, Spanish is 28, 29 **and** 53). `speaker_id: 0` now means the first voice of the selected language, and the voice moves with `tts_language` — which makes an incoherent voice/language pair **unrepresentable**, so `_warn_if_voice_mismatches_language` and its test were deleted. Out of range at load is a `ValueError`; out of range after a language switch clamps to voice 0 with a warning, because language is free per-utterance and `fr` has exactly one voice.

## ⚠️ `ja` is wrong, not merely unverified

Verified from source rather than assumed: sherpa's frontend routes every character in `[一-鿿]` to its **Chinese** branch with no language check, and Japanese kanji are in that range (`展` U+5C55, `示` U+793A). So Japanese comes out as kana via espeak-ja plus kanji pronounced in **Mandarin** from `lexicon-zh.txt`. Nothing in this PR can fix it — it needs a Japanese lexicon in sherpa-onnx.

## Fixed after deployment: TTS died whenever the face card was started

Reported from a deployed build. `kokoro-multi` synthesized fine until `face_recognition` started, after which **every** utterance failed with

```
SequenceInsert ... TensorSeq::Add ... IsSameDataType(tensor) was false
```

The ONNX error is a symptom. One line above it, espeak had lost its voice — `Unknown phoneme table: ''` — so no phonemes were produced and the graph's `Loop` got an empty sequence. (`en_dict` is present and readable throughout.)

**Root cause: two builds of ONNX Runtime in one process.** sherpa-onnx bundles its own `libonnxruntime.so`; the face plugin uses the standalone `onnxruntime` package. Same symbols, so whichever arrives first wins resolution for both — and `face_runtime` imported it *lazily inside `FaceAnalyzer.__init__`*, i.e. after sherpa.

Minimal repro, no perception process involved:

```
1. Kokoro synthesizes "ok"                                    -> 20496 samples ✅
2. create a session in the standalone onnxruntime             (what face does)
3. Kokoro synthesizes the same text                           -> CRASH ❌
```

**Not a Kokoro bug** — the conflict has always been in the image. Kokoro is just the first model here whose graph uses `Loop`/`SequenceInsert`. sherpa's sensevoice ASR was measured unaffected before and after.

Fix is one import moved to module scope in `plugins/face_runtime.py`. Import alone suffices; no session needed (+27 MB, 0.19 s), and only when `face_recognition` is enabled. An AST test guards the placement, since moving it back looks tidier and nothing else would catch it.

Verified in the running process on Orin 6 in the order that used to break — TTS started, then face started, then speak: `185 chars -> 400650 bytes, ACP completed`, zero `SequenceInsert` errors since restart. English `2026` reads in English; `今天是2026年1月15日，有25个展品。` still normalises; switching to `zh` moved the voice to `zf_xiaobei` automatically.

## Fixed after review: Japanese was read in Mandarin

Reported: `こんにちは！今日は2026年10月1日です。…` sounded Chinese, and the date was read in Chinese. Two causes.

**a) My `zh_text_norm` claimed the sentence.** Kanji are inside `[一-鿿]`, so the adjacency rule marked the Japanese digits as Chinese and the ZH FSTs rewrote `2026年10月1日` into `二零二六年十月一日`. Text containing kana is now treated as Japanese and left alone.

**b) sherpa-onnx reads Japanese kanji in Mandarin, and `lang` cannot stop it.** Its frontend hands `[一-鿿]` to `ConvertChineseToTokenIDs`, which reads `lexicon-zh.txt` — and that function never receives the requested language. Measured on Orin 6:

| text | `ja` | `en-us` | `es` | `fr` |
|---|---|---|---|---|
| `今日私何` (kanji only) | 30682 | 30682 | 30682 | 30682 |
| `こんにちは` (kana only) | 28908 | 114986 | — | — |

Identical for kanji, 4x apart for kana. No sherpa release ships a Japanese lexicon (checked v0_19, v1_0, v1_1), so the fix must happen before the engine sees the text.

`plugins/ja_text_norm.py` converts every kanji to kana — the same role `thai_frontend.py` plays for Thai:

```
こんにちは！今日は2026年10月1日です。私はシャオ・ファンと申します。何かお手伝いしましょうか？
 -> コンニチハ！キョウハニセンニジュウロクネンジュウガツツイタチデス。
    ワタシハシャオ・ファントモウシマス。ナニカオテツダイシマショウカ？
 kanji left: none; 122 frames, 12.11 s of audio
```

Dates/times/counters are done **by rule**, because a morphological analyser gives the isolated-morpheme reading (Janome: `10月`→`ツキ`, `1日`→`ニチ`; a speaker says `ジュウガツ`, `ツイタチ`). The irregulars follow the **trailing** digit, so a flat table gets `14時` and `30分` wrong — the tests caught that during development.

Library choice was constrained: **pykakasi is GPL-3.0**, and **fugashi/cutlet declare `requires_python >= 3.9`** so they cannot run on jp5.11's cp38. **Janome** is Apache-2.0, `py3-none-any`, and was verified to import *and convert correctly* on cp38 and cp310 before being chosen. It costs ~180 MB, gated by `ENABLE_JA_TTS` (default 1) in the last Dockerfile layer.

Caveat, measured: espeak-ja emits phonemes Kokoro's token table lacks (`U+0308`, `U+031E`, `ʑ U+0291`) and sherpa drops them — about a dozen per long sentence. Japanese is unmistakably Japanese now, but not as clean as English or Chinese.

## Japanese: why it was broken, and how far this gets

The first Japanese build was unintelligible — audible gaps. I had called it "unmistakably Japanese" after inferring that from "no kanji left in the text" without listening. That was wrong.

**Root cause: upstream drives Kokoro with misaki G2P; sherpa-onnx drives it with espeak-ng.** Kokoro's 114-token table *is* misaki's inventory (`ʣ ʥ ʦ ʨ ᵝ` are in it), but `ʑ` is not — and espeak-ja emits exactly that for じ. sherpa looks each phoneme up in the misaki table and silently drops the misses: **12 from one sentence**. The model is fine; the front end is not.

Feeding misaki phonemes directly is structurally unreachable, with the exact reason:

```cpp
SHERPA_ONNX_READ_META_DATA_STR_WITH_DEFAULT(meta_data_.voice, "voice", "en-us");
// absent -> "en-us";  explicitly empty -> SHERPA_ONNX_EXIT(-1)
```

The lexicon branch only runs when `voice` is empty, and it can never be. There is also no Japanese TTS model anywhere in sherpa-onnx (643 assets, zero).

So `ja_text_norm` emits **romaji** and `LANGUAGE_VOICES["ja"]` is `"it"` — the espeak voice is chosen for its *phoneme inventory*, not its language:

| | dropped | duration |
|---|---|---|
| kana + `ja` | **12** | 12.11 s |
| romaji + `ja` | 0 | 14.78 s — spelled out letter by letter |
| **romaji + `it`** | **0** | **7.85 s** |

> ⚠️ **Honest limit, verified by ear:** this sounds like a **non-native speaker** reading Japanese. Nothing is dropped and it is intelligible, which the kana version was not, but Italian phonemes are not Japanese ones. Going further means driving the ONNX graph directly with misaki phonemes — the way `plugins/vits2_tts_trt` already bypasses sherpa for VITS2 — and even then misaki carries pitch accent, which is dictionary knowledge Janome does not expose.

## Chinese is not broken — but prefer `vits2-zh-en`

Measured, so this is not a guess:

| text | dropped |
|---|---|
| Chinese, ordinary / mixed / rare characters | **0 / 0 / 0** |
| English | **0** |
| Japanese kana (contrast) | **12** |

Chinese takes `ConvertChineseToTokenIDs` → `lexicon-zh.txt`, whose entries are already misaki phonemes (`七 ʨ ʰ i →`), never touching espeak. There is no bug to fix. What remains is that Kokoro is one 82 M model covering nine languages, while `vits2-zh-en` is purpose-trained 16 kHz Chinese and already the default engine.

## Japanese now uses the phonemes Kokoro was trained on

The romaji workaround dropped nothing but sounded non-native. `plugins/kokoro_direct.py` runs the ONNX graph directly (`tokens/style/speed -> audio`) — the same bypass `vits2_tts_trt` already makes — and `plugins/ja_phonemes.py` feeds it misaki phonemes.

The vendored mora table is **pinned to misaki `fdc9c5e5e` (2025-01-13)**, and the version is the point:

| misaki | phonemes | missing from Kokoro's vocab |
|---|---|---|
| **2025-01-13** | 31 | **0** |
| 2025-04-05 (`pip install misaki`) | 39 | **12** — `G K g ƫ ᶀ ᶁ ᶃ ᶄ ᶆ ᶈ ᶉ` |

A test asserts every character the table can emit is in the model's vocabulary — the check whose absence caused this whole thread.

**Two corrections to earlier claims in this PR**, both the same mistake of reading "this token exists" as "Japanese uses it":
- `ʣ ʥ ʦ ʨ` are **Mandarin** phonemes here (`ʨ` appears 16 987× in `lexicon-zh.txt`).
- `↓ → ↗ ↘` are **Chinese tone** marks (67 908 of 68 036 lexicon-zh lines), not a pitch-accent channel. **Kokoro v1.0 has no accent channel** — the contemporary misaki has zero mentions of pitch/accent, and sherpa's v1.1 token list is a symlink to v1.0's. Pitch accent needs a newer model, so it is not attempted.

Verified on device: 121 tokens, **0 outside the vocabulary**, style row indexed by speaker *and* inner token count exactly as sherpa's `Run()`. Two bugs caught by measuring: word-final `ん` assimilated across a space (`neɲ` for `neɴ`), and `num_threads=2` gave RTF 1.171 — one per core gives **0.521**, real time on CPU. The direct session coexists with sherpa's, checked in the order that previously broke TTS.

## jp6.1 face recognition was on the CPU — one line fixes it

Measured in the **deployed** image, no perception code involved, `buffalo_sc/w600k_mbf.onnx`:

| | latency | throughput |
|---|---|---|
| deployed today | 18.53 ms | 54 FPS (CPU) |
| COS gpu wheel alone | 19.10 ms | 52 FPS (still CPU) |
| **COS gpu wheel + this layer's copy** | **5.89 ms** | **170 FPS (GPU)** |

Both halves are needed and each shipped alone at some point. The PyPI wheel is a CPU build with no provider bridge, so copying a CUDA `.so` beside it is a no-op. The COS wheel has the bridge but was built against **cuDNN 8** while JP6.1 ships **9** (`libcudnn.so.8: cannot open shared object file`). Install the COS wheel *and* overwrite its provider with sherpa's cuDNN 9 build → **3.1x**.

The copy step already existed; only the wheel selection was wrong. **Not caused by this branch** — the pre-existing image behaves identically. This also moves `kokoro_direct` off CPU.

## Naming

`kokoro-multi`, not `kokoro-zh-en`: nine languages, and a name claiming two would mislead anyone reading the dropdown. `multi` also matches upstream's own `kokoro-multi-lang-v1_0`. No `ENGINE_ALIASES` entry — nothing has ever persisted this name, and that table exists for values already on deployed robots.

## Three things measured on device that guessing got wrong

| | |
|---|---|
| **`en-gb` is not an espeak voice** | espeak-ng ships `en-GB-x-rp`, `en-029`, `en-GB-scotland`… but no plain `en-GB`. Result: *no audio at all*, one stderr line, silent utterance. Matching is case-insensitive, which is why `en-us` → `en-US` works and made `en-gb` look fine. |
| **`fr-FR` is worse — it silently truncates** | 18280 samples where `fr` gave 63277 on the same sentence. Nothing raised, nothing logged. |
| **`lang` is not a language selector** | It picks the espeak voice for the **non-Chinese** runs. Chinese always comes from `lexicon-zh.txt`, which never consults it. So `zh` maps to an English voice *on purpose* (it only decides how embedded Latin is read), and the mismatch warning exempts it — an earlier version would have warned on the recommended Chinese setup. |

Hence `LANGUAGE_VOICES` is a closed map of measured names, plus a construction-time probe that refuses to load if the resolved voice produces nothing.

## Performance (Orin 6, jp6.1)

| device | weights | RTF | verdict |
|---|---|---|---|
| **gpu** | fp32 | **0.07–0.10** | 10–14x faster than real time |
| cpu | int8 | **1.6** | **slower than real time — not viable for streaming** |

So `ENGINE_DEVICE_DEFAULTS` puts this engine on gpu, and the two devices load *different weight files* (`provider_for_device` refuses int8 on CUDA) — separate pinned archives in `/models/kokoro-multi/{gpu,cpu}`. Session build 2.6 s, well inside `ENGINE_SWITCH_WAIT_S = 20`.

Known wart, documented rather than hidden: the dashboard form renders the schema's `cpu` default while the effective default is gpu. JSON Schema cannot express a per-engine default.

## Language is free to change

sherpa-onnx reads `lang` from `GenerationConfig.extra` on **every** `generate()` call, so it is a scale on the resident model exactly like `speed`, and is deliberately **absent from `_session_keys`** — in it, a dropdown change would tear down and reload a 310 MB fp32 CUDA session. Verified on the shipped wheels for **both** Python ABIs (cp38/jp5.11, cp310/jp6.1): `extra` accepts a dict and round-trips.

## The 24 kHz problem

Kokoro is 24 kHz; everything downstream is 16 kHz and has no way to be told otherwise (`AudioChunk` carries the rate inside its `format` string, and pacing derives from `SAMPLE_RATE`). Rather than change that wire contract, `utils/resample.py` converts **inside the adapter** — 2:3 polyphase, 97-tap Blackman-windowed sinc, numpy only, because scipy would move the hard-pinned numpy that both plugin requirements files exist to protect.

Validated against `scipy.signal.resample_poly` on a real 8.5 s Kokoro utterance:

- correlation **0.999997**, peak error −39.6 dB
- residual confined to the 7–8 kHz transition band (3.8e-3) vs ~1e-6 below 6 kHz
- the 2–5% DC offset in the output is **Kokoro's own** (raw 24 kHz +0.0236, resampled +0.0236)

## Process-exit guard

`_validate_kokoro_manifest` runs **before** `OfflineTts` is constructed. For a `version >= 2` model with both `lexicon` and `lang` empty, sherpa-onnx's `InitFrontend` calls `SHERPA_ONNX_EXIT(-1)` — a *process* exit that takes ASR, VOP and OCR down with it, which `main.py`'s try/except cannot catch. Same hazard `_validate_thai_manifest` exists for. It also refuses `model_version: 1` (v0.19 ignores `lang`, so the dropdown would be visibly present and silently inert) and any rate other than 24000.

## Artefact

Repacked from `kokoro-multi-lang-v1_0`, dropping what cannot be read:

- `lexicon-us-en.txt` / `lexicon-gb-en.txt` (11.6 MB) — **unreachable**, see the `lang` row above
- `dict/` (14 MB) — ignored since sherpa-onnx v1.12.15

Result **~358 MB unpacked on gpu, ~157 MB on cpu** (from 384/183 MB upstream).

## Testing

`677 passed`. The 3 `test_face_plugin` failures are **pre-existing and unrelated** — verified by stashing this branch and re-running on a clean tree.

- `tests/test_resample.py` (22) — no model, no device, runs in CI. Caught a real bug: `np.convolve(mode="same")` returns `max(len(signal), len(taps))`, so an utterance shorter than the 97-tap filter came back as 97 samples of filter tail — which a punctuation-only chunk hits.
- `tests/test_kokoro_tts_engine.py` — language never rebuilds the session, survives a rebuild triggered by another key, manifest guards, per-device archive layout, and the per-language speaker mapping (including the `fr` single-voice clamp).
- `tests/test_zh_text_norm.py` — the adjacency heuristic, with a fake normaliser so it needs no kaldifst, no model and no device. Includes an AST guard that no adapter passes a non-empty `rule_fsts` again.

**On device (Orin 6):** the full download-from-COS path was exercised (67 s, sha256 verified, warm re-check 0.00 s). The real `KokoroTTSAdapter` built in 3.4 s and synthesized `en-us`/`en-gb`/`zh`/`ja` with correct 3200-byte framing; `speaker_id: 999` → `ValueError`; unknown language falls back with the supported list; a 22050 manifest is refused; the mismatch warning fired for `bm_george`+`en-us` and stayed quiet for the Chinese voice.

## Verified on both JetPack lines

| | Orin 6 (jp6.1 / cp310) | Orin 5 (jp5.11 / cp38) |
|---|---|---|
| COS download + sha256 | 67 s | 73 s |
| warm re-check | 0.00 s | 0.00 s |
| adapter build | 3.3 s | 10.6 s |
| synthesis | ok | ok |

## Still outstanding

- [x] ~~Publish the two COS archives and pin their size/sha256~~ — done, see above
- [x] ~~Run the same on-device check on Orin 5 (jp5.11/cp38)~~ — done: download 73 s, adapter built in **10.6 s** (vs 3.3 s on Orin 6 — the older ORT 1.16 / TensorRT 8.5 is slower to build the CUDA session, still inside the 20 s `ENGINE_SWITCH_WAIT_S` budget), en-us and mixed zh/en both synthesized
- [ ] **Listening check.** Only `en-us`, `en-gb` and `zh` have been listened to. `ja` is known-broken (see above). sherpa-onnx documents English and Chinese as this model's supported pair — Kokoro was trained with misaki G2P, and for the other six the espeak phoneme set is not guaranteed to match what the acoustic model learned. They all produce audio of a plausible length; treat them as best-effort until someone who reads the language has heard them.
- [ ] A/B against `vits2-zh-en` on a robot with a speaker (neither Orin has one)

---

## Final commits: Japanese phonemes, the jp6.1 GPU wheel, and the collision between them

**`10266c2` — Japanese now gets the phonemes Kokoro was trained on.** `plugins/kokoro_direct.py` drives the ONNX graph directly with misaki phonemes instead of letting sherpa phonemise with espeak-ng. The mora table is vendored and **pinned to misaki `fdc9c5e5e` (2025-01-13)**, the commit matching Kokoro v1.0 — `pip install misaki` is actively wrong here, because current misaki targets a newer Kokoro and emits 12 phonemes this vocabulary does not have. A test asserts every phoneme the table can emit exists in `tokens.txt`; the absence of that assertion is what let the original 12-drop bug ship. On device: 121 tokens, **0 outside vocabulary**.

Same commit fixes jp6.1's face GPU. Both halves are required and each alone leaves face on the CPU while claiming otherwise:

| jp6.1 `ORT_WHEEL` | compiled-in providers | face (buffalo_sc/w600k_mbf) |
|---|---|---|
| `onnxruntime==1.18.0` (PyPI, what was here) | `['Azure','CPU']` | 18.5 ms, 54 FPS |
| COS `onnxruntime_gpu-1.18.0` **alone** | has the bridge | fails — `libcudnn.so.8` missing (built against cuDNN 8, JP6.1 ships 9) |
| **COS wheel + sherpa's cuDNN-9 provider copy** | `['TensorRT','CUDA','CPU']` | **6.0 ms, 167 FPS** |

The PyPI wheel's pybind has no provider bridge compiled in, so `CUDAExecutionProvider` is not registerable and copying `.so` files beside it is a no-op — ORT says so in a warning. Re-measured in both images with and without `sherpa_onnx` imported first, so symbol interposition was given its chance: **import order makes no difference.**

**`5971969` — and the price of that copy, which I paid in production.** The engine failed to load with `Error mapping output names: Could not find OrtValue with name '/Squeeze_2_output_0'`. `kokoro_direct.py` had been requesting CUDA all along behind a docstring asserting the request was inert because the wheel was CPU-only — true when written, false one commit later, with nothing testing it either way.

Two ONNX Runtimes live in this process (sherpa's **1.18.1**, the standalone **1.18.0**) and now share one `libonnxruntime_providers_cuda.so`, since the soname collides and the first `dlopen` wins. Separate graphs are fine — face keeps its 3x with a sherpa CUDA session live — but the *second* CUDA session on the **Kokoro** graph dies inside whichever runtime did not load the provider, symmetrically:

| order | result |
|---|---|
| sherpa's session first | the standalone one fails, error names `/home/tian/Yxh/…` |
| the standalone one first | **sherpa** fails, error names `/home/yifanl/…` |

Order does not fix it. `KokoroDirect` now takes **no device argument at all**, and a test asserts both the CPU-only provider list and the absence of the parameter.

The cost is confined to Japanese and is affordable. Measured on Orin 6 in one process, Japanese synthesized first so its CPU session is live throughout:

| language | runtime | RTF |
|---|---|---|
| en-us / en-gb | sherpa, cuda | 0.31 / 0.21 |
| zh | sherpa, cuda | 0.14 |
| es / fr / it / pt-br / hi | sherpa, cuda | 0.10 – 0.11 |
| **ja** | **direct ONNX, cpu** | **0.54** |

Verified in the deployed image with the fixed files mounted over it: Japanese 9.35 s of audio at RTF 0.542, English through sherpa still works afterwards, and a face session in the same process still reports `CUDAExecutionProvider`.

**Pitch accent is not implemented and cannot be with this model.** The pinned misaki has no accent code (it arrived 2025-04, alongside the larger vocabulary), and sherpa's v1.1 token table is a symlink to v1.0's. Japanese here is correctly *phonemised* but flat; fixing that needs a newer Kokoro.

**Corrections to claims made earlier in this PR.** Two statements of mine were the same mistake — treating "this token exists" as "Japanese uses it". `ʣ ʥ ʦ ʨ` are **Mandarin** phonemes here (`ʨ` appears 16 987× in `lexicon-zh.txt`), and `↓ → ↗ ↘` are **Chinese tone marks** (67 908 of 68 036 `lexicon-zh` lines). Neither was evidence of Japanese support.

**This needs a fresh image build to take effect** — the currently deployed `release.260910.10266c2` is the build that crashes.

678 passed; the 3 `test_face_plugin` failures are pre-existing on this line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

