### PR TITLE
fix: relax deploy disk-space gate, fix overlapping minimized deploy widgets

### DIFF
--- a/agent-core/src/api/preflight.py
+++ b/agent-core/src/api/preflight.py
@@ -17,11 +17,17 @@ from typing import Optional
 import docker as docker_sdk
 
 
-def check_disk_space(required_gb: float = 20.0) -> dict:
+def check_disk_space(required_gb: float = 20.0, min_gb: float = 1.0) -> dict:
     """Check if sufficient disk space is available.
 
+    Only blocks deployment (status='fail') when free space drops below the
+    absolute floor `min_gb`. Falling short of the recommended `required_gb`
+    (e.g. 2.5x image size) is a non-blocking warning, since that figure is a
+    comfort margin for pull+extract, not a hard requirement.
+
     Args:
-        required_gb: Minimum free space required in GB
+        required_gb: Recommended free space in GB (comfort margin)
+        min_gb: Absolute minimum free space in GB below which deploy is blocked
 
     Returns:
         {
@@ -44,7 +50,7 @@ def check_disk_space(required_gb: float = 20.0) -> dict:
                 'total_gb': round(total_gb, 1),
                 'message': f'磁盘空间充足：{free_gb:.1f} GB 可用',
             }
-        elif free_gb >= required_gb * 0.6:
+        elif free_gb >= min_gb:
             return {
                 'status': 'warning',
                 'free_gb': round(free_gb, 1),
@@ -57,7 +63,7 @@ def check_disk_space(required_gb: float = 20.0) -> dict:
                 'status': 'fail',
                 'free_gb': round(free_gb, 1),
                 'total_gb': round(total_gb, 1),
-                'message': f'磁盘空间不足：仅 {free_gb:.1f} GB 可用（需要 {required_gb:.0f} GB）',
+                'message': f'磁盘空间不足：仅 {free_gb:.1f} GB 可用（需要至少 {min_gb:.0f} GB）',
                 'suggestion': '必须清理磁盘空间：docker image prune -a && docker builder prune -a',
             }
     except Exception as e:

--- a/agent-core/web/js/deploy-progress.js
+++ b/agent-core/web/js/deploy-progress.js
@@ -166,6 +166,17 @@ class DeployProgressUI {
         this._attachCallbacks();
     }
 
+    static _getMinimizedStack() {
+        let stack = document.getElementById('deploy-progress-minimized-stack');
+        if (!stack) {
+            stack = document.createElement('div');
+            stack.id = 'deploy-progress-minimized-stack';
+            stack.className = 'deploy-progress-minimized-stack';
+            document.body.appendChild(stack);
+        }
+        return stack;
+    }
+
     _createUI() {
         // Create modal overlay
         this.container = document.createElement('div');
@@ -205,7 +216,7 @@ class DeployProgressUI {
                 <div class="deploy-progress-minimized-progress"></div>
             </div>
         `;
-        document.body.appendChild(this.minimizedIndicator);
+        DeployProgressUI._getMinimizedStack().appendChild(this.minimizedIndicator);
 
         // Add styles if not already present
         if (!document.getElementById('deploy-progress-styles')) {
@@ -345,11 +356,18 @@ class DeployProgressUI {
                     color: #4caf50;
                 }
 
-                /* Minimized indicator */
-                .deploy-progress-minimized {
+                /* Minimized indicator stack — holds one indicator per active deployment
+                   so multiple concurrent deploys don't render on top of each other */
+                .deploy-progress-minimized-stack {
                     position: fixed;
                     bottom: 20px;
                     right: 20px;
+                    display: flex;
+                    flex-direction: column-reverse;
+                    gap: 12px;
+                    z-index: 9999;
+                }
+                .deploy-progress-minimized {
                     background: #1e1e1e;
                     border: 1px solid #333;
                     border-radius: 8px;
@@ -357,7 +375,6 @@ class DeployProgressUI {
                     min-width: 280px;
                     box-shadow: 0 4px 12px rgba(0,0,0,0.3);
                     cursor: pointer;
-                    z-index: 9999;
                     transition: transform 0.2s, box-shadow 0.2s;
                 }
                 .deploy-progress-minimized:hover {


### PR DESCRIPTION
## Summary
- `check_disk_space()` in `agent-core/src/api/preflight.py` now only blocks deployment (`status='fail'`) when free disk drops below an absolute 1GB floor. Falling short of the recommended 2.5x-image-size comfort margin (e.g. 45GB for the perception image) now surfaces as a non-blocking warning instead of hard-failing the deploy precheck.
- Minimized deploy-progress widgets (`agent-core/web/js/deploy-progress.js`) were each independently `position: fixed; bottom: 20px; right: 20px`, so deploying two drivers concurrently and minimizing both rendered one widget on top of the other. They now append into a shared `#deploy-progress-minimized-stack` flex container so multiple active deployments stack vertically instead of overlapping.

## Test plan
- [x] `python3 -m py_compile agent-core/src/api/preflight.py`
- [x] `node --check agent-core/web/js/deploy-progress.js`
- [ ] Manual: trigger a deploy on a host with <45GB but >1GB free — precheck should warn, not block
- [ ] Manual: deploy two drivers at once, minimize both — indicators should stack, not overlap

🤖 Generated with [Claude Code](https://claude.com/claude-code)