### PR TITLE
fix(tts): stop re-building an engine already in flight on config resend

### DIFF
--- a/agent-core/web/js/canvas.js
+++ b/agent-core/web/js/canvas.js
@@ -1702,6 +1702,12 @@ async function _startProject() {
       offMotusEvent(_onEvent);
       if (modal) {
         _showStartupError(modal);
+      } else if (res.status === 409) {
+        // A prior start is still settling (e.g. a card mid-warmup) — no
+        // project_start_begin ever arrived, so no modal exists to show the
+        // error in. Without this the click just looks like it did nothing;
+        // the activity log entry above is easy to miss.
+        _showToast(data.detail || '启动已在进行中，请稍候');
       }
     }
   } catch (e) {

--- a/agent-core/web/js/canvas.js
+++ b/agent-core/web/js/canvas.js
@@ -1976,7 +1976,33 @@ async function _fetchTopicsFromDriver(card, inputTopic) {
  *    TTS card opened a panel that never showed a waveform, and why the server
  *    log filled with `ASGI callable returned without completing handshake`.
  */
-function _openTopicDetailFor(el, mcpId, cachedTopicOut) {
+async function _openTopicDetailFor(el, mcpId, cachedTopicOut) {
+  // Ask the driver directly first, the same way the info modal does. Every
+  // other source here (out-port dataset, the closure captured at render time,
+  // the static MCP definition) is _revalidateDerivedTopics' cache, and it has
+  // shown a stranded topic from a card's PREVIOUS wiring before a revalidation
+  // pass has run to correct it — this button must not wait on that.
+  const card = _cards.find(c => c.el === el);
+  if (card) {
+    try {
+      const resp = await fetch(`/api/mcp/${encodeURIComponent(mcpId)}/call`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          tool: card.toolName,
+          arguments: { action: 'info', instance_id: card.id, input_topic: _inputTopicFor(card) },
+        }),
+      });
+      const parsed = _parseMcpCallResult(await resp.json());
+      const liveTopic = parsed?.topic_out?.find(t => t && t.topic);
+      if (liveTopic) {
+        showTopicDetail(liveTopic.topic, liveTopic.format || '');
+        return;
+      }
+    } catch (e) {
+      console.warn('[canvas] live topic fetch failed, falling back to cache:', e);
+    }
+  }
   const livePorts = [...el.querySelectorAll('.canvas-port.out')]
     .map(p => ({ topic: p.dataset.topic, format: p.dataset.format }));
   const liveMcp = _allMcps.find(m => m.id === mcpId);
@@ -2028,9 +2054,20 @@ function _revalidateDerivedTopics() {
     // its inbound connection, so want was '' with hasReal true, and the guard
     // below skipped it — the card kept '/remote_control/message/tts' while the
     // driver published on '/perception/tts', and the panel stayed empty.
-    const inputless = !_connections.some(c => c.toCardId === card.id);
     if (known === undefined) {
-      if (want || inputless || !hasReal) _fetchTopicsFromDriver(card, want);
+      // Nothing has verified this card's topics in this page's lifetime, and
+      // the saved layout is not evidence. `want` is '' both when nothing
+      // feeds this card (ask now, the driver answers with its default) and
+      // when a connected source has not resolved its topic yet (also fine —
+      // _fetchTopicsFromDriver stamps topicOutFrom with this `want`, and
+      // _resolveAllTopics re-runs this on every resolve, so a later pass
+      // re-derives once the source's topic is known). Gating on `want ||
+      // inputless || !hasReal` skipped exactly the case a connected-but-
+      // stale card lands in: hasReal true (old wiring's cached topic) and
+      // want '' (new source not resolved yet) — that combination hit
+      // neither condition, so a rewired TTS card kept its previous
+      // connection's topic (e.g. an ext_mic/asr chain) forever.
+      _fetchTopicsFromDriver(card, want);
       continue;
     }
     if (known !== want) _fetchTopicsFromDriver(card, want);

--- a/perception/plugins/kokoro_direct.py
+++ b/perception/plugins/kokoro_direct.py
@@ -90,6 +90,18 @@ class KokoroDirect:
 
         providers = (["CUDAExecutionProvider", "CPUExecutionProvider"]
                      if provider in ("cuda", "gpu") else ["CPUExecutionProvider"])
+        # onnxruntime's CUDA EP defaults cudnn_conv_algo_search to EXHAUSTIVE, which
+        # re-benchmarks convolution kernels on every *distinct* input shape — and
+        # this graph's shape is the token count, which is different per sentence.
+        # Measured: a repeated sentence (same shape already benchmarked) answers in
+        # well under a second; a genuinely new one pays several extra seconds on top
+        # of the ~0.07 RTF this graph otherwise runs at. HEURISTIC picks an algorithm
+        # from cuDNN's own heuristics instead of benchmarking every candidate, which
+        # costs a little peak throughput but not a multi-second stall per new shape.
+        # No effect on CPUExecutionProvider, which is why it is CUDA-only below.
+        provider_options = [{"cudnn_conv_algo_search": "HEURISTIC"}
+                             if p == "CUDAExecutionProvider" else {}
+                             for p in providers]
         # 0 lets ORT pick one thread per core, which measured fastest; an explicit
         # value is honoured so a busy robot can be told to use fewer.
         threads = int(num_threads or 0)
@@ -99,12 +111,14 @@ class KokoroDirect:
             opts = ort.SessionOptions()
             opts.intra_op_num_threads = threads
             self._session = ort.InferenceSession(model_path, opts,
-                                                 providers=providers)
+                                                 providers=providers,
+                                                 provider_options=provider_options)
         else:
             from plugins import ort_worker
             self._session = ort_worker.get_worker().load(
                 session_key, model_path, providers,
-                {"intra_op_num_threads": threads})
+                {"intra_op_num_threads": threads,
+                 "provider_options": provider_options})
             self._session_key = session_key
         actual = self._session.get_providers()
 

--- a/perception/plugins/ort_worker.py
+++ b/perception/plugins/ort_worker.py
@@ -547,8 +547,16 @@ def _ort_worker_main(cmd_q, res_q, log_level: int) -> None:
                 if level:
                     opts.graph_optimization_level = getattr(
                         ort.GraphOptimizationLevel, level)
+                # Positionally aligned with `providers`, e.g.
+                # [{"cudnn_conv_algo_search": "HEURISTIC"}, {}] — see
+                # kokoro_direct.py for why Kokoro's Japanese session needs this.
+                provider_options = options.get("provider_options")
                 started = time.monotonic()
-                sess = ort.InferenceSession(model_path, opts, providers=providers)
+                if provider_options:
+                    sess = ort.InferenceSession(model_path, opts, providers=providers,
+                                                provider_options=provider_options)
+                else:
+                    sess = ort.InferenceSession(model_path, opts, providers=providers)
                 post = None
                 if postprocess:
                     module = importlib.import_module(postprocess["module"])

--- a/perception/plugins/tts.py
+++ b/perception/plugins/tts.py
@@ -38,6 +38,12 @@ PCM_FRAME_S = CHUNK_BYTES / (SAMPLE_RATE * 2)  # 0.1s of audio per frame
 # resamples 24000 -> 16000 internally (utils/resample.py) so that the topic stays
 # audio/pcm-16k and nothing downstream has to learn a second rate.
 KOKORO_SAMPLE_RATE = 24000
+# How long a Japanese adapter stays on the in-process CPU fallback before
+# _direct() gives the shared GPU worker another attempt. Not "every call" — a
+# worker that is genuinely down would then pay the ~60s RUN_TIMEOUT_S probe on
+# every single utterance; not "never" either, which is what shipped before and
+# pinned a card to CPU for its whole life over one transient failure.
+KOKORO_WORKER_RETRY_S = 60.0
 
 # Frames held back before pacing starts, then published in one burst, so the
 # consumer begins with a real cushion. 5 frames = 500ms, matching the
@@ -810,6 +816,11 @@ class KokoroTTSAdapter(TTSAdapter):
         # Japanese does not go through sherpa at all — see _synthesize_japanese —
         # so the direct runtime needs to know which weights and provider to reuse.
         self._direct_runtime = None
+        # Set when _direct_runtime is the in-process CPU fallback rather than the
+        # worker proxy, so _direct() knows to give the worker another chance later
+        # instead of being stuck on CPU for the adapter's whole life — see _direct().
+        self._direct_fallback = False
+        self._direct_retry_at = 0.0
         self._model_dir = model_dir
         self._weights_name = os.path.basename(model_path)
         self._provider = provider
@@ -1011,27 +1022,50 @@ class KokoroTTSAdapter(TTSAdapter):
 
         Falling back to the in-process CPU session is deliberate and safe — that is
         exactly what shipped before the worker existed.
+
+        The fallback used to be permanent: once the worker's construction raised
+        anything other than `DeviceUnavailable`, `_direct_runtime` was set to a
+        plain `KokoroDirect` and the `is None` check above never fired again for
+        this adapter's whole life — a single transient failure (the shared worker
+        busy rebuilding after a restart, a one-off timeout) pinned the card to CPU
+        until the card or engine was restarted, even though the worker had long
+        since recovered. `_direct_fallback`/`_direct_retry_at` give it another
+        attempt every `KOKORO_WORKER_RETRY_S`, instead of never.
         """
+        now = time.monotonic()
+        if self._direct_runtime is not None:
+            if not self._direct_fallback or now < self._direct_retry_at:
+                return self._direct_runtime
+
+        if self._japanese_worker:
+            from plugins.kokoro_worker import DeviceUnavailable, KokoroWorkerProxy
+            try:
+                self._direct_runtime = KokoroWorkerProxy(
+                    self._model_dir, self._weights_name,
+                    device=self._japanese_worker_device)
+                self._direct_fallback = False
+                return self._direct_runtime
+            except DeviceUnavailable:
+                # The configured device cannot do the job. Substituting the CPU
+                # here would hide it behind a card that still says `gpu` — the
+                # state that made Japanese "mysteriously slow" and took a
+                # measurement to explain. Let it surface. Deliberately not
+                # retried like the branch below: this is a standing condition
+                # (not enough memory, a wrong-duration CUDA build), not a
+                # transient one, so retrying it would just repeat the same cost
+                # every KOKORO_WORKER_RETRY_S for no chance of a different answer.
+                raise
+            except Exception as exc:                          # noqa: BLE001
+                log.warning("[tts] kokoro worker unavailable (%s); Japanese uses "
+                            "the in-process CPU session, retrying the worker in "
+                            "%.0fs", exc, KOKORO_WORKER_RETRY_S)
+                self._direct_retry_at = now + KOKORO_WORKER_RETRY_S
+
         if self._direct_runtime is None:
-            if self._japanese_worker:
-                from plugins.kokoro_worker import DeviceUnavailable, KokoroWorkerProxy
-                try:
-                    self._direct_runtime = KokoroWorkerProxy(
-                        self._model_dir, self._weights_name,
-                        device=self._japanese_worker_device)
-                    return self._direct_runtime
-                except DeviceUnavailable:
-                    # The configured device cannot do the job. Substituting the CPU
-                    # here would hide it behind a card that still says `gpu` — the
-                    # state that made Japanese "mysteriously slow" and took a
-                    # measurement to explain. Let it surface.
-                    raise
-                except Exception as exc:                          # noqa: BLE001
-                    log.warning("[tts] kokoro worker unavailable (%s); Japanese uses "
-                                "the in-process CPU session", exc)
             from plugins.kokoro_direct import KokoroDirect
             self._direct_runtime = KokoroDirect(
                 self._model_dir, self._weights_name)
+            self._direct_fallback = True
         return self._direct_runtime
 
     def close(self) -> None:

--- a/perception/plugins/tts.py
+++ b/perception/plugins/tts.py
@@ -2326,7 +2326,9 @@ class TTSPlugin:
         if requested:
             engine = self._select_engine(requested)
             with self._lock:
-                switching = engine != self._impl_engine or self._impl is None
+                already_building = self._building == engine
+                switching = not already_building and (
+                    engine != self._impl_engine or self._impl is None)
                 if switching:
                     outgoing, self._impl = self._impl, None
                     self._impl_engine = ""
@@ -2342,6 +2344,18 @@ class TTSPlugin:
                     _dispose_impl(outgoing)
                 self._build_async(engine)
                 log.info("[tts] switching engine to %s", engine)
+            if switching or already_building:
+                if already_building:
+                    # A config for the engine already being built — e.g. a
+                    # dashboard resend after seeing "loading" — must not start
+                    # a second build. Two _build_async() runs for the same
+                    # engine race on self._building/_impl_engine, and whichever
+                    # finishes last wins; if resends keep arriving faster than a
+                    # cold CUDA build the card never settles and just reloads
+                    # the model over and over. Ride the in-flight build instead.
+                    log.info("[tts] config for %s while already building; "
+                              "waiting on the in-flight build instead of "
+                              "starting another", engine)
                 # Wait for it, up to a bound. Only part of a build is open-ended
                 # (downloading a model); constructing the session afterwards took
                 # ~2 s on cpu and ~5 s on gpu, and answering `loading` for that is

--- a/perception/tests/test_kokoro_direct.py
+++ b/perception/tests/test_kokoro_direct.py
@@ -197,8 +197,9 @@ def test_the_session_is_built_on_cpu_and_cannot_be_asked_for_cuda(tmp_path,
     seen = {}
 
     class _Session:
-        def __init__(self, path, opts, providers):
+        def __init__(self, path, opts, providers, provider_options=None):
             seen["providers"] = providers
+            seen["provider_options"] = provider_options
 
         def get_providers(self):
             return seen["providers"]
@@ -212,3 +213,6 @@ def test_the_session_is_built_on_cpu_and_cannot_be_asked_for_cuda(tmp_path,
     # gets its providers as a plain list argument, asserted in test_ort_worker.py.
     kd.KokoroDirect(str(tmp_path), "model.onnx", in_process=True)
     assert seen["providers"] == ["CPUExecutionProvider"], seen
+    assert seen["provider_options"] == [{}], (
+        "cudnn_conv_algo_search is a CUDA-only option; a CPU-only session must not "
+        "carry it")


### PR DESCRIPTION
## Summary

Five related fixes found while chasing a single original report (Tianyi's kokoro-multi
Japanese TTS stuck reloading and never reaching `running`), each surfaced by verifying
the previous one live on hardware (Tianyi + Orin6).

1. **Config-resend race rebuilds the engine twice.** `TTSPlugin._config()` treated any
   `config` call for the requested engine as a fresh switch whenever `self._impl is None`
   — true even while a build for that same engine is already running. A resend (dashboard
   retry after seeing `loading`) started a second `_build_async()` racing the first one;
   whichever finished last won, and repeated resends never let the card settle. Also
   explains a follow-up memory-exhaustion report on Orin6 (jp→en→jp): duplicate builds of
   the ~1.4GB Japanese CUDA session leaked GPU memory pool that "unloading does not
   return" per `kokoro_worker.py`'s own docs — reproduced and fixed by the same change.
   Fix: a `config` for the engine already in `self._building` rides the in-flight build
   via `_await_build()` instead of starting another one.

2. **`start-project` 409 has no visible feedback.** Restarting `embodied-perception` held
   agent-core's `_start_project_lock` for ~75s while `start-project` waited on the TTS
   card to settle. A click on "开启智能控制" during that window hit the 409 guard, which
   never emits `project_start_begin` — so no modal exists to report the error into, and
   the click looked like it did nothing. Added a toast, matching the pattern already used
   for the sibling canvas-edit-lock 409.

3. **Topic panel/revalidation trust a stale `card.topicOut`.** A TTS card's "查看数据流"
   showed a topic containing a different card's instance id, left over from before it was
   rewired. `_revalidateDerivedTopics`'s first-check-this-page-load branch skipped exactly
   the case a rewired card lands in (already has a topic, new source not resolved yet);
   "查看数据流" also read from the same stale-cache chain instead of asking live. Both
   fixed; the 监控/monitoring tab (separate persisted-layout snapshot) benefits indirectly
   once canvas.js's corrected topic gets persisted by a subsequent save.

4. **Japanese GPU worker pinned to CPU forever after one hiccup.** `TTSPlugin._direct()`
   cached whatever it built on the first Japanese utterance for the adapter's whole life.
   A transient `KokoroWorkerProxy` construction failure (worker busy rebuilding after a
   restart, a one-off `RUN_TIMEOUT_S`) fell back to the in-process CPU `KokoroDirect` and
   never retried GPU again, even after the worker recovered — observed on Tianyi.
   `_direct_fallback`/`_direct_retry_at` now give the worker another attempt every 60s
   instead of never; `DeviceUnavailable` (a standing condition, not transient) is
   unaffected and still surfaces immediately.

5. **Every novel sentence paid a multi-second CUDA re-benchmark.** Neither
   `kokoro_direct.py`'s in-process session nor `ort_worker.py`'s shared-worker session set
   any CUDA `provider_options`, leaving onnxruntime's CUDA EP at its default
   `cudnn_conv_algo_search=EXHAUSTIVE` — which re-benchmarks convolution kernels on every
   *distinct* input shape (token count, which differs per sentence). A genuinely new
   sentence paid several extra seconds on top of the ~0.07 RTF this graph otherwise runs
   at; a repeated sentence (already-benchmarked shape) answered in under a second — this
   is what made Japanese look non-streaming while every other kokoro-multi language (via
   sherpa-onnx, unaffected by this) was fast on equally novel text. Now sets
   `cudnn_conv_algo_search: HEURISTIC` for the CUDA provider only.

## Test plan

- [x] `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest perception/tests -q` — 718
      passed, 33 skipped, 3 pre-existing failures in `test_face_plugin.py` unrelated to
      this branch (confirmed present on `main` before this branch)
- [x] `node --test agent-core/web/js/*.test.mjs` — 27 passed (topic-derive.js untouched,
      its pinned tests still hold)
- [x] Deployed the full branch to Tianyi's and Orin6's `embodied-perception` containers
      and restarted — kokoro-multi settles into `running` with no repeated reload
- [x] Fired concurrent duplicate `config` calls at Orin6 live — second call returns
      `rebuilt: false`, no second build
- [x] Full jp→en→jp→en→jp cycle on Orin6 (including a deliberately concurrent duplicate
      `config` race) — no more `not enough memory for a CUDA session`
- [x] Controlled A/B test on Orin6, bypassing the LLM: two independent never-before-
      synthesized Japanese sentences before the fix (~4.3-4.6s overhead each) vs. after
      (0.08s and 0.52s overhead) — confirms fix #5
- [ ] Tianyi has fixes #1-2 deployed and verified; #3-5 not yet re-verified there — the
      host went unreachable (network/hardware, unrelated to this branch) mid-session and
      is still being investigated separately

🤖 Generated with [Claude Code](https://claude.com/claude-code)