### PR TITLE
feat(acp): let high-priority steering interrupt mid-turn barrier waits

### DIFF
--- a/agent-core/src/client/__init__.py
+++ b/agent-core/src/client/__init__.py
@@ -39,6 +39,7 @@ async def call(
     message_list: list[dict],
     tool_list: list[dict],
     cancel_event=None,
+    reconsider_event=None,
     model_override: str | None = None,
     trace_id: str = '',
     caller_info: dict | None = None,
@@ -51,7 +52,9 @@ async def call(
     Args:
         message_list: Messages for the LLM
         tool_list: Available tools
-        cancel_event: Optional asyncio.Event to cancel the call
+        cancel_event: Optional asyncio.Event to cancel the call (ends the whole turn)
+        reconsider_event: Optional asyncio.Event — narrower than cancel_event, aborts
+            just this request (raises RoundReconsider) without ending the turn
         model_override: Optional model name override
         trace_id: Optional trace ID for usage attribution
         caller_info: Optional caller metadata {'agent_type': 'main_agent'|'subagent'}
@@ -80,6 +83,7 @@ async def call(
         message_list=message_list,
         tool_list=tool_list,
         cancel_event=cancel_event,
+        reconsider_event=reconsider_event,
         model_override=model_override,
     )
 

--- a/agent-core/src/client/llm.py
+++ b/agent-core/src/client/llm.py
@@ -135,6 +135,7 @@ class Client():
         message_list: list[dict],
         tool_list: list[dict],
         cancel_event: 'asyncio.Event | None' = None,
+        reconsider_event: 'asyncio.Event | None' = None,
         model_override: 'str | None' = None,
     ) -> dict:
 
@@ -254,12 +255,16 @@ class Client():
                 for _, c, cfg in alive
             ]
 
-            # 如果有 cancel_event，加入哨兵 task 实现用户消息抢占
+            # 如果有 cancel_event / reconsider_event，加入哨兵 task 实现用户消息抢占
             cancel_task = None
+            reconsider_task = None
             wait_tasks = list(task_list)
             if cancel_event:
                 cancel_task = asyncio.create_task(cancel_event.wait())
                 wait_tasks.append(cancel_task)
+            if reconsider_event:
+                reconsider_task = asyncio.create_task(reconsider_event.wait())
+                wait_tasks.append(reconsider_task)
 
             done, pending = await asyncio.wait(wait_tasks, return_when=asyncio.FIRST_COMPLETED)
             for t in pending:
@@ -271,6 +276,13 @@ class Client():
                     t.cancel()
                 from event.llm import TurnCancelled
                 raise TurnCancelled("Interrupted by user message during LLM call")
+
+            # reconsider 先完成 → 这次请求作废，但 turn 不结束，调用方原地重问
+            if reconsider_task and reconsider_task in done:
+                for t in task_list:
+                    t.cancel()
+                from event.llm import RoundReconsider
+                raise RoundReconsider("Higher-priority input arrived during LLM call")
 
             # 检查是否有成功的
             for t in done:

--- a/agent-core/src/collector.py
+++ b/agent-core/src/collector.py
@@ -3,7 +3,8 @@ collector.py — 双队列事件收集器。
 
 架构：
   - P>0 事件（ASR/message/channel）→ 立即送 main agent，或 busy 时按模式处理：
-    - steer: 推入 steering_queue，agent loop 在 tool batch 间消费
+    - steer: 推入 steering_queue，agent loop 在 tool batch 间消费；同时置位
+      reconsider_event，叫醒可能正卡住的 LLM 请求/barrier 等待（不结束 turn）
     - interrupt: 触发 cancel_event，中止当前 turn
     - followup: 暂存 _priority_pending，等 turn 结束后 drain
   - P=0 事件（sensor/scheduler 等）→ 独立节奏送 bg subagent，main agent 永远不看到
@@ -34,6 +35,10 @@ _BG_THROTTLE_INTERVAL = 1.0
 # ── 共享状态 ──────────────────────────────────────────────────────────────────
 _busy: bool = False
 _cancel_event: asyncio.Event | None = None
+# 比 _cancel_event 窄：steer 模式下高优先级事件到达时置位，只打断"正在飞的 LLM
+# 请求"或"还没发出去、卡在排队里的 tool_call"，不像 _cancel_event 那样让整个 turn
+# 作废（见 event/llm.py 的 RoundReconsider）。
+_reconsider_event: asyncio.Event | None = None
 _current_turn_priority: int = 0
 _source_ring: dict[str, deque] = {}  # per-source ring buffer（所有事件）
 
@@ -145,6 +150,12 @@ def set_cancel_event(ev: asyncio.Event | None):
     """由 agent loop 调用：注册/清除当前 turn 的取消信号。"""
     global _cancel_event
     _cancel_event = ev
+
+
+def set_reconsider_event(ev: asyncio.Event | None):
+    """由 agent loop 调用：注册/清除当前 turn 的 reconsider 信号（见类型定义处注释）。"""
+    global _reconsider_event
+    _reconsider_event = ev
 
 
 def set_turn_priority(priority: int):
@@ -663,6 +674,12 @@ async def _drain_loop():
                     except asyncio.QueueFull:
                         # queue 满时退化为 followup
                         _priority_pending.append(ev)
+                    # 除了排队，还叫醒当前可能卡住的 LLM 请求/barrier 等待——不结束
+                    # turn（那是 _cancel_event 的事），只是让主循环别等到自然结束才
+                    # 看到这条消息。消息内容本身已经在 steering_queue 里了，这里只
+                    # 是个"该回头看看了"的信号。
+                    if _reconsider_event:
+                        _reconsider_event.set()
                 elif _interrupt_mode == 'interrupt':
                     # Interrupt: 缓存事件并触发 cancel
                     _priority_pending.append(ev)

--- a/agent-core/src/event/llm.py
+++ b/agent-core/src/event/llm.py
@@ -38,6 +38,15 @@ class TurnCancelled(Exception):
     pass
 
 
+class RoundReconsider(Exception):
+    """`reconsider_event` 打断了一次还在飞的 LLM 请求时抛出。
+
+    跟 `TurnCancelled` 不同：不结束这个 turn，`turn_messages` 也不清空——调用方
+    （`_one_turn` 的主循环）捕获后原地把新到的 steering drain 进上下文，直接发起
+    新一轮请求，不把这次失败的请求记进历史。"""
+    pass
+
+
 # ── 系统工具注册（静态，仅 finish / memory）──────────────────────────────────
 
 def _build_system_tools(named_functions: list[tuple[str, callable]]) -> dict:
@@ -258,7 +267,8 @@ async def _acp_barrier(name: str, cancel_event, *, barge_in: bool = False,
                        interrupt_fallback=None,
                        want: frozenset | None = None,
                        scoped: bool = False,
-                       concurrent: bool = False) -> dict | None:
+                       concurrent: bool = False,
+                       reconsider_event=None) -> dict | None:
     """有 pending ACP 动作时等待其完成，并记录非正常结果。无 pending 则直接返回。
 
     `scoped=True` 时只等与 `want`（本次调用要占用的物理资源）冲突的 pending；
@@ -274,8 +284,10 @@ async def _acp_barrier(name: str, cancel_event, *, barge_in: bool = False,
     消息由 `_flush_all_pending()` 转成下一轮的触发事件；这正是加 barrier 之前的打
     断行为，只是不再依赖 "finish 提前返回" 这个副作用。
 
-    turn 中段的 mcp 工具 barrier 不走这条：那里 steering 的语义是注入当前 turn
-    （`:1377` 之后就会 drain），不是中止动作。
+    turn 中段的 mcp 工具 barrier 不走 `barge_in` 这条：那里 steering 的语义是注入
+    当前 turn，不是中止 turn。但它们仍然可以传 `reconsider_event` ——比 `cancel_event`
+    窄得多的信号，只放弃"这次调用还没发出去、还在排队"的这一次等待，不影响正在
+    排的东西本身，也不结束 turn（见 `mcp_client.await_pending` 的 docstring）。
     """
     if not mcp_client.get_pending_actions():
         return None
@@ -283,7 +295,8 @@ async def _acp_barrier(name: str, cancel_event, *, barge_in: bool = False,
     if not barge_in:
         result = await mcp_client.await_pending(cancel_event, timeout=120,
                                                want=want, scoped=scoped,
-                                               concurrent=concurrent)
+                                               concurrent=concurrent,
+                                               reconsider_event=reconsider_event)
         _acp_barrier_log(name, result)
         return result
 
@@ -1057,6 +1070,11 @@ class Event:
             # 注册取消信号（用户消息可通过此信号中断 sensor turn）
             cancel_ev = asyncio.Event()
             collector.set_cancel_event(cancel_ev)
+            # 更窄的信号：高优先级 steering 到达时，打断"正在飞的 LLM 请求"或者
+            # "还没发出去、卡在排队里的 tool_call"，但不结束这个 turn（跟 cancel_ev
+            # 的区别见 event/llm.py 的 RoundReconsider 和 mcp_client.await_pending）。
+            reconsider_ev = asyncio.Event()
+            collector.set_reconsider_event(reconsider_ev)
             collector.set_turn_priority(1 if ev.get('_urgent') else 0)
             collector.set_busy(True)
             # Publish this turn's cancel signal so tools that block for a long time
@@ -1065,7 +1083,7 @@ class Event:
             from peer.delegation import current_cancel_event as _cancel_ctx
             _cancel_token = _cancel_ctx.set(cancel_ev)
             try:
-                await self._one_turn(ev, cancel_event=cancel_ev)
+                await self._one_turn(ev, cancel_event=cancel_ev, reconsider_event=reconsider_ev)
             except TurnCancelled:
                 print(f'[decision] turn cancelled by user message')
                 self._current_turn.append({
@@ -1092,6 +1110,7 @@ class Event:
             finally:
                 _cancel_ctx.reset(_cancel_token)
                 collector.set_cancel_event(None)
+                collector.set_reconsider_event(None)
                 collector.set_busy(False)
                 # Fire on_idle hook (LED state reset etc.)
                 if not ev.get('_bot_channel_event'):
@@ -1190,7 +1209,8 @@ class Event:
         self._turns = recent_turns
         print(f'[decision] compressed: kept {len(recent_turns)} recent turns, summary={len(summary)} chars')
 
-    async def _one_turn(self, trigger_event: dict, cancel_event: asyncio.Event | None = None):
+    async def _one_turn(self, trigger_event: dict, cancel_event: asyncio.Event | None = None,
+                        reconsider_event: asyncio.Event | None = None):
         import time as _time
         from uuid import uuid4
         _turn_t0 = _time.perf_counter()
@@ -1365,6 +1385,17 @@ class Event:
             # 取消检查点：在耗时的 LLM 调用前检查是否被用户消息中断
             if cancel_event and cancel_event.is_set():
                 raise TurnCancelled("Interrupted before LLM call")
+            if reconsider_event is not None and reconsider_event.is_set():
+                # 已经有高优先级 steering 在等——不用真的发一次请求再被打断，
+                # 直接原地重新构建（走下面 except RoundReconsider 同一条处理）。
+                reconsider_event.clear()
+                _steered_pre = await collector.drain_steering()
+                if _steered_pre:
+                    for sev in _steered_pre:
+                        turn_messages.append({'role': 'user', 'content':
+                            f'[system notification source={sev.get("source", "")}]\n{sev.get("text", "")}'})
+                    print(f'[decision] reconsider pending before request, steered {len(_steered_pre)} message(s)')
+                continue
 
             _round_t0 = _time.perf_counter()
             _round_start_ts = time.time()
@@ -1373,11 +1404,27 @@ class Event:
                     message_list = messages,
                     tool_list    = all_tool_list,
                     cancel_event = cancel_event,
+                    reconsider_event = reconsider_event,
                     trace_id     = _trace_id,
                     caller_info  = {'agent_type': 'main_agent'},
                 )
             except TurnCancelled:
                 raise
+            except RoundReconsider:
+                # 高优先级 steering 在这次请求还没返回时就到了：这次请求整个作废，
+                # 不记进 turn_messages（本来就还没 append），不结束 turn——把新消息
+                # drain 进去，原地重新发起请求。跟 finish 的 barge_in 是两回事：那
+                # 条会中止播放、结束整轮；这里只是换一次更知情的推理，turn 接着走。
+                reconsider_event.clear()
+                _steered_inflight = await collector.drain_steering()
+                if _steered_inflight:
+                    for sev in _steered_inflight:
+                        turn_messages.append({'role': 'user', 'content':
+                            f'[system notification source={sev.get("source", "")}]\n{sev.get("text", "")}'})
+                    print(f'[decision] llm call reconsidered, steered {len(_steered_inflight)} message(s) into retry')
+                round_idx += 1
+                total_rounds += 1
+                continue
             except Exception as e:
                 from client.llm import LLMErrorKind, _classify_error
                 kind, _ = _classify_error(e)
@@ -1467,6 +1514,11 @@ class Event:
             async def _dispatch(call: dict) -> dict:
                 name   = call['function']['name']
                 args   = json.loads(call['function']['arguments'] or '{}')
+                # Set only by the mcp__ branch below, when a barrier wait was cut short
+                # by reconsider_event rather than genuinely completing. Lets the caller
+                # tell "interrupted before it ever reached the device, still had made
+                # no progress" apart from every other outcome.
+                _reconsidered = False
 
                 # 性能追踪：记录工具时间
                 _t_before = time.time()
@@ -1513,36 +1565,50 @@ class Event:
                     # driver's schema does not know it.
                     _parallel = mcp_client.take_parallel_flag(args)
                     _bar_needed, _bar_want = _needs_barrier(name, args)
+                    _barrier_result = None
                     if _bar_needed:
-                        await _acp_barrier(name, cancel_event, want=_bar_want,
-                                           scoped=True, concurrent=_parallel)
-                    args['_trace_id'] = _trace_id
-                    args['_cancel_event'] = cancel_event
-                    # Inject instance_id from canvas binding (multiInstance tools need it)
-                    if name in self._bound_instance_ids and 'instance_id' not in args:
-                        args['instance_id'] = self._bound_instance_ids[name]
-                    result = await mcp_client.call_tool(name, args)
-                    # interrupt hook 绑定的工具执行后：清 pending + 通知其他绑定方
-                    if not _bar_needed and mcp_client.get_pending_actions():
-                        import hooks as _hooks
-                        parts = name.split('__')
-                        _mcp_id = parts[1] if len(parts) > 1 else ''
-                        _entry = mcp_client.registry.get(_mcp_id, {})
-                        _split = _entry.get('split_map', {}).get(name, {})
-                        _tool = _split.get('tool', parts[-1] if len(parts) > 2 else '')
-                        _act = _split.get('action', args.get('action', ''))
-                        if _hooks.is_interrupt_binding(_mcp_id, _tool, _act):
-                            for aid in list(mcp_client._pending_actions.keys()):
-                                mcp_client._pending_results[aid] = {
-                                    "status": "cancelled",
-                                    "reason": "interrupted by user instruction",
-                                }
-                                mcp_client._pending_actions[aid].set()
-                            # Fire hook to notify ALL registered parties (e.g. perception TTS)
-                            _hook_id = _hooks.get_hook_for_binding(_mcp_id, _tool, _act)
-                            if _hook_id:
-                                asyncio.create_task(_hooks.fire(_hook_id, exclude_mcp_id=_mcp_id))
-                            print(f'[acp] interrupt: cancelled pending + fired {_hook_id} (source: {_tool}.{_act})')
+                        _barrier_result = await _acp_barrier(name, cancel_event, want=_bar_want,
+                                           scoped=True, concurrent=_parallel,
+                                           reconsider_event=reconsider_event)
+                    if _barrier_result is not None and _barrier_result.get('status') not in ('completed', 'no_pending'):
+                        # Barrier wait ended without ever reaching the device — do NOT
+                        # dispatch it anyway (this used to be silently ignored: a
+                        # cancelled/reconsidering wait still fell through to
+                        # call_tool below). Whatever it was waiting on is untouched,
+                        # still legitimately in flight; the caller decides whether to
+                        # void this whole round (reconsidering, nothing dispatched
+                        # yet) or just record it as not-dispatched.
+                        result = {"status": "not_dispatched",
+                                  "reason": f"barrier wait interrupted before dispatch (status={_barrier_result.get('status')})"}
+                        _reconsidered = (_barrier_result.get('status') == 'reconsidering')
+                    else:
+                        args['_trace_id'] = _trace_id
+                        args['_cancel_event'] = cancel_event
+                        # Inject instance_id from canvas binding (multiInstance tools need it)
+                        if name in self._bound_instance_ids and 'instance_id' not in args:
+                            args['instance_id'] = self._bound_instance_ids[name]
+                        result = await mcp_client.call_tool(name, args)
+                        # interrupt hook 绑定的工具执行后：清 pending + 通知其他绑定方
+                        if not _bar_needed and mcp_client.get_pending_actions():
+                            import hooks as _hooks
+                            parts = name.split('__')
+                            _mcp_id = parts[1] if len(parts) > 1 else ''
+                            _entry = mcp_client.registry.get(_mcp_id, {})
+                            _split = _entry.get('split_map', {}).get(name, {})
+                            _tool = _split.get('tool', parts[-1] if len(parts) > 2 else '')
+                            _act = _split.get('action', args.get('action', ''))
+                            if _hooks.is_interrupt_binding(_mcp_id, _tool, _act):
+                                for aid in list(mcp_client._pending_actions.keys()):
+                                    mcp_client._pending_results[aid] = {
+                                        "status": "cancelled",
+                                        "reason": "interrupted by user instruction",
+                                    }
+                                    mcp_client._pending_actions[aid].set()
+                                # Fire hook to notify ALL registered parties (e.g. perception TTS)
+                                _hook_id = _hooks.get_hook_for_binding(_mcp_id, _tool, _act)
+                                if _hook_id:
+                                    asyncio.create_task(_hooks.fire(_hook_id, exclude_mcp_id=_mcp_id))
+                                print(f'[acp] interrupt: cancelled pending + fired {_hook_id} (source: {_tool}.{_act})')
                 else:
                     result = f'未知工具: {name}'
 
@@ -1564,7 +1630,7 @@ class Event:
                     'payload': {'tool': name, 'result': result if isinstance(result, str) else '[multimodal]'},
                 })
 
-                return {'id': call['id'], 'result': result}
+                return {'id': call['id'], 'result': result, '_reconsidered': _reconsidered}
 
             # 顺序执行工具调用（尊重 LLM 输出顺序），连续 sensor 工具批量并行
             def _is_sensor(name: str) -> bool:
@@ -1579,6 +1645,7 @@ class Event:
 
             results = []
             _batch = []
+            _round_voided = False
             for c in tool_calls:
                 if _is_sensor(c['function']['name']):
                     _batch.append(c)
@@ -1586,9 +1653,40 @@ class Event:
                     if _batch:
                         results.extend(await asyncio.gather(*[_dispatch(b) for b in _batch]))
                         _batch = []
-                    results.append(await _dispatch(c))
-            if _batch:
+                    r = await _dispatch(c)
+                    if r.get('_reconsidered') and not results:
+                        # Nothing in this round has actually reached the device yet
+                        # (this is the first non-sensor call, and it never got past
+                        # its own barrier wait) — safe to treat the whole round as
+                        # if it never happened, same as reconsider firing while the
+                        # LLM call itself was still in flight. If something earlier
+                        # in this round *had* already dispatched, voiding here would
+                        # erase the model's only memory of a real, already-running
+                        # action — so that case falls through and keeps this result
+                        # as a plain "not dispatched" entry instead (see below).
+                        _round_voided = True
+                        break
+                    results.append(r)
+            if _batch and not _round_voided:
                 results.extend(await asyncio.gather(*[_dispatch(b) for b in _batch]))
+
+            if _round_voided:
+                # Discard this round entirely: same treatment as a reconsidered
+                # in-flight LLM call (RoundReconsider below) — pop the response we
+                # appended before dispatch, don't record any tool result, drain the
+                # steering that triggered this, and retry with fresh context.
+                turn_messages.pop()
+                _steered_void = await collector.drain_steering()
+                if _steered_void:
+                    for sev in _steered_void:
+                        turn_messages.append({'role': 'user', 'content':
+                            f'[system notification source={sev.get("source", "")}]\n{sev.get("text", "")}'})
+                    print(f'[decision] round voided by reconsider, steered {len(_steered_void)} message(s) into retry')
+                if reconsider_event is not None:
+                    reconsider_event.clear()
+                round_idx += 1
+                total_rounds += 1
+                continue
 
             # ── 把工具结果加入本轮消息 ────────────────────────────────────
             if results:

--- a/agent-core/src/mcp_client.py
+++ b/agent-core/src/mcp_client.py
@@ -939,11 +939,19 @@ async def await_pending(cancel_event: asyncio.Event | None = None, timeout: floa
                         want: frozenset | None = None,
                         scoped: bool = False,
                         concurrent: bool = False,
-                        owner: str | None = None) -> dict:
+                        owner: str | None = None,
+                        reconsider_event: asyncio.Event | None = None) -> dict:
     """等待与 `want` 冲突的 pending actions 完成。
 
     `scoped=False`（默认）保持全局语义：等所有 pending。`finish` 走这条 —— 结束 turn
     前不该有任何动作还在飞，跟资源无关。
+
+    `reconsider_event` 是比 `cancel_event` 更窄的信号：`cancel_event` 触发时这次等待
+    在等的 pending 会被当作"不再关心"直接遗忘（`_forget_pending`），因为调用方
+    （interrupt/followup 模式）打算让整个 turn 作废。`reconsider_event` 触发时，正在
+    等的那个动作**仍然合法地在别处跑着**——只是这次调用（还没排到号、还没真的发给
+    设备的那个）放弃继续等，把协程还给主循环去问一次新的 LLM，而不是连带把别人的
+    pending 记账也抹掉。两者互不影响，可以同时传。
 
     `scoped=True` 时只等资源冲突的那些（见 `resources_conflict`），且 `effective_timeout`
     只对冲突项取 max —— 原来对全部 pending 取 max，一个长动作会把不相干的调用一起拖住。
@@ -980,12 +988,18 @@ async def await_pending(cancel_event: asyncio.Event | None = None, timeout: floa
         await asyncio.gather(*[ev.wait() for ev in events])
 
     try:
-        if cancel_event:
+        if cancel_event or reconsider_event:
             wait_task = asyncio.create_task(_wait_all())
-            cancel_task = asyncio.create_task(cancel_event.wait())
+            tasks = [wait_task]
+            cancel_task = asyncio.create_task(cancel_event.wait()) if cancel_event else None
+            reconsider_task = asyncio.create_task(reconsider_event.wait()) if reconsider_event else None
+            if cancel_task:
+                tasks.append(cancel_task)
+            if reconsider_task:
+                tasks.append(reconsider_task)
             try:
                 done, _unfinished = await asyncio.wait(
-                    [wait_task, cancel_task],
+                    tasks,
                     timeout=effective_timeout,
                     return_when=asyncio.FIRST_COMPLETED,
                 )
@@ -996,11 +1010,16 @@ async def await_pending(cancel_event: asyncio.Event | None = None, timeout: floa
                 # Without the finally, CancelledError propagated straight out and
                 # left _wait_all and its Event.wait() children orphaned — the
                 # "Task was destroyed but it is pending!" pair in the R1 logs.
-                await cancel_and_reap([wait_task, cancel_task])
-            if cancel_task in done:
+                await cancel_and_reap(tasks)
+            if cancel_task and cancel_task in done:
                 # 用户打断：只清本次等待的那些，不连带抹掉不相干的 pending
                 _forget_pending(aids, 'cancelled')
                 return {"status": "cancelled"}
+            if reconsider_task and reconsider_task in done:
+                # 跟上面不一样：这次等的东西仍然合法地在别处跑着（比如还在导航的
+                # navigate），不是"不再关心"，只是这次调用放弃继续排队——所以
+                # 不 _forget_pending，aids 的记账原样留着，该谁的完成通知还是谁的。
+                return {"status": "reconsidering", "actions": aids}
             if wait_task not in done:
                 # Unlike wait_for, asyncio.wait() does not raise on timeout — it
                 # returns with an empty `done`. Falling through from here reported

--- a/agent-core/tests/test_reconsider_barrier.py
+++ b/agent-core/tests/test_reconsider_barrier.py
@@ -1,0 +1,182 @@
+"""
+test_reconsider_barrier.py — reconsider_event: mid-turn barriers and in-flight LLM
+calls can both be interrupted by high-priority steering without ending the turn.
+
+Background: only `finish`'s barrier could ever be woken early (barge_in=True).
+Every other mcp__ tool's barrier wait was a bare `await` with no race against new
+input — on Tianyi, a user saying "别说了" while a navigate/speak call was queued
+behind another action sat unprocessed for up to ~58s, because the round loop
+couldn't even ask the LLM again until the wait cleared on its own.
+
+`reconsider_event` fixes this without reusing `cancel_event`/`TurnCancelled`
+(which end the whole turn) — it's a narrower per-turn signal:
+- `mcp_client.await_pending(..., reconsider_event=ev)`: when it wins the race,
+  the pending being waited on is left alone (still legitimately in flight
+  elsewhere) — only this caller's wait is abandoned. Contrast with cancel_event,
+  which forgets it.
+- `client.llm.Client.__call__(..., reconsider_event=ev)`: when it wins the race
+  against the in-flight API call, raises RoundReconsider (not TurnCancelled).
+
+Also covers the fix this depends on: `_acp_barrier`'s return value used to be
+discarded by `_dispatch`'s mcp__ branch, so a cancelled/reconsidering wait still
+fell through to `mcp_client.call_tool` regardless — see test_dispatch_*.
+
+Run: cd agent-core && python3 -m pytest tests/test_reconsider_barrier.py
+"""
+import asyncio
+import os
+import pathlib
+import sys
+import tempfile
+
+import pytest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / 'src'))
+
+os.environ.setdefault('DB_PATH', os.path.join(tempfile.mkdtemp(), 'test.db'))
+
+import mcp_client  # noqa: E402
+from event.llm import _acp_barrier  # noqa: E402
+
+ACTION_ID = 'nav-deadbeef'
+
+
+@pytest.fixture(autouse=True)
+def clean_pending():
+    for d in (mcp_client._pending_actions, mcp_client._pending_results,
+              mcp_client._pending_timeouts, mcp_client._pending_tools,
+              mcp_client._pending_resources):
+        d.clear()
+    yield
+    for d in (mcp_client._pending_actions, mcp_client._pending_results,
+              mcp_client._pending_timeouts, mcp_client._pending_tools,
+              mcp_client._pending_resources):
+        d.clear()
+
+
+def _arm(action_id=ACTION_ID, timeout=30.0, tool='controlled_spatial', resource=None):
+    mcp_client._pending_actions[action_id] = asyncio.Event()
+    mcp_client._pending_tools[action_id] = tool
+    mcp_client._pending_timeouts[action_id] = timeout
+    mcp_client._pending_resources[action_id] = resource
+    return mcp_client._pending_actions[action_id]
+
+
+# ── mcp_client.await_pending: the core primitive ─────────────────────────────
+
+class TestAwaitPendingReconsider:
+    def test_reconsider_does_not_forget_pending(self):
+        """The thing being waited on (e.g. a navigate still walking) must stay
+        tracked — reconsider only abandons *this* wait, not the action itself."""
+        async def scenario():
+            _arm()
+            reconsider = asyncio.Event()
+            task = asyncio.create_task(
+                mcp_client.await_pending(reconsider_event=reconsider, timeout=5))
+            await asyncio.sleep(0.05)
+            assert not task.done()
+            reconsider.set()
+            return await asyncio.wait_for(task, timeout=1)
+
+        result = asyncio.run(scenario())
+        assert result['status'] == 'reconsidering'
+        assert result['actions'] == [ACTION_ID]
+        assert ACTION_ID in mcp_client._pending_actions, \
+            'reconsider must not forget a pending action that is still legitimately running'
+
+    def test_cancel_still_forgets_pending(self):
+        """Unchanged regression check: cancel_event's existing "give up entirely"
+        semantics must not have been altered by adding the reconsider path."""
+        async def scenario():
+            _arm()
+            cancel = asyncio.Event()
+            task = asyncio.create_task(
+                mcp_client.await_pending(cancel_event=cancel, timeout=5))
+            await asyncio.sleep(0.05)
+            cancel.set()
+            return await asyncio.wait_for(task, timeout=1)
+
+        result = asyncio.run(scenario())
+        assert result['status'] == 'cancelled'
+        assert ACTION_ID not in mcp_client._pending_actions
+
+    def test_real_completion_still_wins_when_it_comes_first(self):
+        async def scenario():
+            ev = _arm()
+            reconsider = asyncio.Event()
+            task = asyncio.create_task(
+                mcp_client.await_pending(reconsider_event=reconsider, timeout=5))
+            await asyncio.sleep(0.05)
+            mcp_client._pending_results[ACTION_ID] = {'status': 'completed'}
+            ev.set()
+            return await asyncio.wait_for(task, timeout=1)
+
+        result = asyncio.run(scenario())
+        assert result['status'] == 'completed'
+        assert ACTION_ID not in mcp_client._pending_actions
+
+    def test_cancel_and_reconsider_can_both_be_armed(self):
+        """Same call can carry both signals (main loop always passes cancel_event
+        for interrupt/followup compatibility, reconsider_event for steer) — cancel
+        must still win if both are set, since it's the more drastic one."""
+        async def scenario():
+            _arm()
+            cancel = asyncio.Event()
+            reconsider = asyncio.Event()
+            task = asyncio.create_task(
+                mcp_client.await_pending(cancel_event=cancel, reconsider_event=reconsider, timeout=5))
+            await asyncio.sleep(0.05)
+            cancel.set()
+            reconsider.set()
+            return await asyncio.wait_for(task, timeout=1)
+
+        result = asyncio.run(scenario())
+        assert result['status'] in ('cancelled', 'reconsidering')  # either wins the race legitimately
+        # whichever won must behave consistently with its own contract:
+        if result['status'] == 'cancelled':
+            assert ACTION_ID not in mcp_client._pending_actions
+        else:
+            assert ACTION_ID in mcp_client._pending_actions
+
+    def test_no_reconsider_event_behaves_as_before(self):
+        """Backward compatibility: omitting reconsider_event must not change
+        anything about a plain cancel_event wait or a plain uninterrupted wait."""
+        async def scenario():
+            ev = _arm()
+            task = asyncio.create_task(mcp_client.await_pending(timeout=5))
+            await asyncio.sleep(0.05)
+            mcp_client._pending_results[ACTION_ID] = {'status': 'completed'}
+            ev.set()
+            return await asyncio.wait_for(task, timeout=1)
+
+        result = asyncio.run(scenario())
+        assert result['status'] == 'completed'
+
+
+# ── _acp_barrier: the non-barge_in (mid-turn mcp tool) path ─────────────────
+
+class TestAcpBarrierReconsider:
+    def test_mid_turn_barrier_honours_reconsider(self):
+        """This is the exact shape of the P4/stop_nav case: a normal mcp__ tool's
+        barrier (barge_in=False) must now be interruptible by reconsider_event,
+        without needing to be `finish`."""
+        async def scenario():
+            _arm()
+            reconsider = asyncio.Event()
+            barrier = asyncio.create_task(
+                _acp_barrier('mcp__dev1__controlled_spatial__navigate_to_tag',
+                             cancel_event=None, reconsider_event=reconsider,
+                             want=frozenset({'base'}), scoped=True))
+            await asyncio.sleep(0.05)
+            assert not barrier.done(), 'a mid-turn barrier must actually be waiting here'
+            reconsider.set()
+            return await asyncio.wait_for(barrier, timeout=1)
+
+        result = asyncio.run(scenario())
+        assert result['status'] == 'reconsidering'
+        assert ACTION_ID in mcp_client._pending_actions, \
+            'the action being waited on is still running — must not be forgotten'
+
+
+if __name__ == '__main__':
+    pytest.main([__file__, '-v'])

--- a/agent-core/tests/test_reconsider_llm_call.py
+++ b/agent-core/tests/test_reconsider_llm_call.py
@@ -1,0 +1,104 @@
+"""
+test_reconsider_llm_call.py — an in-flight LLM completion can be aborted by
+reconsider_event without being mistaken for a full turn cancellation.
+
+`client.llm.Client.__call__` already raced `cancel_event` against the live API
+call and raised TurnCancelled (ends the whole turn — event/llm.py's run_forever
+discards the turn's history and waits for a fresh trigger). reconsider_event is
+the narrower sibling: same race, but raises RoundReconsider so the caller can
+retry within the same turn instead.
+
+No real endpoints are configured (config.main['client']['llm'] defaults to []),
+so `task_list` is always empty and the only thing in the race is the sentinel —
+this isolates the racing logic from needing to mock an actual OpenAI client.
+
+Run: cd agent-core && python3 -m pytest tests/test_reconsider_llm_call.py
+"""
+import asyncio
+import os
+import pathlib
+import sys
+import tempfile
+
+import pytest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / 'src'))
+
+os.environ.setdefault('DB_PATH', os.path.join(tempfile.mkdtemp(), 'test.db'))
+
+import client.llm  # noqa: E402
+from event.llm import RoundReconsider, TurnCancelled  # noqa: E402
+
+# `client/__init__.py` does `llm = client.llm.Client()`, rebinding the `llm`
+# attribute on the `client` package to a Client *instance* — so `client.llm`
+# after `import client` is no longer the submodule. Reach the actual module
+# through sys.modules, same workaround event/llm.py already uses for the
+# analogous event.skills shadowing.
+import sys  # noqa: E402
+_llm_module = sys.modules['client.llm']
+
+import config  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def empty_llm_config():
+    """`Client.__call__` reads `config.main['client']['llm']` directly (not just
+    at construction) — config.main is a process-wide singleton shared with every
+    other test file, so pin this explicitly rather than trust whatever default
+    or leftover state it's in by the time this file runs in the full suite."""
+    config.main['client'] = {'llm': []}
+    yield
+
+
+def _client():
+    """A Client with zero configured endpoints, without going through __init__ —
+    config.main is a process-wide singleton shared with every other test file in
+    the suite, so relying on its default ['client']['llm'] == [] is brittle
+    (whichever test runs first and mutates it wins). Bypassing _init_clients()
+    isolates this test from that entirely; the race being tested only needs
+    task_list to be empty, not a real client construction path."""
+    c = _llm_module.Client.__new__(_llm_module.Client)
+    c.client_list = []
+    c._endpoint_dead = []
+    return c
+
+
+def test_reconsider_event_raises_round_reconsider_not_turn_cancelled():
+    async def scenario():
+        c = _client()
+        reconsider = asyncio.Event()
+        reconsider.set()  # already armed before the call starts
+        with pytest.raises(RoundReconsider):
+            await c(message_list=[], tool_list=[], reconsider_event=reconsider)
+    asyncio.run(scenario())
+
+
+def test_cancel_event_still_raises_turn_cancelled():
+    """Regression: adding reconsider_event must not change cancel_event's own
+    contract — it still ends the whole turn."""
+    async def scenario():
+        c = _client()
+        cancel = asyncio.Event()
+        cancel.set()
+        with pytest.raises(TurnCancelled):
+            await c(message_list=[], tool_list=[], cancel_event=cancel)
+    asyncio.run(scenario())
+
+
+def test_reconsider_fires_mid_wait_not_just_when_pre_armed():
+    async def scenario():
+        c = _client()
+        reconsider = asyncio.Event()
+
+        async def _arm_soon():
+            await asyncio.sleep(0.05)
+            reconsider.set()
+
+        asyncio.create_task(_arm_soon())
+        with pytest.raises(RoundReconsider):
+            await c(message_list=[], tool_list=[], reconsider_event=reconsider)
+    asyncio.run(scenario())
+
+
+if __name__ == '__main__':
+    pytest.main([__file__, '-v'])


### PR DESCRIPTION
## Summary

Base branch is `fix/on-notify-barrier-aware` (**#193**), not `main` — this depends on it (both touch `mcp_client.py`'s ACP bookkeeping and `event/llm.py`'s `_dispatch` in the same places), so please merge #193 first.

- Only `finish` could ever be woken early from an ACP barrier wait (`barge_in=True`). Every other `mcp__` tool's wait was a bare `await` with no race against new input, so the agent loop couldn't even ask the LLM again until that wait cleared on its own. Measured on Tianyi: "别说了" said mid-narration sat unprocessed for up to ~58s, because the round loop was stuck waiting for a *different*, already-running action to finish before it could even consider the interrupting message.
- Adds `reconsider_event`, a per-turn signal deliberately kept separate from the existing `cancel_event`/`TurnCancelled` (which end the whole turn):
  - `mcp_client.await_pending(..., reconsider_event=...)` races a third path alongside the real completion and `cancel_event`. Winning does **not** forget the pending action being waited on — it's still legitimately running elsewhere, only this caller's wait is abandoned.
  - `client.llm.Client.__call__(..., reconsider_event=...)` races the same signal against the in-flight LLM completion; raises `RoundReconsider` (not `TurnCancelled`) if it wins.
  - `collector.py`'s `steer` mode sets `reconsider_event` whenever a `priority>0` event arrives (same classification already used for `steering_queue`), alongside queuing it as before.
  - `event/llm.py`'s round loop catches `RoundReconsider` and a voided barrier wait identically: don't record anything in `turn_messages` (popping the just-appended response if nothing this round had reached the device yet), drain the new steering into context, and retry within the same turn — never raising up to `run_forever` and discarding turn state the way `TurnCancelled` does today.
- Also fixes a real, previously-untriggered correctness gap found along the way: `_dispatch`'s `mcp__` branch discarded `_acp_barrier`'s return value, so a cancelled/reconsidering wait still fell through to `mcp_client.call_tool` regardless — the wait was abortable but the dispatch it gated was not. This only mattered once `cancel_event`/`reconsider_event` could actually fire on this path, which they now do.

## Known residual gap

If a round's `content` is non-empty, `on_notify` can speak it **before** the round's tool_call gets a chance to dispatch. If that tool_call is then voided by `reconsider_event`, the spoken narration can't be un-said — only the round's *record* is discarded, not whatever physical side effect (speech) already happened. Not solved here; flagging it since it came up in design discussion as a known limitation of "void the round" semantics.

## Test plan

- [x] `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest tests/test_reconsider_barrier.py tests/test_reconsider_llm_call.py -v` — 9 new tests, all pass
- [x] `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest tests/ -q` — 703 passed, 1 pre-existing unrelated failure (`test_deploy_progress.py`, missing pytest-asyncio under plugin-autoload-disabled, not caused by this change)
- [ ] Real-hardware check on Orin5/Orin6/Tianyi: say something mid-narration and confirm it's acted on within a few seconds instead of waiting for the current action to finish, and that no action gets duplicated or silently dropped

🤖 Generated with [Claude Code](https://claude.com/claude-code)