### PR TITLE
perception: add on_notify hook binding to shared TTS plugin

### DIFF
--- a/perception/plugins/tts.py
+++ b/perception/plugins/tts.py
@@ -177,6 +177,7 @@ TOOLS = [
             "x-resource": "mouth",
             "x-hooks": {
                 "on_interrupt_speak": {"action": "interrupt"},
+                "on_notify": {"action": "speak"},
             }
         },
         "configSchema": {


### PR DESCRIPTION
## Summary
- Part of the auto-notify redesign in `feat/progress-notification-prompt` (agent-core): a new `on_notify` hook fires whenever the LLM produces narratable content, replacing prose-based prompt instructions that didn't reliably get followed.
- Adds a sibling `on_notify` x-hooks binding next to the existing `on_interrupt_speak` on the shared perception TTS plugin's tool schema, so any robot using this plugin picks up narration automatically with no further changes.

## Test plan
- [x] `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest perception/tests -k tts` — 132 passed, 1 skipped
- [ ] Live check on a robot using this plugin: `POST /api/hooks/fire {"hook": "on_notify", "extra_params": {"text": "测试播报"}}` produces audible speech