### PR TITLE
fix(tts): stream Japanese synthesis chunk-by-chunk instead of blocking on the whole utterance

### DIFF
--- a/perception/plugins/kokoro_direct.py
+++ b/perception/plugins/kokoro_direct.py
@@ -184,20 +184,39 @@ class KokoroDirect:
         longer than 510 tokens is synthesized in chunks and concatenated, because
         sherpa's equivalent calls SHERPA_ONNX_EXIT(-1) at that boundary and losing a
         long sentence is worse than a seam in it.
+
+        Callers that can consume audio as it is produced should use
+        `synthesize_stream` instead — this just drains it and concatenates, which is
+        exactly the "wait for the whole utterance" cost that made a long sentence on
+        CPU (RTF ~0.52) sit in silence for as long as it took to compute all of it.
+        """
+        pieces = list(self.synthesize_stream(phonemes, speaker_id, speed))
+        if not pieces:
+            return np.zeros(0, dtype=np.float32)
+        return np.concatenate(pieces) if len(pieces) > 1 else pieces[0]
+
+    def synthesize_stream(self, phonemes: str, speaker_id: int = 0, speed: float = 1.0):
+        """Like `synthesize`, but yields each chunk's audio as it is computed.
+
+        Kokoro is not autoregressive, so a single chunk's `_run` cannot itself be
+        streamed — one ONNX call computes that chunk's whole waveform in one shot.
+        The win here is for an utterance that `chunk_ids` splits into more than one
+        chunk (over 510 tokens): the caller can start playing chunk 1 while this
+        generator is still computing chunk 2, instead of waiting for every chunk and
+        the final `np.concatenate` before anything is audible.
         """
         ids, unknown = self.encode(phonemes)
         if unknown:
             log.warning("[tts] kokoro_direct: %d phoneme(s) not in the vocabulary "
                         "and skipped: %s", len(unknown), "".join(sorted(set(unknown))))
         if not ids:
-            return np.zeros(0, dtype=np.float32)
+            return
         if not 0 <= speaker_id < self._n_speakers:
             raise ValueError(
                 f"speaker_id must be 0..{self._n_speakers - 1}, got {speaker_id}")
 
-        pieces = [self._run(chunk, speaker_id, speed)
-                  for chunk in chunk_ids(ids, STYLE_LENGTHS - 1, self._break_ids)]
-        return np.concatenate(pieces) if len(pieces) > 1 else pieces[0]
+        for chunk in chunk_ids(ids, STYLE_LENGTHS - 1, self._break_ids):
+            yield self._run(chunk, speaker_id, speed)
 
     def _run(self, ids, speaker_id: int, speed: float):
         # A leading and trailing 0, and the style row is chosen by the *inner* count —

--- a/perception/plugins/kokoro_direct.py
+++ b/perception/plugins/kokoro_direct.py
@@ -138,6 +138,15 @@ class KokoroDirect:
                  os.path.basename(model_path), len(self._token_to_id),
                  self._n_speakers, actual)
 
+    @property
+    def providers(self) -> list:
+        """What the session actually got, e.g. `['CPUExecutionProvider']` after a
+        `gpu` request was silently declined — mirrors `KokoroWorkerProxy.providers`
+        so a caller can treat the two interchangeably (see tts.py's chunk-size
+        decision, which needs to know CPU vs GPU is actually resident, not just
+        which one was originally asked for)."""
+        return list(self._session.get_providers())
+
     def close(self) -> None:
         """Release the session.
 
@@ -195,15 +204,29 @@ class KokoroDirect:
             return np.zeros(0, dtype=np.float32)
         return np.concatenate(pieces) if len(pieces) > 1 else pieces[0]
 
-    def synthesize_stream(self, phonemes: str, speaker_id: int = 0, speed: float = 1.0):
+    def synthesize_stream(self, phonemes: str, speaker_id: int = 0, speed: float = 1.0,
+                          max_chunk_tokens: int | None = None):
         """Like `synthesize`, but yields each chunk's audio as it is computed.
 
         Kokoro is not autoregressive, so a single chunk's `_run` cannot itself be
         streamed — one ONNX call computes that chunk's whole waveform in one shot.
-        The win here is for an utterance that `chunk_ids` splits into more than one
-        chunk (over 510 tokens): the caller can start playing chunk 1 while this
-        generator is still computing chunk 2, instead of waiting for every chunk and
-        the final `np.concatenate` before anything is audible.
+        The win here is for an utterance `chunk_ids` splits into more than one
+        chunk: the caller can start playing chunk 1 while this generator is still
+        computing chunk 2, instead of waiting for every chunk and the final
+        `np.concatenate` before anything is audible.
+
+        `max_chunk_tokens` defaults to the style table's own ceiling (510), which
+        is a correctness limit, not a latency target — most utterances are well
+        under it and so never actually split, which is why on CPU (RTF ~0.5-1 for
+        a single chunk, since there is no GPU-fast path to hide it behind) a
+        ~400-token sentence measured ~25s of silence before the first frame: one
+        `_run` call, computed in full before this generator could yield anything.
+        A caller chasing time-to-first-sound over CPU can pass a smaller value —
+        `style` is looked up by each chunk's own token count
+        (`self._styles[speaker_id, len(ids)]`), so a chunk of any size is a
+        correct, independent unit; there is no bound below which a smaller value
+        is *wrong*, only smaller ONNX calls with proportionally more per-call
+        fixed overhead and one more potential seam per split.
         """
         ids, unknown = self.encode(phonemes)
         if unknown:
@@ -215,7 +238,10 @@ class KokoroDirect:
             raise ValueError(
                 f"speaker_id must be 0..{self._n_speakers - 1}, got {speaker_id}")
 
-        for chunk in chunk_ids(ids, STYLE_LENGTHS - 1, self._break_ids):
+        limit = STYLE_LENGTHS - 1
+        if max_chunk_tokens is not None:
+            limit = max(1, min(limit, int(max_chunk_tokens)))
+        for chunk in chunk_ids(ids, limit, self._break_ids):
             yield self._run(chunk, speaker_id, speed)
 
     def _run(self, ids, speaker_id: int, speed: float):

--- a/perception/plugins/kokoro_worker.py
+++ b/perception/plugins/kokoro_worker.py
@@ -413,8 +413,14 @@ class KokoroWorkerProxy:
             return np.zeros(0, dtype=np.float32)
         return np.concatenate(pieces) if len(pieces) > 1 else pieces[0]
 
-    def synthesize_stream(self, phonemes: str, speaker_id: int = 0, speed: float = 1.0):
+    def synthesize_stream(self, phonemes: str, speaker_id: int = 0, speed: float = 1.0,
+                          max_chunk_tokens: int | None = None):
         """Like `synthesize`, but yields each chunk as `KokoroDirect` computes it.
+
+        `max_chunk_tokens` is passed straight through to `KokoroDirect` — see its
+        docstring. Applies equally to the worker and the in-process fallback, so
+        switching devices mid-utterance (the failure path below) does not change
+        how finely the rest of the utterance is chunked.
 
         Falls back to the in-process CPU session on the same conditions
         `synthesize` used to, but only up to the first chunk: once a chunk from
@@ -428,7 +434,7 @@ class KokoroWorkerProxy:
             self._last_used = time.monotonic()
             if self._closed:
                 yield from self._use_fallback().synthesize_stream(
-                    phonemes, speaker_id, speed)
+                    phonemes, speaker_id, speed, max_chunk_tokens)
                 return
             if self._direct is None:
                 try:
@@ -442,12 +448,13 @@ class KokoroWorkerProxy:
                                 "Japanese falls back to the in-process CPU session",
                                 exc)
                     yield from self._use_fallback().synthesize_stream(
-                        phonemes, speaker_id, speed)
+                        phonemes, speaker_id, speed, max_chunk_tokens)
                     return
             started = False
             try:
                 for chunk in self._direct.synthesize_stream(
-                        phonemes, speaker_id=speaker_id, speed=speed):
+                        phonemes, speaker_id=speaker_id, speed=speed,
+                        max_chunk_tokens=max_chunk_tokens):
                     started = True
                     yield chunk
             except Exception as exc:                              # noqa: BLE001
@@ -457,7 +464,7 @@ class KokoroWorkerProxy:
                             "falling back to the in-process CPU session", exc)
                 self._direct = None
                 yield from self._use_fallback().synthesize_stream(
-                    phonemes, speaker_id, speed)
+                    phonemes, speaker_id, speed, max_chunk_tokens)
 
     def _use_fallback(self):
         """The in-process CPU session — what shipped before any of this existed."""

--- a/perception/plugins/kokoro_worker.py
+++ b/perception/plugins/kokoro_worker.py
@@ -408,10 +408,28 @@ class KokoroWorkerProxy:
     # ── the one call ─────────────────────────────────────────────────────────
 
     def synthesize(self, phonemes: str, speaker_id: int = 0, speed: float = 1.0):
+        pieces = list(self.synthesize_stream(phonemes, speaker_id, speed))
+        if not pieces:
+            return np.zeros(0, dtype=np.float32)
+        return np.concatenate(pieces) if len(pieces) > 1 else pieces[0]
+
+    def synthesize_stream(self, phonemes: str, speaker_id: int = 0, speed: float = 1.0):
+        """Like `synthesize`, but yields each chunk as `KokoroDirect` computes it.
+
+        Falls back to the in-process CPU session on the same conditions
+        `synthesize` used to, but only up to the first chunk: once a chunk from
+        the worker has already reached the caller, restarting on the fallback
+        would either replay it (an audible repeat) or skip it (a dropped chunk).
+        A failure after that point is left to surface like any other
+        mid-utterance synthesis failure — the caller already plays whatever
+        arrived before the error.
+        """
         with self._lock:
             self._last_used = time.monotonic()
             if self._closed:
-                return self._use_fallback().synthesize(phonemes, speaker_id, speed)
+                yield from self._use_fallback().synthesize_stream(
+                    phonemes, speaker_id, speed)
+                return
             if self._direct is None:
                 try:
                     self._build()
@@ -423,15 +441,23 @@ class KokoroWorkerProxy:
                     log.warning("[tts] kokoro session could not be rebuilt (%s); "
                                 "Japanese falls back to the in-process CPU session",
                                 exc)
-                    return self._use_fallback().synthesize(phonemes, speaker_id, speed)
+                    yield from self._use_fallback().synthesize_stream(
+                        phonemes, speaker_id, speed)
+                    return
+            started = False
             try:
-                return self._direct.synthesize(phonemes, speaker_id=speaker_id,
-                                               speed=speed)
+                for chunk in self._direct.synthesize_stream(
+                        phonemes, speaker_id=speaker_id, speed=speed):
+                    started = True
+                    yield chunk
             except Exception as exc:                              # noqa: BLE001
+                if started:
+                    raise
                 log.warning("[tts] kokoro synthesis in the worker failed (%s); "
                             "falling back to the in-process CPU session", exc)
                 self._direct = None
-                return self._use_fallback().synthesize(phonemes, speaker_id, speed)
+                yield from self._use_fallback().synthesize_stream(
+                    phonemes, speaker_id, speed)
 
     def _use_fallback(self):
         """The in-process CPU session — what shipped before any of this existed."""

--- a/perception/plugins/tts.py
+++ b/perception/plugins/tts.py
@@ -1154,17 +1154,28 @@ class KokoroTTSAdapter(TTSAdapter):
                         "normalisation", text)
             return
 
+        # Chunk-by-chunk, not synthesize()+concatenate: an utterance past the
+        # 510-token style-table limit is split into several ONNX calls
+        # (kokoro_direct.chunk_ids), and waiting for every one of them before
+        # yielding anything meant a long sentence sat in silence for as long as
+        # it took to compute all of it — ~0.5s of that is the model's own RTF at
+        # 1x realtime on CPU, so a 26s utterance measured 25s of dead air before
+        # the first frame. Streaming lets chunk 1 start playing while chunk 2 is
+        # still being computed, same as sherpa's per-segment pipelining above.
+        produced_any = False
         with self._lock:
-            samples = self._direct().synthesize(
-                phonemes, speaker_id=self._sid, speed=self._speed)
+            for samples in self._direct().synthesize_stream(
+                    phonemes, speaker_id=self._sid, speed=self._speed):
+                if samples.size == 0:
+                    continue
+                produced_any = True
+                pcm = downsample_24k_to_16k(samples)
+                for i in range(0, len(pcm), CHUNK_BYTES):
+                    yield pcm[i:i + CHUNK_BYTES]
 
-        if samples.size == 0:
+        if not produced_any:
             log.warning("[tts] kokoro_direct produced no audio for %r (%r)",
                         text, phonemes)
-            return
-        pcm = downsample_24k_to_16k(samples)
-        for i in range(0, len(pcm), CHUNK_BYTES):
-            yield pcm[i:i + CHUNK_BYTES]
 
     def set_speed(self, speed: float) -> None:
         # Applied per generate() call, so nothing reloads — same as the other two.

--- a/perception/plugins/tts.py
+++ b/perception/plugins/tts.py
@@ -52,7 +52,7 @@ KOKORO_WORKER_RETRY_S = 60.0
 # with its own fixed overhead) and one more potential seam per split, larger
 # means more silence before the first frame. Has no effect on GPU, where a
 # whole utterance is fast enough that this rarely mattered in the first place.
-KOKORO_JA_CHUNK_TOKENS = 50
+KOKORO_JA_CHUNK_TOKENS = 250
 
 # Frames held back before pacing starts, then published in one burst, so the
 # consumer begins with a real cushion. 5 frames = 500ms, matching the

--- a/perception/plugins/tts.py
+++ b/perception/plugins/tts.py
@@ -44,6 +44,15 @@ KOKORO_SAMPLE_RATE = 24000
 # every single utterance; not "never" either, which is what shipped before and
 # pinned a card to CPU for its whole life over one transient failure.
 KOKORO_WORKER_RETRY_S = 60.0
+# Forces KokoroDirect.synthesize_stream() to split every Japanese utterance
+# into chunks of at most this many tokens, well under the style table's 510
+# ceiling — see _synthesize_japanese. Tuned starting point: on Orin5 CPU,
+# ~400 tokens measured ~60ms/token, so 50 targets first sound in a few
+# seconds rather than tens of seconds; smaller means more ONNX calls (each
+# with its own fixed overhead) and one more potential seam per split, larger
+# means more silence before the first frame. Has no effect on GPU, where a
+# whole utterance is fast enough that this rarely mattered in the first place.
+KOKORO_JA_CHUNK_TOKENS = 50
 
 # Frames held back before pacing starts, then published in one burst, so the
 # consumer begins with a real cushion. 5 frames = 500ms, matching the
@@ -1154,18 +1163,39 @@ class KokoroTTSAdapter(TTSAdapter):
                         "normalisation", text)
             return
 
-        # Chunk-by-chunk, not synthesize()+concatenate: an utterance past the
-        # 510-token style-table limit is split into several ONNX calls
-        # (kokoro_direct.chunk_ids), and waiting for every one of them before
-        # yielding anything meant a long sentence sat in silence for as long as
-        # it took to compute all of it — ~0.5s of that is the model's own RTF at
-        # 1x realtime on CPU, so a 26s utterance measured 25s of dead air before
-        # the first frame. Streaming lets chunk 1 start playing while chunk 2 is
-        # still being computed, same as sherpa's per-segment pipelining above.
+        # Chunk-by-chunk, not synthesize()+concatenate. On CPU, also forced to
+        # small chunks rather than the style table's 510-token ceiling: the
+        # ceiling is a correctness limit, not a latency target, and most
+        # utterances never reach it — measured on Orin5 (CPU-only, jp5.11's CUDA
+        # computes this graph's durations wrongly), a single ~400-token sentence
+        # is one `_run` call and sat in 25s of silence before the first frame,
+        # because there was nothing to split. KOKORO_JA_CHUNK_TOKENS forces a
+        # split regardless of length, so chunk 1 (a few seconds of compute) can
+        # start playing while chunk 2 is still being computed.
+        #
+        # GPU does not get this: after fixing the CUDA EP's cudnn_conv_algo_search
+        # default (see kokoro_direct.py), the SAME long sentence measured 3.18s
+        # to first frame on GPU with no chunking at all — RTF is fast enough there
+        # that forcing small chunks would only buy back a couple of seconds while
+        # paying the leading/trailing-silence cost of every extra chunk boundary
+        # (measured: chunking one utterance into ~9 pieces added ~7.5s of audible
+        # mid-utterance pauses). The device actually in use, not the one asked
+        # for, decides this — a session that fell back to the in-process CPU path
+        # after a worker failure is exactly the case this exists for.
         produced_any = False
         with self._lock:
-            for samples in self._direct().synthesize_stream(
-                    phonemes, speaker_id=self._sid, speed=self._speed):
+            runtime = self._direct()
+            # The session actually resident, not the device once asked for: a
+            # KokoroWorkerProxy configured for gpu that has silently fallen back
+            # to its in-process CPU session (worker failure, mid-retry-window)
+            # must not be judged "gpu" just because that is what device_used
+            # still says — it would skip exactly the chunking this exists for.
+            providers = getattr(runtime, "providers", None) or []
+            using_gpu = any("CUDA" in p or "Tensorrt" in p for p in providers)
+            chunk_limit = None if using_gpu else KOKORO_JA_CHUNK_TOKENS
+            for samples in runtime.synthesize_stream(
+                    phonemes, speaker_id=self._sid, speed=self._speed,
+                    max_chunk_tokens=chunk_limit):
                 if samples.size == 0:
                     continue
                 produced_any = True

--- a/perception/tests/test_kokoro_worker.py
+++ b/perception/tests/test_kokoro_worker.py
@@ -55,6 +55,9 @@ class _FakeDirect:
         return np.zeros(self.lengths.get(self.provider, kw.PROBE_SAMPLES),
                         dtype=np.float32)
 
+    def synthesize_stream(self, phonemes, speaker_id=0, speed=1.0):
+        yield self.synthesize(phonemes, speaker_id, speed)
+
     def close(self):
         _FakeDirect.closed.append(self.provider)
 

--- a/perception/tests/test_kokoro_worker.py
+++ b/perception/tests/test_kokoro_worker.py
@@ -55,7 +55,8 @@ class _FakeDirect:
         return np.zeros(self.lengths.get(self.provider, kw.PROBE_SAMPLES),
                         dtype=np.float32)
 
-    def synthesize_stream(self, phonemes, speaker_id=0, speed=1.0):
+    def synthesize_stream(self, phonemes, speaker_id=0, speed=1.0,
+                          max_chunk_tokens=None):
         yield self.synthesize(phonemes, speaker_id, speed)
 
     def close(self):


### PR DESCRIPTION
## Summary

`KokoroDirect.synthesize()` collected every `chunk_ids()` piece into a list and only
returned after `np.concatenate` — so nothing was audible until the *entire* utterance
had been computed, not just enough to start playing. On GPU (RTF ~0.07, and after
PR #190's `cudnn_conv_algo_search` fix) this was nearly invisible. On CPU — the
required fallback on jp5.11, where CUDA computes Kokoro's duration path wrongly — it
was dramatic: measured on Orin5, a 26s utterance took 51.69s wall time, ~25s of that
pure silence before the first frame played.

1. **Stream instead of block.** Added `KokoroDirect.synthesize_stream()` (generator,
   yields each chunk as `_run()` computes it) and a matching
   `KokoroWorkerProxy.synthesize_stream()` (same locking/fallback semantics as
   `synthesize()`, but only falls back to the in-process CPU session up to the first
   chunk — once a chunk has already reached the caller, restarting on the fallback
   would replay or drop audio). `tts.py`'s `_synthesize_japanese()` now consumes the
   stream chunk-by-chunk. Kokoro is not autoregressive, so this only helps an
   utterance `chunk_ids()` actually splits (over 510 tokens) — a short single-chunk
   utterance still waits for that one ONNX call, same as before.

2. **Force a split on CPU only.** `KOKORO_JA_CHUNK_TOKENS` forces every Japanese
   utterance below the 510-token ceiling to split anyway, tuned to 250 tokens after
   measuring the trade-off on Orin5: 50 tokens gets to first sound in 3.9s but splits
   into ~9 chunks, each paying its own leading/trailing silence padding (26.0s of
   audio inflates to 33.0s, +27%, audible as choppiness throughout). 250 tokens
   splits the same sentence into just 2 chunks — 14.4s to first sound (~half the
   unchunked baseline) with only +2.7% audio inflation. Applied CPU-only: the same
   sentence on GPU (post cudnn fix) took 3.18s to first frame with *zero* chunking,
   so forcing small chunks there would only pay the padding cost for negligible
   latency benefit. Device check uses the actually-resident session's providers
   (added `KokoroDirect.providers`, mirroring the existing `KokoroWorkerProxy` one),
   not the device once asked for — so a GPU session that silently fell back to CPU
   mid-retry-window still gets chunked correctly.

3. **Fixed a gap between two live-tested commits.** `KokoroWorkerProxy.synthesize_stream()`
   didn't pick up the `max_chunk_tokens` parameter when CPU-only chunking landed —
   it was deployed and tested live on Orin5/Orin6 outside git, but the parameter
   silently never reached the worker proxy in what got committed. Fixed alongside
   the 250-token tuning since both were verified together in the same round of
   on-hardware testing.

## Test plan

- [x] `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest perception/tests -q` — 718
      passed, 33 skipped, 3 pre-existing failures in `test_face_plugin.py` unrelated
      to this branch (confirmed present on `main` before this branch)
- [x] Deployed to Orin5 (CPU, jp5.11) and Orin6 (GPU, jp6.1), restarted, reconfigured
- [x] Orin5 CPU, same 139-char/404-token sentence throughout:
  - unchunked (pre-fix): ~25s to first sound, 26.0s audio
  - 50 tokens: 3.9s to first sound, 33.0s audio (+27%, audible choppiness)
  - **250 tokens (shipped): 14.4s to first sound, 26.7s audio (+2.7%)**
- [x] Orin6 GPU, same sentence: 3.18-3.49s to first sound, 261 frames (26.1s,
      matching the unchunked baseline exactly — confirms GPU correctly skips forced
      chunking)
- [x] Discovered and fixed along the way: `device` (generic/sherpa) and
      `japanese_worker_device` (Japanese-specific, config.yaml-only, not live
      MCP-configurable) are separate keys — documented for future debugging

🤖 Generated with [Claude Code](https://claude.com/claude-code)