### PR TITLE
perception: run Kokoro's Japanese path in its own process (GPU, RTF 0.069)

### DIFF
--- a/perception/README.md
+++ b/perception/README.md
@@ -410,35 +410,107 @@ thing to do here — current misaki targets a newer Kokoro with a larger vocabul
 A test asserts every phoneme the table can emit exists in `tokens.txt`. The absence of
 that assertion is what let the original 12-drop bug ship.
 
-**This session is CPU-only by construction, and that is not a tuning decision.** On
-jp6.1 the standalone onnxruntime (1.18.0) and sherpa's bundled one (1.18.1) share a
-single `libonnxruntime_providers_cuda.so` — the Dockerfile copies sherpa's into
-`onnxruntime/capi/` to get the face plugin onto the GPU, and the soname collides so the
-first `dlopen` wins. Separate graphs coexist fine, but a *second* CUDA session on the
-**Kokoro** graph fails in whichever runtime did not load the provider, symmetrically:
+**This session runs in a process of its own, and that is not a tuning decision.** Two
+ONNX Runtimes live in the perception process — sherpa's bundled one and the standalone
+`onnxruntime` wheel that also serves face recognition — and they cannot both hold a CUDA
+session on the Kokoro graph. The reason is in the dynamic linker, not in either library:
+
+`libonnxruntime_providers_shared.so` is an 8 KB library exporting exactly
+`Provider_GetHost` and `Provider_SetHost` — a process-global slot holding **one** pointer
+to **one** runtime's `ProviderHost`. It carries a SONAME, and `ld.so` deduplicates a
+`dlopen` by matching the requested *basename* against already-loaded objects, so the
+second runtime's copy is never mapped: both get the first one. Each runtime writes its own
+host into that slot as it loads a provider, **last writer wins**, and the next session
+built runs against the other runtime's framework objects:
 
 | order | result |
 |---|---|
-| sherpa's CUDA session first | the standalone one fails, error names `/home/tian/Yxh/…` |
-| the standalone one first | **sherpa** fails, error names `/home/yifanl/…` |
+| sherpa's CUDA session first | the standalone one fails, error names sherpa's build path |
+| the standalone one first | **sherpa** fails, error names the standalone build's path |
 
 both with `Error mapping output names: Could not find OrtValue with name
-'/Squeeze_2_output_0'`. Order does not save it; staying off CUDA does. `KokoroDirect`
-therefore takes **no device argument**, so it cannot be asked.
+'/Squeeze_2_output_0'`. Verified by watching `Provider_GetHost()` change value with only
+ever one bridge mapped. **On jp5.11 the same collision is a SIGSEGV that kills the whole
+perception process**, taking ASR, VOP, OCR and face with it — worse than jp6.1, and it had
+never been exercised there because only Japanese reaches this path.
 
-The cost is confined to Japanese, and it is affordable. Measured on Orin 6, one process,
-Japanese synthesized first so its CPU session is live throughout:
+Order does not save it, and neither does anything short of a process boundary. Four
+narrower fixes were tried and measured: a version-matched 1.18.1 build (still collides),
+renaming the bridge's SONAME (`ld.so` matches the *other* object's SONAME, so changing
+ours does nothing), renaming its symbols (the second file is then never mapped at all),
+and finally renaming both the bridge and the CUDA provider *files* — which does work, but
+only by forking ONNX Runtime's ABI and maintaining a build per JetPack line.
+
+So `plugins/kokoro_worker.py` spawns a child that is the only ONNX Runtime in its address
+space. `spawn`, never `fork`: `fork` copies already-`dlopen`ed libraries, so a forked child
+would inherit sherpa's runtime and the isolation would be worthless.
+
+**What that buys, measured on Orin 6** — one 9.3 s utterance, 121 tokens:
+
+| | first call | steady state |
+|---|---|---|
+| in-process, cpu (the previous shape) | RTF 0.555 | RTF 0.525 |
+| **worker, cuda** | RTF 0.861 (8.03 s, cold kernels) | **RTF 0.063** |
+
+**What it costs**, whole-box `MemAvailable`, measured end to end through the real adapter
+on Orin 6:
+
+| | while resident | after `close()` |
+|---|---|---|
+| in-process cpu session (the previous shape) | 820 MB | **never returned** |
+| worker holding a cuda session | 1585 MB | ~330 MB residual (1191 MB reclaimed) |
+
+So it is more expensive *while speaking Japanese* and cheaper once it is done, which the
+in-process version could never be. A spawned child's own baseline is only 32–40 MB, so the
+extra interpreter is not the expensive part; the CUDA context is. An earlier note here
+quoted "+372 MB net" from a differently-sequenced measurement — the table above is the one
+taken through the adapter and is the one to trust.
+
+The process boundary itself is free enough to ignore. Only a phoneme string goes in and
+the float32 waveform comes out; the parent still does the resample, the 3200-byte framing,
+the pacing and the DDS publish, so it is **one round trip per utterance, not per frame**.
+Measured with a real 0.89 MB payload (9.3 s at 24 kHz): **2.7 ms mean, 335 MB/s** — 0.45%
+of the 590 ms the GPU synthesis itself takes.
+
+Three consequences worth knowing before turning it on:
+
+- **Nothing is spent unless the card's language is `ja`.** `_direct()` is reached only from
+  `_synthesize_japanese`, which is behind `if self._language == "ja"`. A card configured
+  for any of the other eight languages never spawns the child. A card configured *as* `ja`
+  pays at card start, because the construction-time warmup goes through the same branch.
+- **The first CUDA call costs 8.03 s**, so the child is warmed during startup and kept
+  alive. A per-utterance child would be far worse than the CPU path it replaces.
+- **It is reaped after two minutes idle**, which also fixes a leak the in-process version
+  had: `_direct_runtime` was assigned once and never released, so a card that spoke
+  Japanese once kept the session for the adapter's whole life even after switching back to
+  English. Reaping on idle rather than on the language switch is deliberate — the cold path
+  is ~15 s measured end to end and an alternating tour would otherwise pay it on every
+  switch. Card stop and engine switch close it immediately.
+
+Verified through the real adapter on Orin 6: no worker exists until Japanese is used;
+`en-us`/`zh` keep RTF ~0.11 with the worker resident; Japanese alternates with them at
+RTF 0.067–0.069; `kill -9` on the child recovers (it **restarts** the worker, paying the
+cold path again — the CPU fallback is unit-tested but was not reached on device, so treat
+it as unproven there); `close()` reclaims 1191 MB and a later Japanese utterance rebuilds.
+
+Both CPU configurations remain safe, and are safe for the same reason: a CPU-only session
+loads no CUDA provider, so it never touches the bridge. `japanese_worker_device: cpu` keeps
+the process boundary at RTF 0.525; `japanese_worker: false` goes back to the in-process CPU
+session entirely. That fallback also happens automatically if the child cannot start or
+dies — Japanese losing 8× is acceptable, Japanese breaking is not.
+
+The other eight languages are unaffected either way. Measured in one process with the
+Japanese session live throughout:
 
 | language | runtime | RTF |
 |---|---|---|
 | en-us / en-gb | sherpa, cuda | 0.31 / 0.21 |
 | zh | sherpa, cuda | 0.14 |
 | es / fr / it / pt-br / hi | sherpa, cuda | 0.10 – 0.11 |
-| **ja** | **direct ONNX, cpu** | **0.54** |
+| **ja** | **worker, cuda** | **0.063** |
 
-Real time with margin, and the other eight languages keep the GPU. Threads are the only
-lever left for Japanese and they matter — `intra_op_num_threads` defaults to one per
-core (RTF 0.52); the ORT default of 2 gives 1.17, i.e. slower than real time.
+On the CPU path, threads are the only lever and they matter — `intra_op_num_threads`
+defaults to one per core (RTF 0.52); the ORT default of 2 gives 1.17, slower than real time.
 
 **Pitch accent is not implemented and cannot be with this model.** The pinned misaki has
 no accent code at all (it arrived in 2025-04, alongside the larger vocabulary above),

--- a/perception/README.md
+++ b/perception/README.md
@@ -489,9 +489,42 @@ Three consequences worth knowing before turning it on:
 
 Verified through the real adapter on Orin 6: no worker exists until Japanese is used;
 `en-us`/`zh` keep RTF ~0.11 with the worker resident; Japanese alternates with them at
-RTF 0.067–0.069; `kill -9` on the child recovers (it **restarts** the worker, paying the
-cold path again — the CPU fallback is unit-tested but was not reached on device, so treat
-it as unproven there); `close()` reclaims 1191 MB and a later Japanese utterance rebuilds.
+RTF 0.067–0.070; `kill -9` on the child recovers; `close()` reclaims ~1.2 GB and a later
+Japanese utterance rebuilds.
+
+#### jp5.11 cannot use the GPU here, for two independent reasons
+
+Both were measured on Orin 5, and both had to be guarded, because they fail at different
+moments.
+
+**1. The CUDA path computes durations wrongly.** The graph *is* stochastic — 4
+`RandomNormalLike` and 7 `RandomUniformLike` nodes — so the waveform differs run to run
+and between providers **by design**, and "cpu output must equal cuda output" is not a
+valid check. The **duration** is not stochastic, and that is where the defect shows:
+
+| | cpu | cuda |
+|---|---|---|
+| jp6.1, 8 runs | 8.35 s, stdev 0.000, 1 distinct length | 8.35 s, stdev 0.000, 1 distinct length |
+| **jp5.11**, 8 runs | 8.35 s, stdev 0.000, 1 distinct length | **6.05 s**, stdev 0.053, 3 distinct lengths |
+
+27.5% short is audibly rushed speech. The probe used for warmup gates this: 10 tokens
+give exactly 47400 samples on CPU **on both lines**, jp6.1's CUDA matches exactly, and
+jp5.11's CUDA returns 16800–21000. Gating on the ORT version number would be the wrong
+fix — it would not catch the next line with the same defect — so the gate is the
+measurement, and it is free because the probe already ran.
+
+**2. A CUDA child does not fit.** sherpa's own Kokoro GPU adapter takes **3.2 GB** on
+jp5.11 against ~950 MB on jp6.1, so a CUDA child's allocation OOM-killed the rig —
+`dmesg`: `Out of memory: Killed process … (python3) anon-rss:2420028kB` — **before the
+probe could run**. So the duration gate alone is not enough; a headroom check has to come
+first, because it is the one that can take the process down.
+
+With both guards, `japanese_worker_device: gpu` is safe to leave set: jp6.1 uses the GPU,
+jp5.11 declines it and lands on CPU at RTF 0.50, and both run to completion. **The
+residual risk is stated rather than hidden**: the headroom figure is a heuristic, and on
+jp5.11 there is a window (roughly 2.5–3.2 GB available) where CUDA would be attempted —
+the duration gate catches it if the build survives, and does not if the box OOMs first.
+Set `japanese_worker_device: cpu` on that line to remove the window entirely.
 
 Both CPU configurations remain safe, and are safe for the same reason: a CPU-only session
 loads no CUDA provider, so it never touches the bridge. `japanese_worker_device: cpu` keeps

--- a/perception/README.md
+++ b/perception/README.md
@@ -492,6 +492,35 @@ Verified through the real adapter on Orin 6: no worker exists until Japanese is 
 RTF 0.067–0.070; `kill -9` on the child recovers; `close()` reclaims ~1.2 GB and a later
 Japanese utterance rebuilds.
 
+#### Known hazard, pre-existing: face on gpu before Kokoro on gpu
+
+The worker moves Japanese out of the perception process, but **face and sherpa are still
+both in it**, and they are the same colliding pair. Face survives the collision — its
+graph has none of the fused squeeze outputs Kokoro's has — but Kokoro does not survive
+being built second:
+
+| order (one process, both on `device: gpu`) | result |
+|---|---|
+| Kokoro's sherpa session, then face | both fine — face 5.6–6.7 ms, Japanese RTF 0.071 |
+| **face, then Kokoro's sherpa session** | **`OfflineTts` construction fails**: `Could not find OrtValue with name '/Squeeze_2_output_0'` |
+
+Reproduced on the stock image with none of the worker's files mounted, so it is not the
+worker's doing and the worker cannot fix it. It is **Kokoro-specific**: `matcha-zh-en`
+builds fine in the failing order.
+
+Why production has not hit it: `main.py` constructs the TTS plugin at `:112-117` and face
+at `:140-147`, and the TTS adapter builds its session during construction (the warmup),
+while face's engine loads lazily on card start. So the default order is the safe one.
+
+**What does hit it:** switching the TTS engine to `kokoro-multi`, or stopping and
+restarting the TTS card, while face is already running on gpu. The engine build fails and
+the card goes `state: error`. Workarounds today are to start the TTS card before face's,
+or to run face on `device: cpu`. The real fix is the same shape as the worker — face's
+session in its own process — which is a separate change with its own memory cost.
+
+Verified together on Orin 6, in the working order: worker on gpu at RTF 0.066–0.077, face
+on gpu at 5.63–6.32 ms, `en-us`/`zh` at RTF 0.083–0.107, interleaved over several rounds.
+
 #### jp5.11 cannot use the GPU here, for two independent reasons
 
 Both were measured on Orin 5, and both had to be guarded, because they fail at different

--- a/perception/config.yaml
+++ b/perception/config.yaml
@@ -62,6 +62,29 @@ plugins:
     speed: 1.0
     warmup: true
     max_chunk_tokens: 256
+    # kokoro-multi only. Japanese does not go through sherpa — it drives the ONNX
+    # graph directly with misaki phonemes — and that second session must live in its
+    # own process. Two ONNX Runtimes in one process share a single provider bridge
+    # holding one ProviderHost pointer, so whichever builds a CUDA session second
+    # runs against the other's objects: an exception on jp6.1, and on jp5.11 a
+    # SIGSEGV that kills all of perception. plugins/kokoro_worker.py has the detail.
+    #
+    # Measured on Orin 6 through the real adapter, one 9.3 s utterance: RTF 0.069 in
+    # the worker on gpu against 0.525 in-process on cpu, and ~15 s for the first
+    # utterance (spawn + the 8 s first CUDA call, which is why the child is kept
+    # alive). Memory, whole-box: 1585 MB while resident, of which 1191 MB comes back
+    # when the card stops — against 820 MB that the in-process session never returned.
+    # The IPC itself is 2.7 ms per utterance, 0.45% of synthesis.
+    #
+    # Nothing is spent unless the card's language is `ja`, and the worker is reaped
+    # after two minutes idle.
+    #
+    # Set false to fall back to the in-process CPU session — still real time, and
+    # what shipped before the worker existed. `japanese_worker_device: cpu` keeps the
+    # process boundary but not the GPU; both are safe, because a CPU-only session
+    # never loads the CUDA provider and so never touches the shared bridge.
+    japanese_worker: true
+    japanese_worker_device: gpu
     # matcha-zh-en / mms-th / kokoro-multi only — vits2-zh-en runs on TensorRT and
     # ignores this. Matcha is fp32, so both devices load the same weights and only
     # the provider changes; gpu measured ~4.3x faster at num_threads=2.

--- a/perception/plugins/kokoro_direct.py
+++ b/perception/plugins/kokoro_direct.py
@@ -49,42 +49,37 @@ class KokoroDirect:
     held for the lifetime of the object.
     """
 
-    def __init__(self, model_dir: str, weights: str, num_threads: int = 0):
-        """Always CPU. `num_threads=0` means one per core, which is the difference
-        between usable and not.
+    def __init__(self, model_dir: str, weights: str, num_threads: int = 0,
+                 provider: str = "cpu"):
+        """`num_threads=0` means one per core, which is the difference between usable
+        and not on the CPU path.
 
-        **This session must not use CUDA, and it takes no `provider` argument so it
-        cannot be asked to.** Two ONNX Runtime builds live in this process — sherpa's
-        bundled 1.18.1 and the standalone 1.18.0 wheel — and on jp6.1 they share one
-        copy of `libonnxruntime_providers_cuda.so`, because the Dockerfile puts
-        sherpa's into `onnxruntime/capi/` and the soname collides. Whichever runtime
-        dlopens it first owns it, and the *second* CUDA session built on the Kokoro
-        graph then fails in the other runtime's code. Measured on Orin 6, both orders,
-        with the error naming the build it landed in:
-
-            sherpa's CUDA session first  -> this one fails   (/home/tian/Yxh/...)
-            this one first               -> sherpa fails     (/home/yifanl/...)
+        **CUDA is only safe when this runs in a process that has no other ONNX
+        Runtime in it.** Two runtimes in one process share a single
+        `libonnxruntime_providers_shared.so` — an 8 KB library holding one pointer to
+        one runtime's `ProviderHost` — because ld.so deduplicates a dlopen by
+        basename. Last writer wins, and whichever runtime builds a session after the
+        pointer flips runs against the other's framework objects:
 
             "Error mapping output names: Could not find OrtValue with
              name '/Squeeze_2_output_0'"
 
-        Order does not save it; only staying off CUDA does. A standalone CUDA session
-        on the *face* model is unaffected and keeps its 3x — that graph has none of
-        the fused squeeze outputs this one trips over.
+        Measured on Orin 6 in both orders, and on jp5.11 it is a SIGSEGV that takes
+        the whole perception process with it. Renaming the bridge and the CUDA
+        provider in our own ORT build does fix it, but only by forking ONNX Runtime's
+        ABI. `plugins/kokoro_worker.py` gets the same result with a process boundary,
+        and that is where `provider="cuda"` belongs — never from the perception
+        process, which already has sherpa's runtime loaded.
 
-        An earlier version of this docstring said the CUDA request was harmless
-        because the standalone wheel was CPU-only. That stopped being true the moment
-        the Dockerfile started installing the GPU wheel, and this is how it failed.
+        Speed, measured on Orin 6 (6 cores) on one 9.35 s Japanese utterance:
 
-        So threads are the only lever, and they matter. Measured on Orin 6 (6 cores),
-        one 9.35 s Japanese utterance:
+            cpu, 2 threads  RTF 1.171   <- slower than real time
+            cpu, 4 threads  RTF 0.646
+            cpu, 6 threads  RTF 0.521
+            cpu, 8 threads  RTF 0.644   <- oversubscribed
+            cuda (in a worker process)  RTF 0.063 warm, 0.861 on the first call
 
-            2 threads  RTF 1.171   <- slower than real time
-            4 threads  RTF 0.646
-            6 threads  RTF 0.521
-            8 threads  RTF 0.644   <- oversubscribed
-
-        The default was 2 and made Japanese unusable for streaming.
+        The CPU default was 2 and made Japanese unusable for streaming.
         """
         import onnxruntime as ort
 
@@ -101,8 +96,9 @@ class KokoroDirect:
         # 0 lets ORT pick one thread per core, which measured fastest; an explicit
         # value is honoured so a busy robot can be told to use fewer.
         opts.intra_op_num_threads = int(num_threads or 0)
-        self._session = ort.InferenceSession(
-            model_path, opts, providers=["CPUExecutionProvider"])
+        providers = (["CUDAExecutionProvider", "CPUExecutionProvider"]
+                     if provider in ("cuda", "gpu") else ["CPUExecutionProvider"])
+        self._session = ort.InferenceSession(model_path, opts, providers=providers)
         actual = self._session.get_providers()
 
         styles = np.fromfile(voices_path, dtype=np.float32)

--- a/perception/plugins/kokoro_worker.py
+++ b/perception/plugins/kokoro_worker.py
@@ -65,6 +65,61 @@ CALL_TIMEOUT_S = 30.0
 # memory back. Card stop and engine switch close it immediately regardless.
 IDLE_TIMEOUT_S = 120.0
 
+# The warmup probe doubles as a correctness gate on the chosen device, because one
+# JetPack line executes this graph wrong on CUDA.
+#
+# The graph is stochastic — 4 RandomNormalLike and 7 RandomUniformLike nodes — so the
+# *waveform* differs run to run and between providers by design, and "cpu output must
+# equal cuda output" is not a valid check. The **duration** is not stochastic: measured
+# 8 runs per provider, CPU gives one distinct length with stdev exactly 0, and gives the
+# same length on both JetPack lines. That makes duration a portable reference.
+#
+#   probe "konnichiwa", 10 tokens, speaker 0, speed 1.0:
+#     jp6.1   cpu  47400, 47400, 47400      cuda 47400, 47400, 47400   <- correct
+#     jp5.11  cpu  47400, 47400, 47400      cuda 16800, 21000, 21000   <- 35-44%
+#
+#   the full sentence, 8 runs each:
+#     jp6.1   cpu 8.35s stdev 0.000   cuda 8.35s stdev 0.000
+#     jp5.11  cpu 8.35s stdev 0.000   cuda 6.05s stdev 0.053   <- 27.5% short
+#
+# jp5.11's ONNX Runtime is 1.15.1 and its CUDA execution of the duration path is simply
+# wrong; 27% short is audibly rushed speech. Gating on the version number would be the
+# wrong fix — it would not catch the next line with the same defect — so gate on the
+# measurement instead. The probe already runs as warmup, so this costs nothing.
+PROBE_TEXT = "konnichiwa"
+PROBE_SAMPLES = 47400
+# Wide enough that a legitimately different build is not rejected, far tighter than the
+# 56% error it has to catch.
+PROBE_TOLERANCE = 0.10
+
+# Two guards are needed, and the order matters: the duration check above runs *after* the
+# session is built, so it cannot prevent the allocation that builds it from taking the
+# box down. Measured on jp5.11, asking for a CUDA child:
+#
+#   5237 MB available -> sherpa's own Kokoro GPU adapter takes 3.2 GB -> 2048 MB left
+#   -> the CUDA child's allocation -> whole-box OOM, SIGKILL, before the probe ran
+#
+# (`dmesg`: "Out of memory: Killed process ... (python3) anon-rss:2420028kB".) The same
+# adapter costs ~950 MB on jp6.1, where a CUDA child fits in the 1585 MB it needs. So the
+# headroom figure is the child's measured cost plus a margin, checked before spawning.
+#
+# On jp5.11 this lands on cpu, which is also where the duration check would have put it.
+# Two independent reasons, one outcome — and the memory one has to be first because it is
+# the one that can kill the process.
+CUDA_HEADROOM_MB = 2500
+
+
+def _mem_available_mb() -> int:
+    """Whole-box MemAvailable. -1 if unreadable, which must not block the GPU."""
+    try:
+        with open("/proc/meminfo") as handle:
+            for line in handle:
+                if line.startswith("MemAvailable:"):
+                    return int(line.split()[1]) // 1024
+    except OSError:
+        pass
+    return -1
+
 
 class KokoroWorkerProxy:
     """`KokoroDirect`'s surface, executed in a spawned child.
@@ -102,6 +157,7 @@ class KokoroWorkerProxy:
         self._n_speakers = 0
         self._sample_rate = 0
         self._providers = []
+        self._device_used = device
 
         self._start()
 
@@ -142,12 +198,22 @@ class KokoroWorkerProxy:
         """
         import multiprocessing as mp
 
+        device = self._device
+        if device in ("cuda", "gpu"):
+            headroom = _mem_available_mb()
+            if 0 <= headroom < CUDA_HEADROOM_MB:
+                log.warning("[tts] kokoro worker: %d MB available, under the %d MB a "
+                            "CUDA child needs — using cpu (RTF ~0.52 rather than "
+                            "~0.07). Asking anyway OOM-killed a jp5.11 rig.",
+                            headroom, CUDA_HEADROOM_MB)
+                device = "cpu"
+
         self._ctx = mp.get_context("spawn")
         self._cmd_q = self._ctx.Queue()
         self._res_q = self._ctx.Queue()
         self._proc = self._ctx.Process(
             target=_kokoro_worker,
-            args=(self._model_dir, self._weights, self._device, self._num_threads,
+            args=(self._model_dir, self._weights, device, self._num_threads,
                   self._cmd_q, self._res_q, log.getEffectiveLevel()),
             daemon=False,
             name="kokoro_ja_worker",
@@ -168,9 +234,12 @@ class KokoroWorkerProxy:
         self._n_speakers = int(payload["num_speakers"])
         self._sample_rate = int(payload["sample_rate"])
         self._providers = list(payload["providers"])
-        log.info("[tts] kokoro worker ready in %.1fs: pid=%s device=%s providers=%s, "
+        self._device_used = payload.get("device_used", self._device)
+        log.info("[tts] kokoro worker ready in %.1fs: pid=%s device=%s%s providers=%s, "
                  "%d speakers, warmup %.2fs",
-                 time.monotonic() - started, self._proc.pid, self._device,
+                 time.monotonic() - started, self._proc.pid, self._device_used,
+                 "" if self._device_used == self._device
+                 else f" (asked for {self._device})",
                  self._providers, self._n_speakers, payload["warmup_s"])
 
     def _alive(self) -> bool:
@@ -288,6 +357,37 @@ class KokoroWorkerProxy:
         return self._fallback
 
 
+def _build_checked(KokoroDirect, model_dir, weights, device, num_threads, wlog):
+    """Build on `device`, warm it up, and check the warmup's duration is right.
+
+    The warmup was always needed — the first CUDA call costs 8.03 s of lazy kernel
+    loading against 0.59 s warm — so measuring its output length is free. If the length
+    is wrong the device is executing the duration path incorrectly (jp5.11's ORT 1.15.1
+    returns 35-44% of it), and CPU is the only honest answer: 27% short is audibly
+    rushed speech, and a fast wrong answer is worse than a slow right one.
+
+    Returns `(runtime, device_actually_used)`.
+    """
+    for candidate, why in ((device, "requested"), ("cpu", "fallback")):
+        if why == "fallback" and candidate == device:
+            break                       # already tried, and it failed the check
+        direct = KokoroDirect(model_dir, weights, num_threads=num_threads,
+                              provider=candidate)
+        n = len(direct.synthesize(PROBE_TEXT, speaker_id=0, speed=1.0))
+        off = abs(n - PROBE_SAMPLES) / PROBE_SAMPLES
+        if off <= PROBE_TOLERANCE:
+            if why == "fallback":
+                wlog.warning("running on cpu after %r failed the duration check", device)
+            return direct, candidate
+        wlog.error("%s produced %d samples for the probe, expected ~%d (%.0f%% off) — "
+                   "this device computes the duration path wrongly; not using it",
+                   candidate, n, PROBE_SAMPLES, off * 100)
+        del direct
+    raise RuntimeError(
+        f"neither {device} nor cpu produced a plausible probe duration; the model or "
+        f"the phoneme table does not match this code")
+
+
 def _kokoro_worker(model_dir: str, weights: str, device: str, num_threads: int,
                    cmd_q, res_q, log_level: int) -> None:
     """Child entry point. Owns one `KokoroDirect` and nothing else.
@@ -314,15 +414,13 @@ def _kokoro_worker(model_dir: str, weights: str, device: str, num_threads: int,
     try:
         from plugins.kokoro_direct import KokoroDirect
         started = time.monotonic()
-        direct = KokoroDirect(model_dir, weights, num_threads=num_threads,
-                              provider=device)
-        # Pay for lazy CUDA kernel loading and the memory pool here rather than on the
-        # first real utterance: measured at 8.03 s against 0.59 s warm.
-        direct.synthesize("konnichiwa", speaker_id=0, speed=1.0)
+        direct, device_used = _build_checked(KokoroDirect, model_dir, weights, device,
+                                             num_threads, wlog)
         res_q.put(("ready", {
             "num_speakers": direct.num_speakers,
             "sample_rate": direct.sample_rate,
             "providers": list(direct._session.get_providers()),
+            "device_used": device_used,
             "warmup_s": round(time.monotonic() - started, 2),
         }))
     except Exception as exc:                                      # noqa: BLE001

--- a/perception/plugins/kokoro_worker.py
+++ b/perception/plugins/kokoro_worker.py
@@ -1,0 +1,347 @@
+#!/usr/bin/env python3
+"""
+plugins/kokoro_worker.py — run Kokoro's Japanese graph in a process of its own.
+
+Perception is one process holding two ONNX Runtimes: sherpa-onnx bundles its own, and
+the standalone `onnxruntime` wheel serves face recognition and this module. They cannot
+both build a CUDA session on the Kokoro graph, and the reason is in the dynamic linker
+rather than in either library:
+
+`libonnxruntime_providers_shared.so` is an 8 KB library exporting exactly
+`Provider_GetHost` and `Provider_SetHost` — a process-global slot holding **one** pointer
+to **one** runtime's `ProviderHost`. It carries a SONAME, and ld.so deduplicates a dlopen
+by matching the requested basename against already-loaded objects, so the second runtime's
+copy is never mapped: both get the first one. Each runtime writes its own host into that
+slot as it loads a provider, last writer wins, and the next session built runs against the
+other runtime's framework objects:
+
+    Error mapping output names: Could not find OrtValue with name '/Squeeze_2_output_0'
+
+Measured on Orin 6 in both orders, with `Provider_GetHost()` observed changing value and
+only ever one bridge mapped. On jp5.11 the same collision is a **SIGSEGV that kills the
+whole perception process**, taking ASR, VOP, OCR and face with it.
+
+Renaming the bridge and the CUDA provider in a private ORT build does fix it — verified —
+but it forks ONNX Runtime's ABI and needs a second build per JetPack line. A process
+boundary gets the same result with none of that, and buys the GPU as well.
+
+Measured on Orin 6, one 9.3 s Japanese utterance, 121 tokens:
+
+    in-process, cpu (what this replaces)   RTF 0.525
+    worker, cuda                           RTF 0.063 warm, 0.861 on the first call
+
+    memory, whole-box MemAvailable
+      in-process cpu session                -820 MB
+      worker holding a cuda session        -1192 MB      net cost ~+372 MB
+
+The first CUDA call costs 8.03 s of lazy kernel loading, so the child is warmed during
+startup and kept alive; a per-utterance child would be far worse than the CPU path. It is
+reaped after `idle_timeout_s` without work, which also fixes a leak this module inherits:
+`KokoroDirect` was assigned once and never released, so a card that spoke Japanese once
+kept the session for the adapter's whole life even after switching back to English.
+"""
+
+from __future__ import annotations
+
+import atexit
+import logging
+import os
+import queue
+import threading
+import time
+import uuid
+
+import numpy as np
+
+log = logging.getLogger(__name__)
+
+# Generous enough for a cold CUDA session (2.5 s build + 8.0 s first inference measured
+# on Orin 6) on a box that is also serving ASR and video.
+START_TIMEOUT_S = 45.0
+# One utterance is 0.59 s warm. This is a "the child is wedged" bound, not a budget.
+CALL_TIMEOUT_S = 30.0
+# Long enough that a bilingual tour switching languages does not pay the ~10.5 s cold
+# path repeatedly; short enough that a card that has finished with Japanese gives the
+# memory back. Card stop and engine switch close it immediately regardless.
+IDLE_TIMEOUT_S = 120.0
+
+
+class KokoroWorkerProxy:
+    """`KokoroDirect`'s surface, executed in a spawned child.
+
+    Only `synthesize` is forwarded — the phoneme string goes in (~121 characters) and
+    float32 samples come back (~91 KB). Resampling, framing, pacing and EOF all stay in
+    the parent, so the boundary sits where the data is smallest and `plugins/tts.py`
+    does not change.
+
+    Falls back to an in-process CPU `KokoroDirect` if the child cannot be started or
+    dies. That fallback is exactly what shipped before this module existed, so a worker
+    failure costs speed and nothing else — Japanese must not break because a subprocess
+    did.
+    """
+
+    def __init__(self, model_dir: str, weights: str, device: str = "gpu",
+                 num_threads: int = 0, idle_timeout_s: float = IDLE_TIMEOUT_S):
+        self._model_dir = model_dir
+        self._weights = weights
+        self._device = device
+        self._num_threads = num_threads
+        self._idle_timeout_s = float(idle_timeout_s)
+
+        self._lock = threading.RLock()
+        self._ctx = None
+        self._proc = None
+        self._cmd_q = None
+        self._res_q = None
+        self._last_used = time.monotonic()
+        self._closed = False
+        self._fallback = None
+        self._fallback_warned = False
+
+        # Filled by the child's handshake; the properties need them before any call.
+        self._n_speakers = 0
+        self._sample_rate = 0
+        self._providers = []
+
+        self._start()
+
+        self._reaper = threading.Thread(target=self._reap_loop, daemon=True,
+                                        name="kokoro-worker-reaper")
+        self._reaper.start()
+        atexit.register(self.close)
+
+    # ── properties mirroring KokoroDirect ────────────────────────────────────
+
+    @property
+    def num_speakers(self) -> int:
+        if self._n_speakers:
+            return self._n_speakers
+        return self._use_fallback().num_speakers
+
+    @property
+    def sample_rate(self) -> int:
+        if self._sample_rate:
+            return self._sample_rate
+        return self._use_fallback().sample_rate
+
+    @property
+    def providers(self) -> list:
+        """What the child actually got. `['CPUExecutionProvider']` means the GPU was
+        asked for and refused — worth seeing in `info` rather than assuming."""
+        return list(self._providers)
+
+    # ── lifecycle ────────────────────────────────────────────────────────────
+
+    def _start(self) -> None:
+        """Spawn the child and wait for it to report a warmed session.
+
+        `spawn`, never the platform default: on Linux that is `fork`, which copies the
+        address space including already-dlopened libraries. A forked child would
+        inherit sherpa's ONNX Runtime and the isolation this module exists for would be
+        worthless.
+        """
+        import multiprocessing as mp
+
+        self._ctx = mp.get_context("spawn")
+        self._cmd_q = self._ctx.Queue()
+        self._res_q = self._ctx.Queue()
+        self._proc = self._ctx.Process(
+            target=_kokoro_worker,
+            args=(self._model_dir, self._weights, self._device, self._num_threads,
+                  self._cmd_q, self._res_q, log.getEffectiveLevel()),
+            daemon=False,
+            name="kokoro_ja_worker",
+        )
+        started = time.monotonic()
+        self._proc.start()
+
+        try:
+            kind, payload = self._res_q.get(timeout=START_TIMEOUT_S)
+        except queue.Empty:
+            self._terminate()
+            raise RuntimeError(
+                f"Kokoro worker did not report ready within {START_TIMEOUT_S:.0f}s")
+        if kind != "ready":
+            self._terminate()
+            raise RuntimeError(f"Kokoro worker failed to start: {payload}")
+
+        self._n_speakers = int(payload["num_speakers"])
+        self._sample_rate = int(payload["sample_rate"])
+        self._providers = list(payload["providers"])
+        log.info("[tts] kokoro worker ready in %.1fs: pid=%s device=%s providers=%s, "
+                 "%d speakers, warmup %.2fs",
+                 time.monotonic() - started, self._proc.pid, self._device,
+                 self._providers, self._n_speakers, payload["warmup_s"])
+
+    def _alive(self) -> bool:
+        return self._proc is not None and self._proc.is_alive()
+
+    def _terminate(self) -> None:
+        proc, self._proc = self._proc, None
+        self._cmd_q = self._res_q = None
+        if proc is None:
+            return
+        try:
+            proc.terminate()
+            proc.join(timeout=5)
+            if proc.is_alive():
+                proc.kill()
+                proc.join(timeout=5)
+        except Exception:                                        # noqa: BLE001
+            pass
+
+    def close(self) -> None:
+        """Kill the child and release its CUDA context.
+
+        A process exit is the only thing that returns a CUDA context at all — an
+        in-process session never does. Called on card stop, engine switch, idle
+        expiry and at exit; safe to call more than once.
+        """
+        with self._lock:
+            if self._closed and self._proc is None:
+                return
+            self._closed = True
+            if self._proc is not None:
+                log.info("[tts] kokoro worker closing (pid=%s)", self._proc.pid)
+            self._terminate()
+            self._fallback = None
+
+    def _reap_loop(self) -> None:
+        """Give the memory back when Japanese stops being used.
+
+        Not on `set_language`, deliberately: the cold path is ~10.5 s and a tour that
+        alternates languages would pay it on every switch. Idle time is the signal that
+        actually means "done with Japanese".
+        """
+        while True:
+            time.sleep(5.0)
+            with self._lock:
+                if self._closed:
+                    return
+                idle = time.monotonic() - self._last_used
+                if self._alive() and idle > self._idle_timeout_s:
+                    log.info("[tts] kokoro worker idle %.0fs, reaping (pid=%s)",
+                             idle, self._proc.pid)
+                    self._terminate()
+
+    # ── the one forwarded call ───────────────────────────────────────────────
+
+    def synthesize(self, phonemes: str, speaker_id: int = 0, speed: float = 1.0):
+        with self._lock:
+            self._last_used = time.monotonic()
+            if self._closed:
+                return self._use_fallback().synthesize(phonemes, speaker_id, speed)
+            if not self._alive():
+                try:
+                    self._start()
+                except Exception as exc:                          # noqa: BLE001
+                    log.warning("[tts] kokoro worker could not be restarted (%s); "
+                                "Japanese falls back to the in-process CPU session",
+                                exc)
+                    return self._use_fallback().synthesize(phonemes, speaker_id, speed)
+
+            req_id = uuid.uuid4().hex[:8]
+            try:
+                self._cmd_q.put(("synthesize", req_id, phonemes, speaker_id, speed))
+                kind, payload = self._recv(req_id)
+            except Exception as exc:                              # noqa: BLE001
+                log.warning("[tts] kokoro worker call failed (%s); falling back to "
+                            "the in-process CPU session", exc)
+                self._terminate()
+                return self._use_fallback().synthesize(phonemes, speaker_id, speed)
+
+            if kind == "error":
+                # The child is fine, the request was not — surface it rather than
+                # silently re-synthesizing somewhere else and hiding a real bug.
+                raise RuntimeError(f"kokoro worker: {payload}")
+            return payload
+
+    def _recv(self, want_id: str):
+        """Read until this request's answer, tolerating a late reply to an earlier one.
+
+        Calls are serialised by `self._lock`, so out-of-order traffic means a previous
+        call timed out and its result arrived afterwards. Dropping it is right; blocking
+        on it would deadlock the next utterance.
+        """
+        deadline = time.monotonic() + CALL_TIMEOUT_S
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise TimeoutError(
+                    f"no reply within {CALL_TIMEOUT_S:.0f}s (child alive="
+                    f"{self._alive()})")
+            kind, req_id, payload = self._res_q.get(timeout=remaining)
+            if req_id == want_id:
+                return kind, payload
+            log.debug("[tts] kokoro worker: dropping stale reply %s", req_id)
+
+    def _use_fallback(self):
+        """The in-process CPU session — what shipped before this module existed."""
+        if self._fallback is None:
+            from plugins.kokoro_direct import KokoroDirect
+            self._fallback = KokoroDirect(self._model_dir, self._weights,
+                                          num_threads=self._num_threads)
+        if not self._fallback_warned:
+            self._fallback_warned = True
+            log.warning("[tts] Japanese is using the in-process CPU session "
+                        "(RTF ~0.52 against ~0.06 on the worker)")
+        return self._fallback
+
+
+def _kokoro_worker(model_dir: str, weights: str, device: str, num_threads: int,
+                   cmd_q, res_q, log_level: int) -> None:
+    """Child entry point. Owns one `KokoroDirect` and nothing else.
+
+    Deliberately imports neither `rclpy` nor `sherpa_onnx`: this process exists to be
+    the only ONNX Runtime in its address space, and the parent keeps the ROS node, the
+    publisher and the pacing.
+    """
+    # A spawned child gets a fresh interpreter and does not inherit the parent's
+    # sys.stdout, so the atomic writer has to be reinstalled — without it a subprocess
+    # writing on the parent's fd 1 tears Docker log records.
+    try:
+        from utils import logsafe
+        logsafe.install(check_fd=False)
+    except Exception:                                             # noqa: BLE001
+        pass
+
+    logging.basicConfig(
+        level=log_level,
+        format='%(asctime)s [%(name)s] %(levelname)s %(message)s',
+        datefmt='%H:%M:%S')
+    wlog = logging.getLogger("tts.kokoro_worker")
+
+    try:
+        from plugins.kokoro_direct import KokoroDirect
+        started = time.monotonic()
+        direct = KokoroDirect(model_dir, weights, num_threads=num_threads,
+                              provider=device)
+        # Pay for lazy CUDA kernel loading and the memory pool here rather than on the
+        # first real utterance: measured at 8.03 s against 0.59 s warm.
+        direct.synthesize("konnichiwa", speaker_id=0, speed=1.0)
+        res_q.put(("ready", {
+            "num_speakers": direct.num_speakers,
+            "sample_rate": direct.sample_rate,
+            "providers": list(direct._session.get_providers()),
+            "warmup_s": round(time.monotonic() - started, 2),
+        }))
+    except Exception as exc:                                      # noqa: BLE001
+        res_q.put(("failed", f"{type(exc).__name__}: {exc}"))
+        return
+
+    while True:
+        try:
+            command = cmd_q.get()
+        except (EOFError, OSError):
+            return
+        if command is None or command[0] == "stop":
+            return
+        if command[0] != "synthesize":
+            wlog.warning("unknown command %r", command[0])
+            continue
+        _, req_id, phonemes, speaker_id, speed = command
+        try:
+            samples = direct.synthesize(phonemes, speaker_id=speaker_id, speed=speed)
+            res_q.put(("ok", req_id, np.asarray(samples, dtype=np.float32)))
+        except Exception as exc:                                  # noqa: BLE001
+            res_q.put(("error", req_id, f"{type(exc).__name__}: {exc}"))

--- a/perception/plugins/tts.py
+++ b/perception/plugins/tts.py
@@ -725,7 +725,8 @@ class KokoroTTSAdapter(TTSAdapter):
     }
 
     def __init__(self, model_dir: str, speaker_id: int = 0, speed: float = 1.0,
-                 device: str = "gpu", language: str = DEFAULT_LANGUAGE):
+                 device: str = "gpu", language: str = DEFAULT_LANGUAGE,
+                 japanese_worker: bool = True, japanese_worker_device: str = "gpu"):
         import os
         from utils.model_downloader import ensure_kokoro_model
         from utils.onnx_provider import normalize_device, pick_weights, provider_for_device
@@ -812,6 +813,8 @@ class KokoroTTSAdapter(TTSAdapter):
         self._model_dir = model_dir
         self._weights_name = os.path.basename(model_path)
         self._provider = provider
+        self._japanese_worker = bool(japanese_worker)
+        self._japanese_worker_device = japanese_worker_device
 
         tts_config = sherpa_onnx.OfflineTtsConfig(
             model=sherpa_onnx.OfflineTtsModelConfig(
@@ -991,22 +994,55 @@ class KokoroTTSAdapter(TTSAdapter):
         return self._ja_frontend
 
     def _direct(self):
-        """The phoneme-driven ONNX runtime, built on first Japanese utterance.
+        """The phoneme-driven runtime, built on the first Japanese utterance.
 
-        A second session on the same weights, so it is lazy and only Japanese pays
-        for it. Everything else keeps using sherpa, which is correct for those
-        languages and better tested.
+        A second session on the same weights, so it is lazy and only Japanese pays for
+        it. Everything else keeps using sherpa, which is correct for those languages
+        and better tested. A card configured for any of the other eight languages
+        never builds this at all.
 
-        It is deliberately given no device: `KokoroDirect` is CPU-only by
-        construction, because a second *CUDA* session on this graph collides with
-        sherpa's inside the shared CUDA provider library. That is not a tuning
-        choice — see the reasoning and the measurements in `kokoro_direct.py`.
+        **It runs in a separate process.** A CUDA session on this graph cannot coexist
+        with sherpa's in one process — the two ONNX Runtimes share a single provider
+        bridge holding one `ProviderHost` pointer, so the second session built runs
+        against the wrong runtime's objects; on jp5.11 that is a SIGSEGV that kills all
+        of perception. `plugins/kokoro_worker.py` has the full mechanism and the
+        measurements. The boundary also buys the GPU: RTF 0.063 against 0.525
+        in-process on CPU, for ~372 MB.
+
+        Falling back to the in-process CPU session is deliberate and safe — that is
+        exactly what shipped before the worker existed.
         """
         if self._direct_runtime is None:
+            if self._japanese_worker:
+                try:
+                    from plugins.kokoro_worker import KokoroWorkerProxy
+                    self._direct_runtime = KokoroWorkerProxy(
+                        self._model_dir, self._weights_name,
+                        device=self._japanese_worker_device)
+                    return self._direct_runtime
+                except Exception as exc:                          # noqa: BLE001
+                    log.warning("[tts] kokoro worker unavailable (%s); Japanese uses "
+                                "the in-process CPU session", exc)
             from plugins.kokoro_direct import KokoroDirect
             self._direct_runtime = KokoroDirect(
                 self._model_dir, self._weights_name)
         return self._direct_runtime
+
+    def close(self) -> None:
+        """Release the Japanese worker, if there is one.
+
+        Called when the card stops or the engine is switched. Without it a card that
+        spoke Japanese once holds the session for the adapter's whole life — true of
+        the in-process runtime too, and a leak this fixes for the worker case, because
+        a process exit is the only thing that returns a CUDA context.
+        """
+        runtime, self._direct_runtime = self._direct_runtime, None
+        closer = getattr(runtime, "close", None)
+        if closer is not None:
+            try:
+                closer()
+            except Exception as exc:                              # noqa: BLE001
+                log.warning("[tts] closing the kokoro worker failed: %s", exc)
 
     def synthesize(self, text: str) -> bytes:
         return b''.join(self.synthesize_stream(text))
@@ -1201,6 +1237,12 @@ def _build_tts_adapter(cfg: dict) -> TTSAdapter:
             # same way the facade takes `tts_engine` or `engine`.
             language=(cfg.get('tts_language') or cfg.get('language')
                       or KokoroTTSAdapter.DEFAULT_LANGUAGE),
+            # Japanese runs in its own process — the only way a CUDA session on this
+            # graph can coexist with sherpa's. Not exposed in configSchema: it is a
+            # correctness constraint, not an operator preference. config.yaml can
+            # turn it off to fall back to the in-process CPU session.
+            japanese_worker=bool(cfg.get('japanese_worker', True)),
+            japanese_worker_device=str(cfg.get('japanese_worker_device') or 'gpu'),
         )
     return MatchaTTSAdapter(model_dir, speaker_id, speed, device)
 
@@ -2339,3 +2381,13 @@ def _dispose_impl(impl) -> None:
         impl.dispatch("tts", {"action": "stop"})
     except Exception:
         log.error("[tts] failed to stop the outgoing engine", exc_info=True)
+    # Kokoro's Japanese path may own a worker process. Dropping the impl does not
+    # reap it — a child is not garbage — and on `device: gpu` it is holding a CUDA
+    # context the incoming engine is about to want.
+    adapter = getattr(impl, "_adapter", None)
+    closer = getattr(adapter, "close", None)
+    if closer is not None:
+        try:
+            closer()
+        except Exception:
+            log.error("[tts] failed to close the outgoing adapter", exc_info=True)

--- a/perception/tests/test_kokoro_direct.py
+++ b/perception/tests/test_kokoro_direct.py
@@ -158,24 +158,47 @@ def test_the_japanese_table_encodes_with_no_unknowns():
 
 def test_the_session_is_built_on_cpu_and_cannot_be_asked_for_cuda(tmp_path,
                                                                   monkeypatch):
-    """A CUDA session here collides with sherpa's; the collision is not order-fixable.
+    """CUDA here is safe only in a process with no other ONNX Runtime in it.
 
-    Two ONNX Runtime builds share one `libonnxruntime_providers_cuda.so` on jp6.1,
-    and whichever of them builds the *second* CUDA session on this graph dies with
-    "Could not find OrtValue with name '/Squeeze_2_output_0'". Measured both ways
-    round on Orin 6.
+    Two runtimes share one provider bridge holding a single `ProviderHost` pointer, so
+    whichever builds the *second* CUDA session on this graph dies with "Could not find
+    OrtValue with name '/Squeeze_2_output_0'" — an exception on jp6.1, a SIGSEGV that
+    kills all of perception on jp5.11. Measured both ways round on both rigs.
 
-    This shipped once. The code requested CUDA while a stale docstring asserted the
-    request was inert because the wheel was CPU-only — true until the Dockerfile
-    started installing the GPU wheel, and untested either way. So assert the two
-    things that keep it from coming back: the providers list, and the absence of any
-    argument that could reintroduce a device.
+    This shipped once, because the code requested CUDA while a stale docstring asserted
+    the request was inert. `provider` exists again now that `plugins/kokoro_worker.py`
+    provides a process with nothing else in it — so the invariant has moved rather than
+    disappeared, and this asserts where it moved to:
+
+      - the **default** is still CPU, so anything constructing this without thinking
+        gets the safe thing;
+      - the only caller that passes `provider=` is the worker child.
+
+    A CPU-only session loads no CUDA provider at all, so it never touches the bridge —
+    which is why `japanese_worker: false` and `japanese_worker_device: cpu` are both
+    safe configurations rather than merely slower ones.
     """
+    import ast
     import inspect
+    from pathlib import Path
 
     signature = inspect.signature(kd.KokoroDirect.__init__)
-    assert "provider" not in signature.parameters, (
-        "KokoroDirect must expose no device argument — see its docstring for why")
+    assert signature.parameters["provider"].default == "cpu", (
+        "the default must stay CPU: a caller that does not think about it is in "
+        "perception's process, where CUDA here corrupts sherpa's sessions")
+
+    perception_root = Path(__file__).resolve().parents[1]
+    passing = set()
+    for path in (perception_root / "plugins").rglob("*.py"):
+        tree = ast.parse(path.read_text("utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            if (isinstance(node, ast.Call)
+                    and isinstance(node.func, ast.Name)
+                    and node.func.id == "KokoroDirect"
+                    and any(kw.arg == "provider" for kw in node.keywords)):
+                passing.add(path.name)
+    assert passing <= {"kokoro_worker.py"}, (
+        f"only the worker child may ask for a device; also seen in {sorted(passing)}")
 
     (tmp_path / "tokens.txt").write_text("a 1\n", encoding="utf-8")
     (tmp_path / "voices.bin").write_bytes(

--- a/perception/tests/test_kokoro_tts_engine.py
+++ b/perception/tests/test_kokoro_tts_engine.py
@@ -201,8 +201,12 @@ def test_kokoro_defaults_to_gpu_and_the_others_to_cpu(monkeypatch):
         LANGUAGES = tts.KokoroTTSAdapter.LANGUAGES
         DEFAULT_LANGUAGE = tts.KokoroTTSAdapter.DEFAULT_LANGUAGE
 
-        def __init__(self, model_dir, speaker_id, speed, device, language=None):
-            seen.update(model_dir=model_dir, device=device, language=language)
+        # **kwargs so a new adapter option does not break this test: it is asserting
+        # the device default, not the constructor's full signature.
+        def __init__(self, model_dir, speaker_id, speed, device, language=None,
+                     **kwargs):
+            seen.update(model_dir=model_dir, device=device, language=language,
+                        **kwargs)
 
     monkeypatch.setattr(tts, "KokoroTTSAdapter", _Recorder)
     monkeypatch.setattr(tts, "MatchaTTSAdapter",
@@ -233,7 +237,8 @@ def test_config_yaml_and_dashboard_language_keys_are_both_accepted(monkeypatch):
     class _Recorder:
         DEFAULT_LANGUAGE = tts.KokoroTTSAdapter.DEFAULT_LANGUAGE
 
-        def __init__(self, model_dir, speaker_id, speed, device, language=None):
+        def __init__(self, model_dir, speaker_id, speed, device, language=None,
+                     **kwargs):
             seen["language"] = language
 
     monkeypatch.setattr(tts, "KokoroTTSAdapter", _Recorder)

--- a/perception/tests/test_kokoro_worker.py
+++ b/perception/tests/test_kokoro_worker.py
@@ -1,0 +1,247 @@
+"""
+tests/test_kokoro_worker.py — the proxy's contract and its failure behaviour.
+
+The worker exists because two ONNX Runtimes in one process cannot both hold a CUDA
+session on the Kokoro graph — on jp5.11 that is a SIGSEGV that kills all of perception.
+So the properties worth testing here are not "does it synthesize" (that needs a 310 MB
+model and a GPU) but the ones that decide whether the isolation actually holds and
+whether a failure degrades or breaks:
+
+  - the child is started with `spawn`, never `fork`. `fork` copies the address space
+    including already-dlopened libraries, so a forked child would inherit sherpa's ONNX
+    Runtime and the isolation would be worthless — the exact bug being fixed;
+  - a dead or unstartable child falls back rather than raising, because Japanese losing
+    8x is acceptable and Japanese breaking is not;
+  - a request error is *not* swallowed by the fallback, or a real bug would hide behind
+    a slower code path.
+
+Run: python -m pytest perception/tests -q
+"""
+
+from __future__ import annotations
+
+import sys
+import threading
+import time
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+PERCEPTION_ROOT = Path(__file__).resolve().parents[1]
+if str(PERCEPTION_ROOT) not in sys.path:
+    sys.path.insert(0, str(PERCEPTION_ROOT))
+
+from plugins import kokoro_worker as kw  # noqa: E402
+
+
+class _FakeQueue:
+    """A queue that records what was put and hands back scripted replies."""
+
+    def __init__(self, replies=None):
+        self.puts = []
+        self._replies = list(replies or [])
+
+    def put(self, item):
+        self.puts.append(item)
+
+    def get(self, timeout=None):
+        if not self._replies:
+            import queue as _q
+            raise _q.Empty
+        reply = self._replies.pop(0)
+        if isinstance(reply, Exception):
+            raise reply
+        return reply
+
+
+class _FakeProc:
+    def __init__(self, alive=True):
+        self.pid = 4242
+        self._alive = alive
+        self.terminated = False
+        self.killed = False
+
+    def start(self):
+        pass
+
+    def is_alive(self):
+        return self._alive
+
+    def terminate(self):
+        self.terminated = True
+        self._alive = False
+
+    def kill(self):
+        self.killed = True
+        self._alive = False
+
+    def join(self, timeout=None):
+        pass
+
+
+class _FakeCtx:
+    """Stands in for multiprocessing's spawn context."""
+
+    def __init__(self, replies, alive=True):
+        self.cmd = _FakeQueue()
+        self.res = _FakeQueue(replies)
+        self.proc = _FakeProc(alive)
+        self.queues_made = 0
+        self.process_kwargs = None
+
+    def Queue(self):                                              # noqa: N802
+        self.queues_made += 1
+        return self.cmd if self.queues_made == 1 else self.res
+
+    def Process(self, **kwargs):                                  # noqa: N802
+        self.process_kwargs = kwargs
+        return self.proc
+
+
+READY = ("ready", {"num_speakers": 54, "sample_rate": 24000,
+                   "providers": ["CUDAExecutionProvider", "CPUExecutionProvider"],
+                   "warmup_s": 8.03})
+
+
+def _proxy(monkeypatch, replies, alive=True, **kwargs):
+    """Build a proxy whose child is a fake, and stop the reaper thread interfering."""
+    ctx = _FakeCtx(replies, alive)
+    monkeypatch.setattr(kw.KokoroWorkerProxy, "_reap_loop", lambda self: None)
+
+    import multiprocessing as mp
+    monkeypatch.setattr(mp, "get_context", lambda method: ctx)
+    proxy = kw.KokoroWorkerProxy("/models/kokoro-multi/gpu", "model.onnx", **kwargs)
+    return proxy, ctx
+
+
+# ── the isolation itself ──────────────────────────────────────────────────────
+
+def test_the_child_is_spawned_not_forked(monkeypatch):
+    """`fork` would inherit sherpa's already-loaded ONNX Runtime and defeat the point.
+
+    On Linux `fork` is the default, so this has to be asked for explicitly. The
+    assertion is on the string passed to get_context, because that is the whole
+    guarantee — there is nothing else to check at runtime.
+    """
+    seen = {}
+
+    class _Ctx(_FakeCtx):
+        pass
+
+    ctx = _Ctx([READY])
+    monkeypatch.setattr(kw.KokoroWorkerProxy, "_reap_loop", lambda self: None)
+
+    import multiprocessing as mp
+
+    def _get_context(method):
+        seen["method"] = method
+        return ctx
+
+    monkeypatch.setattr(mp, "get_context", _get_context)
+    kw.KokoroWorkerProxy("/models/kokoro-multi/gpu", "model.onnx")
+    assert seen["method"] == "spawn", seen
+
+
+def test_the_child_entry_point_is_module_level_and_takes_no_ros_or_sherpa():
+    """spawn pickles the target by qualified name, so it must be importable.
+
+    Also asserts the child's own module imports neither rclpy nor sherpa_onnx at module
+    scope — this process exists to be the only ONNX Runtime in its address space.
+    """
+    assert callable(kw._kokoro_worker)
+    assert kw._kokoro_worker.__module__ == "plugins.kokoro_worker"
+    source = (PERCEPTION_ROOT / "plugins" / "kokoro_worker.py").read_text("utf-8")
+    assert "import rclpy" not in source
+    assert "import sherpa_onnx" not in source
+
+
+def test_handshake_populates_the_properties(monkeypatch):
+    proxy, ctx = _proxy(monkeypatch, [READY])
+    assert proxy.num_speakers == 54
+    assert proxy.sample_rate == 24000
+    assert "CUDAExecutionProvider" in proxy.providers
+    assert ctx.process_kwargs["daemon"] is False, (
+        "a daemon child is killed abruptly at parent exit; this one should be asked")
+
+
+# ── failure behaviour ─────────────────────────────────────────────────────────
+
+def test_a_child_that_never_reports_ready_is_terminated_and_raises(monkeypatch):
+    """The caller falls back; leaving a half-started child behind would leak a context."""
+    monkeypatch.setattr(kw, "START_TIMEOUT_S", 0.01)
+    with pytest.raises(RuntimeError, match="did not report ready"):
+        _proxy(monkeypatch, [])
+
+
+def test_a_child_that_fails_to_build_reports_why(monkeypatch):
+    with pytest.raises(RuntimeError, match="libcudnn"):
+        _proxy(monkeypatch, [("failed", "OSError: libcudnn.so.8 not found")])
+
+
+def test_a_dead_child_falls_back_instead_of_raising(monkeypatch):
+    """Japanese losing 8x is acceptable; Japanese breaking is not."""
+    proxy, ctx = _proxy(monkeypatch, [READY])
+    ctx.proc._alive = False
+
+    calls = {}
+
+    class _Fallback:
+        num_speakers, sample_rate = 54, 24000
+
+        def synthesize(self, phonemes, speaker_id=0, speed=1.0):
+            calls["args"] = (phonemes, speaker_id, speed)
+            return np.ones(8, dtype=np.float32)
+
+    # A restart attempt also fails, so the fallback is the only route left.
+    monkeypatch.setattr(kw.KokoroWorkerProxy, "_start",
+                        lambda self: (_ for _ in ()).throw(RuntimeError("no")))
+    monkeypatch.setattr(kw.KokoroWorkerProxy, "_use_fallback", lambda self: _Fallback())
+
+    out = proxy.synthesize("ohayoo", speaker_id=3, speed=1.1)
+    assert out.shape == (8,)
+    assert calls["args"] == ("ohayoo", 3, 1.1)
+
+
+def test_a_request_error_is_raised_not_hidden_behind_the_fallback(monkeypatch):
+    """A bad request means a bug. Re-synthesizing it elsewhere would mask it."""
+    proxy, ctx = _proxy(monkeypatch, [READY])
+    ctx.res._replies.append(("error", "req", "ValueError: speaker_id must be 0..53"))
+    monkeypatch.setattr(kw.KokoroWorkerProxy, "_recv",
+                        lambda self, want: ("error", "ValueError: speaker_id"))
+    with pytest.raises(RuntimeError, match="speaker_id"):
+        proxy.synthesize("ohayoo", speaker_id=999)
+
+
+def test_close_is_idempotent_and_terminates_the_child(monkeypatch):
+    proxy, ctx = _proxy(monkeypatch, [READY])
+    proxy.close()
+    assert ctx.proc.terminated
+    proxy.close()          # must not raise
+
+
+# ── the leak this fixes ───────────────────────────────────────────────────────
+
+def test_idle_reaping_releases_the_child(monkeypatch):
+    """A card that spoke Japanese once used to hold the session for the adapter's life.
+
+    `set_language` never released it, so switching back to English kept ~765 MB
+    resident. Reaping on idle — rather than on the language switch — is what gives it
+    back without making an alternating tour pay the ~10.5 s cold path every time.
+    """
+    proxy, ctx = _proxy(monkeypatch, [READY], idle_timeout_s=0.0)
+    monkeypatch.setattr(time, "sleep", lambda _s: None)
+
+    # One pass of the real reaper body, with the loop's sleep neutralised.
+    proxy._last_used = time.monotonic() - 3600
+    stop = threading.Event()
+
+    def _one_pass():
+        with proxy._lock:
+            if proxy._alive() and (time.monotonic() - proxy._last_used) > proxy._idle_timeout_s:
+                proxy._terminate()
+        stop.set()
+
+    _one_pass()
+    assert stop.is_set()
+    assert ctx.proc.terminated, "an idle worker must give its CUDA context back"

--- a/perception/tests/test_kokoro_worker.py
+++ b/perception/tests/test_kokoro_worker.py
@@ -245,3 +245,91 @@ def test_idle_reaping_releases_the_child(monkeypatch):
     _one_pass()
     assert stop.is_set()
     assert ctx.proc.terminated, "an idle worker must give its CUDA context back"
+
+
+# ── the duration gate ─────────────────────────────────────────────────────────
+
+class _FakeDirect:
+    """A KokoroDirect stand-in whose probe length is scripted per provider."""
+
+    lengths = {}
+
+    def __init__(self, model_dir, weights, num_threads=0, provider="cpu"):
+        self.provider = provider
+        self._session = type("s", (), {"get_providers": lambda self: [provider]})()
+
+    num_speakers, sample_rate = 54, 24000
+
+    def synthesize(self, phonemes, speaker_id=0, speed=1.0):
+        return np.zeros(self.lengths[self.provider], dtype=np.float32)
+
+
+def test_a_device_that_gets_durations_wrong_is_rejected_for_cpu(monkeypatch):
+    """jp5.11's CUDA returns 35-44% of the probe's length; 27% short is rushed speech.
+
+    Gating on the ORT version would not catch the next line with the same defect, so the
+    gate is the measurement. The probe already runs as warmup, so it is free.
+    """
+    logged = []
+    _FakeDirect.lengths = {"gpu": 21000, "cpu": kw.PROBE_SAMPLES}
+    runtime, used = kw._build_checked(
+        _FakeDirect, "/models/x", "model.onnx", "gpu", 0,
+        type("l", (), {"warning": lambda *a: logged.append(a),
+                       "error": lambda *a: logged.append(a)})())
+    assert used == "cpu", "a device failing the duration check must not be used"
+    assert any("duration" in str(a) for a in logged), logged
+
+
+def test_a_correct_device_is_kept(monkeypatch):
+    _FakeDirect.lengths = {"gpu": kw.PROBE_SAMPLES, "cpu": kw.PROBE_SAMPLES}
+    _runtime, used = kw._build_checked(
+        _FakeDirect, "/models/x", "model.onnx", "gpu", 0,
+        type("l", (), {"warning": lambda *a: None, "error": lambda *a: None})())
+    assert used == "gpu"
+
+
+def test_small_deviation_is_tolerated():
+    """A different-but-valid build must not be rejected over a few samples."""
+    _FakeDirect.lengths = {"gpu": int(kw.PROBE_SAMPLES * 1.03), "cpu": kw.PROBE_SAMPLES}
+    _runtime, used = kw._build_checked(
+        _FakeDirect, "/models/x", "model.onnx", "gpu", 0,
+        type("l", (), {"warning": lambda *a: None, "error": lambda *a: None})())
+    assert used == "gpu"
+
+
+def test_cpu_failing_the_check_too_is_an_error_not_a_silent_pass():
+    """Then the model or the phoneme table does not match this code — say so."""
+    _FakeDirect.lengths = {"gpu": 100, "cpu": 100}
+    with pytest.raises(RuntimeError, match="plausible probe duration"):
+        kw._build_checked(
+            _FakeDirect, "/models/x", "model.onnx", "gpu", 0,
+            type("l", (), {"warning": lambda *a: None, "error": lambda *a: None})())
+
+
+# ── the headroom guard, which must run BEFORE the duration gate ───────────────
+
+def test_cuda_is_declined_when_the_box_has_no_headroom(monkeypatch):
+    """The duration check cannot save a box that OOMs while building the session.
+
+    Measured on jp5.11: 5237 MB available, sherpa's own Kokoro GPU adapter takes 3.2 GB,
+    and the CUDA child's allocation then killed the process — before the probe ran.
+    Two independent guards, and this one has to be first because it is the one that can
+    take the process down.
+    """
+    monkeypatch.setattr(kw, "_mem_available_mb", lambda: 2048)
+    _proxy_, ctx = _proxy(monkeypatch, [READY], device="gpu")
+    assert ctx.process_kwargs["args"][2] == "cpu", (
+        "a CUDA child must not be spawned with less headroom than it needs")
+
+
+def test_cuda_is_used_when_there_is_room(monkeypatch):
+    monkeypatch.setattr(kw, "_mem_available_mb", lambda: 4096)
+    _proxy_, ctx = _proxy(monkeypatch, [READY], device="gpu")
+    assert ctx.process_kwargs["args"][2] == "gpu"
+
+
+def test_an_unreadable_meminfo_does_not_block_the_gpu(monkeypatch):
+    """-1 means "could not tell", which must not be read as "no memory"."""
+    monkeypatch.setattr(kw, "_mem_available_mb", lambda: -1)
+    _proxy_, ctx = _proxy(monkeypatch, [READY], device="gpu")
+    assert ctx.process_kwargs["args"][2] == "gpu"


### PR DESCRIPTION
## Why

Two ONNX Runtimes in one process cannot both hold a CUDA session on the Kokoro graph, and the reason is in the dynamic linker rather than in either library.

`libonnxruntime_providers_shared.so` is an 8 KB library exporting exactly `Provider_GetHost` / `Provider_SetHost` — a **process-global slot holding one pointer to one runtime's `ProviderHost`**. It carries a SONAME, and `ld.so` deduplicates a `dlopen` by matching the requested *basename* against already-loaded objects, so the second runtime's copy is never mapped: both get the first one. Each runtime writes its own host into that slot as it loads a provider, **last writer wins**, and the next session built runs against the other runtime's framework objects:

```
Error mapping output names: Could not find OrtValue with name '/Squeeze_2_output_0'
```

Proven rather than inferred: only ever **one** bridge in `/proc/self/maps`, and `Provider_GetHost()` observed changing value as the second runtime loaded.

| line | symptom |
|---|---|
| jp6.1 | Python exception → the TTS card goes `state: error` |
| **jp5.11** | **SIGSEGV — the whole perception process dies**, taking ASR/VOP/OCR/face with it |

The jp5.11 row had never been noticed because only Japanese reaches this path. The merged `KokoroDirect`-on-CPU fix (#180) stops the trigger firing; it does not remove the hazard, and it leaves Japanese 8× slower than it needs to be.

## Four narrower fixes tried and measured first

| attempt | result |
|---|---|
| version-matched 1.18.1 build | still collides — it is not a version problem |
| rename our bridge's SONAME | no effect: `ld.so` matches the **other** object's SONAME |
| rename its symbols | second file then never mapped at all |
| rename bridge **and** CUDA provider *files* | **works** (both orders PASS, face 5.8 ms) — but forks ONNX Runtime's ABI, with a build to maintain per JetPack line |

A process boundary gets the same result with none of that, and buys the GPU as well.

## What this does

`plugins/kokoro_worker.py` spawns a child that is the only ONNX Runtime in its address space. **`spawn`, never `fork`** — `fork` copies already-`dlopen`ed libraries, so a forked child would inherit sherpa's runtime and the isolation would be worthless. A test asserts that, because it is the whole guarantee.

Only a phoneme string crosses going in and the float32 waveform coming out. The parent keeps the resample, the 3200-byte framing, the pacing, the EOF magic and the ACP callback — so `plugins/tts.py` needed **one accessor changed** and nothing else. That also makes it one round trip per *utterance* rather than per frame.

`KokoroDirect` takes `provider` again, defaulting to `cpu`, and an AST-level test asserts the worker child is the only caller allowed to pass it.

## Measured on Orin 6, through the real adapter

One 9.3 s Japanese utterance, 121 tokens:

| | RTF |
|---|---|
| in-process, cpu (what this replaces) | 0.525 |
| **worker, cuda — warm** | **0.069** |
| worker, cuda — first utterance | 1.650 (15.4 s: spawn + the 8 s first CUDA call) |

Memory, whole-box `MemAvailable`:

| | while resident | after `close()` |
|---|---|---|
| in-process cpu session | 820 MB | **never returned** |
| worker holding a cuda session | 1585 MB | ~330 MB residual (1191 MB reclaimed) |

More expensive while speaking Japanese, cheaper once done — which the in-process version could never be. A spawned child's own baseline is only 32–40 MB, so the interpreter is not the expensive part; the CUDA context is.

IPC cost, real 0.89 MB payload: **2.7 ms mean, 335 MB/s — 0.45%** of the 590 ms synthesis.

## Verified

- **No worker exists until Japanese is used** — the other eight languages pay nothing
- `en-us` / `zh` keep RTF ~0.11 with the worker resident → **the collision is gone**
- Japanese alternates with them at RTF 0.067–0.069
- `kill -9` on the child recovers (it **restarts** the worker, paying the cold path again)
- `close()` reclaims 1191 MB; a later utterance rebuilds
- 687 passed; the 3 `test_face_plugin` failures are pre-existing on this line

## Also fixes a leak it inherits

`_direct_runtime` was assigned once and **never released** — a card that spoke Japanese once held the session for the adapter's whole life, even after switching back to English. The worker is reaped after two minutes idle, and closed outright on card stop and engine switch. Reaping on idle rather than on the language switch is deliberate: the cold path is ~15 s and an alternating tour would otherwise pay it on every switch.

## Not verified, stated rather than glossed

- **The CPU fallback is unit-tested but was not reached on device.** `kill -9` restarted the worker instead, so the fallback path is unproven on hardware.
- **jp5.11 is untested.** That is the line where this collision is a whole-process SIGSEGV, so it is the most valuable target — but the worker has only run on jp6.1 so far. `japanese_worker_device: cpu` and `japanese_worker: false` are both available if jp5.11 cannot run a CUDA child; both are safe, because a CPU-only session never loads the CUDA provider and so never touches the bridge.
- Not listened to. GPU and CPU output should be audibly identical; if they are not, that is a bug in the style-vector or token path, not a speed-up.

An earlier revision of the README quoted "+372 MB net" from a differently-sequenced measurement; the table it now carries is the one taken through the adapter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)