### PR TITLE
Fix intermittent missing start-project modal and double-start race

### DIFF
--- a/agent-core/src/api/config.py
+++ b/agent-core/src/api/config.py
@@ -166,7 +166,34 @@ def order_cards_by_dependency(cards, connections):
     return ordered, remaining
 
 
+_start_project_lock = False
+
+
 async def _do_start_project():
+    """Serializes concurrent callers behind a flag.
+
+    The frontend's start button used to accept a second click while the first
+    start was still in flight (it only flips to "running" after the fetch
+    resolves), and api_start_project() had no guard either — two overlapping
+    calls each pushed their own project_start_begin/item/done sequence on
+    /ws/motus. Both browser-side listeners are registered with mcp_id=null
+    (they match every event, not just their own run's), so each one reacted to
+    *both* streams: extra modals, item updates applied against the wrong
+    modal's index, and whichever run errored first called offMotusEvent() on
+    both listeners, silently orphaning the other run's still-loading cards.
+    """
+    global _start_project_lock
+    if _start_project_lock:
+        print('[start-project] already in progress, ignoring concurrent call')
+        return None
+    _start_project_lock = True
+    try:
+        return await _do_start_project_impl()
+    finally:
+        _start_project_lock = False
+
+
+async def _do_start_project_impl():
     """启动所有 canvas cards — 前端按钮和 auto-start 共用此函数。
 
     Topic resolution strategy:
@@ -602,6 +629,11 @@ async def _do_stop_project():
 
 @router.post('/start-project')
 async def api_start_project():
+    if _start_project_lock:
+        return fastapi.responses.JSONResponse(
+            status_code=409,
+            content={'ok': False, 'detail': '启动已在进行中，请稍候'}
+        )
     success = await _do_start_project()
     if success is False:
         return fastapi.responses.JSONResponse(

--- a/agent-core/web/css/style.css
+++ b/agent-core/web/css/style.css
@@ -1061,6 +1061,13 @@ html, body {
   animation: btn-pulse 3s ease-in-out infinite;
 }
 
+.canvas-main-btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+  animation: none;
+  transform: none;
+}
+
 /* Error flash on start failure */
 @keyframes btn-error-shake {
   0%, 100% { transform: translateX(0); }

--- a/agent-core/web/js/canvas.js
+++ b/agent-core/web/js/canvas.js
@@ -471,7 +471,15 @@ function _setupControlButtons() {
   });
 
   document.getElementById('canvas-project-toggle')?.addEventListener('click', () => {
-    _projectRunning ? _stopProject() : _startProject();
+    if (_projectRunning) { _stopProject(); return; }
+    // _projectRunning only flips true once the start fetch resolves, so a
+    // second click during that async window used to fire a second concurrent
+    // /api/config/start-project — two overlapping event streams that stomped
+    // each other's modal state.
+    const btn = document.getElementById('canvas-project-toggle');
+    if (btn?.disabled) return;
+    if (btn) btn.disabled = true;
+    _startProject().finally(() => { if (btn) btn.disabled = false; });
   });
   _syncProjectBtn();
 
@@ -1605,7 +1613,17 @@ async function _startProject() {
   await _saveLayout();
 
   // Import motus for event subscription
-  const { onMotusEvent, offMotusEvent } = await import('./motus-stream.js');
+  const { onMotusEvent, offMotusEvent, whenMotusConnected } = await import('./motus-stream.js');
+
+  // project_start_begin is a fire-and-forget WS push with no server-side
+  // buffering — if this tab's /ws/motus socket is still reconnecting (page
+  // just loaded, brief network blip) the event that would open the modal is
+  // simply lost. Wait for it (briefly) so the listener below is actually
+  // live before the backend starts pushing.
+  const wsReady = await whenMotusConnected(8000);
+  if (!wsReady) {
+    _logActivity('warn', '启动进度推送连接未就绪，启动弹窗可能不会显示');
+  }
 
   // Subscribe to startup progress events
   let modal = null;

--- a/agent-core/web/js/motus-stream.js
+++ b/agent-core/web/js/motus-stream.js
@@ -20,6 +20,31 @@ export function onMotusEvent(mcpId, fn) {
   _listeners.push({ mcpId, fn });
 }
 
+// Resolves true once the socket is actually open, or false after `timeoutMs`.
+// push_event() on the backend is fire-and-forget to whatever clients are
+// registered *right now* — an event fired while this tab's socket is still
+// reconnecting (page just loaded, brief network blip, backend restart) is
+// gone forever, no buffering. Callers that are about to trigger a
+// server-pushed event they need to see (e.g. the start-project modal) should
+// await this first so they don't silently miss it.
+export function whenMotusConnected(timeoutMs = 8000) {
+  if (_lastStatus === 'connected') return Promise.resolve(true);
+  return new Promise((resolve) => {
+    const timer = setTimeout(() => {
+      _statusCbs = _statusCbs.filter((cb) => cb !== onStatus);
+      resolve(false);
+    }, timeoutMs);
+    function onStatus(state) {
+      if (state === 'connected') {
+        clearTimeout(timer);
+        _statusCbs = _statusCbs.filter((cb) => cb !== onStatus);
+        resolve(true);
+      }
+    }
+    _statusCbs.push(onStatus);
+  });
+}
+
 export function offMotusEvent(fn) {
   _listeners = _listeners.filter(l => l.fn !== fn);
 }


### PR DESCRIPTION
## Summary
- `project_start_begin/item/done` are fire-and-forget pushes on `/ws/motus` with no server-side buffering — a client whose socket is still reconnecting (fresh page load, brief network blip) silently misses the event that opens the startup modal, even though the start itself succeeds.
- The start button had no in-flight guard on either side, so a double click fired two concurrent `start-project` runs whose event streams stomped on each other's modal state (both browser listeners match every event via `mcp_id=null`).

## Changes
- `motus-stream.js`: add `whenMotusConnected()` so a caller can wait for the socket to actually be open before triggering a server-pushed event it needs to see.
- `canvas.js`: await it before POSTing `start-project`; disable the toggle button while a start is in flight instead of allowing a second concurrent call; added a `:disabled` style so the button visibly reflects it.
- `config.py`: guard `_do_start_project` with a lock (`_start_project_lock`) so concurrent callers (button + auto-start-on-boot) can't race; the route now returns 409 with a clear message if a start is already in progress.

## Test plan
- [x] `python3 -m ast` parse check on `config.py`
- [x] `node --check` on `canvas.js` / `motus-stream.js`
- [ ] Manual click-through on a live dashboard (including rapid double-click) not yet done — no device available in this session

🤖 Generated with [Claude Code](https://claude.com/claude-code)