### PR TITLE
perception: one process for every standalone-ORT session; face and Japanese share it

### DIFF
--- a/perception/README.md
+++ b/perception/README.md
@@ -577,6 +577,25 @@ jp5.11 against ~950 MB on jp6.1, so a CUDA child's allocation OOM-killed the rig
 probe could run**. So the duration gate alone is not enough; a headroom check has to come
 first, because it is the one that can take the process down.
 
+**No silent substitution.** An earlier revision quietly used the CPU when the GPU was
+unavailable, and that produced the worst state available: a card configured for `gpu`,
+running at RTF 0.52 instead of 0.07, with the reason in a log line nobody reads. It
+took a measurement to explain why Japanese "felt slow". The card now goes
+`state: error` and the message names **which** of the two problems it hit, because they
+have different fixes:
+
+| | what it means | what to do |
+|---|---|---|
+| *not enough memory …* | the GPU is fine, the box is full | free memory, or set `japanese_worker_device: cpu` |
+| *… computes the duration path wrongly* | the GPU works and gets the wrong answer | set `japanese_worker_device: cpu`; freeing memory will not help |
+
+The second verdict is **recorded on the machine**, keyed by the ONNX Runtime version,
+because the attempt is not free: one rejected CUDA session took Orin 5's MemAvailable
+from 5754 MB to 1935 MB and **kept it** — unloading does not return it. A crash restarts
+perception, so an in-memory verdict would be lost and the next start would pay again.
+That is how face's later GPU load tipped that box into the OOM killer. Delete
+`.cuda-duration-verdict` in the model directory to force a re-evaluation.
+
 The headroom figure depends on **who else is in the child**, because the first CUDA
 session there pays for the context and the rest do not:
 
@@ -592,8 +611,26 @@ the GPU in the same child** on jp6.1 — Japanese at RTF 0.089 while face recogn
 29.7–37.8 ms. An earlier version of this section said a 7.4 GB box could not fit both;
 that was true of two CUDA *contexts* and not of two sessions.
 
-jp5.11 still lands on CPU, and correctly: 785 MB free is under even the shared figure,
-and its CUDA gets the durations wrong anyway. Two independent reasons, one outcome.
+jp5.11 needs `japanese_worker_device: cpu` set explicitly, and the error says so if it
+is not. Two independent reasons, either one disqualifying:
+
+- its ONNX Runtime is **1.15.1** and executes this graph's duration path incorrectly —
+  8 runs gave 6.05 s against the CPU's 8.35 s, and the 10-token probe returned
+  16800–24000 samples against 47400. **This is not about memory**: with an empty box and
+  the guard disabled the session builds, does not crash, and still comes out 27–51%
+  short;
+- and separately, the box rarely has room.
+
+Worth being precise about what was *not* broken, because "GPU works on jp5.11" is also
+true: sherpa's own engines and face both run on the GPU there and always have.
+`KokoroDirect` — the standalone session this code builds — is the only thing affected,
+it exists only for Japanese, and it was pinned to the CPU from the day it was written,
+so this path had never been exercised on that line until now.
+
+The fix, if anyone wants it, is a newer ONNX Runtime for jp5.11 — the same work as the
+1.18.1 build for jp6.1, against CUDA 11.4 and cp38. Not guaranteed: recent versions drop
+cp38. The encouraging sign is that sherpa bundles **1.16.0** on that line, so something
+newer than 1.15.1 does build there.
 **The residual risk is stated rather than hidden**: the thresholds are heuristics, and
 there is a window where CUDA would be attempted on jp5.11 — the duration gate catches it
 if the build survives, and does not if the box OOMs first. `japanese_worker_device: cpu`

--- a/perception/README.md
+++ b/perception/README.md
@@ -492,36 +492,65 @@ Verified through the real adapter on Orin 6: no worker exists until Japanese is 
 RTF 0.067–0.070; `kill -9` on the child recovers; `close()` reclaims ~1.2 GB and a later
 Japanese utterance rebuilds.
 
-#### Known hazard, pre-existing: face on gpu before Kokoro on gpu
+#### Fixed: every standalone-ORT session lives in one child process
 
-The worker moves Japanese out of the perception process, but **face and sherpa are still
-both in it**, and they are the same colliding pair. Face survives the collision — its
-graph has none of the fused squeeze outputs Kokoro's has — but Kokoro does not survive
-being built second:
+The hazard this section used to describe — face on gpu before Kokoro on gpu, which
+could not build the TTS engine at all — is gone, and so is the whole class it belonged
+to. `plugins/ort_worker.py` spawns **one** child that owns every standalone-ONNX-Runtime
+session, so the perception process holds only sherpa's runtime and the two can no longer
+reach each other.
 
-| order (one process, both on `device: gpu`) | result |
-|---|---|
-| Kokoro's sherpa session, then face | both fine — face 5.6–6.7 ms, Japanese RTF 0.071 |
-| **face, then Kokoro's sherpa session** | **`OfflineTts` construction fails**: `Could not find OrtValue with name '/Squeeze_2_output_0'` |
+Not one process per card: one per **runtime**, which is the boundary the bug has. CUDA
+contexts therefore do not increase — the parent used to hold sherpa's *and* the
+standalone one's; now it holds sherpa's and the child holds the standalone one.
 
-Reproduced on the stock image with none of the worker's files mounted, so it is not the
-worker's doing and the worker cannot fix it. It is **Kokoro-specific**: `matcha-zh-en`
-builds fine in the failing order.
+`spawn`, never `fork`. `fork` copies the address space including already-`dlopen`ed
+libraries, so a forked child would inherit sherpa's runtime and the isolation would be
+worthless. A test asserts it, because that one word is the entire guarantee.
 
-Why production has not hit it: `main.py` constructs the TTS plugin at `:112-117` and face
-at `:140-147`, and the TTS adapter builds its session during construction (the warmup),
-while face's engine loads lazily on card start. So the default order is the safe one.
+**Where the boundary is, and why not further in.** The first attempt split at
+`InferenceSession.run` and left decoding, letterboxing, alignment and the quality gate
+in the parent. It worked and it was the wrong cut:
 
-**What does hit it:** switching the TTS engine to `kokoro-multi`, or stopping and
-restarting the TTS card, while face is already running on gpu. The engine build fails and
-the card goes `state: error`. Workarounds today are to start the TTS card before face's,
-or to run face on `device: cpu`. The real fix is the same shape as the worker — face's
-session in its own process — which is a separate change with its own memory cost.
+| | in-process | split at `run()` | **whole pipeline in the child** |
+|---|---|---|---|
+| a frame, jp6.1 | ~46 ms | ~78 ms | **48.1 ms** |
+| a frame, jp5.11 | — | — | **26.4 ms** |
 
-Verified together on Orin 6, in the working order: worker on gpu at RTF 0.066–0.077, face
-on gpu at 5.63–6.32 ms, `en-us`/`zh` at RTF 0.083–0.107, interleaved over several rounds.
+because the parent was sending a 2.93 MiB normalised blob and getting **0.96 MiB of
+pre-threshold candidates** back — SCRFD returns 16 800 of them and a frame keeps nought
+to eight — then a 147 kB crop per face for a 2 kB embedding. What the parent actually
+holds is the `CompressedImage` JPEG, ~232 kB, and what it wants is a few boxes and a
+512-float vector each. So the frame crosses **once, compressed**, and
+`plugins/face_service.py` runs decode → detect → decode-head → align → sharpness →
+**the quality gate** → embed inside the child. The gate has to come along: it sits
+between alignment and embedding and decides which faces are worth embedding at all.
 
-#### jp5.11 cannot use the GPU here, for two independent reasons
+What stays in the parent: the FaceDB (`matrix @ embedding` on a 2 kB vector, its lock,
+its files), subject selection, the payload, ROS publishing, the enrolment window. None
+of it touches ONNX.
+
+`FaceAnalyzer` now **refuses to be constructed outside the child** rather than
+documenting that it should not be. A test also walks the plugin tree for
+`ort.InferenceSession` calls and fails on any outside the three files allowed to have
+one, because a new caller adding one would reintroduce a SIGSEGV silently.
+
+**Verified on both lines**, in the order that fails on main: face's sessions up first,
+then sherpa's Kokoro engine builds; Japanese and face share one child and interleave;
+dropping one service leaves the other running.
+
+**Two things that are not settled**, recorded rather than smoothed over:
+
+- **A dropped session does not return memory to the OS.** Measured: unloading Kokoro
+  from the child moved `MemAvailable` by **+0 MB**. The CUDA pool is returned on process
+  exit, not on session destruction, so unloading frees space *inside* the child for
+  reuse and stops the headroom guard mis-reading the box — it does not give memory back.
+  An earlier version of this section claimed it did.
+- **The face path has only been exercised on frames with no faces in them.** The
+  embedding, the aligned-crop return and the registration paths have unit coverage and
+  no on-device run.
+
+#### jp5.11 runs Japanese on the CPU, for two independent reasons
 
 Both were measured on Orin 5, and both had to be guarded, because they fail at different
 moments.
@@ -548,12 +577,27 @@ jp5.11 against ~950 MB on jp6.1, so a CUDA child's allocation OOM-killed the rig
 probe could run**. So the duration gate alone is not enough; a headroom check has to come
 first, because it is the one that can take the process down.
 
-With both guards, `japanese_worker_device: gpu` is safe to leave set: jp6.1 uses the GPU,
-jp5.11 declines it and lands on CPU at RTF 0.50, and both run to completion. **The
-residual risk is stated rather than hidden**: the headroom figure is a heuristic, and on
-jp5.11 there is a window (roughly 2.5–3.2 GB available) where CUDA would be attempted —
-the duration gate catches it if the build survives, and does not if the box OOMs first.
-Set `japanese_worker_device: cpu` on that line to remove the window entirely.
+The headroom figure depends on **who else is in the child**, because the first CUDA
+session there pays for the context and the rest do not:
+
+| | measured | threshold |
+|---|---|---|
+| Kokoro alone, bringing its own context | 1585 MB | 2500 MB |
+| Kokoro beside the face service | **967 MB** | 1400 MB |
+
+A single conservative number refused the second case on the first case's evidence: with
+2158 MB free on an otherwise idle jp6.1 box, a 967 MB allocation was declined. With the
+guard asking `ort_worker.has_cuda_session()` first, face and Japanese now **both run on
+the GPU in the same child** on jp6.1 — Japanese at RTF 0.089 while face recognises at
+29.7–37.8 ms. An earlier version of this section said a 7.4 GB box could not fit both;
+that was true of two CUDA *contexts* and not of two sessions.
+
+jp5.11 still lands on CPU, and correctly: 785 MB free is under even the shared figure,
+and its CUDA gets the durations wrong anyway. Two independent reasons, one outcome.
+**The residual risk is stated rather than hidden**: the thresholds are heuristics, and
+there is a window where CUDA would be attempted on jp5.11 — the duration gate catches it
+if the build survives, and does not if the box OOMs first. `japanese_worker_device: cpu`
+removes the window on that line.
 
 Both CPU configurations remain safe, and are safe for the same reason: a CPU-only session
 loads no CUDA provider, so it never touches the bridge. `japanese_worker_device: cpu` keeps

--- a/perception/README.md
+++ b/perception/README.md
@@ -614,23 +614,17 @@ that was true of two CUDA *contexts* and not of two sessions.
 jp5.11 needs `japanese_worker_device: cpu` set explicitly, and the error says so if it
 is not. Two independent reasons, either one disqualifying:
 
-- its ONNX Runtime is **1.15.1** and executes this graph's duration path incorrectly —
-  8 runs gave 6.05 s against the CPU's 8.35 s, and the 10-token probe returned
-  16800–24000 samples against 47400. **This is not about memory**: with an empty box and
-  the guard disabled the session builds, does not crash, and still comes out 27–51%
-  short;
+- **its CUDA renders this graph wrongly** — confirmed by ear, and the cause is not
+  known. Ruled out: the two-runtime collision, the model file, TF32, the ONNX Runtime
+  version, and the CUDA provider binary. The full record, so nobody repeats those five
+  experiments, is **[docs/jp511-cuda-kokoro.md](docs/jp511-cuda-kokoro.md)**;
 - and separately, the box rarely has room.
 
 Worth being precise about what was *not* broken, because "GPU works on jp5.11" is also
 true: sherpa's own engines and face both run on the GPU there and always have.
-`KokoroDirect` — the standalone session this code builds — is the only thing affected,
-it exists only for Japanese, and it was pinned to the CPU from the day it was written,
-so this path had never been exercised on that line until now.
-
-The fix, if anyone wants it, is a newer ONNX Runtime for jp5.11 — the same work as the
-1.18.1 build for jp6.1, against CUDA 11.4 and cp38. Not guaranteed: recent versions drop
-cp38. The encouraging sign is that sherpa bundles **1.16.0** on that line, so something
-newer than 1.15.1 does build there.
+`KokoroDirect` is the only thing affected, it exists only for Japanese, and it was
+pinned to the CPU from the day it was written, so this path had never been exercised on
+that line until now.
 **The residual risk is stated rather than hidden**: the thresholds are heuristics, and
 there is a window where CUDA would be attempted on jp5.11 — the duration gate catches it
 if the build survives, and does not if the box OOMs first. `japanese_worker_device: cpu`

--- a/perception/docs/jp511-cuda-kokoro.md
+++ b/perception/docs/jp511-cuda-kokoro.md
@@ -1,0 +1,100 @@
+# jp5.11's CUDA renders Kokoro's Japanese wrongly
+
+**Status:** unresolved. The guard in `plugins/kokoro_worker.py` detects it and refuses
+the device; this document records what it is *not*, so the next person does not repeat
+five experiments to find out.
+
+## The symptom
+
+On jp5.11 (Orin 5, L4T R35.6.5), `KokoroDirect` — the standalone ONNX Runtime session
+this code builds for Japanese — produces audio whose duration does not agree with its
+own CPU rendering of the same input, and which is **garbled when listened to**.
+
+Same code, same model, on jp6.1 (Orin 6, L4T R36.4.3) the CUDA output matches the CPU
+exactly, down to the same RMS.
+
+    10-token probe "konnichiwa", expected 47400 samples
+
+    jp6.1   cpu   47400, 47400, 47400, 47400
+            cuda  47400, 47400, 47400, 47400      <- correct
+    jp5.11  cpu   47400, 47400, 47400, 47400
+            cuda  17400, 21000, 21600, 20400      <- 54-63% off, and different each run
+
+Whole sentences, native 24 kHz, no resampling or framing in the way:
+
+| | jp5.11 cpu | jp5.11 cuda | jp6.1 cpu | jp6.1 cuda |
+|---|---|---|---|---|
+| long sentence | 8.35 s | **6.47 s** (22% short) | 8.35 s | 8.35 s |
+| short sentence | 2.45 s | **3.77 s** (54% long) | 2.45 s | 2.45 s |
+
+**The direction is not consistent** — the long sentence comes back short and the short
+one long, and three renders of one input gave 1.4 s, 1.9 s and 2.95 s. So it is not a
+scaling error, and "the audio is rushed" (an early description of mine, inferred from
+the long sentence alone) was wrong.
+
+Confirmed by ear: jp6.1's CUDA output is fine, jp5.11's is garbled.
+
+## What it is not
+
+Each ruled out by measurement. Re-running these is not necessary unless something in the
+stack changes.
+
+| ruled out | how |
+|---|---|
+| the two-runtime collision (see `plugins/ort_worker.py`) | reproduced in a process with exactly one ONNX Runtime mapped in `/proc/self/maps` and `sherpa_onnx` never imported |
+| a different model file | `model.onnx`, `voices.bin` and `tokens.txt` hash identically on both boxes (`b40f62b1…`, `1c5a5b98…`, `6ebb6bb2…`) |
+| TF32 on Ampere | `NVIDIA_TF32_OVERRIDE=0` changes nothing — 63/56/53/56% off either way |
+| the ONNX Runtime **version** | NVIDIA's official 1.16.0 wheel for JetPack 5 behaves exactly like the 1.15.1 that ships |
+| the CUDA **provider binary** | the Dockerfile treats the lines differently — jp6.1 overwrites the wheel's provider with sherpa's, jp5.11 keeps the wheel's. Substituting sherpa's on jp5.11, with versions matched at 1.16.0, gives the same wrong lengths |
+
+That last row is worth spelling out, because the asymmetry in `Dockerfile.jetson` makes
+it a reasonable suspect: jp6.1's working CUDA provider is **sherpa's build**, not the
+COS wheel's, so "1.15.1 versus 1.18.x" was never the only difference between the lines.
+It is still not the cause.
+
+Note the ABI floor found on the way: sherpa's 1.16.0 provider next to a **1.15.1**
+pybind dies with `Illegal instruction (core dumped)`. The version-matched substitution
+(1.16.0 pybind + 1.16.0 provider) runs fine and is what the table above reports.
+
+## What is left
+
+The platform stack itself, which cannot be swapped inside a container:
+
+    jp5.11   L4T R35.6.5   CUDA 11.4   cuDNN 8
+    jp6.1    L4T R36.4.3   CUDA 12.6   cuDNN 9
+
+The next step, if anyone takes it, is comparing an intermediate tensor between the two
+providers to find the first op that diverges — the graph has a second output
+(`onnx::Shape_3411`, int64, from a Squeeze) that looks like the predicted length and
+would localise it quickly.
+
+## What is *not* broken on jp5.11
+
+"GPU works on jp5.11" is also true, and this document is not evidence against it:
+
+- **sherpa-onnx's own engines** run on the GPU there and always have — ASR, and every
+  TTS language except Japanese;
+- **face recognition** runs on the GPU there, measured at 27.1 ms per frame.
+
+`KokoroDirect` is the only thing affected. It exists only for Japanese, and it was
+pinned to the CPU from the day it was written, so this path had never been exercised on
+that line until the shared-worker branch opened it.
+
+## Why the guard is a measurement and not a version check
+
+`plugins/kokoro_worker.py` renders a fixed probe on the chosen device at startup — the
+warmup it had to run anyway — and refuses the device if the duration is more than 10%
+off. It records the verdict in `.cuda-duration-verdict` next to the model so the
+question is answered once per machine rather than once per process start: a rejected
+CUDA session leaves memory behind that unloading does not return, measured at 3.8 GB on
+Orin 5, and paying that on every restart is what tipped that box into the OOM killer.
+
+A version check would have been wrong **twice** over the course of this investigation:
+
+- written against 1.15.1, it would have let the official 1.16.0 through — which produces
+  the same garbled audio;
+- written against "the wheel's own provider", it would have let sherpa's through — same
+  again.
+
+The failure is real and its cause is unknown, which is exactly the situation where
+testing the behaviour beats naming a suspect.

--- a/perception/plugins/face.py
+++ b/perception/plugins/face.py
@@ -65,7 +65,10 @@ from plugins.face_db import (
     FaceDB,
     is_unknown_id,
 )
+from plugins.face_proxy import FaceServiceProxy
 from plugins.face_runtime import (
+    DEFAULT_FACE_MODEL,
+    FACE_MODELS,
     DEFAULT_BLUR_MIN,
     DEFAULT_MAX_IMAGE_PIXELS,
     DEFAULT_MAX_IMAGE_SIDE,
@@ -237,13 +240,19 @@ TOOLS = [
             },
         },
         # Deliberately minimal, as in plugins/ocr.py: only what an operator
-        # meaningfully decides. Expert knobs (model_dir, db_dir, device,
+        # meaningfully decides. `model` is advertised even though there is one entry
+        # today: the enum is generated from FACE_MODELS, so a second entry appears on
+        # the card without touching this file, and an operator who sees the field knows
+        # the choice exists. `model_dir` stays hidden — it points at a local copy of
+        # whatever `model` selected, which is a deployment detail.
+        # Expert knobs (model_dir, db_dir, device,
         # det_size, det_thresh, nms_thresh, num_threads, enroll_window_s,
         # max_batch, image_roots, ...) stay config.yaml-only — dispatch still
         # honours them, they are just not advertised to the config UI.
         "configSchema": {
             "type": "object",
             "properties": {
+                "model":             {"type": "string", "enum": sorted(FACE_MODELS), "default": DEFAULT_FACE_MODEL, "description": "识别模型。切换模型会重新加载并使已存样本失效——不同网络的 embedding 不可比较，已注册人员需重新录入"},
                 "device":            {"type": "string", "enum": ["auto", "cpu", "gpu"], "default": "auto", "description": "推理设备。auto=有 GPU 用 GPU，没有则用 CPU"},
                 "detect_fps":        {"type": "number", "minimum": 0, "default": DEFAULT_DETECT_FPS, "description": "检测频率，每秒 x 次，支持小数（如 0.5 = 每 2 秒一次）；0=每帧都检测", "scope": "instance"},
                 "match_threshold":   {"type": "number", "minimum": 0.0, "maximum": 1.0, "default": DEFAULT_MATCH_THRESHOLD, "description": "余弦相似度阈值，越高越严格（越不容易认错人，但越容易认不出）"},
@@ -303,6 +312,7 @@ def _analyzer_options(cfg: dict) -> dict:
         det_size = DEFAULT_DET_SIZE
     return {
         "model_dir": str(cfg.get("model_dir", DEFAULT_FACE_MODEL_DIR)),
+        "model": str(cfg.get("model", DEFAULT_FACE_MODEL)),
         "device": str(cfg.get("device", "cpu")),
         "det_size": det_size,
         "det_thresh": float(cfg.get("det_thresh", DEFAULT_DET_THRESH)),
@@ -386,7 +396,25 @@ class _FaceEngine:
 
 
 def _build_engine(cfg: dict) -> _FaceEngine:
-    analyzer = FaceAnalyzer(**_analyzer_options(cfg))
+    """The analyzer runs in the ORT worker child; the database stays here.
+
+    A `FaceAnalyzer` in this process would create a standalone ONNX Runtime session
+    next to sherpa-onnx's, and the two corrupt each other — an exception on jp6.1, a
+    SIGSEGV that kills all of perception on jp5.11, and with face's session built first
+    the Kokoro TTS engine cannot be constructed at all. `FaceAnalyzer` now refuses to
+    be built outside the child, so this is not a convention to remember.
+
+    The database is the opposite: `matrix @ embedding` on a 2 kB vector, mutated from
+    MCP threads as well as this worker, and it owns files on disk. It has nothing to do
+    with ONNX and stays where its lock is.
+    """
+    decode = _decode_options(cfg)
+    analyzer = FaceServiceProxy(
+        **_analyzer_options(cfg),
+        # _decode_options names these for decode_image's own signature; the service
+        # holds them for the life of the child instead of taking them per call.
+        max_image_side=decode["max_side"], max_image_pixels=decode["max_pixels"],
+    )
     db = FaceDB(**_db_options(cfg))
     return _FaceEngine(analyzer, db)
 
@@ -1003,22 +1031,25 @@ class _FaceNode(Node):
             analyzer = self._engine.analyzer
             database = self._engine.db
             gates = _gates(self._cfg)
-            image = analyzer.decode_image(
-                image_bytes, **_decode_options(self._cfg)
+            # One round trip, carrying the JPEG as received. Decoding, detection,
+            # alignment, the quality gate and embedding all happen in the ORT worker
+            # child — see plugins/face_service.py for why the boundary is there and
+            # not at the session.
+            shape, faces = analyzer.recognise(
+                image_bytes,
+                max_faces=gates["max_faces"],
+                det_thresh=gates["det_thresh"],
+                min_face_px=gates["min_face_px"],
+                blur_min=gates["blur_min"],
             )
-            if image is None:
+            if shape is None:
                 payload["error"] = "undecodable frame"
                 return payload
-            shape = image.shape[:2]
-            faces = analyzer.detect(image, max_faces=gates["max_faces"])
             entries = []
             for face in faces:
-                analyzer.prepare(image, face)
-                usable = (
-                    face.det_score >= gates["det_thresh"]
-                    and face.min_side >= gates["min_face_px"]
-                    and face.blur >= gates["blur_min"]
-                )
+                # The gate ran in the child; an unusable face is exactly one it did not
+                # think was worth embedding.
+                usable = face.embedding is not None
                 entry = {
                     "bbox": face.bbox_xywh(),
                     "det_score": round(face.det_score, 4),
@@ -1041,7 +1072,7 @@ class _FaceNode(Node):
                     entries.append(entry)
                     continue
 
-                embedding = analyzer.embed(face.aligned)
+                embedding = face.embedding
                 person_id, score = database.match(
                     embedding, gates["match_threshold"]
                 )
@@ -1611,10 +1642,20 @@ class FaceRecognitionPlugin:
         self, engine: _FaceEngine, image_bytes: bytes, gates: dict
     ) -> tuple[np.ndarray | None, dict | None]:
         """One image → the subject's embedding, or the failure record."""
-        image = engine.analyzer.decode_image(
-            image_bytes, **_decode_options(self._plugin_cfg)
+        # embed_all here, unlike the recognition path: `select_subject` picks the
+        # subject *after* seeing every candidate's geometry, so the embedding has to
+        # exist for whichever one it chooses — including a marginal face that the
+        # per-frame gate would have skipped. Registration is a deliberate act with a
+        # human waiting, so paying for a few extra embeddings is the right trade.
+        shape, faces = engine.analyzer.recognise(
+            image_bytes,
+            max_faces=gates["max_faces"],
+            det_thresh=gates["det_thresh"],
+            min_face_px=gates["min_face_px"],
+            blur_min=gates["blur_min"],
+            embed_all=True,
         )
-        if image is None:
+        if shape is None:
             return None, {
                 "ok": False, "reason": REASON_BAD_INPUT,
                 "detail": (
@@ -1623,14 +1664,10 @@ class FaceRecognitionPlugin:
                     "max_image_pixels"
                 ),
             }
-        shape = image.shape[:2]
-        faces = engine.analyzer.detect(image, max_faces=gates["max_faces"])
-        for face in faces:
-            engine.analyzer.prepare(image, face)
         subject, failure = select_subject(faces, shape, gates)
         if subject is None:
             return None, failure
-        return engine.analyzer.embed(subject.aligned), None
+        return subject.embedding, None
 
     def _commit_enrolment(
         self,
@@ -1962,10 +1999,14 @@ class FaceRecognitionPlugin:
         because *enrolment* must resolve to exactly one person, whereas a query
         can simply report everyone it sees.
         """
-        image = engine.analyzer.decode_image(
-            image_bytes, **_decode_options(self._plugin_cfg)
+        shape, faces = engine.analyzer.recognise(
+            image_bytes,
+            max_faces=gates["max_faces"],
+            det_thresh=gates["det_thresh"],
+            min_face_px=gates["min_face_px"],
+            blur_min=gates["blur_min"],
         )
-        if image is None:
+        if shape is None:
             return {
                 "ok": False, "reason": REASON_BAD_INPUT,
                 "detail": (
@@ -1974,28 +2015,23 @@ class FaceRecognitionPlugin:
                     "max_image_pixels"
                 ),
             }
-        faces = engine.analyzer.detect(image, max_faces=gates["max_faces"])
         results = []
         for face in faces:
-            engine.analyzer.prepare(image, face)
             entry = {
                 "bbox": face.bbox_xywh(),
                 "det_score": round(face.det_score, 4),
                 "blur": round(face.blur, 2),
                 "min_side_px": int(face.min_side),
             }
-            if not (
-                face.det_score >= gates["det_thresh"]
-                and face.min_side >= gates["min_face_px"]
-                and face.blur >= gates["blur_min"]
-            ):
+            # The gate ran in the child; no embedding means it was not worth one.
+            if face.embedding is None:
                 entry.update({
                     "person_id": None, "name": "", "known": False,
                     "quality": "low", "reason": REASON_LOW_QUALITY,
                 })
                 results.append(entry)
                 continue
-            embedding = engine.analyzer.embed(face.aligned)
+            embedding = face.embedding
             person_id, score = engine.db.match(
                 embedding, gates["match_threshold"]
             )

--- a/perception/plugins/face.py
+++ b/perception/plugins/face.py
@@ -252,7 +252,12 @@ TOOLS = [
         "configSchema": {
             "type": "object",
             "properties": {
-                "model":             {"type": "string", "enum": sorted(FACE_MODELS), "default": DEFAULT_FACE_MODEL, "description": "识别模型。切换模型会重新加载并使已存样本失效——不同网络的 embedding 不可比较，已注册人员需重新录入"},
+                # The description enumerates what each value actually is: `buffalo_sc`
+                # is InsightFace's *pack* name, not a network name, and an operator
+                # reading the card has no way to know it means SCRFD-500M + ArcFace
+                # MobileFaceNet. Generated from the registry so a second entry
+                # documents itself.
+                "model":             {"type": "string", "enum": sorted(FACE_MODELS), "default": DEFAULT_FACE_MODEL, "description": "识别模型：" + "；".join(f"{name} = {spec['description']}" for name, spec in sorted(FACE_MODELS.items())) + "。切换模型会重新加载，并使已存样本失效——不同网络的 embedding 不可比较，已注册人员需重新录入"},
                 "device":            {"type": "string", "enum": ["auto", "cpu", "gpu"], "default": "auto", "description": "推理设备。auto=有 GPU 用 GPU，没有则用 CPU"},
                 "detect_fps":        {"type": "number", "minimum": 0, "default": DEFAULT_DETECT_FPS, "description": "检测频率，每秒 x 次，支持小数（如 0.5 = 每 2 秒一次）；0=每帧都检测", "scope": "instance"},
                 "match_threshold":   {"type": "number", "minimum": 0.0, "maximum": 1.0, "default": DEFAULT_MATCH_THRESHOLD, "description": "余弦相似度阈值，越高越严格（越不容易认错人，但越容易认不出）"},

--- a/perception/plugins/face_proxy.py
+++ b/perception/plugins/face_proxy.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""
+plugins/face_proxy.py — the parent's handle on face recognition running elsewhere.
+
+`plugins/face_service.py` runs the whole per-frame pipeline inside
+`plugins/ort_worker.py`'s child, because the standalone ONNX Runtime cannot share a
+process with sherpa-onnx's (see that module for the mechanism, and for the SIGSEGV it
+causes on jp5.11). This is what `plugins/face.py` holds instead of a `FaceAnalyzer`.
+
+It reconstructs `DetectedFace` objects from the child's reply, so everything downstream
+— `bbox_xywh()`, `min_side`, `blur`, the subject selection, the payload shape — keeps
+working unchanged. The quality gate ran in the child, and its verdict arrives as
+`embedding is None` rather than as a separate flag: an unusable face is precisely one
+that was not worth embedding.
+
+One round trip per frame, carrying the JPEG the parent already had. The superseded
+version of this split at `InferenceSession.run` instead and cost +27 ms per detection
+and +5.1 ms per face; the numbers and the reasoning are in `face_service.py`.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import numpy as np
+
+from plugins.face_runtime import DetectedFace
+
+log = logging.getLogger(__name__)
+
+SERVICE_KEY = "face.service"
+
+
+class FaceServiceProxy:
+    """Stands in for `FaceAnalyzer`, but with one method instead of four.
+
+    Deliberately *not* a drop-in for the old four-call surface. Offering
+    `decode_image`/`detect`/`prepare`/`embed` here would mean shipping a 6 MB decoded
+    frame back to the parent so it could hand pieces of it forward again, which is the
+    mistake this replaces. The call is the pipeline.
+    """
+
+    def __init__(self, model_dir: str, device: str = "auto", num_threads: int = 2,
+                 det_size=(640, 640), det_thresh: float = 0.5,
+                 nms_thresh: float = 0.4, max_image_side: int = 2048,
+                 max_image_pixels: float = 60e6, warmup: bool = True):
+        from plugins import ort_worker
+        from utils.onnx_provider import ort_providers_for_device, warn_on_parked_cores
+
+        # Resolved here, in the parent, and passed down as a plain list. The child
+        # should not have to ask the runtime what it offers — that question maps the
+        # provider bridge, and the parent needs the answer anyway to report `device`.
+        providers = ort_providers_for_device(device)
+        self._device = "gpu" if providers[0] != "CPUExecutionProvider" else "cpu"
+        # Session creation is where a parked-core Jetson abort()s under a bad ORT
+        # version, and an abort prints no Python traceback. Say the precondition before
+        # the child goes near it, so the last line before a silent death names it.
+        warn_on_parked_cores("face")
+
+        self._worker = ort_worker.get_worker()
+        described = self._worker.service(
+            SERVICE_KEY, "plugins.face_service", "build",
+            model_dir=model_dir, providers=providers, num_threads=num_threads,
+            det_size=tuple(det_size), det_thresh=det_thresh, nms_thresh=nms_thresh,
+            max_image_side=max_image_side, max_image_pixels=max_image_pixels,
+            warmup=warmup,
+        ).describe()
+        self._providers = list(described.get("providers") or providers)
+        self._device = described.get("device", self._device)
+        log.info("[face] service ready in the ORT worker: device=%s providers=%s",
+                 self._device, self._providers)
+
+    # ── the surface plugins/face.py reads ────────────────────────────────────
+
+    @property
+    def device(self) -> str:
+        return self._device
+
+    @property
+    def providers(self) -> list:
+        return list(self._providers)
+
+    def recognise(self, image_bytes: bytes, max_faces: int = 0,
+                  det_thresh: float = 0.5, min_face_px: int = 64,
+                  blur_min: float = 60.0, want_aligned: bool = False,
+                  embed_all: bool = False):
+        """JPEG bytes -> `(shape, faces)`.
+
+        `shape` is `(height, width)` of the decoded frame, or `None` if it could not be
+        decoded — the caller reports "undecodable frame" for that and does not guess.
+        `faces` are `DetectedFace`s with `embedding` set for the ones that passed the
+        gate and `None` for the rest.
+        """
+        reply = self._worker.call(SERVICE_KEY, "recognise", {
+            "image_bytes": image_bytes, "max_faces": max_faces,
+            "det_thresh": det_thresh, "min_face_px": min_face_px,
+            "blur_min": blur_min, "want_aligned": want_aligned,
+            "embed_all": embed_all,
+        })
+        if not reply.get("decoded"):
+            return None, []
+
+        faces = []
+        for entry in reply["faces"]:
+            faces.append(DetectedFace(
+                bbox=tuple(entry["bbox"]),
+                det_score=entry["det_score"],
+                kps=np.asarray(entry["kps"], dtype=np.float32),
+                blur=entry["blur"],
+                aligned=entry.get("aligned"),
+                embedding=entry.get("embedding"),
+            ))
+        return (reply["height"], reply["width"]), faces
+
+    def close(self) -> None:
+        """Drop the service, releasing its models and its share of the GPU pool.
+
+        The child stays: Kokoro's Japanese session may be in it, and a face card
+        stopping must not take Japanese down with it.
+        """
+        try:
+            self._worker.drop(SERVICE_KEY)
+        except Exception as exc:                                  # noqa: BLE001
+            log.warning("[face] dropping the face service failed: %s", exc)

--- a/perception/plugins/face_proxy.py
+++ b/perception/plugins/face_proxy.py
@@ -24,7 +24,7 @@ import logging
 
 import numpy as np
 
-from plugins.face_runtime import DetectedFace
+from plugins.face_runtime import DEFAULT_FACE_MODEL, DetectedFace
 
 log = logging.getLogger(__name__)
 
@@ -43,7 +43,8 @@ class FaceServiceProxy:
     def __init__(self, model_dir: str, device: str = "auto", num_threads: int = 2,
                  det_size=(640, 640), det_thresh: float = 0.5,
                  nms_thresh: float = 0.4, max_image_side: int = 2048,
-                 max_image_pixels: float = 60e6, warmup: bool = True):
+                 max_image_pixels: float = 60e6, warmup: bool = True,
+                 model: str = DEFAULT_FACE_MODEL):
         from plugins import ort_worker
         from utils.onnx_provider import ort_providers_for_device, warn_on_parked_cores
 
@@ -60,8 +61,9 @@ class FaceServiceProxy:
         self._worker = ort_worker.get_worker()
         described = self._worker.service(
             SERVICE_KEY, "plugins.face_service", "build",
-            model_dir=model_dir, providers=providers, num_threads=num_threads,
-            det_size=tuple(det_size), det_thresh=det_thresh, nms_thresh=nms_thresh,
+            model_dir=model_dir, model=model, providers=providers,
+            num_threads=num_threads, det_size=tuple(det_size),
+            det_thresh=det_thresh, nms_thresh=nms_thresh,
             max_image_side=max_image_side, max_image_pixels=max_image_pixels,
             warmup=warmup,
         ).describe()

--- a/perception/plugins/face_runtime.py
+++ b/perception/plugins/face_runtime.py
@@ -96,7 +96,9 @@ FACE_MODELS = {
         "det": "det_500m.onnx",
         "rec": "w600k_mbf.onnx",
         "bundle": "face",
-        "description": "SCRFD-500M + ArcFace MobileFaceNet, 512-d",
+        # `buffalo_sc` is InsightFace's pack name and covers two networks; spelling
+        # them out is what makes the card's dropdown readable.
+        "description": "InsightFace buffalo_sc（SCRFD-500M 检测 + ArcFace MobileFaceNet，512 维）",
     },
 }
 DEFAULT_FACE_MODEL = "buffalo_sc"

--- a/perception/plugins/face_runtime.py
+++ b/perception/plugins/face_runtime.py
@@ -31,6 +31,7 @@ from dataclasses import dataclass, field
 
 import numpy as np
 
+from plugins import scrfd_decode
 from utils.cv2_compat import load_cv2
 from utils.model_downloader import ensure_face_model
 from utils.onnx_provider import ort_providers_for_device, warn_on_parked_cores
@@ -89,9 +90,12 @@ _REC_INPUT_SIZE = 112
 
 # SCRFD wire format for a 3-level, 2-anchor, keypoint-carrying model. Upstream
 # derives these from the output count; det_500m always has 9 outputs.
-_FEAT_STRIDES = (8, 16, 32)
-_NUM_ANCHORS = 2
-_NUM_KPS = 5
+# Single source of truth is plugins/scrfd_decode.py, which the worker child imports
+# too — two copies of "this detector has three strides" is exactly the kind of drift
+# that produces an opaque reshape error.
+_FEAT_STRIDES = scrfd_decode.FEAT_STRIDES
+_NUM_ANCHORS = scrfd_decode.NUM_ANCHORS
+_NUM_KPS = scrfd_decode.NUM_KPS
 
 # ArcFace's canonical 112x112 landmark template. Aligning every face onto these
 # five points is what makes two embeddings comparable at all.
@@ -188,42 +192,12 @@ def _umeyama_similarity(src: np.ndarray, dst: np.ndarray) -> np.ndarray:
     return transform[:dim].astype(np.float32)
 
 
-def _distance2bbox(centers: np.ndarray, distances: np.ndarray) -> np.ndarray:
-    x1 = centers[:, 0] - distances[:, 0]
-    y1 = centers[:, 1] - distances[:, 1]
-    x2 = centers[:, 0] + distances[:, 2]
-    y2 = centers[:, 1] + distances[:, 3]
-    return np.stack([x1, y1, x2, y2], axis=-1)
-
-
-def _distance2kps(centers: np.ndarray, distances: np.ndarray) -> np.ndarray:
-    points = []
-    for index in range(0, distances.shape[1], 2):
-        points.append(centers[:, 0] + distances[:, index])
-        points.append(centers[:, 1] + distances[:, index + 1])
-    return np.stack(points, axis=-1)
-
-
-def _nms(boxes: np.ndarray, scores: np.ndarray, thresh: float) -> list[int]:
-    """Plain greedy IoU suppression — no cv2.dnn, no torchvision."""
-    x1, y1, x2, y2 = boxes[:, 0], boxes[:, 1], boxes[:, 2], boxes[:, 3]
-    areas = np.maximum(0.0, x2 - x1 + 1) * np.maximum(0.0, y2 - y1 + 1)
-    order = scores.argsort()[::-1]
-    keep: list[int] = []
-    while order.size > 0:
-        current = int(order[0])
-        keep.append(current)
-        if order.size == 1:
-            break
-        rest = order[1:]
-        xx1 = np.maximum(x1[current], x1[rest])
-        yy1 = np.maximum(y1[current], y1[rest])
-        xx2 = np.minimum(x2[current], x2[rest])
-        yy2 = np.minimum(y2[current], y2[rest])
-        inter = np.maximum(0.0, xx2 - xx1 + 1) * np.maximum(0.0, yy2 - yy1 + 1)
-        iou = inter / (areas[current] + areas[rest] - inter)
-        order = rest[iou <= thresh]
-    return keep
+# The decode moved to plugins/scrfd_decode.py so the worker child can import the same
+# implementation instead of a copy. Re-exported under the old private names: everything
+# below reads them, and a rename would be churn for its own sake.
+_distance2bbox = scrfd_decode.distance2bbox
+_distance2kps = scrfd_decode.distance2kps
+_nms = scrfd_decode.nms
 
 
 class FaceAnalyzer:
@@ -282,8 +256,21 @@ class FaceAnalyzer:
         # read-only for /models; let ORT keep its optimised graph in memory.
         options.log_severity_level = 3
 
-        self._det = ort.InferenceSession(det_path, options, providers=providers)
-        self._rec = ort.InferenceSession(rec_path, options, providers=providers)
+        # Both sessions go into plugins/ort_worker.py's child process, because the
+        # standalone ONNX Runtime and sherpa-onnx's bundled one corrupt each other's
+        # sessions through a shared provider bridge whenever both are in one process —
+        # an exception on jp6.1, a SIGSEGV that kills all of perception on jp5.11, and
+        # with face's session built first, sherpa's Kokoro engine cannot be constructed
+        # at all. That module's docstring has the mechanism and the measurements.
+        #
+        # `_open_session` keeps this to one branch rather than two code paths: the
+        # proxy answers get_inputs/get_outputs/get_providers from the load reply, so
+        # everything below is unchanged either way.
+        self._session_keys = []
+        self._det = self._open_session("face.det", det_path, providers, options,
+                                       num_threads)
+        self._rec = self._open_session("face.rec", rec_path, providers, options,
+                                       num_threads)
         self._det_input = self._det.get_inputs()[0].name
         self._rec_input = self._rec.get_inputs()[0].name
         self._det_outputs = [output.name for output in self._det.get_outputs()]
@@ -307,6 +294,44 @@ class FaceAnalyzer:
 
         if warmup:
             self._warmup()
+
+    def _open_session(self, key: str, model_path: str, providers, options,
+                      num_threads: int):
+        """One session, in the ORT worker child unless it has been turned off.
+
+        Falls back to an in-process session if the child cannot be reached, and says so
+        loudly: that is the configuration where sherpa's runtime and this one collide,
+        so it is degraded rather than equivalent. Face itself survives the collision —
+        its graph has none of the fused squeeze outputs Kokoro's has — so the fallback
+        keeps face working and puts the *Kokoro engine* at risk instead. That is the
+        lesser harm, and worth a warning either way.
+        """
+        from plugins import ort_worker
+
+        if ort_worker.worker_enabled():
+            try:
+                # Only the detector gets a post-processor: its head is 0.96 MiB of
+                # candidates before thresholding and a few hundred bytes after. The
+                # recogniser already returns a 2 kB embedding, so there is nothing to
+                # reduce and nothing to couple.
+                postprocess = ({"module": "plugins.scrfd_decode", "func": "decode"}
+                               if key == "face.det" else None)
+                session = ort_worker.get_worker().load(
+                    key, model_path, providers,
+                    {"intra_op_num_threads": max(1, int(num_threads)),
+                     "graph_optimization_level": "ORT_ENABLE_ALL",
+                     "log_severity_level": 3},
+                    postprocess=postprocess,
+                )
+                self._session_keys.append(key)
+                return session
+            except Exception as exc:                              # noqa: BLE001
+                log.warning(
+                    "[face] the ORT worker could not load %s (%s); falling back to an "
+                    "in-process session. sherpa-onnx and this runtime then share one "
+                    "provider bridge, which breaks whichever builds a CUDA session "
+                    "second — see plugins/ort_worker.py", key, exc)
+        return ort.InferenceSession(model_path, options, providers=providers)
 
     # ── properties ────────────────────────────────────────────────────────
 
@@ -463,40 +488,23 @@ class FaceAnalyzer:
         blob = (blob - 127.5) / 128.0
         blob = np.ascontiguousarray(blob.transpose(2, 0, 1)[None])
 
-        outputs = self._det.run(self._det_outputs, {self._det_input: blob})
-        levels = len(_FEAT_STRIDES)
+        if self._session_keys:
+            # The session is in the worker; decode there, so the 16 800 candidates
+            # never cross. `post_kwargs` carry what changes per frame.
+            boxes, keypoints, scores = self._det.run(
+                self._det_outputs, {self._det_input: blob},
+                post_kwargs={"input_h": input_h, "input_w": input_w, "scale": scale,
+                             "det_thresh": self._det_thresh,
+                             "nms_thresh": self._nms_thresh})
+        else:
+            outputs = self._det.run(self._det_outputs, {self._det_input: blob})
+            boxes, keypoints, scores = scrfd_decode.decode(
+                outputs, input_h, input_w, scale,
+                self._det_thresh, self._nms_thresh)
 
-        boxes_all: list[np.ndarray] = []
-        kps_all: list[np.ndarray] = []
-        scores_all: list[np.ndarray] = []
-        for index, stride in enumerate(_FEAT_STRIDES):
-            scores = outputs[index].reshape(-1)
-            bbox_preds = outputs[index + levels].reshape(-1, 4) * stride
-            kps_preds = outputs[index + levels * 2].reshape(-1, _NUM_KPS * 2) * stride
-
-            grid_h, grid_w = input_h // stride, input_w // stride
-            centers = np.stack(
-                np.mgrid[:grid_h, :grid_w][::-1], axis=-1
-            ).astype(np.float32).reshape(-1, 2) * stride
-            if _NUM_ANCHORS > 1:
-                centers = np.stack([centers] * _NUM_ANCHORS, axis=1).reshape(-1, 2)
-
-            positive = np.where(scores >= self._det_thresh)[0]
-            if positive.size == 0:
-                continue
-            boxes_all.append(_distance2bbox(centers, bbox_preds)[positive])
-            kps_all.append(
-                _distance2kps(centers, kps_preds)[positive].reshape(-1, _NUM_KPS, 2)
-            )
-            scores_all.append(scores[positive])
-
-        if not scores_all:
+        if scores.size == 0:
             return []
-
-        boxes = np.concatenate(boxes_all) / scale
-        keypoints = np.concatenate(kps_all) / scale
-        scores = np.concatenate(scores_all)
-        keep = _nms(boxes, scores, self._nms_thresh)
+        keep = range(len(scores))
 
         faces = [
             DetectedFace(
@@ -566,7 +574,22 @@ class FaceAnalyzer:
         return faces
 
     def close(self) -> None:
-        """Drop the sessions. Called via `_close_quietly` on config changes."""
+        """Drop the sessions. Called via `_close_quietly` on config changes.
+
+        Dropping the reference is enough for an in-process session, but not for one
+        living in the ORT worker: a child does not notice its parent's garbage
+        collector, so the session would stay resident — 13 MB of weights and its share
+        of the GPU pool — for the life of the process. Unload it explicitly, and keep
+        the child alive for whatever else it holds.
+        """
+        for key in getattr(self, "_session_keys", ()):
+            try:
+                from plugins import ort_worker
+                ort_worker.get_worker().unload(key)
+            except Exception as exc:                              # noqa: BLE001
+                log.warning("[face] could not unload %s from the ORT worker: %s",
+                            key, exc)
+        self._session_keys = []
         self._det = None
         self._rec = None
 

--- a/perception/plugins/face_runtime.py
+++ b/perception/plugins/face_runtime.py
@@ -71,6 +71,36 @@ log = logging.getLogger(__name__)
 
 DEFAULT_FACE_MODEL_DIR = "/models/face/buffalo_sc"
 
+# Which model pair to run. One entry today; the point of the registry is that adding a
+# second is a table row rather than a hunt through the file for hardcoded names, and
+# that the card can offer the choice.
+#
+# What a new entry has to supply: the detector must emit **nine** outputs — score, bbox
+# and five keypoints per stride — because ArcFace alignment needs the landmarks and
+# `plugins/scrfd_decode.py` decodes exactly that shape. A detector without keypoints
+# cannot be used here at all, which is asserted at load time rather than discovered as
+# bad embeddings. The recogniser must take 112x112 and return 512 dimensions, since the
+# stored samples and every existing FaceDB row are that.
+#
+# Changing the model invalidates the database: embeddings from different networks are
+# not comparable, and matching across them would silently confuse identities. The
+# plugin's engine signature includes the model, so a change reloads — but the samples
+# already stored do **not** get re-embedded, which is why this is a deploy-time choice
+# rather than something to flip on a running robot with a populated roster.
+FACE_MODELS = {
+    # insightface v0.7 buffalo_sc: SCRFD-500M-BNKPS + ArcFace MobileFaceNet
+    # (Glint360K). 2.5 MB + 13 MB, which is what makes cpu at one detection per
+    # second the design point.
+    "buffalo_sc": {
+        "dir": "/models/face/buffalo_sc",
+        "det": "det_500m.onnx",
+        "rec": "w600k_mbf.onnx",
+        "bundle": "face",
+        "description": "SCRFD-500M + ArcFace MobileFaceNet, 512-d",
+    },
+}
+DEFAULT_FACE_MODEL = "buffalo_sc"
+
 DET_MODEL_FILE = "det_500m.onnx"
 REC_MODEL_FILE = "w600k_mbf.onnx"
 
@@ -213,11 +243,14 @@ class FaceAnalyzer:
         self,
         model_dir: str = DEFAULT_FACE_MODEL_DIR,
         device: str = "auto",
+        model: str = DEFAULT_FACE_MODEL,
         det_size: tuple[int, int] = DEFAULT_DET_SIZE,
         det_thresh: float = DEFAULT_DET_THRESH,
         nms_thresh: float = DEFAULT_NMS_THRESH,
         num_threads: int = 2,
         warmup: bool = True,
+        providers=None,
+        in_process: bool = False,
     ):
         if ort is None:
             raise RuntimeError(
@@ -235,14 +268,36 @@ class FaceAnalyzer:
         # the reshape below would fail with an opaque numpy error.
         self._det_size = (width - width % 32 or 32, height - height % 32 or 32)
 
-        paths = ensure_face_model(model_dir)
-        det_path = paths.get(DET_MODEL_FILE) or os.path.join(model_dir, DET_MODEL_FILE)
-        rec_path = paths.get(REC_MODEL_FILE) or os.path.join(model_dir, REC_MODEL_FILE)
+        spec = FACE_MODELS.get(model)
+        if spec is None:
+            raise ValueError(
+                f"unknown face model {model!r}; this build has "
+                f"{sorted(FACE_MODELS)}. Adding one is a row in FACE_MODELS, but read "
+                "the note there first: the detector must emit nine outputs and the "
+                "recogniser must be 112x112 -> 512-d, and switching models invalidates "
+                "the stored embeddings."
+            )
+        self._model = model
+        det_name, rec_name = spec["det"], spec["rec"]
+        # An explicitly configured model_dir wins, so an operator can point at a local
+        # copy; otherwise the registry's own directory is used.
+        if model_dir == DEFAULT_FACE_MODEL_DIR:
+            model_dir = spec["dir"]
 
-        providers = ort_providers_for_device(self._requested_device)
-        # `device` resolves here, not in config: `auto` means "gpu when the
-        # installed wheel has one". Recorded so info/logs report what is
-        # actually running rather than what was asked for.
+        paths = ensure_face_model(model_dir, bundle=spec.get("bundle", "face"))
+        det_path = paths.get(det_name) or os.path.join(model_dir, det_name)
+        rec_path = paths.get(rec_name) or os.path.join(model_dir, rec_name)
+
+        # Providers are resolved by whoever built this — the parent, before it decides
+        # whether there is room — and passed in. Resolving them here would mean asking
+        # the standalone onnxruntime what it offers, in a process that may be the
+        # perception one, which is a question with a side effect: it maps the provider
+        # bridge. Falls back to resolving locally when nobody passed any, which is the
+        # in-child default path.
+        if providers is None:
+            providers = ort_providers_for_device(self._requested_device)
+        providers = list(providers)
+        # `device` reports what is actually running rather than what was asked for.
         self._device = "gpu" if providers[0] != "CPUExecutionProvider" else "cpu"
         # Session creation is where a parked-core Jetson abort()s under a bad
         # ORT version, and an abort prints no Python traceback. Say the
@@ -256,37 +311,40 @@ class FaceAnalyzer:
         # read-only for /models; let ORT keep its optimised graph in memory.
         options.log_severity_level = 3
 
-        # Both sessions go into plugins/ort_worker.py's child process, because the
-        # standalone ONNX Runtime and sherpa-onnx's bundled one corrupt each other's
-        # sessions through a shared provider bridge whenever both are in one process —
-        # an exception on jp6.1, a SIGSEGV that kills all of perception on jp5.11, and
-        # with face's session built first, sherpa's Kokoro engine cannot be constructed
-        # at all. That module's docstring has the mechanism and the measurements.
-        #
-        # `_open_session` keeps this to one branch rather than two code paths: the
-        # proxy answers get_inputs/get_outputs/get_providers from the load reply, so
-        # everything below is unchanged either way.
-        self._session_keys = []
-        self._det = self._open_session("face.det", det_path, providers, options,
-                                       num_threads)
-        self._rec = self._open_session("face.rec", rec_path, providers, options,
-                                       num_threads)
+        # Created here, and "here" decides everything: this class runs either inside
+        # plugins/ort_worker.py's child — where it is the only ONNX Runtime and a
+        # session is exactly right — or in the perception process, where sherpa's
+        # runtime is already loaded and a CUDA session corrupts it. Callers in the
+        # perception process must go through plugins/face_proxy.py; `in_process` is the
+        # switch, and it defaults to False so nothing gets it by accident.
+        if not in_process:
+            raise RuntimeError(
+                "FaceAnalyzer creates an ONNX Runtime session, which must not happen "
+                "in the perception process: sherpa-onnx's runtime is already there and "
+                "the two corrupt each other (an exception on jp6.1, a SIGSEGV that "
+                "kills all of perception on jp5.11). Use plugins/face_proxy."
+                "FaceServiceProxy, which runs this in the ORT worker child. "
+                "See plugins/ort_worker.py."
+            )
+
+        self._det = ort.InferenceSession(det_path, options, providers=providers)
+        self._rec = ort.InferenceSession(rec_path, options, providers=providers)
         self._det_input = self._det.get_inputs()[0].name
         self._rec_input = self._rec.get_inputs()[0].name
         self._det_outputs = [output.name for output in self._det.get_outputs()]
 
         if len(self._det_outputs) != len(_FEAT_STRIDES) * 3:
             raise RuntimeError(
-                f"{DET_MODEL_FILE} has {len(self._det_outputs)} outputs; this "
+                f"{det_name} has {len(self._det_outputs)} outputs; this "
                 f"decoder expects {len(_FEAT_STRIDES) * 3} (3 strides x "
                 "score/bbox/kps). A detector without keypoints cannot be "
                 "aligned for recognition."
             )
 
         log.info(
-            "[face] analyzer ready: onnxruntime=%s device=%s (requested %s) "
-            "providers=%s det=%s rec=%s size=%s",
-            ort.__version__, self._device, self._requested_device,
+            "[face] analyzer ready: onnxruntime=%s model=%s device=%s "
+            "(requested %s) providers=%s det=%s rec=%s size=%s",
+            ort.__version__, model, self._device, self._requested_device,
             self._det.get_providers(),
             os.path.basename(det_path), os.path.basename(rec_path),
             self._det_size,
@@ -294,44 +352,6 @@ class FaceAnalyzer:
 
         if warmup:
             self._warmup()
-
-    def _open_session(self, key: str, model_path: str, providers, options,
-                      num_threads: int):
-        """One session, in the ORT worker child unless it has been turned off.
-
-        Falls back to an in-process session if the child cannot be reached, and says so
-        loudly: that is the configuration where sherpa's runtime and this one collide,
-        so it is degraded rather than equivalent. Face itself survives the collision —
-        its graph has none of the fused squeeze outputs Kokoro's has — so the fallback
-        keeps face working and puts the *Kokoro engine* at risk instead. That is the
-        lesser harm, and worth a warning either way.
-        """
-        from plugins import ort_worker
-
-        if ort_worker.worker_enabled():
-            try:
-                # Only the detector gets a post-processor: its head is 0.96 MiB of
-                # candidates before thresholding and a few hundred bytes after. The
-                # recogniser already returns a 2 kB embedding, so there is nothing to
-                # reduce and nothing to couple.
-                postprocess = ({"module": "plugins.scrfd_decode", "func": "decode"}
-                               if key == "face.det" else None)
-                session = ort_worker.get_worker().load(
-                    key, model_path, providers,
-                    {"intra_op_num_threads": max(1, int(num_threads)),
-                     "graph_optimization_level": "ORT_ENABLE_ALL",
-                     "log_severity_level": 3},
-                    postprocess=postprocess,
-                )
-                self._session_keys.append(key)
-                return session
-            except Exception as exc:                              # noqa: BLE001
-                log.warning(
-                    "[face] the ORT worker could not load %s (%s); falling back to an "
-                    "in-process session. sherpa-onnx and this runtime then share one "
-                    "provider bridge, which breaks whichever builds a CUDA session "
-                    "second — see plugins/ort_worker.py", key, exc)
-        return ort.InferenceSession(model_path, options, providers=providers)
 
     # ── properties ────────────────────────────────────────────────────────
 
@@ -488,20 +508,9 @@ class FaceAnalyzer:
         blob = (blob - 127.5) / 128.0
         blob = np.ascontiguousarray(blob.transpose(2, 0, 1)[None])
 
-        if self._session_keys:
-            # The session is in the worker; decode there, so the 16 800 candidates
-            # never cross. `post_kwargs` carry what changes per frame.
-            boxes, keypoints, scores = self._det.run(
-                self._det_outputs, {self._det_input: blob},
-                post_kwargs={"input_h": input_h, "input_w": input_w, "scale": scale,
-                             "det_thresh": self._det_thresh,
-                             "nms_thresh": self._nms_thresh})
-        else:
-            outputs = self._det.run(self._det_outputs, {self._det_input: blob})
-            boxes, keypoints, scores = scrfd_decode.decode(
-                outputs, input_h, input_w, scale,
-                self._det_thresh, self._nms_thresh)
-
+        outputs = self._det.run(self._det_outputs, {self._det_input: blob})
+        boxes, keypoints, scores = scrfd_decode.decode(
+            outputs, input_h, input_w, scale, self._det_thresh, self._nms_thresh)
         if scores.size == 0:
             return []
         keep = range(len(scores))
@@ -574,25 +583,13 @@ class FaceAnalyzer:
         return faces
 
     def close(self) -> None:
-        """Drop the sessions. Called via `_close_quietly` on config changes.
+        """Drop the sessions.
 
-        Dropping the reference is enough for an in-process session, but not for one
-        living in the ORT worker: a child does not notice its parent's garbage
-        collector, so the session would stay resident — 13 MB of weights and its share
-        of the GPU pool — for the life of the process. Unload it explicitly, and keep
-        the child alive for whatever else it holds.
+        Inside the worker child this is all that is needed: the child's own exit, or
+        `ort_worker`'s `drop`, is what actually returns the CUDA context.
         """
-        for key in getattr(self, "_session_keys", ()):
-            try:
-                from plugins import ort_worker
-                ort_worker.get_worker().unload(key)
-            except Exception as exc:                              # noqa: BLE001
-                log.warning("[face] could not unload %s from the ORT worker: %s",
-                            key, exc)
-        self._session_keys = []
         self._det = None
         self._rec = None
-
 
 __all__ = [
     "DEFAULT_BLUR_MIN",

--- a/perception/plugins/face_service.py
+++ b/perception/plugins/face_service.py
@@ -68,13 +68,18 @@ class FaceService:
                  max_image_pixels: float = 60e6, warmup: bool = True):
         from plugins.face_runtime import FaceAnalyzer
 
+        # The decode limits are per-call on decode_image, not analyzer state, so they
+        # are held here and passed through. They are not cosmetic: max_side bounds the
+        # letterbox downscale and max_pixels is the decompression-bomb guard.
+        self._max_side = int(max_image_side)
+        self._max_pixels = int(max_image_pixels)
+
         # in_process=True is correct *here*: this is the isolated process, so a session
-        # created in it is exactly what the design wants. The flag exists so that the
-        # same class does not create one in the perception process by accident.
+        # created in it is exactly what the design wants. The flag exists so the same
+        # class refuses to create one in the perception process by accident.
         self._analyzer = FaceAnalyzer(
             model_dir=model_dir, providers=providers, num_threads=num_threads,
             det_size=det_size, det_thresh=det_thresh, nms_thresh=nms_thresh,
-            max_image_side=max_image_side, max_image_pixels=max_image_pixels,
             warmup=warmup, in_process=True,
         )
         log.info("face service ready: device=%s providers=%s",
@@ -106,7 +111,9 @@ class FaceService:
         `embed_all` overrides the gate for the identify/register paths that want an
         embedding even for a marginal face.
         """
-        image = self._analyzer.decode_image(image_bytes)
+        image = self._analyzer.decode_image(
+            image_bytes, max_side=self._max_side,
+            max_pixels=self._max_pixels)
         if image is None:
             return {"width": 0, "height": 0, "faces": [], "decoded": False}
 

--- a/perception/plugins/face_service.py
+++ b/perception/plugins/face_service.py
@@ -65,7 +65,8 @@ class FaceService:
     def __init__(self, model_dir: str, providers, num_threads: int = 2,
                  det_size=(640, 640), det_thresh: float = 0.5,
                  nms_thresh: float = 0.4, max_image_side: int = 2048,
-                 max_image_pixels: float = 60e6, warmup: bool = True):
+                 max_image_pixels: float = 60e6, warmup: bool = True,
+                 model: str = "buffalo_sc"):
         from plugins.face_runtime import FaceAnalyzer
 
         # The decode limits are per-call on decode_image, not analyzer state, so they
@@ -78,9 +79,9 @@ class FaceService:
         # created in it is exactly what the design wants. The flag exists so the same
         # class refuses to create one in the perception process by accident.
         self._analyzer = FaceAnalyzer(
-            model_dir=model_dir, providers=providers, num_threads=num_threads,
-            det_size=det_size, det_thresh=det_thresh, nms_thresh=nms_thresh,
-            warmup=warmup, in_process=True,
+            model_dir=model_dir, model=model, providers=providers,
+            num_threads=num_threads, det_size=det_size, det_thresh=det_thresh,
+            nms_thresh=nms_thresh, warmup=warmup, in_process=True,
         )
         log.info("face service ready: device=%s providers=%s",
                  self._analyzer.device, self._analyzer.providers)

--- a/perception/plugins/face_service.py
+++ b/perception/plugins/face_service.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""
+plugins/face_service.py — face recognition, entirely inside the ORT worker child.
+
+## Why the boundary is here and not further in
+
+An earlier version of this change put only the two `InferenceSession.run` calls in the
+child and left decoding, letterboxing, alignment and the quality gate in the parent.
+That works, and it was measured, and it was the wrong place to cut:
+
+    detect p50   in-process 38.3 ms   ->   split at run()  65.3 ms   (+27 ms)
+    embed  p50   in-process  7.83 ms  ->   split at run()  12.93 ms  (+5.1 ms)
+
+because the parent was sending a 2.93 MiB normalised blob and getting 0.96 MiB of
+pre-threshold candidates back, then sending a 147 kB crop per face and getting a 2 kB
+embedding back — one round trip for detection plus one per face, with the largest
+possible payload in both directions.
+
+What the parent actually holds is the **`CompressedImage` JPEG**, 50-300 kB
+(`plugins/face.py:920-932`), and what it actually wants is a few bounding boxes and a
+512-float embedding each. So the frame crosses once, compressed, and the results come
+back small:
+
+    in   the JPEG bytes as received                        50-300 kB
+    out  per face: bbox, score, blur, min_side, 512 f32    ~2 kB
+
+The quality gate comes with it, deliberately. It sits between alignment and embedding
+(`face.py:1017-1021`) and decides which faces are worth embedding at all; leaving it in
+the parent would mean either embedding faces the parent then discards, or a second round
+trip to ask.
+
+## What stays in the parent
+
+The FaceDB — `matrix @ embedding` on a 2 kB vector, plus the identity store, its lock
+and its files (`plugins/face_db.py`). It needs nothing from ONNX, it is mutated from MCP
+threads as well as the recognition worker, and it owns files on disk. Also the subject
+selection, the payload shape, ROS publishing and the enrolment window: all cheap, all
+pure, all already there.
+
+## What this must never import
+
+`sherpa_onnx`. This process exists to be the only ONNX Runtime in its address space —
+see `plugins/ort_worker.py` for what happens otherwise. `plugins/face_runtime.py` is
+safe to import: its only path to sherpa is `utils.onnx_provider.cuda_available`, whose
+import is inside the function, and nothing here calls it. Providers arrive from the
+parent as a plain list, so no provider helper is needed at all.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import numpy as np
+
+log = logging.getLogger("face.service")
+
+
+class FaceService:
+    """One `FaceAnalyzer` and the whole per-frame pipeline, in the worker child.
+
+    Created by `plugins/ort_worker.py` on request; the parent talks to it through
+    `FaceServiceProxy` in `plugins/face_proxy.py` and never sees a session.
+    """
+
+    def __init__(self, model_dir: str, providers, num_threads: int = 2,
+                 det_size=(640, 640), det_thresh: float = 0.5,
+                 nms_thresh: float = 0.4, max_image_side: int = 2048,
+                 max_image_pixels: float = 60e6, warmup: bool = True):
+        from plugins.face_runtime import FaceAnalyzer
+
+        # in_process=True is correct *here*: this is the isolated process, so a session
+        # created in it is exactly what the design wants. The flag exists so that the
+        # same class does not create one in the perception process by accident.
+        self._analyzer = FaceAnalyzer(
+            model_dir=model_dir, providers=providers, num_threads=num_threads,
+            det_size=det_size, det_thresh=det_thresh, nms_thresh=nms_thresh,
+            max_image_side=max_image_side, max_image_pixels=max_image_pixels,
+            warmup=warmup, in_process=True,
+        )
+        log.info("face service ready: device=%s providers=%s",
+                 self._analyzer.device, self._analyzer.providers)
+
+    # ── metadata the parent reports in `info` ────────────────────────────────
+
+    def describe(self) -> dict:
+        return {"device": self._analyzer.device,
+                "providers": list(self._analyzer.providers)}
+
+    # ── the one call per frame ───────────────────────────────────────────────
+
+    def recognise(self, image_bytes: bytes, max_faces: int = 0,
+                  det_thresh: float = 0.5, min_face_px: int = 64,
+                  blur_min: float = 60.0, want_aligned: bool = False,
+                  embed_all: bool = False) -> dict:
+        """JPEG bytes in, one dict per face out. No arrays cross except embeddings.
+
+        Returns `{"width", "height", "faces": [...]}` where each face carries
+        `bbox` (xyxy floats), `det_score`, `blur`, `min_side`, `usable`, and
+        `embedding` (512 floats) for the usable ones — `None` otherwise, because an
+        unusable face is reported with `person_id: null` and never embedded
+        (`face.py:1028-1042`).
+
+        `want_aligned` adds the 112x112x3 uint8 crop, 37 kB each. Only the registration
+        paths need it, to store as a sample, so it is opt-in rather than always paid.
+
+        `embed_all` overrides the gate for the identify/register paths that want an
+        embedding even for a marginal face.
+        """
+        image = self._analyzer.decode_image(image_bytes)
+        if image is None:
+            return {"width": 0, "height": 0, "faces": [], "decoded": False}
+
+        height, width = image.shape[:2]
+        faces = self._analyzer.detect(image, max_faces=max_faces)
+
+        out = []
+        for face in faces:
+            self._analyzer.prepare(image, face)
+            min_side = min(face.bbox[2] - face.bbox[0], face.bbox[3] - face.bbox[1])
+            usable = (face.det_score >= det_thresh
+                      and min_side >= min_face_px
+                      and face.blur >= blur_min)
+            entry = {
+                "bbox": [float(v) for v in face.bbox],
+                "det_score": float(face.det_score),
+                "kps": np.asarray(face.kps, dtype=np.float32),
+                "blur": float(face.blur),
+                "min_side": float(min_side),
+                "usable": bool(usable),
+                "embedding": None,
+            }
+            if usable or embed_all:
+                entry["embedding"] = np.asarray(
+                    self._analyzer.embed(face.aligned), dtype=np.float32)
+            if want_aligned:
+                entry["aligned"] = np.ascontiguousarray(face.aligned)
+            out.append(entry)
+
+        return {"width": int(width), "height": int(height), "faces": out,
+                "decoded": True}
+
+    def close(self) -> None:
+        self._analyzer.close()
+
+
+def build(**kwargs) -> FaceService:
+    """Factory the worker resolves by name, so `ort_worker.py` stays face-agnostic."""
+    return FaceService(**kwargs)

--- a/perception/plugins/kokoro_direct.py
+++ b/perception/plugins/kokoro_direct.py
@@ -50,26 +50,22 @@ class KokoroDirect:
     """
 
     def __init__(self, model_dir: str, weights: str, num_threads: int = 0,
-                 provider: str = "cpu"):
+                 provider: str = "cpu", session_key: str = "tts.kokoro",
+                 in_process: bool = False):
         """`num_threads=0` means one per core, which is the difference between usable
         and not on the CPU path.
 
-        **CUDA is only safe when this runs in a process that has no other ONNX
-        Runtime in it.** Two runtimes in one process share a single
-        `libonnxruntime_providers_shared.so` — an 8 KB library holding one pointer to
-        one runtime's `ProviderHost` — because ld.so deduplicates a dlopen by
-        basename. Last writer wins, and whichever runtime builds a session after the
-        pointer flips runs against the other's framework objects:
+        The session goes into `plugins/ort_worker.py`'s child unless `in_process` is
+        set, because the standalone ONNX Runtime and sherpa-onnx's bundled one corrupt
+        each other's sessions through a shared provider bridge whenever both are in one
+        process. That module's docstring has the mechanism and the measurements; the
+        short version is an exception on jp6.1 and a SIGSEGV that kills all of
+        perception on jp5.11.
 
-            "Error mapping output names: Could not find OrtValue with
-             name '/Squeeze_2_output_0'"
-
-        Measured on Orin 6 in both orders, and on jp5.11 it is a SIGSEGV that takes
-        the whole perception process with it. Renaming the bridge and the CUDA
-        provider in our own ORT build does fix it, but only by forking ONNX Runtime's
-        ABI. `plugins/kokoro_worker.py` gets the same result with a process boundary,
-        and that is where `provider="cuda"` belongs — never from the perception
-        process, which already has sherpa's runtime loaded.
+        `in_process=True` is the degraded fallback the callers use when the child cannot
+        be reached. It is only safe on CPU — a CPU-only session loads no CUDA provider,
+        so it never touches the bridge — which is why the fallback paths pair it with
+        the default `provider="cpu"`.
 
         Speed, measured on Orin 6 (6 cores) on one 9.35 s Japanese utterance:
 
@@ -77,7 +73,7 @@ class KokoroDirect:
             cpu, 4 threads  RTF 0.646
             cpu, 6 threads  RTF 0.521
             cpu, 8 threads  RTF 0.644   <- oversubscribed
-            cuda (in a worker process)  RTF 0.063 warm, 0.861 on the first call
+            cuda, in the worker          RTF 0.069 warm, 1.65 on the first utterance
 
         The CPU default was 2 and made Japanese unusable for streaming.
         """
@@ -92,13 +88,24 @@ class KokoroDirect:
 
         self._token_to_id = _read_tokens(tokens_path)
 
-        opts = ort.SessionOptions()
-        # 0 lets ORT pick one thread per core, which measured fastest; an explicit
-        # value is honoured so a busy robot can be told to use fewer.
-        opts.intra_op_num_threads = int(num_threads or 0)
         providers = (["CUDAExecutionProvider", "CPUExecutionProvider"]
                      if provider in ("cuda", "gpu") else ["CPUExecutionProvider"])
-        self._session = ort.InferenceSession(model_path, opts, providers=providers)
+        # 0 lets ORT pick one thread per core, which measured fastest; an explicit
+        # value is honoured so a busy robot can be told to use fewer.
+        threads = int(num_threads or 0)
+
+        self._session_key = None
+        if in_process:
+            opts = ort.SessionOptions()
+            opts.intra_op_num_threads = threads
+            self._session = ort.InferenceSession(model_path, opts,
+                                                 providers=providers)
+        else:
+            from plugins import ort_worker
+            self._session = ort_worker.get_worker().load(
+                session_key, model_path, providers,
+                {"intra_op_num_threads": threads})
+            self._session_key = session_key
         actual = self._session.get_providers()
 
         styles = np.fromfile(voices_path, dtype=np.float32)
@@ -116,6 +123,21 @@ class KokoroDirect:
         log.info("[tts] kokoro_direct ready: %s, %d tokens, %d speakers, providers=%s",
                  os.path.basename(model_path), len(self._token_to_id),
                  self._n_speakers, actual)
+
+    def close(self) -> None:
+        """Release the session.
+
+        Dropping the reference is enough in-process, but not for a session living in
+        the ORT worker: a child does not notice its parent's garbage collector, so it
+        would stay resident — 310 MB of weights plus its share of the GPU pool — for
+        the life of the process. Unload it explicitly and leave the child alive for
+        whatever else it holds, face's sessions included.
+        """
+        key, self._session_key = self._session_key, None
+        self._session = None
+        if key is not None:
+            from plugins import ort_worker
+            ort_worker.get_worker().unload(key)
 
     @property
     def num_speakers(self) -> int:

--- a/perception/plugins/kokoro_worker.py
+++ b/perception/plugins/kokoro_worker.py
@@ -69,10 +69,20 @@ log = logging.getLogger(__name__)
 START_TIMEOUT_S = 45.0
 # One utterance is 0.59 s warm. This is a "the child is wedged" bound, not a budget.
 CALL_TIMEOUT_S = 30.0
-# Long enough that a bilingual tour switching languages does not pay the ~10.5 s cold
-# path repeatedly; short enough that a card that has finished with Japanese gives the
-# memory back. Card stop and engine switch close it immediately regardless.
-IDLE_TIMEOUT_S = 120.0
+# Idle unloading is **off**, and that is a correction rather than a default.
+#
+# It was added to "give the memory back when Japanese stops being used", and then
+# measured: unloading moved whole-box MemAvailable by **+0 MB**. The CUDA pool is
+# returned on process exit, not on session destruction, so the only thing it achieved
+# was making the next utterance pay the cold path again — observed on Orin 6 as
+# "kokoro session ready in 7.4s" after a 120 s gap, which is what a tour with pauses in
+# it feels as the TTS being slow.
+#
+# Card stop and engine switch still release it: those are the points where the answer
+# to "is this needed again" is actually known.
+#
+# Set a positive number to re-enable it, but know what it does and does not buy.
+IDLE_TIMEOUT_S = 0.0
 
 # The warmup probe doubles as a correctness gate on the chosen device, because one
 # JetPack line executes this graph wrong on CUDA.
@@ -124,6 +134,45 @@ CUDA_HEADROOM_FRESH_MB = 2500
 CUDA_HEADROOM_SHARED_MB = 1400
 
 
+def _cuda_verdict_path(model_dir: str) -> str:
+    """Where this machine records that CUDA failed the duration check.
+
+    Persistent, not in-memory, because the process that learns it may not be the one
+    that needs it: a crash restarts perception and an in-memory verdict is lost, so the
+    next start tries CUDA again — which is exactly what happened on Orin 5, where the
+    retry contributed to a whole-box OOM.
+
+    Keyed by the ONNX Runtime version, because the defect is in that build. A new
+    runtime gets a fresh evaluation rather than inheriting a verdict about a different
+    one.
+    """
+    return os.path.join(model_dir, ".cuda-duration-verdict")
+
+
+def _cuda_known_bad(model_dir: str, ort_version: str) -> bool:
+    try:
+        with open(_cuda_verdict_path(model_dir), encoding="utf-8") as handle:
+            return handle.read().strip() == ort_version
+    except OSError:
+        return False
+
+
+def _remember_cuda_is_bad(model_dir: str, ort_version: str) -> None:
+    """Record the verdict so the attempt is made once per machine, not once per start.
+
+    The attempt is not free, which is why this exists. A CUDA session that then gets
+    rejected still leaves its pool behind — measured at ~967 MB that `unload` does not
+    return — so retrying it on every start is a permanent cost for a known answer, and
+    on a full box it is what tips the machine into the OOM killer.
+    """
+    try:
+        with open(_cuda_verdict_path(model_dir), "w", encoding="utf-8") as handle:
+            handle.write(ort_version)
+    except OSError as exc:
+        log.warning("[tts] could not record the CUDA verdict (%s); it will be "
+                    "re-evaluated on the next start", exc)
+
+
 def _mem_available_mb() -> int:
     """Whole-box MemAvailable. -1 if unreadable, which must not block the GPU."""
     try:
@@ -134,6 +183,22 @@ def _mem_available_mb() -> int:
     except OSError:
         pass
     return -1
+
+
+class DeviceUnavailable(RuntimeError):
+    """The configured device cannot be used, and substituting one silently is worse.
+
+    Distinct from every other failure on purpose. A worker that dies, a queue that
+    times out, a child that will not spawn — those are infrastructure, and falling back
+    to an in-process CPU session keeps Japanese working at a cost of speed, which is
+    the right trade. **This** is the operator having asked for a device that will not
+    do the job, and quietly giving them a different one produces the worst state there
+    is: a card configured for gpu, running at RTF 0.52, with the reason in a log line
+    nobody reads.
+
+    So this one propagates: the card goes `state: error` carrying the message, and the
+    operator decides.
+    """
 
 
 class KokoroWorkerProxy:
@@ -198,63 +263,94 @@ class KokoroWorkerProxy:
     # ── build, with both guards ──────────────────────────────────────────────
 
     def _build(self) -> None:
-        """Load the session in the shared worker, on a device that is actually safe.
+        """Load the session on the device asked for, or fail saying why.
 
-        Two guards, and the order matters. The duration check runs *after* the session
-        is built, so it cannot prevent the allocation that builds it from taking the box
-        down — the headroom check has to come first.
+        **No silent substitution.** An earlier version quietly used the CPU when the
+        GPU was unavailable, which produced the worst possible state: a card configured
+        for `gpu`, running at RTF 0.52 instead of 0.07, with the reason in a log line
+        nobody reads. The card now goes `state: error` and names which of the two
+        problems it hit, so the operator can set `japanese_worker_device: cpu` knowing
+        what they are accepting.
+
+        The two are independent and either one alone is disqualifying:
+
+        - **not enough memory.** A CUDA session needs ~967 MB beside an existing
+          context and ~1585 MB bringing its own. Asking anyway OOM-killed a jp5.11 rig.
+        - **wrong durations.** jp5.11's ONNX Runtime 1.15.1 executes this graph's
+          duration path incorrectly: 8 runs gave 6.05 s against the CPU's 8.35 s, and
+          the 10-token probe returned 16800-24000 samples against 47400. 27-51% short
+          is audibly rushed speech, and it has nothing to do with memory.
         """
         from plugins.kokoro_direct import KokoroDirect
 
-        device = self._device
-        if device in ("cuda", "gpu"):
+        want_cuda = self._device in ("cuda", "gpu")
+        ort_version = "unknown"
+        try:
+            import onnxruntime as _ort
+            ort_version = _ort.__version__
+        except Exception:                                         # noqa: BLE001
+            pass
+
+        if want_cuda:
+            # Known-bad first: the attempt is not free. A CUDA session that then gets
+            # rejected still leaves its pool behind — measured at 3.8 GB on Orin 5 that
+            # unloading does not return — so a machine that has already answered this
+            # question must not pay again on every restart.
+            if _cuda_known_bad(self._model_dir, ort_version):
+                raise DeviceUnavailable(
+                    f"this machine's onnxruntime {ort_version} computes Kokoro's "
+                    f"duration path wrongly on CUDA — measured once and recorded in "
+                    f"{_cuda_verdict_path(self._model_dir)}. Japanese would be 27-51% "
+                    f"too short, which is audibly rushed speech. Not a memory problem. "
+                    f"Set japanese_worker_device: cpu (RTF ~0.52, still real time)."
+                )
+
             from plugins import ort_worker
             shared = False
             try:
                 shared = ort_worker.get_worker().has_cuda_session()
             except Exception as exc:                              # noqa: BLE001
-                log.debug("[tts] could not ask the worker about CUDA (%s); "
-                          "assuming a context has to be paid for", exc)
+                log.debug("[tts] could not ask the worker about CUDA (%s); assuming a "
+                          "context has to be paid for", exc)
             needed = CUDA_HEADROOM_SHARED_MB if shared else CUDA_HEADROOM_FRESH_MB
             headroom = _mem_available_mb()
             if 0 <= headroom < needed:
-                log.warning("[tts] kokoro: %d MB available, under the %d MB a CUDA "
-                            "session needs%s — using cpu (RTF ~0.52 rather than "
-                            "~0.07). Asking anyway OOM-killed a jp5.11 rig.",
-                            headroom, needed,
-                            " beside the existing context" if shared
-                            else " including a context of its own")
-                device = "cpu"
+                raise DeviceUnavailable(
+                    f"not enough memory for a CUDA session: {headroom} MB available, "
+                    f"{needed} MB needed{' beside the existing context' if shared else ' including a context of its own'}. "
+                    f"This is a **memory** problem, not a model problem — the GPU "
+                    f"itself is fine. Free memory on the box, or set "
+                    f"japanese_worker_device: cpu (RTF ~0.52, still real time). "
+                    f"Asking anyway OOM-killed a jp5.11 rig mid-utterance."
+                )
 
         started = time.monotonic()
-        for candidate, why in ((device, "requested"), ("cpu", "fallback")):
-            if why == "fallback" and candidate == device:
-                break                       # already tried it, and it failed the check
-            direct = KokoroDirect(self._model_dir, self._weights,
-                                  num_threads=self._num_threads, provider=candidate,
-                                  session_key="tts.kokoro.ja")
-            # The warmup was always needed — the first CUDA call costs 8.03 s of lazy
-            # kernel loading against 0.59 s warm — so checking its output length is
-            # free. A wrong length means this device computes the duration path
-            # incorrectly, and a fast wrong answer is worse than a slow right one.
-            n = len(direct.synthesize(PROBE_TEXT, speaker_id=0, speed=1.0))
-            off = abs(n - PROBE_SAMPLES) / PROBE_SAMPLES
-            if off <= PROBE_TOLERANCE:
-                self._direct = direct
-                self._device_used = candidate
-                log.info("[tts] kokoro session ready in %.1fs on %s%s: providers=%s",
-                         time.monotonic() - started, candidate,
-                         "" if candidate == self._device
-                         else f" (asked for {self._device})",
-                         direct._session.get_providers())
-                return
-            log.error("[tts] %s produced %d samples for the probe, expected ~%d "
-                      "(%.0f%% off) — this device computes the duration path wrongly; "
-                      "not using it", candidate, n, PROBE_SAMPLES, off * 100)
+        direct = KokoroDirect(self._model_dir, self._weights,
+                              num_threads=self._num_threads, provider=self._device,
+                              session_key="tts.kokoro.ja")
+        # The warmup was always needed — the first CUDA call costs 8 s of lazy kernel
+        # loading against 0.6 s warm — so checking its output length is free.
+        n = len(direct.synthesize(PROBE_TEXT, speaker_id=0, speed=1.0))
+        off = abs(n - PROBE_SAMPLES) / PROBE_SAMPLES
+        if off > PROBE_TOLERANCE:
             direct.close()
-        raise RuntimeError(
-            f"neither {self._device} nor cpu produced a plausible probe duration; the "
-            f"model or the phoneme table does not match this code")
+            if want_cuda:
+                _remember_cuda_is_bad(self._model_dir, ort_version)
+            raise DeviceUnavailable(
+                f"{self._device} produced {n} samples for the probe, expected "
+                f"~{PROBE_SAMPLES} ({off * 100:.0f}% off): this device computes "
+                f"Kokoro's duration path wrongly, which comes out as audibly rushed "
+                f"speech. Not a memory problem. "
+                + ("Set japanese_worker_device: cpu (RTF ~0.52, still real time)."
+                   if want_cuda else
+                   "The model or the phoneme table does not match this code.")
+            )
+
+        self._direct = direct
+        self._device_used = self._device
+        log.info("[tts] kokoro session ready in %.1fs on %s: providers=%s",
+                 time.monotonic() - started, self._device,
+                 direct._session.get_providers())
 
     # ── lifecycle ────────────────────────────────────────────────────────────
 
@@ -282,6 +378,8 @@ class KokoroWorkerProxy:
         and a tour that alternates languages would pay it on every switch. Idle time is
         the signal that actually means "done with Japanese".
         """
+        if self._idle_timeout_s <= 0:
+            return                      # off; see IDLE_TIMEOUT_S for why that is default
         while True:
             time.sleep(5.0)
             direct = None
@@ -310,6 +408,10 @@ class KokoroWorkerProxy:
             if self._direct is None:
                 try:
                     self._build()
+                except DeviceUnavailable:
+                    # Not ours to paper over — the operator asked for a device that
+                    # cannot do the job, and the card should say so.
+                    raise
                 except Exception as exc:                          # noqa: BLE001
                     log.warning("[tts] kokoro session could not be rebuilt (%s); "
                                 "Japanese falls back to the in-process CPU session",

--- a/perception/plugins/kokoro_worker.py
+++ b/perception/plugins/kokoro_worker.py
@@ -101,21 +101,27 @@ PROBE_SAMPLES = 47400
 # 56% error it has to catch.
 PROBE_TOLERANCE = 0.10
 
-# Two guards are needed, and the order matters: the duration check above runs *after* the
-# session is built, so it cannot prevent the allocation that builds it from taking the
-# box down. Measured on jp5.11, asking for a CUDA child:
+# Two guards are needed, and the order matters: the duration check above runs *after*
+# the session is built, so it cannot prevent the allocation that builds it from taking
+# the box down. Measured on jp5.11, asking for a CUDA session with no headroom check:
 #
 #   5237 MB available -> sherpa's own Kokoro GPU adapter takes 3.2 GB -> 2048 MB left
-#   -> the CUDA child's allocation -> whole-box OOM, SIGKILL, before the probe ran
+#   -> the CUDA allocation -> whole-box OOM, SIGKILL, before the probe ran
 #
-# (`dmesg`: "Out of memory: Killed process ... (python3) anon-rss:2420028kB".) The same
-# adapter costs ~950 MB on jp6.1, where a CUDA child fits in the 1585 MB it needs. So the
-# headroom figure is the child's measured cost plus a margin, checked before spawning.
+# (`dmesg`: "Out of memory: Killed process ... (python3) anon-rss:2420028kB".)
 #
-# On jp5.11 this lands on cpu, which is also where the duration check would have put it.
-# Two independent reasons, one outcome — and the memory one has to be first because it is
-# the one that can kill the process.
-CUDA_HEADROOM_MB = 2500
+# The figure depends on whether the ORT worker already holds a CUDA session, because
+# the first one in that process pays for the context and the rest do not. Measured on
+# Orin 6:
+#
+#   Kokoro alone in the child, bringing its own context       1585 MB
+#   Kokoro beside the face service, context already there      967 MB
+#
+# A single conservative number would refuse the second case on the first case's
+# evidence — which it did: with 2158 MB free on an otherwise idle box, a 967 MB
+# allocation was declined because the threshold was 2500.
+CUDA_HEADROOM_FRESH_MB = 2500
+CUDA_HEADROOM_SHARED_MB = 1400
 
 
 def _mem_available_mb() -> int:
@@ -202,12 +208,22 @@ class KokoroWorkerProxy:
 
         device = self._device
         if device in ("cuda", "gpu"):
+            from plugins import ort_worker
+            shared = False
+            try:
+                shared = ort_worker.get_worker().has_cuda_session()
+            except Exception as exc:                              # noqa: BLE001
+                log.debug("[tts] could not ask the worker about CUDA (%s); "
+                          "assuming a context has to be paid for", exc)
+            needed = CUDA_HEADROOM_SHARED_MB if shared else CUDA_HEADROOM_FRESH_MB
             headroom = _mem_available_mb()
-            if 0 <= headroom < CUDA_HEADROOM_MB:
+            if 0 <= headroom < needed:
                 log.warning("[tts] kokoro: %d MB available, under the %d MB a CUDA "
-                            "session needs — using cpu (RTF ~0.52 rather than ~0.07). "
-                            "Asking anyway OOM-killed a jp5.11 rig.",
-                            headroom, CUDA_HEADROOM_MB)
+                            "session needs%s — using cpu (RTF ~0.52 rather than "
+                            "~0.07). Asking anyway OOM-killed a jp5.11 rig.",
+                            headroom, needed,
+                            " beside the existing context" if shared
+                            else " including a context of its own")
                 device = "cpu"
 
         started = time.monotonic()

--- a/perception/plugins/kokoro_worker.py
+++ b/perception/plugins/kokoro_worker.py
@@ -101,10 +101,16 @@ IDLE_TIMEOUT_S = 0.0
 #     jp6.1   cpu 8.35s stdev 0.000   cuda 8.35s stdev 0.000
 #     jp5.11  cpu 8.35s stdev 0.000   cuda 6.05s stdev 0.053   <- 27.5% short
 #
-# jp5.11's ONNX Runtime is 1.15.1 and its CUDA execution of the duration path is simply
-# wrong; 27% short is audibly rushed speech. Gating on the version number would be the
-# wrong fix — it would not catch the next line with the same defect — so gate on the
-# measurement instead. The probe already runs as warmup, so this costs nothing.
+# **Confirmed by ear**: jp5.11's CUDA renders this graph as garbled speech, while
+# jp6.1's matches its own CPU exactly. The cause is unknown, and five candidates have
+# been ruled out by measurement — the two-runtime collision, the model file, TF32, the
+# ONNX Runtime version, and the CUDA provider binary. The record is in
+# perception/docs/jp511-cuda-kokoro.md.
+#
+# Which is why the gate is a **measurement** and not a version check. A version check
+# would have been wrong twice: written against 1.15.1 it lets the official 1.16.0
+# through, and 1.16.0 produces the same garbled audio. The probe already runs as
+# warmup, so it costs nothing.
 PROBE_TEXT = "konnichiwa"
 PROBE_SAMPLES = 47400
 # Wide enough that a legitimately different build is not rejected, far tighter than the
@@ -276,10 +282,11 @@ class KokoroWorkerProxy:
 
         - **not enough memory.** A CUDA session needs ~967 MB beside an existing
           context and ~1585 MB bringing its own. Asking anyway OOM-killed a jp5.11 rig.
-        - **wrong durations.** jp5.11's ONNX Runtime 1.15.1 executes this graph's
-          duration path incorrectly: 8 runs gave 6.05 s against the CPU's 8.35 s, and
-          the 10-token probe returned 16800-24000 samples against 47400. 27-51% short
-          is audibly rushed speech, and it has nothing to do with memory.
+        - **wrong durations.** On jp5.11 the CUDA path does not agree with its own
+          CPU: the long sentence came back 22% short and the *short* one 54% long, and
+          three renders of one input gave 1.4 s, 1.9 s and 2.95 s. Confirmed by ear as
+          garbled. Not a version problem — NVIDIA's official 1.16.0 behaves the same as
+          the 1.15.1 that ships — and nothing to do with memory.
         """
         from plugins.kokoro_direct import KokoroDirect
 

--- a/perception/plugins/kokoro_worker.py
+++ b/perception/plugins/kokoro_worker.py
@@ -25,6 +25,15 @@ Renaming the bridge and the CUDA provider in a private ORT build does fix it —
 but it forks ONNX Runtime's ABI and needs a second build per JetPack line. A process
 boundary gets the same result with none of that, and buys the GPU as well.
 
+**This module no longer owns a process.** It owns the *policy* for Japanese — which
+device is safe, whether the duration came out right, and when to give the memory back —
+while `plugins/ort_worker.py` owns the one child that holds every standalone-ORT session
+in this process, face's included. Two children would mean two CUDA contexts; the point of
+moving out of the parent was to keep the count where it already was, not to raise it.
+
+So encoding, the style-table lookup and chunking all run in the parent, as they always
+did, and only `session.run()` crosses: tokens and a 1 kB style row in, the waveform out.
+
 Measured on Orin 6, one 9.3 s Japanese utterance, 121 tokens:
 
     in-process, cpu (what this replaces)   RTF 0.525
@@ -122,17 +131,14 @@ def _mem_available_mb() -> int:
 
 
 class KokoroWorkerProxy:
-    """`KokoroDirect`'s surface, executed in a spawned child.
+    """`KokoroDirect`'s surface, with its ONNX session in the shared ORT worker.
 
-    Only `synthesize` is forwarded — the phoneme string goes in (~121 characters) and
-    float32 samples come back (~91 KB). Resampling, framing, pacing and EOF all stay in
-    the parent, so the boundary sits where the data is smallest and `plugins/tts.py`
-    does not change.
+    Constructed by `plugins/tts.py:_direct()`; its interface is deliberately unchanged
+    from when this class owned a child process, so nothing in tts.py had to move.
 
-    Falls back to an in-process CPU `KokoroDirect` if the child cannot be started or
-    dies. That fallback is exactly what shipped before this module existed, so a worker
-    failure costs speed and nothing else — Japanese must not break because a subprocess
-    did.
+    Falls back to an in-process CPU `KokoroDirect` if the worker cannot serve it. That
+    fallback is what shipped before any of this existed, so a worker failure costs speed
+    and nothing else — Japanese must not break because a subprocess did.
     """
 
     def __init__(self, model_dir: str, weights: str, device: str = "gpu",
@@ -144,25 +150,17 @@ class KokoroWorkerProxy:
         self._idle_timeout_s = float(idle_timeout_s)
 
         self._lock = threading.RLock()
-        self._ctx = None
-        self._proc = None
-        self._cmd_q = None
-        self._res_q = None
+        self._direct = None
+        self._device_used = device
         self._last_used = time.monotonic()
         self._closed = False
         self._fallback = None
         self._fallback_warned = False
 
-        # Filled by the child's handshake; the properties need them before any call.
-        self._n_speakers = 0
-        self._sample_rate = 0
-        self._providers = []
-        self._device_used = device
-
-        self._start()
+        self._build()
 
         self._reaper = threading.Thread(target=self._reap_loop, daemon=True,
-                                        name="kokoro-worker-reaper")
+                                        name="kokoro-session-reaper")
         self._reaper.start()
         atexit.register(self.close)
 
@@ -170,276 +168,155 @@ class KokoroWorkerProxy:
 
     @property
     def num_speakers(self) -> int:
-        if self._n_speakers:
-            return self._n_speakers
-        return self._use_fallback().num_speakers
+        with self._lock:
+            return (self._direct or self._use_fallback()).num_speakers
 
     @property
     def sample_rate(self) -> int:
-        if self._sample_rate:
-            return self._sample_rate
-        return self._use_fallback().sample_rate
+        with self._lock:
+            return (self._direct or self._use_fallback()).sample_rate
 
     @property
     def providers(self) -> list:
-        """What the child actually got. `['CPUExecutionProvider']` means the GPU was
-        asked for and refused — worth seeing in `info` rather than assuming."""
-        return list(self._providers)
+        """What the session actually got. `['CPUExecutionProvider']` after asking for
+        gpu means a guard declined it — worth seeing in `info` rather than assuming."""
+        with self._lock:
+            if self._direct is None:
+                return []
+            return list(self._direct._session.get_providers())
 
-    # ── lifecycle ────────────────────────────────────────────────────────────
+    @property
+    def device_used(self) -> str:
+        return self._device_used
 
-    def _start(self) -> None:
-        """Spawn the child and wait for it to report a warmed session.
+    # ── build, with both guards ──────────────────────────────────────────────
 
-        `spawn`, never the platform default: on Linux that is `fork`, which copies the
-        address space including already-dlopened libraries. A forked child would
-        inherit sherpa's ONNX Runtime and the isolation this module exists for would be
-        worthless.
+    def _build(self) -> None:
+        """Load the session in the shared worker, on a device that is actually safe.
+
+        Two guards, and the order matters. The duration check runs *after* the session
+        is built, so it cannot prevent the allocation that builds it from taking the box
+        down — the headroom check has to come first.
         """
-        import multiprocessing as mp
+        from plugins.kokoro_direct import KokoroDirect
 
         device = self._device
         if device in ("cuda", "gpu"):
             headroom = _mem_available_mb()
             if 0 <= headroom < CUDA_HEADROOM_MB:
-                log.warning("[tts] kokoro worker: %d MB available, under the %d MB a "
-                            "CUDA child needs — using cpu (RTF ~0.52 rather than "
-                            "~0.07). Asking anyway OOM-killed a jp5.11 rig.",
+                log.warning("[tts] kokoro: %d MB available, under the %d MB a CUDA "
+                            "session needs — using cpu (RTF ~0.52 rather than ~0.07). "
+                            "Asking anyway OOM-killed a jp5.11 rig.",
                             headroom, CUDA_HEADROOM_MB)
                 device = "cpu"
 
-        self._ctx = mp.get_context("spawn")
-        self._cmd_q = self._ctx.Queue()
-        self._res_q = self._ctx.Queue()
-        self._proc = self._ctx.Process(
-            target=_kokoro_worker,
-            args=(self._model_dir, self._weights, device, self._num_threads,
-                  self._cmd_q, self._res_q, log.getEffectiveLevel()),
-            daemon=False,
-            name="kokoro_ja_worker",
-        )
         started = time.monotonic()
-        self._proc.start()
+        for candidate, why in ((device, "requested"), ("cpu", "fallback")):
+            if why == "fallback" and candidate == device:
+                break                       # already tried it, and it failed the check
+            direct = KokoroDirect(self._model_dir, self._weights,
+                                  num_threads=self._num_threads, provider=candidate,
+                                  session_key="tts.kokoro.ja")
+            # The warmup was always needed — the first CUDA call costs 8.03 s of lazy
+            # kernel loading against 0.59 s warm — so checking its output length is
+            # free. A wrong length means this device computes the duration path
+            # incorrectly, and a fast wrong answer is worse than a slow right one.
+            n = len(direct.synthesize(PROBE_TEXT, speaker_id=0, speed=1.0))
+            off = abs(n - PROBE_SAMPLES) / PROBE_SAMPLES
+            if off <= PROBE_TOLERANCE:
+                self._direct = direct
+                self._device_used = candidate
+                log.info("[tts] kokoro session ready in %.1fs on %s%s: providers=%s",
+                         time.monotonic() - started, candidate,
+                         "" if candidate == self._device
+                         else f" (asked for {self._device})",
+                         direct._session.get_providers())
+                return
+            log.error("[tts] %s produced %d samples for the probe, expected ~%d "
+                      "(%.0f%% off) — this device computes the duration path wrongly; "
+                      "not using it", candidate, n, PROBE_SAMPLES, off * 100)
+            direct.close()
+        raise RuntimeError(
+            f"neither {self._device} nor cpu produced a plausible probe duration; the "
+            f"model or the phoneme table does not match this code")
 
-        try:
-            kind, payload = self._res_q.get(timeout=START_TIMEOUT_S)
-        except queue.Empty:
-            self._terminate()
-            raise RuntimeError(
-                f"Kokoro worker did not report ready within {START_TIMEOUT_S:.0f}s")
-        if kind != "ready":
-            self._terminate()
-            raise RuntimeError(f"Kokoro worker failed to start: {payload}")
-
-        self._n_speakers = int(payload["num_speakers"])
-        self._sample_rate = int(payload["sample_rate"])
-        self._providers = list(payload["providers"])
-        self._device_used = payload.get("device_used", self._device)
-        log.info("[tts] kokoro worker ready in %.1fs: pid=%s device=%s%s providers=%s, "
-                 "%d speakers, warmup %.2fs",
-                 time.monotonic() - started, self._proc.pid, self._device_used,
-                 "" if self._device_used == self._device
-                 else f" (asked for {self._device})",
-                 self._providers, self._n_speakers, payload["warmup_s"])
-
-    def _alive(self) -> bool:
-        return self._proc is not None and self._proc.is_alive()
-
-    def _terminate(self) -> None:
-        proc, self._proc = self._proc, None
-        self._cmd_q = self._res_q = None
-        if proc is None:
-            return
-        try:
-            proc.terminate()
-            proc.join(timeout=5)
-            if proc.is_alive():
-                proc.kill()
-                proc.join(timeout=5)
-        except Exception:                                        # noqa: BLE001
-            pass
+    # ── lifecycle ────────────────────────────────────────────────────────────
 
     def close(self) -> None:
-        """Kill the child and release its CUDA context.
+        """Unload the session, giving its weights and GPU pool back.
 
-        A process exit is the only thing that returns a CUDA context at all — an
-        in-process session never does. Called on card stop, engine switch, idle
-        expiry and at exit; safe to call more than once.
+        Unloads rather than killing the child: face's sessions live in the same process
+        and must survive Japanese being done with. Called on card stop, engine switch,
+        idle expiry and at exit; safe to call more than once.
         """
         with self._lock:
-            if self._closed and self._proc is None:
-                return
             self._closed = True
-            if self._proc is not None:
-                log.info("[tts] kokoro worker closing (pid=%s)", self._proc.pid)
-            self._terminate()
+            direct, self._direct = self._direct, None
             self._fallback = None
+        if direct is not None:
+            try:
+                direct.close()
+            except Exception as exc:                              # noqa: BLE001
+                log.warning("[tts] unloading the kokoro session failed: %s", exc)
 
     def _reap_loop(self) -> None:
         """Give the memory back when Japanese stops being used.
 
-        Not on `set_language`, deliberately: the cold path is ~10.5 s and a tour that
-        alternates languages would pay it on every switch. Idle time is the signal that
-        actually means "done with Japanese".
+        Not on `set_language`, deliberately: the cold path is ~15 s measured end to end
+        and a tour that alternates languages would pay it on every switch. Idle time is
+        the signal that actually means "done with Japanese".
         """
         while True:
             time.sleep(5.0)
+            direct = None
             with self._lock:
                 if self._closed:
                     return
                 idle = time.monotonic() - self._last_used
-                if self._alive() and idle > self._idle_timeout_s:
-                    log.info("[tts] kokoro worker idle %.0fs, reaping (pid=%s)",
-                             idle, self._proc.pid)
-                    self._terminate()
+                if self._direct is not None and idle > self._idle_timeout_s:
+                    log.info("[tts] kokoro session idle %.0fs, unloading", idle)
+                    direct, self._direct = self._direct, None
+            # Unload outside the lock: it is a round trip to the child, and holding the
+            # lock across it would stall an utterance that arrived meanwhile.
+            if direct is not None:
+                try:
+                    direct.close()
+                except Exception as exc:                          # noqa: BLE001
+                    log.warning("[tts] idle unload failed: %s", exc)
 
-    # ── the one forwarded call ───────────────────────────────────────────────
+    # ── the one call ─────────────────────────────────────────────────────────
 
     def synthesize(self, phonemes: str, speaker_id: int = 0, speed: float = 1.0):
         with self._lock:
             self._last_used = time.monotonic()
             if self._closed:
                 return self._use_fallback().synthesize(phonemes, speaker_id, speed)
-            if not self._alive():
+            if self._direct is None:
                 try:
-                    self._start()
+                    self._build()
                 except Exception as exc:                          # noqa: BLE001
-                    log.warning("[tts] kokoro worker could not be restarted (%s); "
+                    log.warning("[tts] kokoro session could not be rebuilt (%s); "
                                 "Japanese falls back to the in-process CPU session",
                                 exc)
                     return self._use_fallback().synthesize(phonemes, speaker_id, speed)
-
-            req_id = uuid.uuid4().hex[:8]
             try:
-                self._cmd_q.put(("synthesize", req_id, phonemes, speaker_id, speed))
-                kind, payload = self._recv(req_id)
+                return self._direct.synthesize(phonemes, speaker_id=speaker_id,
+                                               speed=speed)
             except Exception as exc:                              # noqa: BLE001
-                log.warning("[tts] kokoro worker call failed (%s); falling back to "
-                            "the in-process CPU session", exc)
-                self._terminate()
+                log.warning("[tts] kokoro synthesis in the worker failed (%s); "
+                            "falling back to the in-process CPU session", exc)
+                self._direct = None
                 return self._use_fallback().synthesize(phonemes, speaker_id, speed)
 
-            if kind == "error":
-                # The child is fine, the request was not — surface it rather than
-                # silently re-synthesizing somewhere else and hiding a real bug.
-                raise RuntimeError(f"kokoro worker: {payload}")
-            return payload
-
-    def _recv(self, want_id: str):
-        """Read until this request's answer, tolerating a late reply to an earlier one.
-
-        Calls are serialised by `self._lock`, so out-of-order traffic means a previous
-        call timed out and its result arrived afterwards. Dropping it is right; blocking
-        on it would deadlock the next utterance.
-        """
-        deadline = time.monotonic() + CALL_TIMEOUT_S
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                raise TimeoutError(
-                    f"no reply within {CALL_TIMEOUT_S:.0f}s (child alive="
-                    f"{self._alive()})")
-            kind, req_id, payload = self._res_q.get(timeout=remaining)
-            if req_id == want_id:
-                return kind, payload
-            log.debug("[tts] kokoro worker: dropping stale reply %s", req_id)
-
     def _use_fallback(self):
-        """The in-process CPU session — what shipped before this module existed."""
+        """The in-process CPU session — what shipped before any of this existed."""
         if self._fallback is None:
             from plugins.kokoro_direct import KokoroDirect
             self._fallback = KokoroDirect(self._model_dir, self._weights,
-                                          num_threads=self._num_threads)
+                                          num_threads=self._num_threads,
+                                          in_process=True)
         if not self._fallback_warned:
             self._fallback_warned = True
             log.warning("[tts] Japanese is using the in-process CPU session "
-                        "(RTF ~0.52 against ~0.06 on the worker)")
+                        "(RTF ~0.52 against ~0.07 in the worker)")
         return self._fallback
-
-
-def _build_checked(KokoroDirect, model_dir, weights, device, num_threads, wlog):
-    """Build on `device`, warm it up, and check the warmup's duration is right.
-
-    The warmup was always needed — the first CUDA call costs 8.03 s of lazy kernel
-    loading against 0.59 s warm — so measuring its output length is free. If the length
-    is wrong the device is executing the duration path incorrectly (jp5.11's ORT 1.15.1
-    returns 35-44% of it), and CPU is the only honest answer: 27% short is audibly
-    rushed speech, and a fast wrong answer is worse than a slow right one.
-
-    Returns `(runtime, device_actually_used)`.
-    """
-    for candidate, why in ((device, "requested"), ("cpu", "fallback")):
-        if why == "fallback" and candidate == device:
-            break                       # already tried, and it failed the check
-        direct = KokoroDirect(model_dir, weights, num_threads=num_threads,
-                              provider=candidate)
-        n = len(direct.synthesize(PROBE_TEXT, speaker_id=0, speed=1.0))
-        off = abs(n - PROBE_SAMPLES) / PROBE_SAMPLES
-        if off <= PROBE_TOLERANCE:
-            if why == "fallback":
-                wlog.warning("running on cpu after %r failed the duration check", device)
-            return direct, candidate
-        wlog.error("%s produced %d samples for the probe, expected ~%d (%.0f%% off) — "
-                   "this device computes the duration path wrongly; not using it",
-                   candidate, n, PROBE_SAMPLES, off * 100)
-        del direct
-    raise RuntimeError(
-        f"neither {device} nor cpu produced a plausible probe duration; the model or "
-        f"the phoneme table does not match this code")
-
-
-def _kokoro_worker(model_dir: str, weights: str, device: str, num_threads: int,
-                   cmd_q, res_q, log_level: int) -> None:
-    """Child entry point. Owns one `KokoroDirect` and nothing else.
-
-    Deliberately imports neither `rclpy` nor `sherpa_onnx`: this process exists to be
-    the only ONNX Runtime in its address space, and the parent keeps the ROS node, the
-    publisher and the pacing.
-    """
-    # A spawned child gets a fresh interpreter and does not inherit the parent's
-    # sys.stdout, so the atomic writer has to be reinstalled — without it a subprocess
-    # writing on the parent's fd 1 tears Docker log records.
-    try:
-        from utils import logsafe
-        logsafe.install(check_fd=False)
-    except Exception:                                             # noqa: BLE001
-        pass
-
-    logging.basicConfig(
-        level=log_level,
-        format='%(asctime)s [%(name)s] %(levelname)s %(message)s',
-        datefmt='%H:%M:%S')
-    wlog = logging.getLogger("tts.kokoro_worker")
-
-    try:
-        from plugins.kokoro_direct import KokoroDirect
-        started = time.monotonic()
-        direct, device_used = _build_checked(KokoroDirect, model_dir, weights, device,
-                                             num_threads, wlog)
-        res_q.put(("ready", {
-            "num_speakers": direct.num_speakers,
-            "sample_rate": direct.sample_rate,
-            "providers": list(direct._session.get_providers()),
-            "device_used": device_used,
-            "warmup_s": round(time.monotonic() - started, 2),
-        }))
-    except Exception as exc:                                      # noqa: BLE001
-        res_q.put(("failed", f"{type(exc).__name__}: {exc}"))
-        return
-
-    while True:
-        try:
-            command = cmd_q.get()
-        except (EOFError, OSError):
-            return
-        if command is None or command[0] == "stop":
-            return
-        if command[0] != "synthesize":
-            wlog.warning("unknown command %r", command[0])
-            continue
-        _, req_id, phonemes, speaker_id, speed = command
-        try:
-            samples = direct.synthesize(phonemes, speaker_id=speaker_id, speed=speed)
-            res_q.put(("ok", req_id, np.asarray(samples, dtype=np.float32)))
-        except Exception as exc:                                  # noqa: BLE001
-            res_q.put(("error", req_id, f"{type(exc).__name__}: {exc}"))

--- a/perception/plugins/ort_worker.py
+++ b/perception/plugins/ort_worker.py
@@ -1,0 +1,486 @@
+#!/usr/bin/env python3
+"""
+plugins/ort_worker.py — the standalone ONNX Runtime, in a process of its own.
+
+## Why this exists
+
+Perception is one process holding **two** ONNX Runtimes: sherpa-onnx bundles its own,
+and the standalone `onnxruntime` wheel serves face recognition and Kokoro's Japanese
+path. They corrupt each other, and the reason is in the dynamic linker rather than in
+either library.
+
+`libonnxruntime_providers_shared.so` is an 8 KB library exporting exactly
+`Provider_GetHost` and `Provider_SetHost` — a process-global slot holding **one** pointer
+to **one** runtime's `ProviderHost`. It carries a SONAME, and `ld.so` deduplicates a
+`dlopen` by matching the requested basename against already-loaded objects, so the second
+runtime's copy is never mapped: both get the first one. Each runtime writes its own host
+into that slot as it loads a provider, **last writer wins**, and the next session built
+runs against the other runtime's framework objects:
+
+    Error mapping output names: Could not find OrtValue with name '/Squeeze_2_output_0'
+
+Measured on Orin 6 with `Provider_GetHost()` observed changing value and only ever one
+bridge mapped. What it costs, per JetPack line:
+
+| | |
+|---|---|
+| jp6.1 | an exception — the affected card goes `state: error` |
+| jp5.11 | **SIGSEGV, killing the whole perception process** — ASR, VOP, OCR and face with it |
+
+And it is not order-fixable, only order-*avoidable*: with face's CUDA session built
+first, `sherpa_onnx.OfflineTts` cannot be constructed at all. Releasing face's session
+does not help — measured: the claim on the bridge outlives the session object, so there is
+no in-process recovery. Production only escapes it because `main.py` happens to construct
+the TTS plugin (`:112-117`) before face (`:140-147`); switching the TTS engine to
+`kokoro-multi` while face is on gpu breaks it today.
+
+## What this does
+
+One child process owns **every** standalone-ORT session, so the parent holds only
+sherpa's runtime and the collision cannot occur. Not one process per card — one process
+per *runtime*, which is the boundary the bug actually has. `plugins/kokoro_worker.py`
+proved the shape on the Japanese path; this generalises it and brings face along.
+
+CUDA contexts do not increase: the parent used to hold sherpa's **and** the standalone
+one's; now it holds sherpa's and the child holds the standalone one.
+
+## What crosses, and what it costs
+
+The boundary is the two `run()` calls, nothing else. Every bit of pre- and
+post-processing — letterboxing, `_distance2bbox`, NMS, Umeyama alignment, the FaceDB
+`matrix @ embedding` — is a pure function on arrays and stays in the parent.
+
+Measured on Orin 6, round trip through a `Queue`:
+
+    detection   in 1x3x640x640 f32  2.93 MiB   out 9 arrays  0.96 MiB   ~13 ms
+    recognition in 1x3x112x112 f32   147 kB    out (1,512)    2 kB      ~0.4 ms
+    Japanese    a phoneme string             out ~0.89 MB              ~2.7 ms
+
+At `detect_fps: 1.0`, the default and the documented design point
+(`config.yaml`: "cpu at 1 detection/second is the design point"), that is **~1.3% of a
+second**. Shared memory measured 2.4-3x faster (3.27 ms against 9.07 ms for a 2.76 MB
+payload) and is the answer if anyone runs `detect_fps: 0` against a fast camera, but it
+is not needed at the design point and a `Queue` is far less to get wrong.
+
+The burst paths are the ones to watch, not the steady state: `register_by_stream`
+analyses up to 8 frames back to back, `register_by_corpus` up to 200. Those pay ~13 ms
+each on top of inference. They are human-initiated and were never latency-critical.
+"""
+
+from __future__ import annotations
+
+import atexit
+import importlib
+import logging
+import os
+import queue
+import threading
+import time
+import uuid
+
+import numpy as np
+
+log = logging.getLogger(__name__)
+
+# A cold CUDA session costs 2.5 s to build plus ~8 s for the first inference on Orin 6,
+# and this may be loading the 310 MB Kokoro graph on a box also serving video.
+LOAD_TIMEOUT_S = 90.0
+# Detection is ~6 ms warm and a Japanese utterance ~0.6 s. This is a "the child is
+# wedged" bound, not a budget.
+RUN_TIMEOUT_S = 60.0
+
+
+class OrtWorkerError(RuntimeError):
+    """The child could not serve the request. Callers decide whether to fall back."""
+
+
+class _SessionMeta:
+    """Input/output names and shapes, so a proxy can answer without a round trip.
+
+    `face_runtime.py` reads `get_inputs()[0].name` once at construction and caches it;
+    the detection path also needs the nine output names. Both are static, so the child
+    reports them at load time and the proxy answers locally afterwards.
+    """
+
+    __slots__ = ("name", "shape", "type")
+
+    # `type` shadows the builtin, deliberately: onnxruntime's own NodeArg calls it that
+    # and callers read `.type`, so matching the shape it stands in for beats tidiness.
+    def __init__(self, name, shape, type):                        # noqa: A002
+        self.name, self.shape, self.type = name, shape, type
+
+
+class OrtWorker:
+    """The child process, and the only place a standalone ORT session may be created.
+
+    One instance per perception process, obtained through `get_worker()`. Sessions are
+    loaded and unloaded independently, so Japanese can give its 310 MB back without
+    disturbing face.
+    """
+
+    def __init__(self, num_threads: int = 0):
+        self._num_threads = num_threads
+        self._lock = threading.RLock()
+        self._ctx = None
+        self._proc = None
+        self._cmd_q = None
+        self._res_q = None
+        # key -> (model_path, providers, options) so a restarted child can be refilled
+        # without every caller having to notice it died.
+        self._loaded = {}
+        self._meta = {}
+        self._closed = False
+        atexit.register(self.close)
+
+    # ── process lifecycle ────────────────────────────────────────────────────
+
+    def _ensure_started(self) -> None:
+        if self._proc is not None and self._proc.is_alive():
+            return
+        import multiprocessing as mp
+
+        # `spawn`, never the platform default. On Linux that is `fork`, which copies the
+        # address space *including already-dlopened libraries* — a forked child would
+        # inherit sherpa's ONNX Runtime and the isolation this module exists for would
+        # be worthless. This is the single most important line in the file.
+        self._ctx = mp.get_context("spawn")
+        self._cmd_q = self._ctx.Queue()
+        self._res_q = self._ctx.Queue()
+        self._proc = self._ctx.Process(
+            target=_ort_worker_main,
+            args=(self._cmd_q, self._res_q, log.getEffectiveLevel()),
+            # daemon, and that is not a style choice. `multiprocessing.util
+            # ._exit_function` joins every non-daemon child at interpreter exit, and it
+            # registers itself when multiprocessing is first imported — which happens
+            # *after* this class registers its own atexit hook, so LIFO puts it first.
+            # It then joins a child that is blocking on `cmd_q.get()` and waits for
+            # ever. Measured: the verification script completed all its checks and then
+            # hung at exit with the child still alive.
+            #
+            # A session host has nothing to flush, so dying with the parent is the
+            # right semantics anyway; `close()` is still the normal path.
+            daemon=True,
+            name="ort_worker",
+        )
+        self._proc.start()
+        try:
+            kind, payload = self._res_q.get(timeout=30)
+        except queue.Empty:
+            self._terminate()
+            raise OrtWorkerError("the ORT worker did not come up within 30s")
+        if kind != "hello":
+            self._terminate()
+            raise OrtWorkerError(f"the ORT worker failed to start: {payload}")
+        log.info("[ort] worker up: pid=%s onnxruntime=%s providers=%s",
+                 self._proc.pid, payload["version"], payload["providers"])
+
+        # Reload whatever was resident before it died, so a caller holding a proxy does
+        # not have to know the child was replaced.
+        stale, self._loaded = dict(self._loaded), {}
+        for key, spec in stale.items():
+            try:
+                self._load_locked(key, *spec)
+                log.info("[ort] reloaded %s after the worker restarted", key)
+            except Exception as exc:                              # noqa: BLE001
+                log.warning("[ort] could not reload %s: %s", key, exc)
+
+    def _terminate(self) -> None:
+        proc, self._proc = self._proc, None
+        self._cmd_q = self._res_q = None
+        self._meta = {}
+        if proc is None:
+            return
+        try:
+            proc.terminate()
+            proc.join(timeout=5)
+            if proc.is_alive():
+                proc.kill()
+                proc.join(timeout=5)
+        except Exception:                                         # noqa: BLE001
+            pass
+
+    def close(self) -> None:
+        """Kill the child, releasing its CUDA context.
+
+        A process exit is the only thing that returns a CUDA context at all — an
+        in-process session never does. Safe to call more than once.
+        """
+        with self._lock:
+            if self._closed and self._proc is None:
+                return
+            self._closed = True
+            if self._proc is not None:
+                log.info("[ort] worker closing (pid=%s)", self._proc.pid)
+            self._terminate()
+            self._loaded = {}
+
+    @property
+    def alive(self) -> bool:
+        return self._proc is not None and self._proc.is_alive()
+
+    # ── sessions ─────────────────────────────────────────────────────────────
+
+    def load(self, key: str, model_path: str, providers, options=None,
+             postprocess=None):
+        """Load a model in the child and return a proxy that behaves like a session.
+
+        `key` is the caller's name for it — reused on a restart to bring it back, and
+        used by `unload`. `options` is a plain dict, because `ort.SessionOptions` is not
+        picklable; the child rebuilds it.
+
+        `postprocess` is `{"module": ..., "func": ...}`, imported by the child and
+        applied to the raw outputs before they are sent back. It exists because a
+        detector head is enormous before thresholding and tiny after — SCRFD returns
+        16 800 candidates of which a frame keeps nought to eight — so shipping the raw
+        arrays across means throwing 99.95% of them away on the far side, measured at
+        +27 ms per detection.
+
+        Passing a module path rather than a callable keeps this class ignorant of what
+        it is hosting: a closure could not be pickled to a spawned child anyway, and a
+        name means the child imports the *same* implementation the in-process path uses
+        rather than a copy of it.
+        """
+        with self._lock:
+            self._closed = False
+            self._ensure_started()
+            return self._load_locked(key, model_path, list(providers),
+                                     dict(options or {}),
+                                     dict(postprocess) if postprocess else None)
+
+    def _load_locked(self, key, model_path, providers, options, postprocess=None):
+        reply = self._request(("load", key, model_path, providers, options,
+                               postprocess),
+                              timeout=LOAD_TIMEOUT_S)
+        self._loaded[key] = (model_path, providers, options)
+        self._meta[key] = reply
+        return OrtSessionProxy(self, key, reply)
+
+    def unload(self, key: str) -> None:
+        """Drop one session, keeping the child and anything else it holds.
+
+        This is why the child is shared rather than one per card: Japanese can give its
+        310 MB back on idle without taking face's sessions down with it.
+        """
+        with self._lock:
+            self._loaded.pop(key, None)
+            self._meta.pop(key, None)
+            if not self.alive:
+                return
+            try:
+                self._request(("unload", key), timeout=30)
+            except Exception as exc:                              # noqa: BLE001
+                log.warning("[ort] unload %s failed: %s", key, exc)
+
+    def run(self, key: str, output_names, feeds, post_kwargs=None):
+        """Run the session. With a postprocessor registered, the reply is its return
+        value rather than the raw outputs, and `post_kwargs` are its per-call
+        arguments — the letterbox scale, for instance, which changes every frame."""
+        with self._lock:
+            if self._closed:
+                raise OrtWorkerError("the ORT worker is closed")
+            if not self.alive:
+                log.warning("[ort] worker died; restarting and reloading its sessions")
+                self._ensure_started()
+            return self._request(("run", key, output_names, feeds, post_kwargs),
+                                 timeout=RUN_TIMEOUT_S)
+
+    def _request(self, command, timeout: float):
+        """Send one command and wait for its reply. Caller holds `self._lock`."""
+        req_id = uuid.uuid4().hex[:8]
+        try:
+            self._cmd_q.put((req_id,) + command)
+        except Exception as exc:                                  # noqa: BLE001
+            self._terminate()
+            raise OrtWorkerError(f"could not reach the ORT worker: {exc}") from exc
+
+        deadline = time.monotonic() + timeout
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                self._terminate()
+                raise OrtWorkerError(
+                    f"no reply to {command[0]!r} within {timeout:.0f}s")
+            try:
+                got_id, kind, payload = self._res_q.get(timeout=remaining)
+            except queue.Empty:
+                continue
+            if got_id != req_id:
+                # Requests are serialised by `self._lock`, so this is a late reply to a
+                # call that already timed out. Dropping it is right; waiting on it would
+                # deadlock the next one.
+                log.debug("[ort] dropping stale reply %s", got_id)
+                continue
+            if kind == "error":
+                raise OrtWorkerError(payload)
+            return payload
+
+
+class OrtSessionProxy:
+    """Enough of `onnxruntime.InferenceSession` for this codebase's two callers.
+
+    `run`, `get_providers`, `get_inputs`, `get_outputs` — that is all
+    `plugins/face_runtime.py` and `plugins/kokoro_direct.py` use. Metadata is answered
+    locally from the load-time reply, so caching `get_inputs()[0].name` at construction
+    costs no round trip.
+    """
+
+    def __init__(self, worker: OrtWorker, key: str, meta: dict):
+        self._worker = worker
+        self._key = key
+        self._providers = list(meta["providers"])
+        self._inputs = [_SessionMeta(**m) for m in meta["inputs"]]
+        self._outputs = [_SessionMeta(**m) for m in meta["outputs"]]
+
+    def run(self, output_names, feeds, run_options=None, post_kwargs=None):
+        del run_options                     # never used by either caller
+        return self._worker.run(self._key, output_names, feeds, post_kwargs)
+
+    def get_providers(self):
+        return list(self._providers)
+
+    def get_inputs(self):
+        return list(self._inputs)
+
+    def get_outputs(self):
+        return list(self._outputs)
+
+    def unload(self):
+        self._worker.unload(self._key)
+
+
+# ── the single instance ───────────────────────────────────────────────────────
+
+_worker = None
+_worker_lock = threading.Lock()
+
+
+def get_worker() -> OrtWorker:
+    """The one ORT worker for this process, created on first use.
+
+    A single child rather than one per plugin: two children would mean two CUDA
+    contexts, and the point of moving out of the parent is to keep the count the same
+    as before, not to raise it.
+    """
+    global _worker
+    with _worker_lock:
+        if _worker is None:
+            _worker = OrtWorker()
+        return _worker
+
+
+def worker_enabled() -> bool:
+    """Whether to route standalone-ORT sessions through the child.
+
+    On by default. `PERCEPTION_ORT_WORKER=0` puts every session back in the perception
+    process — which restores the collision, so it exists for bisecting a problem rather
+    than as a supported configuration.
+    """
+    return os.environ.get("PERCEPTION_ORT_WORKER", "1").strip().lower() not in (
+        "0", "false", "no", "off")
+
+
+# ── the child ─────────────────────────────────────────────────────────────────
+
+def _ort_worker_main(cmd_q, res_q, log_level: int) -> None:
+    """Child entry point. Holds every standalone-ORT session and nothing else.
+
+    Imports neither `rclpy` nor `sherpa_onnx`: this process exists to be the only ONNX
+    Runtime in its address space, and the parent keeps the ROS nodes, the publishers and
+    all pre/post-processing.
+    """
+    # A spawned child gets a fresh interpreter and does not inherit the parent's
+    # sys.stdout, so the atomic writer has to be reinstalled — without it a subprocess
+    # writing on the parent's fd 1 tears Docker log records.
+    try:
+        from utils import logsafe
+        logsafe.install(check_fd=False)
+    except Exception:                                             # noqa: BLE001
+        pass
+
+    logging.basicConfig(
+        level=log_level,
+        format='%(asctime)s [%(name)s] %(levelname)s %(message)s',
+        datefmt='%H:%M:%S')
+    wlog = logging.getLogger("ort.worker")
+
+    try:
+        import onnxruntime as ort
+    except Exception as exc:                                      # noqa: BLE001
+        res_q.put(("failed", f"{type(exc).__name__}: {exc}"))
+        return
+
+    res_q.put(("hello", {"version": ort.__version__,
+                         "providers": ort.get_available_providers()}))
+
+    sessions = {}
+
+    def _meta(entries):
+        return [{"name": e.name, "shape": list(e.shape), "type": e.type}
+                for e in entries]
+
+    while True:
+        try:
+            command = cmd_q.get()
+        except (EOFError, OSError):
+            return
+        if command is None:
+            return
+        req_id, verb = command[0], command[1]
+
+        try:
+            if verb == "load":
+                _, _, key, model_path, providers, options, postprocess = command
+                opts = ort.SessionOptions()
+                if options.get("intra_op_num_threads") is not None:
+                    opts.intra_op_num_threads = int(options["intra_op_num_threads"])
+                if options.get("log_severity_level") is not None:
+                    opts.log_severity_level = int(options["log_severity_level"])
+                level = options.get("graph_optimization_level")
+                if level:
+                    opts.graph_optimization_level = getattr(
+                        ort.GraphOptimizationLevel, level)
+                started = time.monotonic()
+                sess = ort.InferenceSession(model_path, opts, providers=providers)
+                post = None
+                if postprocess:
+                    module = importlib.import_module(postprocess["module"])
+                    post = getattr(module, postprocess["func"])
+                    wlog.info("%s post-processes in the worker via %s.%s",
+                              key, postprocess["module"], postprocess["func"])
+                sessions[key] = (sess, post)
+                wlog.info("loaded %s in %.2fs: %s providers=%s",
+                          key, time.monotonic() - started,
+                          os.path.basename(model_path), sess.get_providers())
+                res_q.put((req_id, "ok", {
+                    "providers": sess.get_providers(),
+                    "inputs": _meta(sess.get_inputs()),
+                    "outputs": _meta(sess.get_outputs()),
+                }))
+
+            elif verb == "unload":
+                _, _, key = command
+                dropped = sessions.pop(key, None)
+                del dropped
+                wlog.info("unloaded %s", key)
+                res_q.put((req_id, "ok", None))
+
+            elif verb == "run":
+                _, _, key, output_names, feeds, post_kwargs = command
+                entry = sessions.get(key)
+                if entry is None:
+                    res_q.put((req_id, "error",
+                               f"session {key!r} is not loaded in the worker"))
+                    continue
+                sess, post = entry
+                outputs = sess.run(output_names, feeds)
+                if post is not None:
+                    # Threshold here, not in the parent: this is where the 0.96 MiB of
+                    # candidates already lives, and the caller wants the survivors.
+                    outputs = post(outputs, **(post_kwargs or {}))
+                res_q.put((req_id, "ok", outputs))
+
+            else:
+                res_q.put((req_id, "error", f"unknown verb {verb!r}"))
+
+        except Exception as exc:                                  # noqa: BLE001
+            res_q.put((req_id, "error", f"{type(exc).__name__}: {exc}"))

--- a/perception/plugins/ort_worker.py
+++ b/perception/plugins/ort_worker.py
@@ -129,6 +129,9 @@ class OrtWorker:
         # without every caller having to notice it died.
         self._loaded = {}
         self._meta = {}
+        # key -> (module, func, kwargs), rebuilt on a restart for the same reason
+        # sessions are: a caller holding a proxy should not have to notice.
+        self._services = {}
         self._closed = False
         atexit.register(self.close)
 
@@ -183,6 +186,15 @@ class OrtWorker:
                 log.info("[ort] reloaded %s after the worker restarted", key)
             except Exception as exc:                              # noqa: BLE001
                 log.warning("[ort] could not reload %s: %s", key, exc)
+        stale_services, self._services = dict(self._services), {}
+        for key, (module, func, kwargs) in stale_services.items():
+            try:
+                self._request(("service", key, module, func, kwargs),
+                              timeout=LOAD_TIMEOUT_S)
+                self._services[key] = (module, func, kwargs)
+                log.info("[ort] rebuilt service %s after the worker restarted", key)
+            except Exception as exc:                              # noqa: BLE001
+                log.warning("[ort] could not rebuild service %s: %s", key, exc)
 
     def _terminate(self) -> None:
         proc, self._proc = self._proc, None
@@ -213,6 +225,32 @@ class OrtWorker:
                 log.info("[ort] worker closing (pid=%s)", self._proc.pid)
             self._terminate()
             self._loaded = {}
+            self._services = {}
+
+    def has_cuda_session(self) -> bool:
+        """Whether the child already holds a CUDA session — and so a CUDA context.
+
+        A caller deciding whether it can afford one needs this, because the first CUDA
+        session in the child pays for the context and the rest do not. Measured on
+        Orin 6: the face service on cuda cost 764 MB, and Kokoro's graph beside it cost
+        **967 MB** including its first inference — against 1585 MB when Kokoro was
+        alone in the child and had to bring a context with it.
+        """
+        with self._lock:
+            for _path, providers, _options in self._loaded.values():
+                if any("CUDA" in p or "Tensorrt" in p for p in providers):
+                    return True
+            # Services resolve their own providers inside the child, so ask them.
+            for key in list(self._services):
+                try:
+                    described = self._request(("call", key, "describe", {}),
+                                              timeout=30) or {}
+                except Exception:                                 # noqa: BLE001
+                    continue
+                if any("CUDA" in p or "Tensorrt" in p
+                       for p in (described.get("providers") or ())):
+                    return True
+        return False
 
     @property
     def alive(self) -> bool:
@@ -229,16 +267,12 @@ class OrtWorker:
         picklable; the child rebuilds it.
 
         `postprocess` is `{"module": ..., "func": ...}`, imported by the child and
-        applied to the raw outputs before they are sent back. It exists because a
-        detector head is enormous before thresholding and tiny after — SCRFD returns
-        16 800 candidates of which a frame keeps nought to eight — so shipping the raw
-        arrays across means throwing 99.95% of them away on the far side, measured at
-        +27 ms per detection.
-
-        Passing a module path rather than a callable keeps this class ignorant of what
-        it is hosting: a closure could not be pickled to a spawned child anyway, and a
-        name means the child imports the *same* implementation the in-process path uses
-        rather than a copy of it.
+        applied to the raw outputs before they are sent back. Kokoro does not use it —
+        its reply is the waveform, which is the thing the caller wanted — and neither
+        does face any more, because hosting the whole pipeline (see `service`) beats
+        shrinking one reply. Kept because a name, not a closure, is the only way to
+        hand code to a spawned child, and the next caller that needs it will need it
+        this way.
         """
         with self._lock:
             self._closed = False
@@ -270,6 +304,51 @@ class OrtWorker:
                 self._request(("unload", key), timeout=30)
             except Exception as exc:                              # noqa: BLE001
                 log.warning("[ort] unload %s failed: %s", key, exc)
+
+    # ── services: a whole pipeline in the child, not just a session ──────────
+
+    def service(self, key: str, module: str, func: str, **kwargs):
+        """Build an object in the child by name and return a handle to call it.
+
+        This exists because splitting at `InferenceSession.run` puts the *largest*
+        payload on the wire. Face measured +27 ms per detection that way: a 2.93 MiB
+        normalised blob out, 0.96 MiB of pre-threshold candidates back, then a crop per
+        face. Hosting the pipeline instead means the frame crosses once as the
+        50-300 kB JPEG the parent already holds, and a few kB of results come back.
+
+        `module`/`func` rather than a callable, for the same reason `postprocess` takes
+        a name: a spawned child cannot be handed a closure, and a name means it imports
+        the same implementation rather than a copy. This class still knows nothing about
+        what it is hosting.
+        """
+        with self._lock:
+            self._closed = False
+            self._ensure_started()
+            reply = self._request(("service", key, module, func, kwargs),
+                                  timeout=LOAD_TIMEOUT_S)
+            self._services[key] = (module, func, kwargs)
+            return ServiceProxy(self, key, reply)
+
+    def call(self, key: str, method: str, kwargs=None, timeout=None):
+        with self._lock:
+            if self._closed:
+                raise OrtWorkerError("the ORT worker is closed")
+            if not self.alive:
+                log.warning("[ort] worker died; restarting and rebuilding its services")
+                self._ensure_started()
+            return self._request(("call", key, method, dict(kwargs or {})),
+                                 timeout=timeout or RUN_TIMEOUT_S)
+
+    def drop(self, key: str) -> None:
+        """Release one service, keeping the child and everything else it holds."""
+        with self._lock:
+            self._services.pop(key, None)
+            if not self.alive:
+                return
+            try:
+                self._request(("drop", key), timeout=30)
+            except Exception as exc:                              # noqa: BLE001
+                log.warning("[ort] drop %s failed: %s", key, exc)
 
     def run(self, key: str, output_names, feeds, post_kwargs=None):
         """Run the session. With a postprocessor registered, the reply is its return
@@ -348,6 +427,34 @@ class OrtSessionProxy:
         self._worker.unload(self._key)
 
 
+class ServiceProxy:
+    """A handle on an object living in the worker child.
+
+    Deliberately thin: `describe()` answers from the build-time reply and everything
+    else is one round trip. The parent-side wrapper that gives it a friendly shape is
+    `plugins/face_proxy.py` — keeping that out of here is what stops this module
+    accumulating knowledge of its tenants.
+    """
+
+    def __init__(self, worker: "OrtWorker", key: str, described: dict):
+        self._worker = worker
+        self._key = key
+        self._described = dict(described or {})
+
+    @property
+    def key(self) -> str:
+        return self._key
+
+    def describe(self) -> dict:
+        return dict(self._described)
+
+    def call(self, method: str, timeout=None, **kwargs):
+        return self._worker.call(self._key, method, kwargs, timeout=timeout)
+
+    def drop(self) -> None:
+        self._worker.drop(self._key)
+
+
 # ── the single instance ───────────────────────────────────────────────────────
 
 _worker = None
@@ -413,6 +520,7 @@ def _ort_worker_main(cmd_q, res_q, log_level: int) -> None:
                          "providers": ort.get_available_providers()}))
 
     sessions = {}
+    services = {}
 
     def _meta(entries):
         return [{"name": e.name, "shape": list(e.shape), "type": e.type}
@@ -456,6 +564,38 @@ def _ort_worker_main(cmd_q, res_q, log_level: int) -> None:
                     "inputs": _meta(sess.get_inputs()),
                     "outputs": _meta(sess.get_outputs()),
                 }))
+
+            elif verb == "service":
+                _, _, key, module_name, func_name, kwargs = command
+                module = importlib.import_module(module_name)
+                started = time.monotonic()
+                obj = getattr(module, func_name)(**kwargs)
+                services[key] = obj
+                describe = getattr(obj, "describe", None)
+                wlog.info("built service %s from %s.%s in %.2fs",
+                          key, module_name, func_name, time.monotonic() - started)
+                res_q.put((req_id, "ok", describe() if describe else {}))
+
+            elif verb == "call":
+                _, _, key, method, kwargs = command
+                obj = services.get(key)
+                if obj is None:
+                    res_q.put((req_id, "error",
+                               f"service {key!r} is not built in the worker"))
+                    continue
+                res_q.put((req_id, "ok", getattr(obj, method)(**kwargs)))
+
+            elif verb == "drop":
+                _, _, key = command
+                obj = services.pop(key, None)
+                closer = getattr(obj, "close", None)
+                if closer is not None:
+                    try:
+                        closer()
+                    except Exception as exc:                      # noqa: BLE001
+                        wlog.warning("closing service %s failed: %s", key, exc)
+                wlog.info("dropped service %s", key)
+                res_q.put((req_id, "ok", None))
 
             elif verb == "unload":
                 _, _, key = command

--- a/perception/plugins/scrfd_decode.py
+++ b/perception/plugins/scrfd_decode.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""
+plugins/scrfd_decode.py — SCRFD's detector head, decoded where it is produced.
+
+## Why this is its own module
+
+The detector returns its head **before thresholding**: nine arrays covering every
+anchor of every stride. At 640x640 with strides 8/16/32 and two anchors that is
+
+    (80*80 + 40*40 + 20*20) * 2 = 16 800 candidates
+
+    scores  16 800 x 1  float32 =  67 kB
+    bbox    16 800 x 4  float32 = 269 kB
+    kps     16 800 x 10 float32 = 672 kB
+                                 -------
+                                 0.96 MiB per detection
+
+of which a typical frame keeps **nought to eight**. Everything else is discarded by the
+score threshold and NMS.
+
+With the session in `plugins/ort_worker.py`'s child, leaving the decode in the parent
+means shipping 16 800 candidates across a process boundary in order to throw 99.95% of
+them away on the far side — measured at +27 ms per detection, which is most of the cost
+of the process boundary. Thresholding belongs on the side that produced the data.
+
+So this module holds the decode, imports **nothing but numpy**, and is used by both
+sides: `plugins/face_runtime.py` calls it directly when the session is in-process, and
+the worker child imports it by name to post-process before replying. One implementation,
+no duplication, and the "these are pure functions" claim is structural rather than a
+comment.
+
+Nothing here knows about ONNX Runtime, cv2, ROS or the plugin. It takes the nine arrays
+and the letterbox scale, and returns the survivors.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+# SCRFD-500M-BNKPS: three feature levels, two anchors each, five keypoints. These
+# describe the shipped `det_500m.onnx` and are asserted against its output count at
+# load time in face_runtime.py — a detector without keypoints cannot be aligned.
+FEAT_STRIDES = (8, 16, 32)
+NUM_ANCHORS = 2
+NUM_KPS = 5
+
+
+def distance2bbox(centers: np.ndarray, distances: np.ndarray) -> np.ndarray:
+    x1 = centers[:, 0] - distances[:, 0]
+    y1 = centers[:, 1] - distances[:, 1]
+    x2 = centers[:, 0] + distances[:, 2]
+    y2 = centers[:, 1] + distances[:, 3]
+    return np.stack([x1, y1, x2, y2], axis=-1)
+
+
+def distance2kps(centers: np.ndarray, distances: np.ndarray) -> np.ndarray:
+    points = []
+    for index in range(0, distances.shape[1], 2):
+        points.append(centers[:, 0] + distances[:, index])
+        points.append(centers[:, 1] + distances[:, index + 1])
+    return np.stack(points, axis=-1)
+
+
+def nms(boxes: np.ndarray, scores: np.ndarray, thresh: float) -> list:
+    """Plain greedy IoU suppression — no cv2.dnn, no torchvision."""
+    x1, y1, x2, y2 = boxes[:, 0], boxes[:, 1], boxes[:, 2], boxes[:, 3]
+    areas = np.maximum(0.0, x2 - x1 + 1) * np.maximum(0.0, y2 - y1 + 1)
+    order = scores.argsort()[::-1]
+    keep: list = []
+    while order.size > 0:
+        current = int(order[0])
+        keep.append(current)
+        if order.size == 1:
+            break
+        rest = order[1:]
+        xx1 = np.maximum(x1[current], x1[rest])
+        yy1 = np.maximum(y1[current], y1[rest])
+        xx2 = np.minimum(x2[current], x2[rest])
+        yy2 = np.minimum(y2[current], y2[rest])
+        inter = np.maximum(0.0, xx2 - xx1 + 1) * np.maximum(0.0, yy2 - yy1 + 1)
+        iou = inter / (areas[current] + areas[rest] - inter)
+        order = rest[iou <= thresh]
+    return keep
+
+
+def decode(outputs, input_h: int, input_w: int, scale: float,
+           det_thresh: float, nms_thresh: float):
+    """The nine head arrays -> `(boxes, keypoints, scores)` for the survivors only.
+
+    `boxes` is (N,4) xyxy in **source-image** coordinates (the letterbox scale is
+    divided out here), `keypoints` is (N,5,2), `scores` is (N,). N is typically 0-8
+    against the 16 800 candidates that went in, which is the entire point.
+
+    Clipping to the frame, sorting by area and the `max_faces` cut stay with the
+    caller: they need the source dimensions and the plugin's own ordering, and they are
+    free.
+
+    This is a faithful move of the loop that was in `FaceAnalyzer.detect`, including the
+    order of operations — NMS runs on the already-rescaled boxes, because it did there
+    and the `+1` in its area terms makes it very slightly scale-dependent.
+    """
+    levels = len(FEAT_STRIDES)
+    boxes_all, kps_all, scores_all = [], [], []
+
+    for index, stride in enumerate(FEAT_STRIDES):
+        scores = np.asarray(outputs[index]).reshape(-1)
+        bbox_preds = np.asarray(outputs[index + levels]).reshape(-1, 4) * stride
+        kps_preds = (np.asarray(outputs[index + levels * 2])
+                     .reshape(-1, NUM_KPS * 2) * stride)
+
+        grid_h, grid_w = input_h // stride, input_w // stride
+        centers = np.stack(
+            np.mgrid[:grid_h, :grid_w][::-1], axis=-1
+        ).astype(np.float32).reshape(-1, 2) * stride
+        if NUM_ANCHORS > 1:
+            centers = np.stack([centers] * NUM_ANCHORS, axis=1).reshape(-1, 2)
+
+        positive = np.where(scores >= det_thresh)[0]
+        if positive.size == 0:
+            continue
+        boxes_all.append(distance2bbox(centers, bbox_preds)[positive])
+        kps_all.append(
+            distance2kps(centers, kps_preds)[positive].reshape(-1, NUM_KPS, 2))
+        scores_all.append(scores[positive])
+
+    if not scores_all:
+        empty = np.zeros((0, 4), dtype=np.float32)
+        return empty, np.zeros((0, NUM_KPS, 2), dtype=np.float32), \
+            np.zeros((0,), dtype=np.float32)
+
+    boxes = np.concatenate(boxes_all) / scale
+    keypoints = np.concatenate(kps_all) / scale
+    scores = np.concatenate(scores_all)
+    keep = nms(boxes, scores, nms_thresh)
+    return (boxes[keep].astype(np.float32),
+            keypoints[keep].astype(np.float32),
+            scores[keep].astype(np.float32))

--- a/perception/plugins/tts.py
+++ b/perception/plugins/tts.py
@@ -1014,12 +1014,18 @@ class KokoroTTSAdapter(TTSAdapter):
         """
         if self._direct_runtime is None:
             if self._japanese_worker:
+                from plugins.kokoro_worker import DeviceUnavailable, KokoroWorkerProxy
                 try:
-                    from plugins.kokoro_worker import KokoroWorkerProxy
                     self._direct_runtime = KokoroWorkerProxy(
                         self._model_dir, self._weights_name,
                         device=self._japanese_worker_device)
                     return self._direct_runtime
+                except DeviceUnavailable:
+                    # The configured device cannot do the job. Substituting the CPU
+                    # here would hide it behind a card that still says `gpu` — the
+                    # state that made Japanese "mysteriously slow" and took a
+                    # measurement to explain. Let it surface.
+                    raise
                 except Exception as exc:                          # noqa: BLE001
                     log.warning("[tts] kokoro worker unavailable (%s); Japanese uses "
                                 "the in-process CPU session", exc)

--- a/perception/tests/test_face_plugin.py
+++ b/perception/tests/test_face_plugin.py
@@ -62,7 +62,19 @@ class _FakeFrame:
 
 
 class _FakeAnalyzer:
-    """Detects whatever the frame bytes say, and embeds by identity number."""
+    """Stands in for `FaceServiceProxy`: one call, results already embedded.
+
+    The plugin no longer calls decode/detect/prepare/embed — that pipeline runs in the
+    ORT worker child (`plugins/face_service.py`), because a standalone ONNX Runtime
+    session cannot share a process with sherpa-onnx's. So the fake implements the same
+    one method the real proxy does, and applies the quality gate itself, which is where
+    the gate now lives.
+
+    Identity used to travel through the aligned crop so that `embed` could read it back.
+    With one call there is nothing to smuggle it through, so it is read straight from
+    the frame spec — simpler, and it removes the int32-vs-uint8 trap that cost a
+    debugging round when a test used identity 300.
+    """
 
     def __init__(self, delay: float = 0.0, frame_shape=(480, 640)):
         self.delay = delay
@@ -70,30 +82,33 @@ class _FakeAnalyzer:
         self.frame_shape = frame_shape
         self.seen: list[bytes] = []
         self.embed_calls = 0
+        self.calls: list[dict] = []
 
-    # -- the surface plugins/face.py uses --
-    def decode_image(self, data: bytes, max_side: int = 0, max_pixels: int = 0):
-        return self.decode_jpeg(data)
+    device = "cpu"
+    providers = ["CPUExecutionProvider"]
 
-    def decode_jpeg(self, data: bytes):
-        self.seen.append(data)
-        if data == b"corrupt":
-            return None
-        image = np.zeros((*self.frame_shape, 3), dtype=np.uint8)
-        image[0, 0, 0] = 1                      # keep .size truthy
-        self._spec = data.decode()
-        return image
-
-    def detect(self, image, max_faces: int = 0):
+    def recognise(self, image_bytes: bytes, max_faces: int = 0,
+                  det_thresh: float = 0.5, min_face_px: int = 64,
+                  blur_min: float = 60.0, want_aligned: bool = False,
+                  embed_all: bool = False):
+        self.seen.append(image_bytes)
+        self.calls.append({"max_faces": max_faces, "det_thresh": det_thresh,
+                           "min_face_px": min_face_px, "blur_min": blur_min,
+                           "want_aligned": want_aligned, "embed_all": embed_all})
         if self.delay:
             time.sleep(self.delay)
-        if not self._spec:
-            return []
-        faces = []
+        if image_bytes == b"corrupt":
+            return None, []
+
+        spec = image_bytes.decode()
         height, width = self.frame_shape
-        segments = self._spec.split("|")
-        # Lay the boxes out left to right; the first one is centred, so it wins
-        # the centre-weighted dominance comparison when sizes are equal.
+        if not spec:
+            return (height, width), []
+
+        faces = []
+        segments = spec.split("|")
+        # Lay the boxes out left to right; the first one is centred, so it wins the
+        # centre-weighted dominance comparison when sizes are equal.
         for index, segment in enumerate(segments):
             identity, size, blur = segment.split(":")
             side = int(size)
@@ -108,42 +123,31 @@ class _FakeAnalyzer:
             )
             face.identity = int(identity)
             faces.append(face)
+
         faces.sort(key=lambda f: f.area, reverse=True)
-        return faces[:max_faces] if max_faces else faces
+        if max_faces:
+            faces = faces[:max_faces]
 
-    def prepare(self, image, face):
-        face.aligned = np.zeros((112, 112, 3), dtype=np.uint8)
-        return face
-
-    def embed(self, aligned):
-        raise AssertionError("subclasses carry the identity; use _SpecAnalyzer")
+        # The gate, where the real service applies it: an unusable face gets no
+        # embedding, and `embedding is None` is how the plugin reads that verdict.
+        for face in faces:
+            usable = (face.det_score >= det_thresh
+                      and face.min_side >= min_face_px
+                      and face.blur >= blur_min)
+            if usable or embed_all:
+                self.embed_calls += 1
+                face.embedding = _unit(face.identity)
+            if want_aligned:
+                face.aligned = np.zeros((112, 112, 3), dtype=np.uint8)
+        return (height, width), faces
 
     def close(self):
         self.closed = True
 
 
-class _SpecAnalyzer(_FakeAnalyzer):
-    """The analyzer the tests use: identity travels in the aligned crop.
-
-    `prepare` stamps the face's identity into cell [0,0,0] and `embed` reads it
-    back, which is how a frame spec like `b"7:120:500"` ends up as a stable
-    512-d vector for person 7 without any model.
-
-    int32, not uint8: a real aligned crop is uint8, but the plugin only ever
-    hands this array straight back to `embed`, and uint8 silently caps the
-    identity space at 255 — which cost a debugging round when a test used
-    identity 300 and got "Python integer 300 out of bounds for uint8".
-    """
-
-    def prepare(self, image, face):
-        aligned = np.zeros((112, 112, 3), dtype=np.int32)
-        aligned[0, 0, 0] = face.identity
-        face.aligned = aligned
-        return face
-
-    def embed(self, aligned):
-        self.embed_calls += 1
-        return _unit(int(aligned[0, 0, 0]))
+# Kept as an alias: the identity-through-the-crop trick it existed for is gone, but
+# several tests name it and the indirection is free.
+_SpecAnalyzer = _FakeAnalyzer
 
 
 @pytest.fixture(autouse=True)
@@ -241,12 +245,11 @@ def test_tool_shape_matches_the_card_contract():
 # ── subject selection / failure reasons ───────────────────────────────────────
 
 def _faces(*specs):
-    analyzer = _SpecAnalyzer()
-    analyzer.decode_jpeg(_FakeFrame.build(*specs))
-    faces = analyzer.detect(None)
-    for face in faces:
-        analyzer.prepare(None, face)
-    return faces, (480, 640)
+    # embed_all, because `select_subject` is what these tests exercise and it has to see
+    # every candidate — including ones the per-frame gate would skip.
+    analyzer = _FakeAnalyzer()
+    shape, faces = analyzer.recognise(_FakeFrame.build(*specs), embed_all=True)
+    return faces, shape
 
 
 def test_no_face_reason():
@@ -1383,21 +1386,18 @@ def test_decode_options_come_from_config():
     assert defaults["max_side"] == 2048 and defaults["max_pixels"] == 60_000_000
 
 
-def test_every_input_path_decodes_through_the_same_options(plugin, tmp_path):
-    """Resize/convert must apply to register and recognize alike, by photo,
-    url, corpus and stream — so they all have to reach decode_image with the
-    configured options rather than each path doing its own thing."""
+def test_every_input_path_goes_through_the_one_recognise_call(plugin, tmp_path):
+    """Resize/convert must apply to register and recognize alike, by photo, url,
+    corpus and stream.
+
+    This used to spy on `decode_image` and assert every path passed the same options.
+    It cannot any more, and that is the improvement: decoding happens in the ORT worker
+    child, which is built **once** with the configured limits
+    (`plugins/face_proxy.py`), so no path can pass its own. What is left to check is
+    that every path reaches the single call rather than growing its own pipeline.
+    """
     engine = plugin._require_engine()
-    seen = []
-    original = engine.analyzer.decode_image
-
-    def spy(data, max_side=0, max_pixels=0):
-        seen.append((max_side, max_pixels))
-        return original(data, max_side, max_pixels)
-
-    engine.analyzer.decode_image = spy
-    plugin._plugin_cfg["max_image_side"] = 1234
-    plugin._plugin_cfg["max_image_pixels"] = 5_000_000
+    before = len(engine.analyzer.calls)
 
     path = _write_photo(tmp_path, "a.jpg", _FakeFrame.one(700))
     plugin.dispatch("face_recognition", {
@@ -1408,8 +1408,34 @@ def test_every_input_path_decodes_through_the_same_options(plugin, tmp_path):
     plugin.dispatch("face_recognition", {
         "action": "register_by_corpus", "package": package})
 
-    assert len(seen) >= 3
-    assert all(opts == (1234, 5_000_000) for opts in seen), seen
+    calls = engine.analyzer.calls[before:]
+    assert len(calls) >= 3, calls
+    # Registration needs an embedding for whichever face select_subject picks, even a
+    # marginal one; the continuous path must not pay for that.
+    assert any(c["embed_all"] for c in calls), calls
+    assert not all(c["embed_all"] for c in calls), calls
+
+
+def test_the_decode_limits_reach_the_service(monkeypatch, tmp_path):
+    """The limits are constructor state on the proxy now, so assert they get there.
+
+    max_side bounds the letterbox downscale and max_pixels is the decompression-bomb
+    guard; a path that silently defaulted them would be a real hole.
+    """
+    seen = {}
+
+    class _Probe(_FakeAnalyzer):
+        def __init__(self, **kwargs):
+            seen.update(kwargs)
+            super().__init__()
+
+    monkeypatch.setattr(face_plugin, "FaceServiceProxy", _Probe)
+    face_plugin._build_engine({"model_dir": str(tmp_path),
+                               "db_dir": str(tmp_path / "db"),
+                               "max_image_side": 1234,
+                               "max_image_pixels": 5_000_000})
+    assert seen["max_image_side"] == 1234
+    assert seen["max_image_pixels"] == 5_000_000
 
 
 def test_the_byte_cap_is_a_transfer_guard_not_a_photo_limit():

--- a/perception/tests/test_face_plugin.py
+++ b/perception/tests/test_face_plugin.py
@@ -1447,3 +1447,63 @@ def test_the_byte_cap_is_a_transfer_guard_not_a_photo_limit():
 def test_corpus_finds_the_formats_both_decoders_read():
     for suffix in (".jpg", ".png", ".webp", ".tif", ".tiff", ".gif", ".bmp"):
         assert suffix in face_plugin._IMAGE_SUFFIXES
+
+
+# ── the wiring nothing else checks ────────────────────────────────────────────
+
+def test_analyzer_options_are_all_accepted_by_the_proxy():
+    """`_analyzer_options` builds the kwargs; the proxy has to accept every one.
+
+    This shipped broken: adding `model` to the options without adding it to
+    `FaceServiceProxy.__init__` gave `TypeError: __init__() got an unexpected keyword
+    argument 'model'` at card start, on a robot. Nothing caught it, because every test
+    either replaces `_build_engine` wholesale or fakes the analyzer with a signature
+    that swallows anything — so the one place the real kwargs meet the real signature
+    was never exercised.
+
+    Checked by signature rather than by calling it, because constructing the real proxy
+    spawns a child and loads two models.
+    """
+    import inspect
+
+    from plugins.face_proxy import FaceServiceProxy
+
+    produced = set(face_plugin._analyzer_options({}))
+    produced |= {"max_image_side", "max_image_pixels"}      # added by _build_engine
+    accepted = set(inspect.signature(FaceServiceProxy.__init__).parameters) - {"self"}
+    assert produced <= accepted, (
+        f"_build_engine would pass {sorted(produced - accepted)}, which "
+        f"FaceServiceProxy.__init__ does not take")
+
+
+def test_the_proxy_forwards_everything_it_takes_to_the_service():
+    """And the service has to accept what the proxy sends, for the same reason.
+
+    One hop further along the same chain: proxy -> ort_worker.service ->
+    plugins.face_service.build -> FaceService.__init__ -> FaceAnalyzer. A parameter
+    that stops halfway is a card that will not start.
+    """
+    import inspect
+
+    from plugins.face_proxy import FaceServiceProxy
+    from plugins.face_service import FaceService
+
+    proxy_takes = set(inspect.signature(FaceServiceProxy.__init__).parameters) - {"self"}
+    service_takes = set(inspect.signature(FaceService.__init__).parameters) - {"self"}
+    # `device` is resolved to `providers` in the proxy and does not travel as-is.
+    forwarded = proxy_takes - {"device"}
+    assert forwarded <= service_takes, (
+        f"the proxy would forward {sorted(forwarded - service_takes)}, which "
+        f"FaceService.__init__ does not take")
+
+
+def test_the_service_passes_the_model_on_to_the_analyzer():
+    """The last hop. `model` selects the weights; silently dropping it would run
+    buffalo_sc while the card said something else."""
+    import inspect
+
+    from plugins.face_runtime import FaceAnalyzer
+    from plugins.face_service import FaceService
+
+    assert "model" in inspect.signature(FaceService.__init__).parameters
+    assert "model" in inspect.signature(FaceAnalyzer.__init__).parameters

--- a/perception/tests/test_kokoro_direct.py
+++ b/perception/tests/test_kokoro_direct.py
@@ -166,40 +166,29 @@ def test_the_session_is_built_on_cpu_and_cannot_be_asked_for_cuda(tmp_path,
     kills all of perception on jp5.11. Measured both ways round on both rigs.
 
     This shipped once, because the code requested CUDA while a stale docstring asserted
-    the request was inert. `provider` exists again now that `plugins/kokoro_worker.py`
-    provides a process with nothing else in it — so the invariant has moved rather than
-    disappeared, and this asserts where it moved to:
+    the request was inert. Both arguments exist again now that
+    `plugins/ort_worker.py` provides a process with nothing else in it — so the
+    invariant moved rather than disappeared, and this asserts where it moved to:
 
-      - the **default** is still CPU, so anything constructing this without thinking
+      - `provider` defaults to **cpu**, so anything constructing this without thinking
         gets the safe thing;
-      - the only caller that passes `provider=` is the worker child.
+      - `in_process` defaults to **False**, so the session goes to the worker child.
+        `in_process=True` puts it next to sherpa's runtime, which is the configuration
+        that collides, and the callers only use it as an explicitly-degraded fallback.
 
     A CPU-only session loads no CUDA provider at all, so it never touches the bridge —
-    which is why `japanese_worker: false` and `japanese_worker_device: cpu` are both
-    safe configurations rather than merely slower ones.
+    which is why the in-process fallback paths are safe despite being in the colliding
+    process, as long as they stay on cpu.
     """
-    import ast
     import inspect
-    from pathlib import Path
 
     signature = inspect.signature(kd.KokoroDirect.__init__)
     assert signature.parameters["provider"].default == "cpu", (
-        "the default must stay CPU: a caller that does not think about it is in "
-        "perception's process, where CUDA here corrupts sherpa's sessions")
-
-    perception_root = Path(__file__).resolve().parents[1]
-    passing = set()
-    for path in (perception_root / "plugins").rglob("*.py"):
-        tree = ast.parse(path.read_text("utf-8"), filename=str(path))
-        for node in ast.walk(tree):
-            if (isinstance(node, ast.Call)
-                    and isinstance(node.func, ast.Name)
-                    and node.func.id == "KokoroDirect"
-                    and any(kw.arg == "provider" for kw in node.keywords)):
-                passing.add(path.name)
-    assert passing <= {"kokoro_worker.py"}, (
-        f"only the worker child may ask for a device; also seen in {sorted(passing)}")
-
+        "the default must stay CPU: a caller that does not think about it may be in "
+        "perception's own process, where CUDA here corrupts sherpa's sessions")
+    assert signature.parameters["in_process"].default is False, (
+        "the default must be the worker child. in_process=True puts this session next "
+        "to sherpa's runtime, which is the configuration that collides")
     (tmp_path / "tokens.txt").write_text("a 1\n", encoding="utf-8")
     (tmp_path / "voices.bin").write_bytes(
         b"\0" * (kd.STYLE_LENGTHS * kd.STYLE_DIM * 4))
@@ -218,5 +207,8 @@ def test_the_session_is_built_on_cpu_and_cannot_be_asked_for_cuda(tmp_path,
         "o", (), {"intra_op_num_threads": 0})(), "InferenceSession": _Session})
     monkeypatch.setitem(sys.modules, "onnxruntime", fake_ort)
 
-    kd.KokoroDirect(str(tmp_path), "model.onnx")
+    # in_process=True on purpose: this is the path the fake onnxruntime above can be
+    # seen from, and it is the path whose provider list matters — the worker child
+    # gets its providers as a plain list argument, asserted in test_ort_worker.py.
+    kd.KokoroDirect(str(tmp_path), "model.onnx", in_process=True)
     assert seen["providers"] == ["CPUExecutionProvider"], seen

--- a/perception/tests/test_kokoro_worker.py
+++ b/perception/tests/test_kokoro_worker.py
@@ -67,30 +67,36 @@ def _reset():
     yield
 
 
-def _proxy(monkeypatch, device="gpu", headroom=8192, idle=1e9):
+def _proxy(monkeypatch, device="gpu", headroom=8192, idle=1e9, model_dir=None):
     """A proxy whose sessions are fakes, with the reaper thread neutered."""
     import plugins.kokoro_direct as kd
     monkeypatch.setattr(kd, "KokoroDirect", _FakeDirect)
     monkeypatch.setattr(kw, "_mem_available_mb", lambda: headroom)
     monkeypatch.setattr(kw.KokoroWorkerProxy, "_reap_loop", lambda self: None)
-    return kw.KokoroWorkerProxy("/models/kokoro-multi/gpu", "model.onnx",
+    return kw.KokoroWorkerProxy(model_dir or "/models/kokoro-multi/gpu", "model.onnx",
                                 device=device, idle_timeout_s=idle)
 
 
 # ── which device ──────────────────────────────────────────────────────────────
 
-def test_a_device_that_gets_durations_wrong_is_rejected_for_cpu(monkeypatch):
-    """jp5.11's CUDA returns 35-44% of the probe's length. 27% short is rushed speech.
+def test_a_device_that_gets_durations_wrong_raises_rather_than_substituting(
+        monkeypatch, tmp_path):
+    """No silent substitution: the card must say the GPU is unusable, not quietly
+    become a CPU card that still reads `gpu`.
 
-    Gating on the ORT version number would be the wrong fix — it would not catch the
-    next line with the same defect — so the gate is the measurement, and it is free
-    because the probe already runs to warm the session.
+    That state is what made Japanese "mysteriously slow" and took a measurement to
+    explain. The message has to distinguish this from the memory case — here the GPU is
+    present and has room, and computes the duration path wrongly (jp5.11's ORT 1.15.1
+    returns 27-51% short, which is audibly rushed speech).
     """
-    _FakeDirect.lengths = {"gpu": 21000, "cpu": kw.PROBE_SAMPLES}
-    proxy = _proxy(monkeypatch, device="gpu")
-    assert proxy.device_used == "cpu"
-    assert [p for p, _ in _FakeDirect.built] == ["gpu", "cpu"]
-    assert "gpu" in _FakeDirect.closed, "the rejected session must be unloaded"
+    _FakeDirect.lengths = {"gpu": 21000}
+    with pytest.raises(kw.DeviceUnavailable) as excinfo:
+        _proxy(monkeypatch, device="gpu", model_dir=str(tmp_path))
+    message = str(excinfo.value)
+    assert "duration" in message
+    assert "Not a memory problem" in message, message
+    assert "japanese_worker_device: cpu" in message, "the message must be actionable"
+    assert "gpu" in _FakeDirect.closed, "the rejected session must be released"
 
 
 def test_a_correct_device_is_kept(monkeypatch):
@@ -106,26 +112,25 @@ def test_a_few_samples_of_deviation_are_tolerated(monkeypatch):
     assert _proxy(monkeypatch, device="gpu").device_used == "gpu"
 
 
-def test_cpu_failing_the_check_too_is_an_error_not_a_silent_pass(monkeypatch):
-    """Then the model or the phoneme table does not match this code — say so."""
-    _FakeDirect.lengths = {"gpu": 100, "cpu": 100}
-    with pytest.raises(RuntimeError, match="plausible probe duration"):
-        _proxy(monkeypatch, device="gpu")
+def test_cpu_failing_the_check_too_is_an_error(monkeypatch, tmp_path):
+    """Then the model or the phoneme table does not match this code — say that, and do
+    not blame the device."""
+    _FakeDirect.lengths = {"cpu": 100}
+    with pytest.raises(kw.DeviceUnavailable, match="does not match this code"):
+        _proxy(monkeypatch, device="cpu", model_dir=str(tmp_path))
 
 
 # ── whether there is room ─────────────────────────────────────────────────────
 
-def test_cuda_is_declined_when_the_box_has_no_headroom(monkeypatch):
-    """The duration check cannot save a box that OOMs while building the session.
-
-    Measured on jp5.11: 5237 MB available, sherpa's own Kokoro GPU adapter takes 3.2 GB,
-    and the CUDA allocation then killed the process — before the probe ran. So this
-    guard has to be first; it is the one that can take the process down.
-    """
-    proxy = _proxy(monkeypatch, device="gpu", headroom=2048)
-    assert proxy.device_used == "cpu"
-    assert [p for p, _ in _FakeDirect.built] == ["cpu"], (
-        "with no headroom it must not even try CUDA")
+def test_no_headroom_raises_and_says_it_is_a_memory_problem(monkeypatch, tmp_path):
+    """The operator has to be able to tell this apart from the durations case: here the
+    GPU works and the box is full, and freeing memory would fix it."""
+    with pytest.raises(kw.DeviceUnavailable) as excinfo:
+        _proxy(monkeypatch, device="gpu", headroom=2048, model_dir=str(tmp_path))
+    message = str(excinfo.value)
+    assert "memory" in message
+    assert "the GPU itself is fine" in message.lower() or "not a model problem" in message
+    assert not _FakeDirect.built, "with no headroom it must not build anything at all"
 
 
 def test_cuda_is_used_when_there_is_room(monkeypatch):
@@ -219,9 +224,8 @@ def test_without_a_shared_context_the_higher_figure_applies(monkeypatch):
     from plugins import ort_worker
     monkeypatch.setattr(ort_worker, "get_worker",
                         lambda: type("w", (), {"has_cuda_session": lambda self: False})())
-    proxy = _proxy(monkeypatch, device="gpu", headroom=1800)
-    assert proxy.device_used == "cpu", (
-        "a fresh context needs the 1585 MB it was measured at, plus margin")
+    with pytest.raises(kw.DeviceUnavailable, match="2500 MB needed"):
+        _proxy(monkeypatch, device="gpu", headroom=1800)
 
 
 def test_asking_the_worker_failing_is_treated_as_no_context(monkeypatch):
@@ -232,4 +236,63 @@ def test_asking_the_worker_failing_is_treated_as_no_context(monkeypatch):
         raise RuntimeError("worker unreachable")
 
     monkeypatch.setattr(ort_worker, "get_worker", _boom)
-    assert _proxy(monkeypatch, device="gpu", headroom=1800).device_used == "cpu"
+    with pytest.raises(kw.DeviceUnavailable, match="2500 MB needed"):
+        _proxy(monkeypatch, device="gpu", headroom=1800)
+
+
+# ── the attempt is not free, so it happens once per machine ───────────────────
+
+def test_a_rejected_cuda_is_remembered_across_restarts(monkeypatch, tmp_path):
+    """Trying CUDA costs memory that unloading does not return, so try it once.
+
+    Measured on Orin 5: one rejected attempt took MemAvailable from 5754 to 1935 MB and
+    kept it. A crash restarts perception, so an in-memory verdict would be lost and the
+    next start would pay again — which is how face's later GPU load tipped that box into
+    the OOM killer.
+    """
+    _FakeDirect.lengths = {"gpu": 21000}
+    with pytest.raises(kw.DeviceUnavailable, match="duration"):
+        _proxy(monkeypatch, device="gpu", model_dir=str(tmp_path))
+    assert (tmp_path / ".cuda-duration-verdict").exists()
+
+    # A restarted process must not build anything before refusing.
+    _FakeDirect.built = []
+    with pytest.raises(kw.DeviceUnavailable, match="recorded in"):
+        _proxy(monkeypatch, device="gpu", model_dir=str(tmp_path))
+    assert not _FakeDirect.built, (
+        "a machine that has already answered this must not pay for the answer again")
+
+
+def test_the_verdict_is_keyed_on_the_runtime_version(monkeypatch, tmp_path):
+    """The defect is in the ONNX Runtime build, so a different one gets re-evaluated."""
+    (tmp_path / ".cuda-duration-verdict").write_text("1.15.1", encoding="utf-8")
+    assert kw._cuda_known_bad(str(tmp_path), "1.15.1") is True
+    assert kw._cuda_known_bad(str(tmp_path), "1.18.1") is False
+
+
+def test_a_missing_verdict_file_is_not_a_verdict(tmp_path):
+    assert kw._cuda_known_bad(str(tmp_path), "1.18.1") is False
+
+
+def test_an_unwritable_model_dir_does_not_break_the_build(monkeypatch, tmp_path):
+    """A read-only /models must cost the memory of a retry, not a crash."""
+    def _boom(*a, **k):
+        raise OSError("read-only file system")
+
+    monkeypatch.setattr("builtins.open", _boom)
+    kw._remember_cuda_is_bad(str(tmp_path), "1.18.1")     # must not raise
+
+
+# ── idle unloading is off, and the reaper honours that ────────────────────────
+
+def test_idle_unloading_is_off_by_default():
+    """It never returned memory — measured at +0 MB — and cost a 5-7 s rebuild."""
+    assert kw.IDLE_TIMEOUT_S == 0
+
+
+def test_the_reaper_exits_immediately_when_disabled(monkeypatch):
+    proxy = _proxy(monkeypatch, idle=0.0)
+    slept = []
+    monkeypatch.setattr(time, "sleep", lambda s: slept.append(s))
+    proxy._reap_loop()                    # returns rather than looping
+    assert slept == [], "a disabled reaper must not even poll"

--- a/perception/tests/test_kokoro_worker.py
+++ b/perception/tests/test_kokoro_worker.py
@@ -1,19 +1,19 @@
 """
-tests/test_kokoro_worker.py — the proxy's contract and its failure behaviour.
+tests/test_kokoro_worker.py — the policy layer for Japanese, now that it owns no process.
 
-The worker exists because two ONNX Runtimes in one process cannot both hold a CUDA
-session on the Kokoro graph — on jp5.11 that is a SIGSEGV that kills all of perception.
-So the properties worth testing here are not "does it synthesize" (that needs a 310 MB
-model and a GPU) but the ones that decide whether the isolation actually holds and
-whether a failure degrades or breaks:
+`plugins/ort_worker.py` owns the one child that holds every standalone-ORT session in
+this process. This module owns the *decisions* about Japanese, and each of them was
+forced by a measurement rather than chosen:
 
-  - the child is started with `spawn`, never `fork`. `fork` copies the address space
-    including already-dlopened libraries, so a forked child would inherit sherpa's ONNX
-    Runtime and the isolation would be worthless — the exact bug being fixed;
-  - a dead or unstartable child falls back rather than raising, because Japanese losing
-    8x is acceptable and Japanese breaking is not;
-  - a request error is *not* swallowed by the fallback, or a real bug would hide behind
-    a slower code path.
+  - **which device is safe.** jp5.11's CUDA execution of this graph computes durations
+    27.5% short (8 runs: cpu 8.35 s stdev 0.000, one distinct length; cuda 6.05 s
+    stdev 0.053, three), which is audibly rushed speech. The graph *is* stochastic — 4
+    RandomNormalLike and 7 RandomUniformLike nodes — so comparing waveforms is not a
+    valid check, and the duration is;
+  - **whether there is room.** Asking for CUDA regardless OOM-killed a jp5.11 rig
+    before the duration probe could run, so the headroom check has to come first;
+  - **when to give the memory back.** On idle, not on the language switch: the cold
+    path is ~15 s end to end and an alternating tour would pay it every time.
 
 Run: python -m pytest perception/tests -q
 """
@@ -21,7 +21,6 @@ Run: python -m pytest perception/tests -q
 from __future__ import annotations
 
 import sys
-import threading
 import time
 from pathlib import Path
 
@@ -35,301 +34,163 @@ if str(PERCEPTION_ROOT) not in sys.path:
 from plugins import kokoro_worker as kw  # noqa: E402
 
 
-class _FakeQueue:
-    """A queue that records what was put and hands back scripted replies."""
-
-    def __init__(self, replies=None):
-        self.puts = []
-        self._replies = list(replies or [])
-
-    def put(self, item):
-        self.puts.append(item)
-
-    def get(self, timeout=None):
-        if not self._replies:
-            import queue as _q
-            raise _q.Empty
-        reply = self._replies.pop(0)
-        if isinstance(reply, Exception):
-            raise reply
-        return reply
-
-
-class _FakeProc:
-    def __init__(self, alive=True):
-        self.pid = 4242
-        self._alive = alive
-        self.terminated = False
-        self.killed = False
-
-    def start(self):
-        pass
-
-    def is_alive(self):
-        return self._alive
-
-    def terminate(self):
-        self.terminated = True
-        self._alive = False
-
-    def kill(self):
-        self.killed = True
-        self._alive = False
-
-    def join(self, timeout=None):
-        pass
-
-
-class _FakeCtx:
-    """Stands in for multiprocessing's spawn context."""
-
-    def __init__(self, replies, alive=True):
-        self.cmd = _FakeQueue()
-        self.res = _FakeQueue(replies)
-        self.proc = _FakeProc(alive)
-        self.queues_made = 0
-        self.process_kwargs = None
-
-    def Queue(self):                                              # noqa: N802
-        self.queues_made += 1
-        return self.cmd if self.queues_made == 1 else self.res
-
-    def Process(self, **kwargs):                                  # noqa: N802
-        self.process_kwargs = kwargs
-        return self.proc
-
-
-READY = ("ready", {"num_speakers": 54, "sample_rate": 24000,
-                   "providers": ["CUDAExecutionProvider", "CPUExecutionProvider"],
-                   "warmup_s": 8.03})
-
-
-def _proxy(monkeypatch, replies, alive=True, **kwargs):
-    """Build a proxy whose child is a fake, and stop the reaper thread interfering."""
-    ctx = _FakeCtx(replies, alive)
-    monkeypatch.setattr(kw.KokoroWorkerProxy, "_reap_loop", lambda self: None)
-
-    import multiprocessing as mp
-    monkeypatch.setattr(mp, "get_context", lambda method: ctx)
-    proxy = kw.KokoroWorkerProxy("/models/kokoro-multi/gpu", "model.onnx", **kwargs)
-    return proxy, ctx
-
-
-# ── the isolation itself ──────────────────────────────────────────────────────
-
-def test_the_child_is_spawned_not_forked(monkeypatch):
-    """`fork` would inherit sherpa's already-loaded ONNX Runtime and defeat the point.
-
-    On Linux `fork` is the default, so this has to be asked for explicitly. The
-    assertion is on the string passed to get_context, because that is the whole
-    guarantee — there is nothing else to check at runtime.
-    """
-    seen = {}
-
-    class _Ctx(_FakeCtx):
-        pass
-
-    ctx = _Ctx([READY])
-    monkeypatch.setattr(kw.KokoroWorkerProxy, "_reap_loop", lambda self: None)
-
-    import multiprocessing as mp
-
-    def _get_context(method):
-        seen["method"] = method
-        return ctx
-
-    monkeypatch.setattr(mp, "get_context", _get_context)
-    kw.KokoroWorkerProxy("/models/kokoro-multi/gpu", "model.onnx")
-    assert seen["method"] == "spawn", seen
-
-
-def test_the_child_entry_point_is_module_level_and_takes_no_ros_or_sherpa():
-    """spawn pickles the target by qualified name, so it must be importable.
-
-    Also asserts the child's own module imports neither rclpy nor sherpa_onnx at module
-    scope — this process exists to be the only ONNX Runtime in its address space.
-    """
-    assert callable(kw._kokoro_worker)
-    assert kw._kokoro_worker.__module__ == "plugins.kokoro_worker"
-    source = (PERCEPTION_ROOT / "plugins" / "kokoro_worker.py").read_text("utf-8")
-    assert "import rclpy" not in source
-    assert "import sherpa_onnx" not in source
-
-
-def test_handshake_populates_the_properties(monkeypatch):
-    proxy, ctx = _proxy(monkeypatch, [READY])
-    assert proxy.num_speakers == 54
-    assert proxy.sample_rate == 24000
-    assert "CUDAExecutionProvider" in proxy.providers
-    assert ctx.process_kwargs["daemon"] is False, (
-        "a daemon child is killed abruptly at parent exit; this one should be asked")
-
-
-# ── failure behaviour ─────────────────────────────────────────────────────────
-
-def test_a_child_that_never_reports_ready_is_terminated_and_raises(monkeypatch):
-    """The caller falls back; leaving a half-started child behind would leak a context."""
-    monkeypatch.setattr(kw, "START_TIMEOUT_S", 0.01)
-    with pytest.raises(RuntimeError, match="did not report ready"):
-        _proxy(monkeypatch, [])
-
-
-def test_a_child_that_fails_to_build_reports_why(monkeypatch):
-    with pytest.raises(RuntimeError, match="libcudnn"):
-        _proxy(monkeypatch, [("failed", "OSError: libcudnn.so.8 not found")])
-
-
-def test_a_dead_child_falls_back_instead_of_raising(monkeypatch):
-    """Japanese losing 8x is acceptable; Japanese breaking is not."""
-    proxy, ctx = _proxy(monkeypatch, [READY])
-    ctx.proc._alive = False
-
-    calls = {}
-
-    class _Fallback:
-        num_speakers, sample_rate = 54, 24000
-
-        def synthesize(self, phonemes, speaker_id=0, speed=1.0):
-            calls["args"] = (phonemes, speaker_id, speed)
-            return np.ones(8, dtype=np.float32)
-
-    # A restart attempt also fails, so the fallback is the only route left.
-    monkeypatch.setattr(kw.KokoroWorkerProxy, "_start",
-                        lambda self: (_ for _ in ()).throw(RuntimeError("no")))
-    monkeypatch.setattr(kw.KokoroWorkerProxy, "_use_fallback", lambda self: _Fallback())
-
-    out = proxy.synthesize("ohayoo", speaker_id=3, speed=1.1)
-    assert out.shape == (8,)
-    assert calls["args"] == ("ohayoo", 3, 1.1)
-
-
-def test_a_request_error_is_raised_not_hidden_behind_the_fallback(monkeypatch):
-    """A bad request means a bug. Re-synthesizing it elsewhere would mask it."""
-    proxy, ctx = _proxy(monkeypatch, [READY])
-    ctx.res._replies.append(("error", "req", "ValueError: speaker_id must be 0..53"))
-    monkeypatch.setattr(kw.KokoroWorkerProxy, "_recv",
-                        lambda self, want: ("error", "ValueError: speaker_id"))
-    with pytest.raises(RuntimeError, match="speaker_id"):
-        proxy.synthesize("ohayoo", speaker_id=999)
-
-
-def test_close_is_idempotent_and_terminates_the_child(monkeypatch):
-    proxy, ctx = _proxy(monkeypatch, [READY])
-    proxy.close()
-    assert ctx.proc.terminated
-    proxy.close()          # must not raise
-
-
-# ── the leak this fixes ───────────────────────────────────────────────────────
-
-def test_idle_reaping_releases_the_child(monkeypatch):
-    """A card that spoke Japanese once used to hold the session for the adapter's life.
-
-    `set_language` never released it, so switching back to English kept ~765 MB
-    resident. Reaping on idle — rather than on the language switch — is what gives it
-    back without making an alternating tour pay the ~10.5 s cold path every time.
-    """
-    proxy, ctx = _proxy(monkeypatch, [READY], idle_timeout_s=0.0)
-    monkeypatch.setattr(time, "sleep", lambda _s: None)
-
-    # One pass of the real reaper body, with the loop's sleep neutralised.
-    proxy._last_used = time.monotonic() - 3600
-    stop = threading.Event()
-
-    def _one_pass():
-        with proxy._lock:
-            if proxy._alive() and (time.monotonic() - proxy._last_used) > proxy._idle_timeout_s:
-                proxy._terminate()
-        stop.set()
-
-    _one_pass()
-    assert stop.is_set()
-    assert ctx.proc.terminated, "an idle worker must give its CUDA context back"
-
-
-# ── the duration gate ─────────────────────────────────────────────────────────
-
 class _FakeDirect:
     """A KokoroDirect stand-in whose probe length is scripted per provider."""
 
-    lengths = {}
+    lengths: dict = {}
+    built: list = []
+    closed: list = []
 
-    def __init__(self, model_dir, weights, num_threads=0, provider="cpu"):
+    def __init__(self, model_dir, weights, num_threads=0, provider="cpu",
+                 session_key="tts.kokoro", in_process=False):
         self.provider = provider
+        self.in_process = in_process
+        self.session_key = session_key
+        _FakeDirect.built.append((provider, in_process))
         self._session = type("s", (), {"get_providers": lambda self: [provider]})()
 
     num_speakers, sample_rate = 54, 24000
 
     def synthesize(self, phonemes, speaker_id=0, speed=1.0):
-        return np.zeros(self.lengths[self.provider], dtype=np.float32)
+        return np.zeros(self.lengths.get(self.provider, kw.PROBE_SAMPLES),
+                        dtype=np.float32)
 
+    def close(self):
+        _FakeDirect.closed.append(self.provider)
+
+
+@pytest.fixture(autouse=True)
+def _reset():
+    _FakeDirect.lengths = {}
+    _FakeDirect.built = []
+    _FakeDirect.closed = []
+    yield
+
+
+def _proxy(monkeypatch, device="gpu", headroom=8192, idle=1e9):
+    """A proxy whose sessions are fakes, with the reaper thread neutered."""
+    import plugins.kokoro_direct as kd
+    monkeypatch.setattr(kd, "KokoroDirect", _FakeDirect)
+    monkeypatch.setattr(kw, "_mem_available_mb", lambda: headroom)
+    monkeypatch.setattr(kw.KokoroWorkerProxy, "_reap_loop", lambda self: None)
+    return kw.KokoroWorkerProxy("/models/kokoro-multi/gpu", "model.onnx",
+                                device=device, idle_timeout_s=idle)
+
+
+# ── which device ──────────────────────────────────────────────────────────────
 
 def test_a_device_that_gets_durations_wrong_is_rejected_for_cpu(monkeypatch):
-    """jp5.11's CUDA returns 35-44% of the probe's length; 27% short is rushed speech.
+    """jp5.11's CUDA returns 35-44% of the probe's length. 27% short is rushed speech.
 
-    Gating on the ORT version would not catch the next line with the same defect, so the
-    gate is the measurement. The probe already runs as warmup, so it is free.
+    Gating on the ORT version number would be the wrong fix — it would not catch the
+    next line with the same defect — so the gate is the measurement, and it is free
+    because the probe already runs to warm the session.
     """
-    logged = []
     _FakeDirect.lengths = {"gpu": 21000, "cpu": kw.PROBE_SAMPLES}
-    runtime, used = kw._build_checked(
-        _FakeDirect, "/models/x", "model.onnx", "gpu", 0,
-        type("l", (), {"warning": lambda *a: logged.append(a),
-                       "error": lambda *a: logged.append(a)})())
-    assert used == "cpu", "a device failing the duration check must not be used"
-    assert any("duration" in str(a) for a in logged), logged
+    proxy = _proxy(monkeypatch, device="gpu")
+    assert proxy.device_used == "cpu"
+    assert [p for p, _ in _FakeDirect.built] == ["gpu", "cpu"]
+    assert "gpu" in _FakeDirect.closed, "the rejected session must be unloaded"
 
 
 def test_a_correct_device_is_kept(monkeypatch):
-    _FakeDirect.lengths = {"gpu": kw.PROBE_SAMPLES, "cpu": kw.PROBE_SAMPLES}
-    _runtime, used = kw._build_checked(
-        _FakeDirect, "/models/x", "model.onnx", "gpu", 0,
-        type("l", (), {"warning": lambda *a: None, "error": lambda *a: None})())
-    assert used == "gpu"
+    _FakeDirect.lengths = {"gpu": kw.PROBE_SAMPLES}
+    proxy = _proxy(monkeypatch, device="gpu")
+    assert proxy.device_used == "gpu"
+    assert _FakeDirect.closed == []
 
 
-def test_small_deviation_is_tolerated():
-    """A different-but-valid build must not be rejected over a few samples."""
-    _FakeDirect.lengths = {"gpu": int(kw.PROBE_SAMPLES * 1.03), "cpu": kw.PROBE_SAMPLES}
-    _runtime, used = kw._build_checked(
-        _FakeDirect, "/models/x", "model.onnx", "gpu", 0,
-        type("l", (), {"warning": lambda *a: None, "error": lambda *a: None})())
-    assert used == "gpu"
+def test_a_few_samples_of_deviation_are_tolerated(monkeypatch):
+    """A different-but-valid build must not be rejected over rounding."""
+    _FakeDirect.lengths = {"gpu": int(kw.PROBE_SAMPLES * 1.03)}
+    assert _proxy(monkeypatch, device="gpu").device_used == "gpu"
 
 
-def test_cpu_failing_the_check_too_is_an_error_not_a_silent_pass():
+def test_cpu_failing_the_check_too_is_an_error_not_a_silent_pass(monkeypatch):
     """Then the model or the phoneme table does not match this code — say so."""
     _FakeDirect.lengths = {"gpu": 100, "cpu": 100}
     with pytest.raises(RuntimeError, match="plausible probe duration"):
-        kw._build_checked(
-            _FakeDirect, "/models/x", "model.onnx", "gpu", 0,
-            type("l", (), {"warning": lambda *a: None, "error": lambda *a: None})())
+        _proxy(monkeypatch, device="gpu")
 
 
-# ── the headroom guard, which must run BEFORE the duration gate ───────────────
+# ── whether there is room ─────────────────────────────────────────────────────
 
 def test_cuda_is_declined_when_the_box_has_no_headroom(monkeypatch):
     """The duration check cannot save a box that OOMs while building the session.
 
     Measured on jp5.11: 5237 MB available, sherpa's own Kokoro GPU adapter takes 3.2 GB,
-    and the CUDA child's allocation then killed the process — before the probe ran.
-    Two independent guards, and this one has to be first because it is the one that can
-    take the process down.
+    and the CUDA allocation then killed the process — before the probe ran. So this
+    guard has to be first; it is the one that can take the process down.
     """
-    monkeypatch.setattr(kw, "_mem_available_mb", lambda: 2048)
-    _proxy_, ctx = _proxy(monkeypatch, [READY], device="gpu")
-    assert ctx.process_kwargs["args"][2] == "cpu", (
-        "a CUDA child must not be spawned with less headroom than it needs")
+    proxy = _proxy(monkeypatch, device="gpu", headroom=2048)
+    assert proxy.device_used == "cpu"
+    assert [p for p, _ in _FakeDirect.built] == ["cpu"], (
+        "with no headroom it must not even try CUDA")
 
 
 def test_cuda_is_used_when_there_is_room(monkeypatch):
-    monkeypatch.setattr(kw, "_mem_available_mb", lambda: 4096)
-    _proxy_, ctx = _proxy(monkeypatch, [READY], device="gpu")
-    assert ctx.process_kwargs["args"][2] == "gpu"
+    assert _proxy(monkeypatch, device="gpu", headroom=4096).device_used == "gpu"
 
 
 def test_an_unreadable_meminfo_does_not_block_the_gpu(monkeypatch):
     """-1 means "could not tell", which must not be read as "no memory"."""
-    monkeypatch.setattr(kw, "_mem_available_mb", lambda: -1)
-    _proxy_, ctx = _proxy(monkeypatch, [READY], device="gpu")
-    assert ctx.process_kwargs["args"][2] == "gpu"
+    assert _proxy(monkeypatch, device="gpu", headroom=-1).device_used == "gpu"
+
+
+# ── when to give it back ──────────────────────────────────────────────────────
+
+def test_close_unloads_the_session_but_not_the_shared_child(monkeypatch):
+    """face's sessions live in the same child and must survive Japanese finishing."""
+    proxy = _proxy(monkeypatch)
+    proxy.close()
+    assert _FakeDirect.closed == ["gpu"]
+    proxy.close()                      # idempotent
+
+
+def test_idle_unloading_releases_the_session(monkeypatch):
+    """A card that spoke Japanese once used to hold the session for the adapter's life:
+    `set_language` never released it, so switching back to English kept it resident."""
+    proxy = _proxy(monkeypatch, idle=0.0)
+    proxy._last_used = time.monotonic() - 3600
+    direct = None
+    with proxy._lock:
+        if proxy._direct is not None and \
+                (time.monotonic() - proxy._last_used) > proxy._idle_timeout_s:
+            direct, proxy._direct = proxy._direct, None
+    assert direct is not None, "an idle session must be picked up for unloading"
+    direct.close()
+    assert _FakeDirect.closed == ["gpu"]
+
+
+def test_a_synthesize_after_idle_unloading_rebuilds(monkeypatch):
+    proxy = _proxy(monkeypatch)
+    proxy._direct = None
+    out = proxy.synthesize("konnichiwa", speaker_id=0, speed=1.0)
+    assert out.size == kw.PROBE_SAMPLES
+    assert proxy._direct is not None
+
+
+# ── failure behaviour ─────────────────────────────────────────────────────────
+
+def test_a_worker_failure_falls_back_in_process_on_cpu(monkeypatch):
+    """Japanese losing 8x is acceptable; Japanese breaking is not.
+
+    The fallback must be in-process **and** cpu: a CPU-only session loads no CUDA
+    provider, so it never touches the bridge the collision runs through.
+    """
+    proxy = _proxy(monkeypatch)
+    monkeypatch.setattr(kw.KokoroWorkerProxy, "_build",
+                        lambda self: (_ for _ in ()).throw(RuntimeError("child gone")))
+    proxy._direct = None
+    out = proxy.synthesize("konnichiwa")
+    assert out.size == kw.PROBE_SAMPLES
+    assert ("cpu", True) in _FakeDirect.built, _FakeDirect.built
+
+
+def test_a_failing_call_falls_back_rather_than_propagating(monkeypatch):
+    proxy = _proxy(monkeypatch)
+    proxy._direct.synthesize = lambda *a, **k: (_ for _ in ()).throw(
+        RuntimeError("the child died mid-utterance"))
+    out = proxy.synthesize("konnichiwa")
+    assert out.size == kw.PROBE_SAMPLES
+    assert ("cpu", True) in _FakeDirect.built

--- a/perception/tests/test_kokoro_worker.py
+++ b/perception/tests/test_kokoro_worker.py
@@ -194,3 +194,42 @@ def test_a_failing_call_falls_back_rather_than_propagating(monkeypatch):
     out = proxy.synthesize("konnichiwa")
     assert out.size == kw.PROBE_SAMPLES
     assert ("cpu", True) in _FakeDirect.built
+
+
+# ── the headroom figure depends on who else is in the child ───────────────────
+
+def test_a_shared_cuda_context_lowers_what_japanese_must_find(monkeypatch):
+    """The first CUDA session in the worker pays for the context; the rest do not.
+
+    Measured on Orin 6: Kokoro alone in the child cost 1585 MB, and Kokoro beside the
+    face service cost 967 MB. One conservative threshold refused the second case on the
+    first case's evidence — with 2158 MB free on an otherwise idle box, a 967 MB
+    allocation was declined because the number was 2500.
+    """
+    from plugins import ort_worker
+    monkeypatch.setattr(ort_worker, "get_worker",
+                        lambda: type("w", (), {"has_cuda_session": lambda self: True})())
+    # Between the two thresholds: too little for a fresh context, ample beside one.
+    proxy = _proxy(monkeypatch, device="gpu", headroom=1800)
+    assert proxy.device_used == "gpu", (
+        "with a context already in the child, 1800 MB is more than the 967 MB measured")
+
+
+def test_without_a_shared_context_the_higher_figure_applies(monkeypatch):
+    from plugins import ort_worker
+    monkeypatch.setattr(ort_worker, "get_worker",
+                        lambda: type("w", (), {"has_cuda_session": lambda self: False})())
+    proxy = _proxy(monkeypatch, device="gpu", headroom=1800)
+    assert proxy.device_used == "cpu", (
+        "a fresh context needs the 1585 MB it was measured at, plus margin")
+
+
+def test_asking_the_worker_failing_is_treated_as_no_context(monkeypatch):
+    """Erring towards the larger figure: guessing wrong the other way OOMs the box."""
+    from plugins import ort_worker
+
+    def _boom():
+        raise RuntimeError("worker unreachable")
+
+    monkeypatch.setattr(ort_worker, "get_worker", _boom)
+    assert _proxy(monkeypatch, device="gpu", headroom=1800).device_used == "cpu"

--- a/perception/tests/test_ort_worker.py
+++ b/perception/tests/test_ort_worker.py
@@ -1,0 +1,257 @@
+"""
+tests/test_ort_worker.py — the process boundary that keeps two ONNX Runtimes apart.
+
+This module exists because the standalone ONNX Runtime and sherpa-onnx's bundled one
+share a single provider bridge — an 8 KB library holding one pointer to one runtime's
+ProviderHost — so whichever builds a CUDA session second runs against the other's
+framework objects. On jp6.1 that is an exception; on jp5.11 it is a SIGSEGV that kills
+all of perception.
+
+What is worth asserting here is not "does inference work" (that needs models and a GPU)
+but the properties that decide whether the isolation holds at all, and whether a failure
+degrades or breaks:
+
+  - the child is started with `spawn`, never `fork`. `fork` copies the address space
+    *including already-dlopened libraries*, so a forked child would inherit sherpa's
+    runtime and the isolation would be worthless — the exact bug being fixed. This is
+    the single most important assertion in the file;
+  - the child imports neither rclpy nor sherpa_onnx, or it would not be the only ONNX
+    Runtime in its address space;
+  - `unload` releases one session without taking the others down, because face and
+    Japanese share the child and Japanese unloads on idle;
+  - a late reply is dropped rather than mistaken for the current one.
+
+Run: python -m pytest perception/tests -q
+"""
+
+from __future__ import annotations
+
+import queue
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+PERCEPTION_ROOT = Path(__file__).resolve().parents[1]
+if str(PERCEPTION_ROOT) not in sys.path:
+    sys.path.insert(0, str(PERCEPTION_ROOT))
+
+from plugins import ort_worker as ow  # noqa: E402
+
+
+HELLO = ("hello", {"version": "1.18.1",
+                   "providers": ["CUDAExecutionProvider", "CPUExecutionProvider"]})
+LOAD_REPLY = {"providers": ["CUDAExecutionProvider", "CPUExecutionProvider"],
+              "inputs": [{"name": "input.1", "shape": [1, 3, 640, 640],
+                          "type": "tensor(float)"}],
+              "outputs": [{"name": f"o{i}", "shape": [16800, 1],
+                           "type": "tensor(float)"} for i in range(9)]}
+
+
+class _Q:
+    def __init__(self, replies=None):
+        self.puts = []
+        self._replies = list(replies or [])
+
+    def put(self, item):
+        self.puts.append(item)
+
+    def get(self, timeout=None):
+        if not self._replies:
+            raise queue.Empty
+        return self._replies.pop(0)
+
+
+class _Proc:
+    def __init__(self):
+        self.pid = 1234
+        self._alive = True
+        self.terminated = False
+
+    def start(self):
+        pass
+
+    def is_alive(self):
+        return self._alive
+
+    def terminate(self):
+        self.terminated = True
+        self._alive = False
+
+    def kill(self):
+        self._alive = False
+
+    def join(self, timeout=None):
+        pass
+
+
+class _Ctx:
+    """Stands in for multiprocessing's spawn context, recording what was asked for."""
+
+    def __init__(self, res_replies):
+        self.cmd = _Q()
+        self.res = _Q(res_replies)
+        self.proc = _Proc()
+        self.n_queues = 0
+        self.process_kwargs = None
+
+    def Queue(self):                                              # noqa: N802
+        self.n_queues += 1
+        return self.cmd if self.n_queues == 1 else self.res
+
+    def Process(self, **kwargs):                                  # noqa: N802
+        self.process_kwargs = kwargs
+        return self.proc
+
+
+def _worker(monkeypatch, res_replies):
+    ctx = _Ctx(res_replies)
+    seen = {}
+
+    import multiprocessing as mp
+
+    def _get_context(method):
+        seen["method"] = method
+        return ctx
+
+    monkeypatch.setattr(mp, "get_context", _get_context)
+    return ow.OrtWorker(), ctx, seen
+
+
+# ── the isolation itself ──────────────────────────────────────────────────────
+
+def test_the_child_is_spawned_not_forked(monkeypatch):
+    """`fork` would inherit sherpa's already-loaded runtime and defeat the whole point.
+
+    On Linux `fork` is the default, so this has to be asked for explicitly, and the
+    string passed to get_context is the entire guarantee — there is nothing else to
+    check at runtime.
+    """
+    w, ctx, seen = _worker(monkeypatch, [HELLO, ("id", "ok", LOAD_REPLY)])
+    w._ensure_started()
+    assert seen["method"] == "spawn", seen
+    assert ctx.process_kwargs["daemon"] is True, (
+        "non-daemon deadlocks at exit: multiprocessing's own atexit hook joins "
+        "non-daemon children, and it runs before ours, so it waits for ever on a child "
+        "blocked in cmd_q.get(). Measured — see the comment at the Process() call.")
+
+
+def test_the_child_holds_no_other_runtime():
+    """spawn pickles the target by qualified name, so it must be importable — and the
+    child must not import the runtime it is being isolated from."""
+    assert callable(ow._ort_worker_main)
+    assert ow._ort_worker_main.__module__ == "plugins.ort_worker"
+    source = (PERCEPTION_ROOT / "plugins" / "ort_worker.py").read_text("utf-8")
+    assert "import rclpy" not in source
+    assert "import sherpa_onnx" not in source
+
+
+def test_no_standalone_session_is_created_outside_the_worker():
+    """The invariant the whole change rests on: every `ort.InferenceSession` in the
+    plugin tree is either inside the worker child or an explicitly-degraded fallback.
+
+    Checked structurally rather than by convention, because a new caller adding one
+    would reintroduce the collision silently — and on jp5.11 that is a SIGSEGV.
+    """
+    import ast
+
+    allowed = {
+        "ort_worker.py",          # the child itself, which is the point
+        "face_runtime.py",        # `_open_session` fallback, warned about
+        "kokoro_direct.py",       # `in_process=True` fallback, cpu-only
+    }
+    offenders = {}
+    for path in (PERCEPTION_ROOT / "plugins").rglob("*.py"):
+        tree = ast.parse(path.read_text("utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            if (isinstance(node, ast.Call)
+                    and isinstance(node.func, ast.Attribute)
+                    and node.func.attr == "InferenceSession"):
+                if path.name not in allowed:
+                    offenders.setdefault(path.name, []).append(node.lineno)
+    assert not offenders, (
+        f"these create a standalone ORT session outside the worker: {offenders}. "
+        "See plugins/ort_worker.py for why that collides with sherpa-onnx.")
+
+
+# ── the protocol ──────────────────────────────────────────────────────────────
+
+def test_load_returns_a_session_shaped_proxy(monkeypatch):
+    w, ctx, _ = _worker(monkeypatch, [HELLO, ("x", "ok", LOAD_REPLY)])
+    monkeypatch.setattr(ow.OrtWorker, "_request",
+                        lambda self, cmd, timeout: LOAD_REPLY)
+    sess = w.load("face.det", "/models/det.onnx", ["CUDAExecutionProvider"], {})
+    assert sess.get_providers()[0] == "CUDAExecutionProvider"
+    assert sess.get_inputs()[0].name == "input.1"
+    assert len(sess.get_outputs()) == 9, (
+        "the SCRFD decoder hard-asserts nine outputs; the proxy must report them all")
+
+
+def test_unload_drops_one_session_and_keeps_the_others(monkeypatch):
+    """Japanese unloads on idle; face's sessions are in the same child and must live."""
+    w, ctx, _ = _worker(monkeypatch, [HELLO])
+    sent = []
+    monkeypatch.setattr(ow.OrtWorker, "_request",
+                        lambda self, cmd, timeout: sent.append(cmd) or LOAD_REPLY)
+    w.load("face.det", "/models/det.onnx", ["CPUExecutionProvider"], {})
+    w.load("tts.kokoro.ja", "/models/kokoro.onnx", ["CPUExecutionProvider"], {})
+    w.unload("tts.kokoro.ja")
+    assert "face.det" in w._loaded
+    assert "tts.kokoro.ja" not in w._loaded
+    assert ("unload", "tts.kokoro.ja") in sent
+    assert w.alive, "unloading a session must not kill the child"
+
+
+def test_a_stale_reply_is_dropped_not_returned(monkeypatch):
+    """Requests are serialised, so an out-of-order id means a call that already timed
+    out. Returning it would hand one caller another's tensors."""
+    w, ctx, _ = _worker(monkeypatch, [HELLO])
+    w._ensure_started()
+    # A reply for a request nobody is waiting on, then the real one.
+    ctx.res._replies.extend([("someone-else", "ok", "stale"), (None, "ok", "fresh")])
+
+    real_id = {}
+    original_put = ctx.cmd.put
+
+    def _capture(item):
+        real_id["id"] = item[0]
+        ctx.res._replies[-1] = (item[0], "ok", "fresh")
+        original_put(item)
+
+    ctx.cmd.put = _capture
+    assert w._request(("run", "k", None, {}), timeout=5) == "fresh"
+
+
+def test_a_worker_error_becomes_an_exception_the_caller_can_catch(monkeypatch):
+    w, ctx, _ = _worker(monkeypatch, [HELLO])
+    w._ensure_started()
+
+    def _put(item):
+        ctx.res._replies.append((item[0], "error", "RuntimeError: no such session"))
+
+    ctx.cmd.put = _put
+    with pytest.raises(ow.OrtWorkerError, match="no such session"):
+        w._request(("run", "k", None, {}), timeout=5)
+
+
+def test_close_is_idempotent(monkeypatch):
+    w, ctx, _ = _worker(monkeypatch, [HELLO])
+    w._ensure_started()
+    w.close()
+    assert ctx.proc.terminated
+    w.close()
+
+
+# ── the escape hatch ──────────────────────────────────────────────────────────
+
+def test_the_worker_is_on_by_default(monkeypatch):
+    monkeypatch.delenv("PERCEPTION_ORT_WORKER", raising=False)
+    assert ow.worker_enabled() is True
+
+
+@pytest.mark.parametrize("value", ["0", "false", "no", "off", "FALSE", " off "])
+def test_it_can_be_turned_off_for_bisecting(monkeypatch, value):
+    """Off restores the collision, so this exists to isolate a problem, not to run in."""
+    monkeypatch.setenv("PERCEPTION_ORT_WORKER", value)
+    assert ow.worker_enabled() is False

--- a/perception/utils/model_downloader.py
+++ b/perception/utils/model_downloader.py
@@ -636,12 +636,27 @@ FACE_MODEL_FILES = {
 }
 
 
-def ensure_face_model(model_dir: str) -> dict[str, str]:
-    """Ensure the face detection + recognition ONNX pair is present."""
+FACE_MODEL_BUNDLES = {
+    "face": (FACE_MODEL_BASE, FACE_MODEL_FILES),
+}
+
+
+def ensure_face_model(model_dir: str, bundle: str = "face") -> dict[str, str]:
+    """Ensure a face detection + recognition ONNX pair is present.
+
+    `bundle` selects which pinned set to fetch, so a second model added to
+    `plugins/face_runtime.FACE_MODELS` brings its own sizes and hashes rather than
+    reusing these. One entry today; the parameter exists so adding the second does not
+    have to touch the call site.
+    """
+    spec = FACE_MODEL_BUNDLES.get(bundle)
+    if spec is None:
+        raise ValueError(
+            f"unknown face model bundle {bundle!r}; this build has "
+            f"{sorted(FACE_MODEL_BUNDLES)}")
+    base, files = spec
     model_dir = require_models_subpath(model_dir)
-    return ensure_verified_bundle(
-        "face", model_dir, FACE_MODEL_BASE, FACE_MODEL_FILES
-    )
+    return ensure_verified_bundle(bundle, model_dir, base, files)
 
 
 def ensure_verified_archive(name: str, model_dir: str, url: str, entry: dict) -> None:


### PR DESCRIPTION
## Why

Perception holds **two** ONNX Runtimes: sherpa-onnx bundles its own, and the standalone wheel serves face and Kokoro's Japanese path. They corrupt each other, and the reason is in the dynamic linker.

`libonnxruntime_providers_shared.so` is an 8 KB library exporting exactly `Provider_GetHost` / `Provider_SetHost` — a process-global slot holding **one** pointer to **one** runtime's `ProviderHost`. It carries a SONAME, `ld.so` deduplicates a `dlopen` by basename, so only one copy is ever mapped. Last writer wins, and the next session built runs against the other runtime's objects:

```
Error mapping output names: Could not find OrtValue with name '/Squeeze_2_output_0'
```

| line | symptom |
|---|---|
| jp6.1 | exception → the card goes `state: error` |
| **jp5.11** | **SIGSEGV — the whole perception process dies** |

And it is not order-fixable, only order-*avoidable*: **with face's CUDA session built first, `sherpa_onnx.OfflineTts` cannot be constructed at all.** That ships today — reproduced on the stock image. Releasing face's session does not recover it; the claim on the bridge outlives the session object. Production only escapes it because `main.py` happens to construct TTS before face.

## What this does

**One child process owns every standalone-ORT session.** Not one per card — one per *runtime*, which is the boundary the bug has. CUDA contexts do not increase: the parent used to hold sherpa's **and** the standalone one's.

`spawn`, never `fork` — `fork` copies already-`dlopen`ed libraries, so a forked child would inherit sherpa's runtime and the isolation would be worthless. A test asserts that one word.

## Where the boundary is, and the wrong cut I made first

`61146ea` is kept in this branch as a comparison point. It split at `InferenceSession.run` and put the **largest** payload on the wire:

| | in-process | split at `run()` | **this** |
|---|---|---|---|
| a frame, jp6.1 | ~46 ms | ~78 ms | **48.1 ms** |
| a frame, jp5.11 | — | — | **26.4 ms** |

The detector returns its head *before* thresholding — 16 800 candidates as nine arrays, 0.96 MiB, of which a frame keeps nought to eight. Shipping those across to discard 99.95% of them on the far side was most of the +27 ms.

The parent already holds the `CompressedImage` JPEG (~232 kB) and wants a few boxes and a 512-float vector each. So the frame crosses **once, compressed**, and the whole pipeline — decode, detect, decode-head, align, sharpness, **the quality gate**, embed — runs in the child. The gate had to come along: it sits between alignment and embedding and decides which faces are worth embedding at all.

The FaceDB stays in the parent: `matrix @ embedding` on a 2 kB vector, its lock, its files. It touches no ONNX.

## Guardrails, because a regression here is a SIGSEGV

- `FaceAnalyzer` **raises** if constructed outside the child, rather than documenting that it should not be.
- A test walks the plugin tree for `ort.InferenceSession` calls and fails on any outside the three files allowed one.

## The headroom guard was calibrated for the wrong case

The first CUDA session in the child pays for the context; the rest do not:

| | measured | threshold |
|---|---|---|
| Kokoro alone, own context | 1585 MB | 2500 MB |
| Kokoro beside the face service | **967 MB** | 1400 MB |

One number refused the second case on the first case's evidence — with 2158 MB free on an idle box, a 967 MB allocation was declined. Now it asks `has_cuda_session()` first, and **face and Japanese both run on the GPU in one child on jp6.1**: Japanese at RTF 0.089 while face recognises at 29.7–37.8 ms.

## jp5.11, including the combination nobody had tried

Forced on an emptied box with the guard disabled, face-gpu + Japanese-gpu does **not** crash: `exit 0`, face and sherpa both fine afterwards. The duration probe caught it instead — `gpu produced 24000 samples for the probe, expected ~47400 (49% off)` — and fell back to CPU, which is right on a line whose CUDA computes that path wrongly. **Safe but useless**, which is worth knowing rather than assuming.

## `face_recognition` gains a model selector

`model`, enum generated from `FACE_MODELS`, default `buffalo_sc` — today's model, so nothing changes. The registry records what a second entry must satisfy (nine detector outputs, 112×112 → 512-d) and the consequence that is easy to miss: **switching models invalidates every stored embedding.**

## Corrected here, having claimed otherwise earlier in this branch

- **A dropped session does not return memory to the OS.** Unloading Kokoro moved `MemAvailable` by **+0 MB**; the forced jp5.11 run went 3072 → 305 → 1122 MB, not back to 3072. The CUDA pool returns on process exit. Unloading frees space *inside* the child and stops the guard mis-reading the box — it does not give memory back.
- **"A 7.4 GB box cannot fit face and Japanese on gpu"** was true of two CUDA *contexts*, not two sessions.
- **"~13 ms of IPC per detection"** was extrapolated from a single-array benchmark. The detector returns nine arrays.

## Not verified

- **The face path has only run on frames with no faces in them.** Embedding, the aligned-crop return and the registration paths have unit coverage and no on-device run.
- No listening check on Japanese.

709 passed; the 3 `test_face_plugin` failures are pre-existing on this line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)