### PR TITLE
feat(web): show LLM request duration in the activity log, double its retention

### DIFF
--- a/agent-core/src/client/llm.py
+++ b/agent-core/src/client/llm.py
@@ -206,6 +206,7 @@ class Client():
                         'completion_tokens': usage.completion_tokens,
                         'total_tokens': usage.total_tokens,
                         'cached_tokens': cached_tokens,
+                        'elapsed_s': round(elapsed, 2),
                     }
                 return msg
             except Exception as e:

--- a/agent-core/web/js/activity-log.js
+++ b/agent-core/web/js/activity-log.js
@@ -48,7 +48,7 @@ function _append(event) {
   `;
   log.appendChild(row);
 
-  while (log.children.length > 500) log.removeChild(log.firstChild);
+  while (log.children.length > 1000) log.removeChild(log.firstChild);
 
   if (atBottom) log.scrollTop = log.scrollHeight;
 }
@@ -67,7 +67,8 @@ function _summarize(event) {
       ? `${p.peer || 'peer'} ← ${p.tool} 完成${p.elapsed_ms != null ? ` ${p.elapsed_ms}ms` : ''}${p.action_id ? ` [${p.action_id}]` : ''}`
       : `${p.peer || 'peer'} ← ${p.tool} 失败: ${_trunc(String(p.error || ''), 80)}`;
     case 'render':         return `renderer=${p.renderer}`;
-    case 'llm_usage':      return `tokens: in=${p.prompt_tokens} out=${p.completion_tokens} cached=${p.cached_tokens}`;
+    case 'llm_usage':      return `tokens: in=${p.prompt_tokens} out=${p.completion_tokens} cached=${p.cached_tokens}`
+                              + (p.elapsed_s != null ? ` · ${p.elapsed_s}s` : '');
     case 'turn_end':
       if (p.usage) return `✓ ${p.rounds}轮 ${p.duration_s}s | tokens: in=${p.usage.prompt_tokens} out=${p.usage.completion_tokens} cached=${p.usage.cached_tokens}`;
       return '✓ turn complete';


### PR DESCRIPTION
## Summary
- `llm_usage`'s payload never carried request duration, only token counts — `elapsed` was already computed in `client/llm.py` and printed to the console log, just never attached to the `_usage` dict that gets pushed to the web activity log. Adds `elapsed_s` there, and renders it in `activity-log.js`'s `llm_usage` line (e.g. `tokens: in=10640 out=4 cached=10560 · 8.54s`).
- Doubles the activity log's retention from 500 to 1000 entries. It's a pure in-DOM count cap (`activity-log.js`) — there's no server-side backlog to widen, `motus_stream.py` is live-broadcast only with no history replay.

## Test plan
- [x] `python3 -m py_compile src/client/llm.py src/event/llm.py`
- [x] `node -c web/js/activity-log.js`
- [ ] Visual check on a live dashboard: confirm the LLM_USAGE log line shows the trailing `· Xs`, and that scrolling the activity strip now keeps ~1000 entries before trimming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)