### PR TITLE
feat(perception): VOP 分割最近点相对深度与监控预览

### DIFF
--- a/perception/Dockerfile.jetson
+++ b/perception/Dockerfile.jetson
@@ -483,6 +483,15 @@ print('[build] Thai deps import ok: pythainlp %s, khanaa %s, wunsen %s' % \
 (pythainlp.__version__, m.version('khanaa'), m.version('wunsen')))"; \
     fi && rm -f /tmp/thai-requirements.txt
 
+# Keep the depth API version reproducible without replacing NVIDIA torch,
+# torchvision, NumPy or the system OpenCV. Late layer preserves the base cache.
+COPY perception/plugins/requirements.vop-depth.txt /tmp/vop-depth-requirements.txt
+RUN pip3 install --no-cache-dir --no-deps -i "${PYPI_MIRROR}" \
+      -r /tmp/vop-depth-requirements.txt \
+      "filelock>=3.16.1" "polars==0.20.31" "nvidia-ml-py>=12.0.0" "ultralytics-thop>=2.1.6" && \
+    python3 -c "import cloudpickle, cv2, filelock, polars, pynvml, thop, torch, torchvision, ultralytics; from ultralytics import YOLO, SAM; assert ultralytics.__version__ == '8.4.144'; assert torch.version.cuda, 'NVIDIA CUDA torch required'" && \
+    rm /tmp/vop-depth-requirements.txt
+
 # ── Application code ───────────────────────────────────────────────
 WORKDIR /work
 COPY perception/main.py    /work/main.py

--- a/perception/Dockerfile.vop-replay
+++ b/perception/Dockerfile.vop-replay
@@ -1,0 +1,18 @@
+# CPU development/replay image, independent of the production Jetson image.
+ARG ROS_BASE_IMAGE=ros:humble
+FROM ${ROS_BASE_IMAGE}
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    python3-pip git libgl1 libglib2.0-0 && rm -rf /var/lib/apt/lists/*
+WORKDIR /work
+COPY plugins/requirements.vop-depth.txt /tmp/requirements.vop-depth.txt
+RUN python3 -m pip install --no-cache-dir --index-url https://pypi.org/simple \
+    numpy==1.26.4 torch==2.2.2 torchvision==0.17.2 opencv-python==4.11.0.86 \
+    websockets==16.1.1 pytest==8.3.3 pytest-mock==3.14.0 \
+    -r /tmp/requirements.vop-depth.txt && \
+    python3 -m pip install --no-cache-dir --no-deps \
+    git+https://github.com/ultralytics/CLIP.git@a13192f8cb767260d7dfd98c843b0716593169e7 && \
+    python3 -m pip install --no-cache-dir --index-url https://pypi.org/simple ftfy==6.3.1 regex==2024.11.6
+COPY . /work/
+ENV YOLO_CONFIG_DIR=/work YOLO_MODEL_DIR=/models PYTHONUNBUFFERED=1
+ENV CONFIG_PATH=/work/vop-replay.yaml
+CMD ["bash", "-c", "source /opt/ros/humble/setup.bash && python3 main.py"]

--- a/perception/README.md
+++ b/perception/README.md
@@ -2,6 +2,11 @@
 
 Modular ASR/TTS perception plugins running as an MCP HTTP server. Connects to Agent Core via MCP tool calls and exchanges audio/text over ROS2 DDS topics.
 
+## VOP 物体最近点相对深度
+
+现有 vop 可选启用 SAM 2.1 掩码与 YOLO26-Depth，在监控面板显示原图、检测框、分割轮廓、最近点及相对深度。
+默认关闭；运行方式、数据契约和必须完成的人工验收见 [VOP 深度与监控验收](VOP_DEPTH.md)。
+
 ## Audio Requirements for ASR
 
 The ASR plugin (VAD + speech recognition) has strict requirements on the audio stream it receives. Any mic driver that does not meet these requirements will produce no output.

--- a/perception/VOP_DEPTH.md
+++ b/perception/VOP_DEPTH.md
@@ -1,0 +1,129 @@
+# VOP 物体最近点相对深度与监控验收
+
+vop（Video Object Perception）保留 YOLOv8-World 开放词汇检测。开启 `depth_enabled` 后，SAM 2.1 Tiny 根据同帧检测框生成掩码，YOLO26n-Depth 预测深度；每个物体输出掩码内最小的正数有限预测值。
+
+**这是可见物体的预测掩码内最近相对深度，不是米制距离，也不是完整物体的真实最近点。** 不做逐帧归一化；跨帧绝对尺度未经验证。单像素噪声、掩码越界及漏分割会影响最小值，本版不以分位数替代最小值。不得用于米制制动阈值或证明避障安全。
+
+## 卡片与契约
+
+在 vop 的实例配置中启用 `depth_enabled`，再启动。生产默认值为 `false`；配置修改会停止受影响实例，需重新启动。关闭深度不加载 SAM/深度模型，原有类别扩展和识别字段保留。
+
+- 输入：原有 `sensor_msgs/CompressedImage` JPEG。
+- 输出 `{input_topic}/objects`：原有 `std_msgs/String` JSON。
+- 输出 `{input_topic}/objects/preview`：`sensor_msgs/CompressedImage` JPEG；通过运行时 `info.topic_out` 发现，在监控面板选择该输出。
+- 预览包含原始推理图像、检测框、半透明掩码、轮廓、最近点十字标记；图中编号对应右侧名称、置信度与相对深度。编号仅在当前帧有效。
+- JSON 与预览使用同一帧、物体列表和 `sequence`；预览保留源 `header`，图像右侧附加图例不改变 JSON 的原图像素坐标。
+- `timestamp` 继续表示发布时间（Unix 秒）；新增 `source_timestamp`、`frame_id` 保留输入头。`frame_age_s` 为从本进程接收该源帧到发布的单调时钟耗时，包含排队和推理，不冒充设备端采集延迟。
+
+物体结果示例：
+
+```json
+{
+  "id": 1,
+  "name": "cup",
+  "position": [-0.1, 0.2],
+  "confidence": 0.91,
+  "bbox_xyxy": [10, 20, 100, 200],
+  "obstacle_depth": {
+    "value": 1.2345,
+    "unit": "relative",
+    "method": "mask_min",
+    "status": "ok",
+    "pixel": [35, 75]
+  }
+}
+```
+
+无掩码为 `empty_mask`，无正数有限深度为 `invalid_depth`，模型失败为 `error`，数值和像素均为 `null`。模型失败保留检测结果，顶层 `status=depth_unavailable`，并给出 `error`；不回退到检测框或旧深度。输入中断超过 3 秒，输出空物体列表和 `stale: no input` 预览；停止发布一次 `stopped`，然后停止业务输出。推理未结束时 `stop` 返回 `stopping`，保留实例并在推理退出后自动清理，不谎报停止完成。
+
+`info.state` 使用 Core 可判定的 `loading/running/error/idle`，细分阶段放在 `phase`；等待首帧不是 ready，输入过期为 `state=error, phase=stale`。
+
+同一输入只允许一个 vop 实例，避免两个实例共用既有 `/objects` 输出路径。不同输入复用模型并串行推理；模型配置更新与推理互斥。
+
+## 天轶 2.0 镜像测试
+
+在 draft PR 评论 `/request_bot_review perception jetson-5.11 jetson-6.1`，bot 分别构建两个 JetPack 版本并 review。只使用与设备 JetPack 匹配、且对应 PR 当前 head SHA 的成功构建镜像；不要使用旧提交的构建结果。Jetson Dockerfile 安装锁定的深度 API 依赖，保留 NVIDIA torch/torchvision 与系统 OpenCV，构建时检查导入和 CUDA torch；模型推理及真机性能仍由设备测试验证。
+
+由测试人在设备上更新 Perception 镜像后，从实际话题列表选择相机 `CompressedImage` 输入，启用 vop 实例的 `depth_enabled` 并启动。在监控面板选择该输入对应的 `/objects/preview`，按照下文人工验收步骤核对图像、框、掩码与相对深度。首次启用需能访问权重下载地址，或预先将校验一致的两个权重放入持久化 `/models/vop-depth`；失败必须显示 N/A，不能算通过。
+
+本 PR 不更改 Driver 或动作链路。记录设备 JetPack、镜像完整标签/摘要、PR SHA 和验收结果；当前仍待天轶 2.0 测试。
+
+## 开发机回放
+
+以下是独立本地开发环境，不执行真机部署。命令从业务仓根目录运行。Core 镜像需已在本机存在；本次复用 `local/phanthy-motus/core:release.260904.4d38a2c`，将当前源码与前端只读挂载覆盖旧实现，不挂载用户配置或 Docker socket。
+
+```bash
+# CPU 回放镜像；首次构建和权重下载不计入五分钟人工验收。
+docker build -f perception/Dockerfile.vop-replay \
+  -t local/phanthy-motus/perception:vop-depth-replay perception
+
+docker network create vop-depth-replay
+
+docker run -d --name vop-depth-dev --network vop-depth-replay \
+  -p 127.0.0.1:18720:15720 \
+  -e ROS_DOMAIN_ID=73 -e RMW_IMPLEMENTATION=rmw_fastrtps_cpp \
+  -e AGENT_CORE_URL=http://127.0.0.1:9 \
+  -v vop-depth-models:/models \
+  local/phanthy-motus/perception:vop-depth-replay
+
+docker run -d --name vop-depth-ui --network vop-depth-replay \
+  -p 127.0.0.1:18778:15678 \
+  -e ROS_DOMAIN_ID=73 -e RMW_IMPLEMENTATION=rmw_fastrtps_cpp \
+  -v "$PWD/agent-core/src:/work/src:ro" \
+  -v "$PWD/agent-core/web:/work/web:ro" \
+  --entrypoint bash local/phanthy-motus/core:release.260904.4d38a2c \
+  -c 'source /opt/ros/humble/setup.bash; source /ros_ws/install/setup.bash; .venv/bin/python -m uvicorn start:app --app-dir src --host 0.0.0.0 --port 15678'
+
+docker exec -it vop-depth-dev bash -c \
+  'source /opt/ros/humble/setup.bash; python3 tools/replay_vop.py bus \
+   --output /tmp/vop-evidence --duration 300 \
+   --core-url http://vop-depth-ui:15678 --mcp-url http://vop-depth-dev:15720/mcp'
+```
+
+`AGENT_CORE_URL` 的禁用端口只用于隔离本机原有自动注册（它假定所有容器共享 localhost）；回放脚本通过 `--core-url/--mcp-url` 显式注册真实地址。脚本保留已有画布卡片，只追加 `vop-replay`，不会强占其他编辑者。未传这两个参数时仅发布/采集 DDS，适合已有实例。
+
+`bus` 使用安装包自带的真实示例图片；不将图片、人脸或模型权重提交到仓库。也可把有使用权限的图片或视频只读挂载进容器，把 `bus` 换成该文件路径；视频循环回放。`--duration 0` 持续运行至 Ctrl-C。结束后 vop 会显示输入过期；再次运行回放即可恢复。
+
+已有同名验收容器时复用它们，不覆盖别人的容器。源码只读挂载的开发环境，把命令中的 `tools/replay_vop.py` 改成实际挂载路径下的脚本。
+
+## 五分钟人工验收（必须由验收人确认）
+
+1. 打开 `http://localhost:18778`，切换 **监控**，查看 `/vop_replay/camera/objects/preview` 面板，放大面板使图例可读。
+2. 核对原图、每个物体框、分割轮廓、编号、名称、置信度和深度是否一一对应；核对十字标记位于对应物体的预测掩码内。
+3. 使用近远物体、遮挡场景和物体进出画面的自有视频；确认未用检测框内的其他区域代替物体掩码。发现掩码包含遮挡物时记为模型质量问题，不以数值测试通过掩盖它。
+4. 对照同帧 JSON 的 `sequence`、`source_timestamp`、物体编号、`obstacle_depth.value` 与像素坐标；检查预览明确标注 `RELATIVE DEPTH / UNCALIBRATED` 和帧处理耗时。
+5. 停止回放，确认面板在输入中断后显示 `stale: no input`，清除旧物体与深度；恢复回放后恢复结果。模型失败时必须看到 `depth_unavailable`、N/A 和 JSON 错误信息。
+
+保存 `docker cp vop-depth-dev:/tmp/vop-evidence ./vop-evidence` 的结果，并自行录制浏览器短视频。目录含结构化逐帧记录、最近预览及至多 20 个源帧预览；异常状态可能覆盖同源帧截图，以 `results.ndjson` 和录屏核对过程。证据仅本地保存，不加入 Git。
+
+验收记录必须填写：验收人、时间、源码 SHA/本地 diff、镜像与模型版本、素材来源、以上各项通过/不通过、截图/录屏路径及问题。**自动测试、API/WS 通过和 agent 查看输出图像，均不能代替用户在监控面板的人工验收。**
+
+## 依赖与验证
+
+Ultralytics 固定 `8.4.144`；CPU 回放验证使用 torch `2.2.2`、torchvision `0.17.2`、NumPy `1.26.4`。默认 `ros:humble` 基础镜像构建路径尚需独立验证；本次 Dockerfile 实测复用了本地已存在的 ROS/torch 基础镜像：
+
+```bash
+docker build --build-arg ROS_BASE_IMAGE=local/phanthy-motus/perception:release.260817.e7d5abb-navigation \
+  -f perception/Dockerfile.vop-replay -t local/phanthy-motus/perception:vop-depth-replay perception
+
+docker exec vop-depth-dev bash -c 'cd /work; PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 \
+  python3 -m pytest tests/test_vop_depth.py tests/test_bundle_dispatch.py tests/test_shared_utils.py \
+  -q -p pytest_mock -o cache_dir=/tmp/pytest-vop'
+```
+
+新增权重在 `/models/vop-depth` 缓存，下载完成且校验成功后才原子安装，加载前校验 SHA-256：
+
+| 权重 | SHA-256 |
+|---|---|
+| `yolo26n-depth.pt` | `befed1b8561d8b2eaa66274b070cdfc9c44853bda6d6d62a04759f9383af74e9` |
+| `sam2.1_t.pt` | `3c1e81ca9b037dd39d70a014ddb9a813d6c4c4e12555420db7eaff31689bd4e3` |
+
+来源为 Ultralytics assets `v8.4.0` release，固定校验值防止同名资产更新后静默改变模型。原有 YOLO-World/CLIP 加载逻辑继续使用已有缓存约定。
+
+Ultralytics 代码与 YOLO 权重适用 AGPL-3.0 / Enterprise；SAM 2.1 上游为 Apache-2.0，CLIP 为 MIT。本次仅开发与仿真验证，不据此授权闭源分发。官方接口参考：[YOLO26-Depth](https://docs.ultralytics.com/tasks/depth/)、[SAM 2](https://docs.ultralytics.com/models/sam-2/)。
+
+Jetson CUDA wheel、真机性能和米制标定未验证；不要在生产 Jetson 上直接安装本 CPU 回放栈。回滚只需关闭实例 `depth_enabled` 后重启该实例；完整移除此功能可回滚本次业务仓改动。
+
+独立 GPU 容器接入已有 Core 时，设置 `AGENT_CORE_URL`、Core 可访问的 `MCP_ADVERTISE_URL` 和唯一的 `MCP_SERVER_NAME`。Core 按服务身份去重；多个 Perception 容器不能共用默认身份，否则会合并已有服务。未设置这些变量时保留原来的本机注册行为。
+
+本次另在 Linux amd64 / A100 / Torch 2.2.2+cu121 上验证：52 项测试通过，Core 收到 20 帧实际仿真相机的标注输出，接收至发布帧龄中位约 79 ms；独立回放断流后显示 stale 并清空物体。当前模型把仿真红盘识别为 frisbee，色块漏检，尚未通过人工语义验收；这个性能数字也不代表真机端到端延迟。

--- a/perception/config.yaml
+++ b/perception/config.yaml
@@ -66,6 +66,7 @@ plugins:
     enabled: true
     namespace: ""       # auto-detect from hostname if empty
     model: "yolov8s-worldv2"
+    depth_enabled: false  # mask-min relative depth; uncalibrated, opt in per instance
     confidence: 0.3
     classes: []         # empty = default broad set
     fps: 5

--- a/perception/main.py
+++ b/perception/main.py
@@ -367,7 +367,7 @@ def make_handler():
                 if method == "initialize":
                     log.debug(f"[mcp] initialize request from client")
                     ok({"protocolVersion": "2024-11-05", "capabilities": {"tools": {}},
-                        "serverInfo": {"name": "perception-bundle", "version": "1.0.0"}})
+                        "serverInfo": {"name": os.environ.get("MCP_SERVER_NAME", "perception-bundle"), "version": "1.0.0"}})
                 elif method == "tools/list":
                     ok({"tools": _bundle.get_all_tools()})
                 elif method == "tools/call":
@@ -508,7 +508,7 @@ def _start_registration(mcp_port: int, name: str, category: str):
     _ctx.verify_mode = _ssl.CERT_NONE
     payload = json.dumps({
         "name": name,
-        "url":  f"http://localhost:{mcp_port}/mcp",
+        "url": os.environ.get("MCP_ADVERTISE_URL", f"http://localhost:{mcp_port}/mcp"),
         "category": category,
     }).encode()
     def _run():
@@ -560,7 +560,7 @@ def main():
     # Start WebSocket ASR server in a separate thread
     threading.Thread(target=_start_ws_thread, args=(ws_port,), daemon=True, name="ws_asr").start()
 
-    _start_registration(mcp_port, "Perception Stack", "perception")
+    _start_registration(mcp_port, os.environ.get("MCP_SERVER_NAME", "Perception Stack"), "perception")
 
     server = ThreadingHTTPServer(("", mcp_port), make_handler())
     log.info(f"MCP server → http://0.0.0.0:{mcp_port}")

--- a/perception/plugins/requirements.vop-depth.txt
+++ b/perception/plugins/requirements.vop-depth.txt
@@ -1,0 +1,5 @@
+# VOP depth API pins shared by replay and Jetson images.
+# Jetson installs with --no-deps to preserve NVIDIA CUDA wheels and system OpenCV.
+# Ultralytics code/models: AGPL-3.0 or Enterprise. SAM 2.1 upstream: Apache-2.0.
+ultralytics==8.4.144
+cloudpickle==3.1.2

--- a/perception/plugins/vop.py
+++ b/perception/plugins/vop.py
@@ -9,22 +9,25 @@ Supports multi-instance (one instance per input topic).
 
 from __future__ import annotations
 
+import copy
+import hashlib
 import json
+import math
 import logging
 import os
 import queue
 import threading
 import time
 import urllib.request
-from pathlib import Path
-from typing import Optional
 
 import numpy as np
-import rclpy
 from rclpy.node import Node
 from rclpy.qos import QoSProfile, ReliabilityPolicy, HistoryPolicy, DurabilityPolicy
 from sensor_msgs.msg import CompressedImage
 from std_msgs.msg import String
+
+from plugins.vop_depth import DepthEstimator, extract_objects, render_preview, unavailable
+from utils.cv2_compat import load_cv2
 
 log = logging.getLogger(__name__)
 
@@ -84,18 +87,27 @@ TOOLS = [
                     "description": "Extra object classes to add on top of COCO-80 base (for set_classes action)"
                 },
             },
-            "required": ["action"]
+            "required": ["action"],
+            "x-action-params": {
+                "start": {"params": ["input_topic"], "description": "Start VOP on an image topic"},
+                "stop": {"params": [], "description": "Stop and release this instance"},
+                "info": {"params": ["input_topic"], "description": "Read state and output topics"},
+                "set_classes": {"params": ["classes"], "description": "Add open-vocabulary classes"},
+                "config": {"params": [], "description": "Configure this instance before starting"},
+            }
         },
         "configSchema": {
             "type": "object",
             "properties": {
-                "confidence": {"type": "number", "description": "Detection confidence threshold (0-1)", "default": 0.3, "scope": "instance"},
-                "fps":        {"type": "integer", "description": "Max inference frames per second", "default": 5, "scope": "instance"},
+                "confidence": {"type": "number", "description": "Detection confidence threshold (0-1)", "default": 0.3, "minimum": 0, "maximum": 1, "scope": "instance"},
+                "fps":        {"type": "integer", "description": "Max inference frames per second", "default": 5, "minimum": 1, "maximum": 60, "scope": "instance"},
+                "depth_enabled": {"type": "boolean", "default": False, "scope": "instance", "description": "物体轮廓内最近相对深度（未标定，不是米制避障距离）"},
                 "classes":    {"type": "array", "items": {"type": "string"}, "description": "Extra object classes to add on top of COCO-80 base", "scope": "instance"},
             },
         },
         "topic_in":  [{"format": "image/jpeg", "desc": "camera image input"}],
-        "topic_out": [{"format": "data/json",  "desc": "detected objects with positions"}],
+        "topic_out": [{"format": "data/json", "desc": "detected objects with positions and relative depth"},
+                      {"format": "image/jpeg", "desc": "VOP 图像、分割轮廓与最近相对深度"}],
     }
 ]
 
@@ -103,112 +115,197 @@ TOOLS = [
 # ── ROS2 Node (one per instance/topic) ────────────────────────────────────────
 
 class _VOPNode(Node):
-    """Per-topic YOLO inference node."""
+    """One cancellable worker per input; previews and JSON share a source frame."""
 
-    def __init__(self, input_topic: str, model, confidence: float, fps: float,
-                 extra_classes: list[str], node_suffix: str):
+    def __init__(self, input_topic, plugin, config, node_suffix):
         super().__init__(f"vop_{node_suffix}")
         self._input_topic = input_topic
         self._output_topic = f"{input_topic}/objects"
-        self._model = model
-        self._confidence = confidence
-        self._fps = fps
-        self._frame_interval = 1.0 / max(fps, 0.1)
-        self._extra_classes = extra_classes
-        self._classes = list(_COCO_80_CLASSES) + [c for c in extra_classes if c not in _COCO_80_CLASSES]
-
+        self._preview_topic = f"{input_topic}/objects/preview"
+        self._plugin = plugin
+        self._confidence = config["confidence"]
+        self._fps = config["fps"]
+        self._extra_classes = config["classes"]
+        self._depth_enabled = config["depth_enabled"]
         self._pub = self.create_publisher(String, self._output_topic, _PUB_QOS)
-        self._sub: Optional[object] = None
-        self._frame_queue: queue.Queue = queue.Queue(maxsize=1)
-        self._stop_event = threading.Event()
-        self._worker: Optional[threading.Thread] = None
-        self._last_inference_time = 0.0
-        self._detect_count = 0
-
-    def start(self) -> dict:
-        if self._sub is not None:
-            return {"state": "running", "input": self._input_topic, "output": self._output_topic}
-        self._stop_event.clear()
-        self._sub = self.create_subscription(
-            CompressedImage, self._input_topic, self._image_cb, _LOW_LAT_QOS
-        )
-        self._worker = threading.Thread(target=self._inference_worker, daemon=True,
-                                        name=f"vop_worker_{self._input_topic}")
-        self._worker.start()
-        log.info(f"[vop] started: {self._input_topic} → {self._output_topic}")
-        return {"state": "running", "input": self._input_topic, "output": self._output_topic}
-
-    def stop(self) -> dict:
-        if self._sub is not None:
-            self.destroy_subscription(self._sub)
-            self._sub = None
-        self._stop_event.set()
-        if self._worker and self._worker.is_alive():
-            self._worker.join(timeout=3.0)
+        self._preview_pub = self.create_publisher(CompressedImage, self._preview_topic, _PUB_QOS)
+        self._sub = None
+        self._timer = None
         self._worker = None
-        log.info(f"[vop] stopped: {self._input_topic}")
-        return {"state": "idle", "input": self._input_topic}
+        self._frame_queue = queue.Queue(maxsize=1)
+        self._stop_event = threading.Event()
+        self._lifecycle_lock = threading.RLock()
+        self._publish_lock = threading.RLock()
+        self._state = "idle"
+        self._error = None
+        self._last_received = self._last_result = self._last_admitted = 0.0
+        self._started = 0.0
+        self._last_frame = np.zeros((480, 640, 3), dtype=np.uint8)
+        self._last_header = None
+        self._source_received = 0.0
+        self._detect_count = 0
+        self._sequence = 0
 
-    def _image_cb(self, msg: CompressedImage):
+    def start(self):
+        with self._lifecycle_lock:
+            if self._worker and self._worker.is_alive():
+                if self._state == "stale" and not self._stop_event.is_set():
+                    self._state, self._error = "waiting", None
+                    self._started = time.monotonic()
+                    self._last_received = self._last_result = 0.0
+                return self.info()
+            if self._stop_event.is_set():
+                return {"state": "idle", "error": "Stopped instance; start again after stop completes"}
+            self._state = "waiting"
+            self._started = time.monotonic()
+            self._sub = self.create_subscription(CompressedImage, self._input_topic,
+                                                  self._image_cb, _LOW_LAT_QOS)
+            self._timer = self.create_timer(1.0, self._watchdog)
+            self._worker = threading.Thread(target=self._run, daemon=True,
+                                            name=f"vop_{self.get_name()}")
+            self._worker.start()
+            return self.info()
+
+    def stop(self):
+        # Cancellation precedes the lifecycle lock so a concurrent start cannot win.
+        with self._publish_lock:
+            if not self._stop_event.is_set():
+                try:
+                    self._publish_status("stopped")
+                except Exception:
+                    log.exception("[vop] stop preview failed; continuing resource cleanup")
+            self._stop_event.set()
+            self._state = "stopping"
+        with self._lifecycle_lock:
+            if self._sub is not None:
+                self.destroy_subscription(self._sub)
+                self._sub = None
+            if self._timer is not None:
+                self.destroy_timer(self._timer)
+                self._timer = None
+            if self._worker:
+                self._worker.join(timeout=3.0)
+            if self._worker and self._worker.is_alive():
+                return {"state": "stopping", "input": self._input_topic}
+            self._state = "idle"
+            return {"state": "idle", "input": self._input_topic}
+
+    def info(self):
         now = time.monotonic()
-        if now - self._last_inference_time < self._frame_interval:
+        state = self._state
+        error = self._error
+        if state in ("waiting", "loading") or (state == "processing" and not self._last_result):
+            state = "loading"
+        elif state == "processing":
+            state = "running"
+        elif state in ("stale", "stopping"):
+            error = error or ("No image input for 3 seconds" if state == "stale" else "Stop is still in progress")
+            state = "error"
+        return {"state": state, "phase": self._state, "error": error,
+                "input": self._input_topic, "output": self._output_topic,
+                "preview": self._preview_topic, "confidence": self._confidence,
+                "fps": self._fps, "extra_classes": self._extra_classes,
+                "depth_enabled": self._depth_enabled, "detect_count": self._detect_count,
+                "result_age_s": now - self._last_result if self._last_result else None}
+
+    def _image_cb(self, msg):
+        if self._stop_event.is_set():
             return
-        self._last_inference_time = now
-        # Drop old frame if queue full (no backpressure)
+        now = time.monotonic()
+        self._last_received = now
+        if now - self._last_admitted < 1.0 / self._fps:
+            return
+        self._last_admitted = now
+        item = (msg, now)
         try:
-            self._frame_queue.put_nowait(msg.data)
+            self._frame_queue.put_nowait(item)
         except queue.Full:
             try:
                 self._frame_queue.get_nowait()
             except queue.Empty:
                 pass
             try:
-                self._frame_queue.put_nowait(msg.data)
+                self._frame_queue.put_nowait(item)
             except queue.Full:
                 pass
 
-    def _inference_worker(self):
-        import cv2
+    def _watchdog(self):
+        with self._publish_lock:
+            if self._stop_event.is_set():
+                return
+            now = time.monotonic()
+            if now - (self._last_received or self._started) > 3.0:
+                self._state = "stale"
+                self._publish_status("stale: no input")
+            elif self._state == "error" or (not self._last_result and self._state in ("loading", "processing")):
+                self._publish_status(self._state)
+
+    def _publish_status(self, status):
+        self._publish([], None, self._last_frame, self._last_header, status)
+
+    def _publish(self, objects, masks, frame, header, status):
+        with self._publish_lock:
+            if self._stop_event.is_set():
+                return
+            stamp = None
+            if header is not None:
+                stamp = header.stamp.sec + header.stamp.nanosec / 1e9
+            self._sequence += 1
+            frame_age = time.monotonic() - self._source_received if self._source_received else None
+            preview = render_preview(frame, objects, masks, status=status,
+                                     depth_enabled=self._depth_enabled,
+                                     source_stamp=stamp, sequence=self._sequence, frame_age_s=frame_age)
+            data = {"timestamp": time.time(), "source_timestamp": stamp,
+                    "frame_id": header.frame_id if header else "",
+                    "sequence": self._sequence, "status": status, "error": self._error,
+                    "frame_age_s": frame_age,
+                    "objects": objects}
+            message = String()
+            message.data = json.dumps(data, ensure_ascii=False, allow_nan=False)
+            image = CompressedImage()
+            if header is not None:
+                image.header = copy.deepcopy(header)
+            image.format, image.data = "jpeg", preview
+            self._pub.publish(message)
+            self._preview_pub.publish(image)
+
+    def _run(self):
         while not self._stop_event.is_set():
             try:
-                jpeg_bytes = self._frame_queue.get(timeout=1.0)
+                msg, received = self._frame_queue.get(timeout=0.2)
             except queue.Empty:
                 continue
+            if time.monotonic() - received > 3.0:
+                continue
             try:
-                frame = cv2.imdecode(
-                    np.frombuffer(jpeg_bytes, np.uint8), cv2.IMREAD_COLOR
-                )
+                cv2 = load_cv2()
+                frame = cv2.imdecode(np.frombuffer(msg.data, np.uint8), cv2.IMREAD_COLOR)
                 if frame is None:
-                    continue
-                results = self._model(frame, conf=self._confidence, verbose=False)
-                objects = self._extract_objects(results[0], frame.shape)
-                self._publish_objects(objects)
-            except Exception as e:
-                log.error(f"[vop] inference error: {e}", exc_info=True)
-
-    def _extract_objects(self, result, shape) -> list:
-        H, W = shape[:2]
-        half_w, half_h = W / 2.0, H / 2.0
-        objects = []
-        for box in result.boxes:
-            x1, y1, x2, y2 = box.xyxy[0].tolist()
-            cx, cy = (x1 + x2) / 2.0, (y1 + y2) / 2.0
-            x_norm = round((cx - half_w) / half_w, 3)
-            y_norm = round((cy - half_h) / half_h, 3)
-            cls_id = int(box.cls[0])
-            name = result.names[cls_id]
-            conf = round(float(box.conf[0]), 2)
-            objects.append({"name": name, "position": [x_norm, y_norm], "confidence": conf})
-        return objects
-
-    def _publish_objects(self, objects: list):
-        self._detect_count += 1
-        msg = String()
-        msg.data = json.dumps({
-            "timestamp": time.time(),
-            "objects": objects,
-        }, ensure_ascii=False)
-        self._pub.publish(msg)
+                    raise ValueError("Invalid JPEG input")
+                with self._publish_lock:
+                    self._last_frame, self._last_header = frame, copy.deepcopy(msg.header)
+                    self._source_received = received
+                    self._state = "loading" if self._plugin._model is None else "processing"
+                objects, masks, error = self._plugin._infer(frame, self._confidence,
+                                                          self._depth_enabled, self._stop_event)
+                with self._publish_lock:
+                    if self._stop_event.is_set():
+                        break
+                    self._error = error
+                    # Never republish a completed inference as live after input has disappeared.
+                    if time.monotonic() - self._last_received > 3.0:
+                        self._state = "stale"
+                        self._publish_status("stale: no input")
+                        continue
+                    self._state = "error" if error else "running"
+                    self._publish(objects, masks, frame, msg.header, "depth_unavailable" if error else "ok")
+                    self._detect_count += 1
+                    self._last_result = time.monotonic()
+            except Exception as exc:
+                log.exception("[vop] frame failed")
+                with self._publish_lock:
+                    self._error, self._state = str(exc), "error"
+                    self._publish_status("error")
 
 
 # ── Plugin class ──────────────────────────────────────────────────────────────
@@ -225,36 +322,59 @@ class VideoObjectPerceptionPlugin:
         self._base_classes = list(_COCO_80_CLASSES)
         self._extra_classes: list[str] = plugin_cfg.get("classes") or []
         self._model = None  # lazy load
-        self._model_loading = False
-        self._model_load_error = None
-        self._model_lock = threading.Lock()
+        self._model_lock = threading.RLock()
+        self._nodes_lock = threading.RLock()
+        self._depth_enabled = plugin_cfg.get("depth_enabled", False)
+        self._depth = None
+        self._device = "cpu"
         self._nodes: dict[str, _VOPNode] = {}
         self._instance_configs: dict[str, dict] = {}  # per-instance config overrides
 
     def _get_all_classes(self) -> list[str]:
         """Merge base COCO-80 + global extra + all instance extra classes."""
         all_extra = set(self._extra_classes)
-        for cfg in self._instance_configs.values():
+        with self._nodes_lock:
+            configs = list(self._instance_configs.values())
+        for cfg in configs:
             for c in cfg.get("classes") or []:
                 all_extra.add(c)
         return self._base_classes + [c for c in sorted(all_extra) if c not in self._base_classes]
 
     def _sync_model_classes(self):
-        """Re-sync model classes after config change."""
-        if self._model is None:
-            return
-        classes = self._get_all_classes()
-        # Move model to CPU for set_classes (CLIP tokenizer outputs CPU tensors)
-        # then move back to GPU for inference
-        try:
+        with self._model_lock:
+            if self._model is None:
+                return
+            classes = self._get_all_classes()
             self._model.model.cpu()
-            self._model.set_classes(classes)
-            if self._device and self._device != "cpu":
+            try:
+                self._model.set_classes(classes)
+            finally:
                 self._model.model.to(self._device)
-        except Exception as e:
-            log.warning(f"[vop] set_classes failed: {e}, trying without device move")
-            self._model.set_classes(classes)
-        log.info(f"[vop] model classes synced: {len(classes)} total (+{len(classes) - len(self._base_classes)} extra)")
+
+    def _infer(self, frame, confidence, depth_enabled, cancelled):
+        # ponytail: shared models serialize instances; use per-device workers if throughput requires it.
+        with self._model_lock:
+            if cancelled.is_set():
+                return [], None, None
+            self._ensure_model()
+            if cancelled.is_set():
+                return [], None, None
+            result = self._model(frame, conf=confidence, verbose=False, device=self._device)[0]
+            objects = extract_objects(result, frame.shape)
+            if not depth_enabled or not objects:
+                return objects, None, None
+            try:
+                if self._depth is None:
+                    directory = os.path.join(os.environ.get("YOLO_MODEL_DIR", "/models"), "vop-depth")
+                    self._depth = DepthEstimator(directory, self._device)
+                depths, masks = self._depth.estimate(frame, [obj["bbox_xyxy"] for obj in objects])
+                for obj, depth in zip(objects, depths):
+                    obj["obstacle_depth"] = depth
+                return objects, masks, None
+            except Exception as exc:
+                for obj in objects:
+                    obj["obstacle_depth"] = unavailable("error")
+                return objects, None, str(exc)
 
     def _ensure_model(self):
         if self._model is not None:
@@ -270,30 +390,7 @@ class VideoObjectPerceptionPlugin:
             os.makedirs(_model_dir, exist_ok=True)
             os.environ.setdefault("TORCH_HOME", _model_dir)
 
-            # Fix broken system cv2 on Jetson (circular import in mat_wrapper)
-            # and patch missing imshow for headless environments
-            try:
-                import cv2
-                # Test if cv2 is functional
-                _ = cv2.IMREAD_COLOR
-            except (ImportError, AttributeError):
-                import importlib.util, sys as _sys
-                import glob as _glob
-                # Find the .so directly
-                _so_candidates = _glob.glob("/usr/lib/python*/dist-packages/cv2/python-*/cv2.cpython-*.so")
-                if _so_candidates:
-                    _spec = importlib.util.spec_from_file_location("cv2", _so_candidates[0])
-                    _mod = importlib.util.module_from_spec(_spec)
-                    _spec.loader.exec_module(_mod)
-                    _sys.modules["cv2"] = _mod
-                    import cv2
-                else:
-                    import cv2  # let it fail naturally
-
-            if not hasattr(cv2, 'imshow'):
-                cv2.imshow = lambda *a, **k: None
-                cv2.waitKey = lambda *a, **k: 0
-                cv2.destroyAllWindows = lambda *a, **k: None
+            load_cv2()
 
             from ultralytics import YOLO
             import torch
@@ -303,16 +400,17 @@ class VideoObjectPerceptionPlugin:
 
             model_path = self._resolve_model_path()
             log.info(f"[vop] loading model: {model_path} (device={self._device})")
-            self._model = YOLO(model_path)
+            model = YOLO(model_path)
 
             # Ensure CLIP weights are available locally before set_classes
             self._ensure_clip_weights()
 
             classes = self._get_all_classes()
             # set_classes on CPU (model loads on CPU by default), then move to GPU
-            self._model.set_classes(classes)
+            model.set_classes(classes)
             if self._device != "cpu":
-                self._model.model.to(self._device)
+                model.model.to(self._device)
+            self._model = model
             log.info(f"[vop] model loaded, {len(classes)} classes ({len(classes) - len(self._base_classes)} extra)")
 
     def _resolve_model_path(self) -> str:
@@ -363,172 +461,133 @@ class VideoObjectPerceptionPlugin:
         urllib.request.urlretrieve(url, target_path)
         log.info(f"[vop] CLIP download complete: {target_path}")
 
-    def _start_node(self, node_key: str, input_topic: str):
-        """Create and start a VOPNode for the given topic."""
-        icfg = self._instance_configs.get(node_key, {})
-        confidence = float(icfg.get("confidence", self._confidence))
-        fps = int(icfg.get("fps", self._fps))
-        extra_classes = icfg.get("classes") or list(self._extra_classes)
-        suffix = node_key.replace("/", "_").replace("-", "_").lstrip("_")
-        node = _VOPNode(input_topic, self._model, confidence, fps,
-                        extra_classes, node_suffix=suffix)
-        self._executor.add_node(node)
-        self._nodes[node_key] = node
-        node.start()
-        log.info(f"[vop] node started (background): {input_topic}")
+    def _config_for(self, key):
+        return {"confidence": self._confidence, "fps": self._fps,
+                "classes": self._extra_classes, "depth_enabled": self._depth_enabled,
+                **self._instance_configs.get(key, {})}
 
-    def get_tools(self) -> list:
+    @staticmethod
+    def _validate_config(cfg):
+        if "depth_enabled" in cfg and type(cfg["depth_enabled"]) is not bool:
+            raise ValueError("depth_enabled must be boolean")
+        for key, low, high in (("confidence", 0, 1), ("fps", 1, 60)):
+            if key in cfg:
+                value = cfg[key]
+                if isinstance(value, bool) or not isinstance(value, (int, float)) or not math.isfinite(value) or not low <= value <= high:
+                    raise ValueError(f"{key} must be between {low} and {high}")
+                if key == "fps" and int(value) != value:
+                    raise ValueError("fps must be an integer")
+        if "classes" in cfg and (not isinstance(cfg["classes"], list) or
+                any(not isinstance(c, str) or not c.strip() or len(c) > 100 for c in cfg["classes"])):
+            raise ValueError("classes must be a list of nonempty strings (max 100 characters)")
+
+    def _stop_nodes(self, instance_id):
+        with self._nodes_lock:
+            selected = [(k, n) for k, n in self._nodes.items() if not instance_id or k == instance_id]
+        results = []
+        for key, node in selected:
+            result = node.stop()
+            results.append(result)
+            if result["state"] == "idle":
+                self._dispose_node(key, node)
+            else:
+                with self._nodes_lock:
+                    if not getattr(node, "_cleanup_started", False):
+                        node._cleanup_started = True
+                        threading.Thread(target=self._finish_stop, args=(key, node), daemon=True,
+                                         name=f"vop_cleanup_{node.get_name()}").start()
+        if any(r["state"] == "stopping" for r in results):
+            return {"state": "stopping"}
+        return {"state": "idle"}
+
+    def _finish_stop(self, key, node):
+        node._worker.join()
+        self._dispose_node(key, node)
+
+    def _dispose_node(self, key, node):
+        with self._nodes_lock:
+            if self._nodes.get(key) is not node:
+                return
+            self._executor.remove_node(node)
+            node.destroy_node()
+            node._state = "idle"
+            del self._nodes[key]
+            # The shared depth models can be released once the final instance is gone.
+            if not self._nodes and self._model_lock.acquire(blocking=False):
+                try:
+                    self._depth = None
+                finally:
+                    self._model_lock.release()
+
+    def get_tools(self):
         return TOOLS
 
-    def dispatch(self, name: str, args: dict) -> dict | None:
+    def dispatch(self, name, args):
         action = args.get("action", name)
         instance_id = args.get("instance_id", "")
-
+        input_topic = args.get("input_topic") or next(iter(args.get("input_topics") or []), "")
         if action == "info":
-            # Report loading/error state
-            if self._model_loading:
-                return {
-                    "name": "VideoObjectPerception", "manufacture": "Embodied", "model": self._model_name,
-                    "state": "loading",
-                    "desc": "Loading YOLO model...",
-                }
-            if self._model_load_error:
-                return {
-                    "name": "VideoObjectPerception", "manufacture": "Embodied", "model": self._model_name,
-                    "state": "error",
-                    "desc": f"Model load failed: {self._model_load_error}",
-                }
-            instances = {}
-            for key, node in self._nodes.items():
-                instances[key] = {
-                    "input": node._input_topic,
-                    "output": node._output_topic,
-                    "confidence": node._confidence,
-                    "fps": node._fps,
-                    "extra_classes": node._extra_classes,
-                    "detect_count": node._detect_count,
-                }
-            # Determine topic info: from running instance, args, or empty
-            input_topic = args.get("input_topic", "")
-            if not input_topic:
-                topics_list = args.get("input_topics") or []
-                if topics_list:
-                    input_topic = topics_list[0]
-            # If instance_id specified and running, use its topics
-            if instance_id and instance_id in self._nodes:
-                node = self._nodes[instance_id]
-                input_topic = node._input_topic
-            # If no explicit topic but there are running instances, use first one
-            elif not input_topic and self._nodes:
-                first_node = next(iter(self._nodes.values()))
-                input_topic = first_node._input_topic
-            topics_in = [{"topic": input_topic, "format": "image/jpeg"}] if input_topic else []
-            topics_out = [{"topic": f"{input_topic}/objects", "format": "data/json"}] if input_topic else []
-            state = "running" if instances else "idle"
-            return {
-                "name": "VideoObjectPerception", "manufacture": "Embodied", "model": self._model_name,
-                "state": state,
-                "base_classes_count": len(self._base_classes),
-                "total_classes": len(self._get_all_classes()),
-                "instances": instances,
-                "topic_in": topics_in,
-                "topic_out": topics_out,
-                "desc": "YOLOv8-World open-vocabulary object detection",
-            }
-
-        elif action == "start":
-            input_topic = args.get("input_topic")
-            if not input_topic:
-                topics_list = args.get("input_topics") or []
-                if topics_list:
-                    input_topic = topics_list[0]
-            if not input_topic:
-                raise ValueError("input_topic is required")
-            node_key = instance_id or input_topic
-            if node_key not in self._nodes:
-                if self._model is None:
-                    if self._model_loading:
-                        return {"state": "loading", "message": "Model is still loading, please wait..."}
-                    if self._model_load_error:
-                        return {"state": "error", "message": f"Model failed to load: {self._model_load_error}"}
-                    # Model not loaded yet — start loading in background
-                    def _bg_start():
-                        self._model_loading = True
-                        self._model_load_error = None
-                        try:
-                            self._ensure_model()
-                            self._model_loading = False
-                            self._start_node(node_key, input_topic)
-                        except Exception as e:
-                            self._model_loading = False
-                            self._model_load_error = str(e)
-                            log.error(f"[vop] model load failed: {e}", exc_info=True)
-                    threading.Thread(target=_bg_start, daemon=True, name="vop_model_load").start()
-                    return {"state": "loading", "input": input_topic, "output": f"{input_topic}/objects",
-                            "message": "Model loading in background, will start automatically"}
-                self._start_node(node_key, input_topic)
-            return self._nodes[node_key].start()
-
-        elif action == "stop":
-            if instance_id and instance_id in self._nodes:
-                node = self._nodes[instance_id]
-                result = node.stop()
-                self._executor.remove_node(node)
-                del self._nodes[instance_id]
-                return result
-            elif not instance_id and self._nodes:
-                results = []
-                for key in list(self._nodes.keys()):
-                    node = self._nodes[key]
-                    node.stop()
-                    self._executor.remove_node(node)
-                    del self._nodes[key]
-                    results.append(key)
-                return {"state": "idle", "stopped_instances": results}
-            return {"state": "idle"}
-
-        elif action == "set_classes":
-            classes = args.get("classes")
-            if not classes:
-                raise ValueError("classes list is required")
-            if instance_id:
-                # Per-instance extra classes
-                cfg = self._instance_configs.setdefault(instance_id, {})
-                cfg["classes"] = classes
-                # Update running node if exists
-                if instance_id in self._nodes:
-                    self._nodes[instance_id]._extra_classes = classes
-                    self._nodes[instance_id]._classes = list(_COCO_80_CLASSES) + [c for c in classes if c not in _COCO_80_CLASSES]
-            else:
-                # Global extra classes
-                self._extra_classes = classes
-            # Sync model classes in background to avoid blocking HTTP (GPU model move is slow)
-            threading.Thread(target=self._sync_model_classes, daemon=True, name="vop_sync_classes").start()
-            return {"base_classes": len(self._base_classes), "extra_classes": classes, "total": len(self._get_all_classes())}
-
-        elif action == "config":
-            cfg = {k: v for k, v in args.items() if k not in ('action', 'instance_id') and v is not None and v != ''}
-            if instance_id:
-                self._instance_configs[instance_id] = cfg
-                # If instance is running, restart with new config
-                if instance_id in self._nodes:
-                    node = self._nodes[instance_id]
-                    input_topic = node._input_topic
-                    node.stop()
-                    self._executor.remove_node(node)
-                    del self._nodes[instance_id]
-                    # Will be re-created on next start with new config
-                return {"status": "configured", "instance_id": instance_id, "config": cfg}
-            else:
-                # Update global defaults
-                if "confidence" in cfg:
-                    self._confidence = float(cfg["confidence"])
-                if "fps" in cfg:
-                    self._fps = int(cfg["fps"])
-                if "classes" in cfg:
-                    self._extra_classes = cfg["classes"]
-                    # Sync model classes in background to avoid blocking HTTP
-                    threading.Thread(target=self._sync_model_classes, daemon=True, name="vop_sync_classes").start()
-                return {"status": "configured", "config": cfg}
-
+            with self._nodes_lock:
+                instances = {key: node.info() for key, node in self._nodes.items()}
+                selected = instances.get(instance_id) if instance_id else next(iter(instances.values()), None)
+                if selected:
+                    input_topic = selected["input"]
+                state = selected["state"] if selected else "idle"
+                return {"name": "VideoObjectPerception", "manufacture": "Embodied",
+                        "model": self._model_name, "state": state,
+                        "phase": selected["phase"] if selected else "idle",
+                        "error": selected["error"] if selected else None,
+                        "base_classes_count": len(self._base_classes),
+                        "total_classes": len(self._get_all_classes()), "instances": instances,
+                        "topic_in": [{"topic": input_topic, "format": "image/jpeg"}] if input_topic else [],
+                        "topic_out": [
+                            {"topic": f"{input_topic}/objects", "format": "data/json", "desc": "物体识别与相对深度"},
+                            {"topic": f"{input_topic}/objects/preview", "format": "image/jpeg", "desc": "VOP 分割与最近点预览"},
+                        ] if input_topic else [],
+                        "desc": "Open-vocabulary objects; optional uncalibrated mask-min depth"}
+        if action == "start":
+            if not isinstance(input_topic, str) or not input_topic.startswith("/"):
+                raise ValueError("input_topic must be an absolute ROS image topic")
+            key = instance_id or input_topic
+            with self._nodes_lock:
+                node = self._nodes.get(key)
+                if node is None:
+                    if any(n._input_topic == input_topic for n in self._nodes.values()):
+                        raise ValueError("This input already has a VOP instance; stop it before rebinding")
+                    cfg = self._config_for(key)
+                    self._validate_config(cfg)
+                    suffix = hashlib.sha256(key.encode()).hexdigest()[:12]
+                    node = _VOPNode(input_topic, self, cfg, suffix)
+                    try:
+                        self._executor.add_node(node)
+                    except Exception:
+                        node.destroy_node()
+                        raise
+                    self._nodes[key] = node
+                elif node._input_topic != input_topic:
+                    raise ValueError("Stop the instance before changing its input")
+            return node.start()
+        if action == "stop":
+            return self._stop_nodes(instance_id)
+        if action in ("config", "set_classes"):
+            fields = ("confidence", "fps", "classes", "depth_enabled")
+            cfg = {k: args[k] for k in fields if k in args}
+            if action == "set_classes":
+                if "classes" not in cfg:
+                    raise ValueError("classes is required")
+                cfg = {"classes": cfg["classes"]}
+            self._validate_config(cfg)
+            if action == "config":
+                result = self._stop_nodes(instance_id)
+                if result["state"] == "stopping":
+                    return {"status": "error", "error": "Inference is stopping; retry config after stop completes"}
+            with self._nodes_lock:
+                if instance_id:
+                    self._instance_configs.setdefault(instance_id, {}).update(cfg)
+                else:
+                    for key, value in cfg.items():
+                        setattr(self, "_extra_classes" if key == "classes" else f"_{key}", value)
+            if "classes" in cfg:
+                self._sync_model_classes()
+            return {"status": "configured", "instance_id": instance_id, "config": cfg}
         return None

--- a/perception/plugins/vop_depth.py
+++ b/perception/plugins/vop_depth.py
@@ -1,0 +1,166 @@
+"""Optional, uncalibrated mask-min depth and same-frame VOP preview."""
+from __future__ import annotations
+
+import hashlib
+import os
+from pathlib import Path
+import tempfile
+import urllib.request
+
+import numpy as np
+
+from utils.cv2_compat import load_cv2
+
+ULTRALYTICS_VERSION = "8.4.144"
+WEIGHTS = {
+    "yolo26n-depth.pt": "befed1b8561d8b2eaa66274b070cdfc9c44853bda6d6d62a04759f9383af74e9",
+    "sam2.1_t.pt": "3c1e81ca9b037dd39d70a014ddb9a813d6c4c4e12555420db7eaff31689bd4e3",
+}
+
+
+def ensure_weight(directory: Path, name: str) -> Path:
+    """Verify cached bytes before unpickling; install complete downloads atomically."""
+    directory.mkdir(parents=True, exist_ok=True)
+    target = directory / name
+
+    def digest(path):
+        h = hashlib.sha256()
+        with path.open("rb") as f:
+            for chunk in iter(lambda: f.read(1024 * 1024), b""):
+                h.update(chunk)
+        return h.hexdigest()
+
+    if target.exists():
+        if digest(target) != WEIGHTS[name]:
+            raise ValueError(f"Weight checksum mismatch: {name}; replace the cached file")
+        return target
+    url = f"https://github.com/ultralytics/assets/releases/download/v8.4.0/{name}"
+    fd, temporary = tempfile.mkstemp(dir=directory, suffix=".partial")
+    try:
+        with os.fdopen(fd, "wb") as out, urllib.request.urlopen(url, timeout=30) as src:
+            while chunk := src.read(1024 * 1024):
+                out.write(chunk)
+        if digest(Path(temporary)) != WEIGHTS[name]:
+            raise ValueError(f"Downloaded weight checksum mismatch: {name}")
+        os.replace(temporary, target)
+    finally:
+        Path(temporary).unlink(missing_ok=True)
+    return target
+
+
+def unavailable(status: str) -> dict:
+    return {"value": None, "unit": "relative", "method": "mask_min",
+            "status": status, "pixel": None}
+
+
+def mask_min(depth: np.ndarray, mask: np.ndarray) -> dict:
+    """Minimum positive finite prediction inside the *visible predicted mask*."""
+    if depth.ndim != 2 or mask.shape != depth.shape:
+        raise ValueError("Depth and mask must match the original image dimensions")
+    mask = mask.astype(bool)
+    if not mask.any():
+        return unavailable("empty_mask")
+    valid = mask & np.isfinite(depth) & (depth > 0)
+    if not valid.any():
+        return unavailable("invalid_depth")
+    # Exact minimum, not a quantile: single-pixel noise remains a known model limit.
+    y, x = np.unravel_index(np.argmin(np.where(valid, depth, np.inf)), depth.shape)
+    return {"value": float(depth[y, x]), "unit": "relative", "method": "mask_min",
+            "status": "ok", "pixel": [int(x), int(y)]}
+
+
+class DepthEstimator:
+    """Caller serializes model access with the VOP inference lock."""
+    def __init__(self, directory: str, device: str):
+        self.directory = Path(directory)
+        self.device = device
+        self.depth_model = self.segment_model = None
+        self.error = None
+
+    def estimate(self, frame, boxes):
+        if self.error:
+            raise RuntimeError(self.error)
+        if self.depth_model is None:
+            try:
+                import ultralytics
+                from ultralytics import YOLO, SAM
+                if ultralytics.__version__ != ULTRALYTICS_VERSION:
+                    raise RuntimeError(f"Depth requires ultralytics=={ULTRALYTICS_VERSION}")
+                self.depth_model = YOLO(str(ensure_weight(self.directory, "yolo26n-depth.pt")))
+                self.segment_model = SAM(str(ensure_weight(self.directory, "sam2.1_t.pt")))
+            except Exception as exc:
+                self.depth_model = self.segment_model = None
+                self.error = str(exc)
+                raise
+        depth_result = self.depth_model(frame, device=self.device, verbose=False)[0]
+        depth = depth_result.depth.data.detach().cpu().numpy()
+        masks = self.segment_model(frame, bboxes=boxes, device=self.device,
+                                   verbose=False)[0].masks
+        if masks is None:
+            masks = np.zeros((len(boxes), *frame.shape[:2]), dtype=bool)
+        else:
+            masks = masks.data.detach().cpu().numpy().astype(bool)
+        if depth.shape != frame.shape[:2] or masks.shape != (len(boxes), *frame.shape[:2]):
+            raise ValueError("Model output is not aligned to the source image")
+        return [mask_min(depth, mask) for mask in masks], masks
+
+
+def extract_objects(result, shape):
+    height, width = shape[:2]
+    objects = []
+    for index, box in enumerate(result.boxes):
+        x1, y1, x2, y2 = box.xyxy[0].tolist()
+        objects.append({
+            "id": index + 1,
+            "name": str(result.names[int(box.cls[0])]),
+            "position": [round((x1 + x2) / width - 1, 3),
+                         round((y1 + y2) / height - 1, 3)],
+            "confidence": round(float(box.conf[0]), 2),
+            "bbox_xyxy": [x1, y1, x2, y2],
+        })
+    return objects
+
+
+def render_preview(frame, objects, masks=None, *, status="ok", depth_enabled=False,
+                   source_stamp=None, sequence=0, frame_age_s=None):
+    """Render metadata onto the actual inference frame, never the latest camera frame."""
+    cv2 = load_cv2()
+    height, width = frame.shape[:2]
+    image = np.zeros((max(height, 70 + len(objects) * 60), width + 340, 3), dtype=np.uint8)
+    image[:height, :width] = frame
+    scene = image[:height, :width]
+    colors = [(80, 230, 80), (255, 180, 50), (180, 80, 255), (40, 220, 255)]
+    for i, obj in enumerate(objects):
+        color = colors[i % len(colors)]
+        if masks is not None:
+            mask = masks[i]
+            scene[mask] = (scene[mask] * 0.75 + np.array(color) * 0.25).astype(np.uint8)
+            contours, _ = cv2.findContours(mask.astype(np.uint8), cv2.RETR_EXTERNAL,
+                                          cv2.CHAIN_APPROX_SIMPLE)
+            cv2.drawContours(image, contours, -1, color, 2)
+        x1, y1, x2, y2 = np.rint(obj["bbox_xyxy"]).astype(int)
+        cv2.rectangle(image, (x1, y1), (x2, y2), color, 2)
+        depth = obj.get("obstacle_depth", unavailable("disabled"))
+        if depth["pixel"] is not None:
+            cv2.drawMarker(image, tuple(depth["pixel"]), color, cv2.MARKER_CROSS, 16, 2)
+        # Short frame-local IDs stay by the boxes; a legend avoids overlapping labels.
+        cv2.putText(image, f'#{obj["id"]}', (max(0, min(x1, width - 35)), max(50, y1 - 5)),
+                    cv2.FONT_HERSHEY_SIMPLEX, 0.6, color, 2, cv2.LINE_AA)
+        label = f'#{obj["id"]} {obj["name"][:30]} ({obj["confidence"]:.2f})'
+        detail = (f'nearest: {depth["value"]:.4f} rel' if depth["status"] == "ok"
+                  else f'depth: N/A ({depth["status"]})')
+        for row, text in enumerate((label, detail)):
+            cv2.putText(image, text, (width + 12, 65 + i * 60 + row * 20),
+                        cv2.FONT_HERSHEY_SIMPLEX, 0.48, color, 1, cv2.LINE_AA)
+    banner = f'VOP #{sequence} | {status} | ' + (
+        'RELATIVE DEPTH / UNCALIBRATED' if depth_enabled else 'depth disabled')
+    cv2.rectangle(image, (0, 0), (image.shape[1], 38), (0, 0, 0), -1)
+    cv2.putText(image, banner, (6, 16), cv2.FONT_HERSHEY_SIMPLEX, 0.42,
+                (255, 255, 255) if status == "ok" else (80, 80, 255), 1, cv2.LINE_AA)
+    age = f'{frame_age_s:.2f}s' if frame_age_s is not None else 'N/A'
+    cv2.putText(image, f'source stamp: {source_stamp} | frame age at publish: {age}', (6, 32),
+                cv2.FONT_HERSHEY_SIMPLEX, 0.4, (255, 255, 255), 1, cv2.LINE_AA)
+    ok, encoded = cv2.imencode(".jpg", image, [cv2.IMWRITE_JPEG_QUALITY, 85])
+    if not ok:
+        raise RuntimeError("Preview JPEG encoding failed")
+    return encoded.tobytes()

--- a/perception/tests/test_vop_depth.py
+++ b/perception/tests/test_vop_depth.py
@@ -1,0 +1,191 @@
+"""Numerical, lifecycle and wire-contract checks; real-model replay is separate."""
+import json
+import threading
+import time
+from types import SimpleNamespace
+
+import cv2
+import numpy as np
+import pytest
+
+from vision_stubs import _FakeExecutor, _FakeNode, _wait_until
+from plugins import vop
+from plugins.vop_depth import mask_min, render_preview, unavailable, ensure_weight
+
+
+def test_mask_min_excludes_outside_and_invalid_and_keeps_exact_minimum():
+    depth = np.array([[0.01, 4, 3], [np.nan, 2, np.inf], [-1, 0, 1.25]])
+    mask = np.ones((3, 3), bool); mask[0, 0] = False
+    assert mask_min(depth, mask) == {"value": 1.25, "unit": "relative", "method": "mask_min",
+                                     "status": "ok", "pixel": [2, 2]}
+    assert mask_min(depth, np.zeros((3, 3), bool))["status"] == "empty_mask"
+    assert mask_min(np.zeros((3, 3)), mask)["status"] == "invalid_depth"
+    with pytest.raises(ValueError):
+        mask_min(depth, np.ones((2, 2)))
+
+
+def test_cached_weight_must_match_before_loading(tmp_path):
+    (tmp_path / "sam2.1_t.pt").write_bytes(b"incomplete")
+    with pytest.raises(ValueError, match="checksum"):
+        ensure_weight(tmp_path, "sam2.1_t.pt")
+
+
+@pytest.fixture
+def plugin(monkeypatch):
+    monkeypatch.setattr(_FakeNode, "create_timer", lambda *a: object(), raising=False)
+    monkeypatch.setattr(_FakeNode, "destroy_timer", lambda *a: None, raising=False)
+    monkeypatch.setattr(_FakeNode, "destroy_subscription", lambda *a: None, raising=False)
+    class Image:
+        def __init__(self):
+            self.header = SimpleNamespace(stamp=SimpleNamespace(sec=123, nanosec=500000000), frame_id="camera")
+            self.format = "jpeg"
+            self.data = cv2.imencode(".jpg", np.full((96, 160, 3), 90, np.uint8))[1].tobytes()
+    monkeypatch.setattr(vop, "CompressedImage", Image)
+    p = vop.VideoObjectPerceptionPlugin({}, "test", _FakeExecutor())
+    yield p
+    p.dispatch("vop", {"action": "stop"})
+
+
+def test_preview_and_json_same_frame_and_stale_clears_objects(plugin, monkeypatch):
+    obj = {"id": 1, "name": "cup", "position": [0, 0], "confidence": 0.9,
+           "bbox_xyxy": [10, 40, 120, 80], "obstacle_depth":
+           {**unavailable("ok"), "value": 1.2, "pixel": [30, 60]}}
+    mask = np.zeros((1, 96, 160), bool); mask[:, 40:80, 10:120] = True
+    monkeypatch.setattr(plugin, "_infer", lambda *a: ([obj], mask, None))
+    captures = []
+    original = vop.render_preview
+    def capture(frame, objects, masks, **kwargs):
+        captures.append((objects, kwargs))
+        return original(frame, objects, masks, **kwargs)
+    monkeypatch.setattr(vop, "render_preview", capture)
+    plugin.dispatch("vop", {"action": "config", "instance_id": "one", "depth_enabled": True})
+    plugin.dispatch("vop", {"action": "start", "instance_id": "one", "input_topic": "/camera"})
+    node = plugin._nodes["one"]
+    node._image_cb(vop.CompressedImage())
+    assert _wait_until(lambda: node._detect_count == 1)
+    data = json.loads(node._pub.messages[-1])
+    assert data["source_timestamp"] == 123.5 and data["frame_id"] == "camera"
+    assert data["objects"] == captures[-1][0]
+    assert data["sequence"] == captures[-1][1]["sequence"]
+    image = cv2.imdecode(np.frombuffer(node._preview_pub.messages[-1], np.uint8), cv2.IMREAD_COLOR)
+    assert image.shape == (130, 500, 3) and image.std() > 10
+    node._last_received = time.monotonic() - 4
+    node._watchdog()
+    stale = json.loads(node._pub.messages[-1])
+    assert stale["status"].startswith("stale") and stale["objects"] == []
+    assert captures[-1][0] == []
+
+
+def test_stop_during_model_work_prevents_late_publish_and_duplicate_start(plugin, monkeypatch):
+    entered, release = threading.Event(), threading.Event()
+    def infer(*args):
+        entered.set(); release.wait(5)
+        return [], None, None
+    monkeypatch.setattr(plugin, "_infer", infer)
+    args = {"action": "start", "input_topic": "/camera", "instance_id": "one"}
+    threads = [threading.Thread(target=plugin.dispatch, args=("vop", args)) for _ in range(4)]
+    for t in threads: t.start()
+    for t in threads: t.join()
+    assert len(plugin._executor.nodes) == 1
+    node = plugin._nodes["one"]; node._image_cb(vop.CompressedImage())
+    assert entered.wait(2)
+    stopper = threading.Thread(target=plugin.dispatch, args=("vop", {"action": "stop", "instance_id": "one"}))
+    stopper.start()
+    assert node._stop_event.wait(2)
+    count = len(node._pub.messages)
+    release.set(); stopper.join(2)
+    assert not stopper.is_alive() and len(node._pub.messages) == count
+    assert node.destroyed and not plugin._nodes and not plugin._executor.nodes
+    assert json.loads(node._pub.messages[-1])["status"] == "stopped"
+
+
+def test_config_validation_and_topics(plugin):
+    for cfg in ({"fps": 0}, {"fps": True}, {"confidence": float("nan")},
+                {"depth_enabled": "false"}, {"classes": [""]}):
+        with pytest.raises(ValueError):
+            plugin.dispatch("vop", {"action": "config", **cfg})
+    plugin.dispatch("vop", {"action": "config", "instance_id": "one", "fps": 2})
+    plugin.dispatch("vop", {"action": "config", "instance_id": "one", "depth_enabled": True})
+    assert plugin._config_for("one")["fps"] == 2
+    info = plugin.dispatch("vop", {"action": "info", "input_topic": "/camera"})
+    assert info["topic_out"][-1]["topic"] == "/camera/objects/preview"
+    assert info["topic_out"][-1]["format"] == "image/jpeg"
+    assert plugin._config_for("other")["depth_enabled"] is False
+
+
+def test_depth_failure_preserves_detection_and_disabled_does_not_load(plugin, monkeypatch):
+    monkeypatch.setattr(vop, "extract_objects", lambda *a: [{"bbox_xyxy": [0, 0, 2, 2]}])
+    plugin._model = lambda *a, **kw: [object()]
+    class BrokenDepth:
+        def estimate(self, *a): raise RuntimeError("model unavailable")
+    plugin._depth = BrokenDepth()
+    frame = np.zeros((3, 3, 3), np.uint8)
+    objects, masks, error = plugin._infer(frame, 0.3, True, threading.Event())
+    assert error == "model unavailable" and len(objects) == 1 and masks is None
+    assert objects[0]["obstacle_depth"] == unavailable("error")
+    objects, _, error = plugin._infer(frame, 0.3, False, threading.Event())
+    assert error is None and "obstacle_depth" not in objects[0]
+
+
+def test_class_update_waits_for_shared_inference_lock(plugin, monkeypatch):
+    moved = threading.Event()
+    model = SimpleNamespace(cpu=lambda: None, to=lambda device: None)
+    plugin._model = SimpleNamespace(model=model, set_classes=lambda classes: moved.set())
+    plugin._model_lock.acquire()
+    updater = threading.Thread(target=plugin._sync_model_classes)
+    updater.start()
+    try:
+        assert not moved.wait(0.05)
+    finally:
+        plugin._model_lock.release()
+    updater.join(2)
+    assert moved.is_set() and not updater.is_alive()
+
+
+def test_stop_cannot_restart_a_cancelled_node_or_share_output(plugin):
+    plugin.dispatch("vop", {"action": "start", "instance_id": "one", "input_topic": "/camera"})
+    node = plugin._nodes["one"]
+    with pytest.raises(ValueError, match="already has"):
+        plugin.dispatch("vop", {"action": "start", "instance_id": "two", "input_topic": "/camera"})
+    plugin.dispatch("vop", {"action": "stop", "instance_id": "one"})
+    assert node.start()["state"] == "idle"
+    assert node.destroyed and node._sub is None
+
+
+def test_actions_have_matching_parameter_metadata(plugin):
+    schema = plugin.get_tools()[0]["inputSchema"]
+    assert set(schema["properties"]["action"]["enum"]) == set(schema["x-action-params"])
+
+
+def test_long_inference_is_eventually_disposed_without_second_stop(plugin, monkeypatch):
+    entered, release = threading.Event(), threading.Event()
+    def infer(*args):
+        entered.set(); release.wait(8)
+        return [], None, None
+    monkeypatch.setattr(plugin, "_infer", infer)
+    plugin.dispatch("vop", {"action": "start", "instance_id": "one", "input_topic": "/camera"})
+    node = plugin._nodes["one"]; node._image_cb(vop.CompressedImage())
+    assert entered.wait(2)
+    try:
+        assert plugin.dispatch("vop", {"action": "stop", "instance_id": "one"})["state"] == "stopping"
+        assert not node.destroyed
+    finally:
+        release.set()
+    assert _wait_until(lambda: node.destroyed and not plugin._nodes)
+    assert not plugin._executor.nodes
+
+
+def test_core_does_not_treat_waiting_or_stale_as_ready(plugin):
+    started = plugin.dispatch("vop", {"action": "start", "instance_id": "one", "input_topic": "/camera"})
+    assert started["state"] == "loading" and started["phase"] == "waiting"
+    node = plugin._nodes["one"]
+    node._state = "processing"
+    assert node.info()["state"] == "loading"
+    node._last_result = time.monotonic()
+    assert node.info()["state"] == "running"
+    node._last_received = time.monotonic() - 4
+    node._watchdog()
+    info = plugin.dispatch("vop", {"action": "info", "instance_id": "one"})
+    assert info["state"] == "error" and info["phase"] == "stale" and info["error"]
+    resumed = plugin.dispatch("vop", {"action": "start", "instance_id": "one", "input_topic": "/camera"})
+    assert resumed["state"] == "loading" and plugin._nodes["one"] is node

--- a/perception/tools/replay_vop.py
+++ b/perception/tools/replay_vop.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""Publish a real local image/video and capture VOP JSON + annotated JPEG over DDS."""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+import time
+import urllib.request
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+
+
+def setup_monitor(core_url, mcp_url, topic, instance_id):
+    """Opt-in: start a real replay instance and append its card without replacing a canvas."""
+    opener = urllib.request.build_opener(urllib.request.ProxyHandler({}))
+    def request(url, data=None):
+        req = urllib.request.Request(url, data=None if data is None else json.dumps(data).encode(),
+                                     headers={"Content-Type": "application/json"})
+        with opener.open(req, timeout=30) as response:
+            body = json.load(response)
+        if body.get("error") or body.get("code", 200) != 200:
+            raise RuntimeError(body)
+        return body
+    started = request(mcp_url, {"jsonrpc": "2.0", "id": 1, "method": "tools/call", "params": {
+        "name": "vop", "arguments": {"action": "start", "instance_id": instance_id, "input_topic": topic}}})
+    result = json.loads(started["result"]["content"][0]["text"])
+    if result.get("error") or result.get("state") in ("error", "idle", "stopping"):
+        raise RuntimeError(result)
+    base = core_url.rstrip("/")
+    request(base + "/api/mcp", {"name": "VOP replay perception", "transport": "http",
+                                 "url": mcp_url, "category": "perception"})
+    mcp = next(m for m in request(base + "/api/mcp")["data"] if m.get("url") == mcp_url)
+    layout = request(base + "/api/canvas/layout").get("data") or {}
+    cards = layout.setdefault("cards", [])
+    existing = next((c for c in cards if c.get("id") == instance_id), None)
+    if existing and (existing.get("mcpId") != mcp["id"] or existing.get("toolName") != "vop"):
+        raise RuntimeError("Instance ID belongs to a different canvas card")
+    if not existing:
+        cards.append({"id": instance_id, "mcpId": mcp["id"], "toolName": "vop", "type": "processor",
+                      "x": 100, "y": 100, "topicIn": [{"topic": topic, "format": "image/jpeg"}],
+                      "topicOut": [{"topic": topic + "/objects", "format": "data/json"},
+                                   {"topic": topic + "/objects/preview", "format": "image/jpeg"}]})
+        owner = "vop-replay-setup"
+        request(base + "/api/canvas/claim-edit", {"session_id": owner})
+        try:
+            request(base + "/api/canvas/layout", {**layout, "session_id": owner})
+        finally:
+            request(base + "/api/canvas/release-edit", {"session_id": owner})
+    print(json.dumps({"monitor": base, "instance": instance_id, "topic": topic}), flush=True)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("source", help="Local image/video, or 'bus' for the Ultralytics example image")
+    parser.add_argument("--topic", default="/vop_replay/camera")
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--duration", type=float, default=60, help="Seconds; 0 means until Ctrl-C")
+    parser.add_argument("--fps", type=float, default=2)
+    parser.add_argument("--core-url", help="Opt in to registering the MCP and adding a monitor card")
+    parser.add_argument("--mcp-url", help="Perception endpoint reachable from both replay and Core")
+    parser.add_argument("--instance-id", default="vop-replay")
+    args = parser.parse_args()
+    if bool(args.core_url) != bool(args.mcp_url):
+        parser.error("Supply both --core-url and --mcp-url, or neither")
+    if args.fps <= 0 or args.duration < 0:
+        parser.error("fps must be positive and duration nonnegative")
+    from utils.cv2_compat import load_cv2
+    import rclpy
+    from sensor_msgs.msg import CompressedImage
+    from std_msgs.msg import String
+    from rclpy.qos import qos_profile_sensor_data
+    cv2 = load_cv2()
+    if args.source == "bus":
+        from ultralytics.utils import ASSETS
+        source = ASSETS / "bus.jpg"
+    else:
+        source = Path(args.source)
+    if not source.is_file():
+        parser.error(f"Not a local file: {source}")
+    frame = cv2.imread(str(source))
+    video = None if frame is not None else cv2.VideoCapture(str(source))
+    if frame is None and not video.isOpened():
+        parser.error("Cannot decode source")
+    if args.core_url:
+        setup_monitor(args.core_url, args.mcp_url, args.topic, args.instance_id)
+    args.output.mkdir(parents=True, exist_ok=True)
+    rclpy.init()
+    node = rclpy.create_node("vop_replay")
+    pub = node.create_publisher(CompressedImage, args.topic, qos_profile_sensor_data)
+    records = (args.output / "results.ndjson").open("a")
+    successful = 0
+    def result(msg):
+        nonlocal successful
+        data = json.loads(msg.data)
+        records.write(json.dumps(data, ensure_ascii=False) + "\n"); records.flush()
+        if data.get("status") == "ok":
+            successful += 1
+            (args.output / "latest.json").write_text(json.dumps(data, indent=2, ensure_ascii=False))
+    def preview(msg):
+        (args.output / "latest.jpg").write_bytes(bytes(msg.data))
+        key = f"{msg.header.stamp.sec}-{msg.header.stamp.nanosec}"
+        # Bounded capture: latest only plus the first 20 source frames, including failure banners.
+        existing = list(args.output.glob("frame-*.jpg"))
+        path = args.output / f"frame-{key}.jpg"
+        if path.exists() or len(existing) < 20:
+            path.write_bytes(bytes(msg.data))
+    node.create_subscription(String, args.topic + "/objects", result, qos_profile_sensor_data)
+    node.create_subscription(CompressedImage, args.topic + "/objects/preview", preview, qos_profile_sensor_data)
+    start, next_frame = time.monotonic(), 0.0
+    try:
+        while rclpy.ok() and (args.duration == 0 or time.monotonic() - start < args.duration):
+            if time.monotonic() >= next_frame:
+                if video is not None:
+                    ok, frame = video.read()
+                    if not ok:
+                        video.set(cv2.CAP_PROP_POS_FRAMES, 0)
+                        ok, frame = video.read()
+                        if not ok: raise RuntimeError("Video contains no decodable frames")
+                ok, encoded = cv2.imencode(".jpg", frame)
+                if not ok: raise RuntimeError("Input JPEG encoding failed")
+                msg = CompressedImage()
+                msg.header.stamp = node.get_clock().now().to_msg()
+                msg.header.frame_id = "vop_replay_camera_optical_frame"
+                msg.format, msg.data = "jpeg", encoded.tobytes()
+                pub.publish(msg)
+                next_frame = time.monotonic() + 1 / args.fps
+            rclpy.spin_once(node, timeout_sec=0.02)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        if video is not None: video.release()
+        records.close(); node.destroy_node(); rclpy.shutdown()
+    print(json.dumps({"successful_frames": successful, "evidence": str(args.output)}))
+    if successful == 0:
+        raise SystemExit("No successful VOP results received; this replay has not passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/perception/vop-replay.yaml
+++ b/perception/vop-replay.yaml
@@ -1,0 +1,10 @@
+# Development only. Production config keeps depth disabled.
+mcp_port: 15720
+ws_port: 15721
+plugins:
+  vop:
+    enabled: true
+    model: yolov8s-worldv2
+    confidence: 0.3
+    fps: 2
+    depth_enabled: true


### PR DESCRIPTION
VOP 原有监控只能输出检测数据。本变更保留 YOLOv8-World 开放词汇检测，按实例可选启用 SAM 2.1 Tiny 分割与 YOLO26n-Depth，在同一源帧的预览中显示图像、检测框、掩码轮廓、最近点及相对深度，支持天轶 2.0 人工验收。

- 深度默认关闭；开启后取预测掩码内最小正数有限值，输出明确标记 relative。输入中断清空旧结果；深度失败保留检测并显示 N/A。
- 共享模型推理与类别更新互斥，处理并发启停、慢推理退出及节点回收。独立 Perception 容器可配置 MCP 地址与唯一身份。
- 增加数值/生命周期/消息契约测试、开发回放工具及人工验收说明。Jetson 镜像固定 Ultralytics 8.4.144 与 cloudpickle，保留 NVIDIA CUDA wheels，并增加构建时导入检查。

验证：Linux amd64 / A100 / Torch 2.2.2+cu121 容器中 `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest tests/test_vop_depth.py tests/test_bundle_dispatch.py tests/test_shared_utils.py -q -p pytest_mock -o cache_dir=/tmp/pytest-vop-pr`：52 passed（4.37s）。真实仿真相机经 Core 收到 20 帧标注结果；独立回放断流后 DDS 输出 stale 和空物体。此前 CPU 三模型回放及校验失败注入也已通过。

尚未通过：Jetson 镜像构建/推理、天轶 2.0 性能及监控面板人工验收。新增 Jetson 依赖层等待 bot 实际构建；默认 ros:humble 回放镜像从零构建尚未验证。当前仿真红盘被识别为 frisbee，色块漏检，不能把显示链路通过等同于语义质量通过。深度未经米制标定，不接入机器人控制或避障安全判断。

保持 draft，申请 bot 构建及 review 后，由测试人使用匹配设备 JetPack、对应当前 PR SHA 的镜像验收，再依据 review 与实测结果修改。验收步骤见 `perception/VOP_DEPTH.md`。Ultralytics 代码/YOLO 权重沿用 AGPL-3.0 或 Enterprise 许可，SAM 上游为 Apache-2.0；本 PR 不包含权重或采集图像。
