### PR TITLE
fix: preview channel should also show release/ga builds

### DIFF
--- a/agent-core/src/api/drivers.py
+++ b/agent-core/src/api/drivers.py
@@ -589,14 +589,14 @@ async def _run_in_executor(fn, *args):
 # Which tag channels each update channel may resolve to. Must stay in sync with
 # _CHANNEL_TAGS in web/js/deploy-panel.js — the version list the user picks from
 # is built with the frontend's copy, and if this one disagrees the manifest ends
-# up pointing at a tag the panel never offers. That divergence is invisible until
-# it isn't: on preview, the unfiltered tags[0] is usually a ga build, so the
-# update banner (which reads manifest.image) advertises a version the deploy
-# panel simultaneously reports as already-latest.
+# up pointing at a tag the panel never offers. Each channel includes its own
+# tags plus every more-stable channel's tags (preview -> +release -> +ga), so
+# switching to a less-stable channel never hides a build already visible on a
+# more-stable one.
 _CHANNEL_TAGS = {
     'ga':      ('ga',),
     'release': ('release', 'ga'),
-    'preview': ('preview',),
+    'preview': ('preview', 'release', 'ga'),
 }
 
 

--- a/agent-core/web/js/deploy-panel.js
+++ b/agent-core/web/js/deploy-panel.js
@@ -92,17 +92,17 @@ async function _onChannelChange(e) {
   } catch { /* ignore */ }
 }
 
-// Versions visible per channel. Release also shows ga (a stable fallback);
-// preview is deliberately NOT inclusive of release/ga — mixing in the far
-// more sparsely-published stable tags just buries the preview builds you're
-// there to see. Anything not in this map's active list is hidden, not merely
-// re-labelled — resource-center's own channel param already narrows what it
-// returns, this is the client's independent guarantee that the version list
-// never shows a build outside the selected channel.
+// Versions visible per channel, most-stable last: each channel shows its own
+// tags plus every more-stable channel's tags (preview -> +release -> +ga), so
+// picking a less-stable channel never hides a build you could already see on
+// a more-stable one. Anything not in this map's active list is hidden, not
+// merely re-labelled — resource-center's own channel param already narrows
+// what it returns, this is the client's independent guarantee that the
+// version list never shows a build outside the selected channel's reach.
 const _CHANNEL_TAGS = {
   ga:      ['ga'],
   release: ['release', 'ga'],
-  preview: ['preview'],
+  preview: ['preview', 'release', 'ga'],
 };
 
 function _channelTags(item) {


### PR DESCRIPTION
## Summary
`_CHANNEL_TAGS` in both `agent-core/web/js/deploy-panel.js` and `agent-core/src/api/drivers.py` scoped the `preview` update channel to preview-only tags — a deliberate choice per the original comments, to avoid burying sparse preview builds among more common stable ones. In practice this meant selecting `preview` in the deploy modal (and the topbar's manifest resolution) hid `release`/`ga` builds that were visible on the more-stable channels, which is backwards for a "this channel and anything more stable" picker.

`preview` now resolves to `('preview', 'release', 'ga')`, matching the existing pattern where `release` already includes `ga`. Frontend and backend copies are kept in sync per the existing comment contract.

## Test plan
- [x] `node --check agent-core/web/js/deploy-panel.js`
- [x] `python3 -m py_compile agent-core/src/api/drivers.py`
- [ ] Manual: open deploy modal, switch to preview channel — version list should include preview + release + ga builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)